### PR TITLE
[Web & messaging OTel] Regenerate OTel dashboards with adHocDataViews

### DIFF
--- a/packages/activemq_otel/changelog.yml
+++ b/packages/activemq_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/activemq_otel/changelog.yml
+++ b/packages/activemq_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20378
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/activemq_otel/kibana/dashboard/activemq_otel-broker-health.json
+++ b/packages/activemq_otel/kibana/dashboard/activemq_otel-broker-health.json
@@ -168,13 +168,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e",
+                                    "name": "indexpattern-datasource-layer-aac5154e-4e4b-9447-5d5c-aacd238eb44f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e": {
+                                    "id": "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -270,13 +291,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3",
+                                    "name": "indexpattern-datasource-layer-0d807522-0497-0018-7002-60d884c68000"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3": {
+                                    "id": "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -372,13 +414,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "dae479c0-fe2e-e08d-e272-135ccd5fc6f3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "dae479c0-fe2e-e08d-e272-135ccd5fc6f3",
+                                    "name": "indexpattern-datasource-layer-8c915a62-b4fd-e806-4254-267c945d51a3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "dae479c0-fe2e-e08d-e272-135ccd5fc6f3": {
+                                    "id": "dae479c0-fe2e-e08d-e272-135ccd5fc6f3",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -474,13 +537,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "141ff175-680a-bcd4-9f52-c7293b9cec44"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "141ff175-680a-bcd4-9f52-c7293b9cec44",
+                                    "name": "indexpattern-datasource-layer-2ef97c82-b3d1-9f11-6f90-3b96c3267ff9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "141ff175-680a-bcd4-9f52-c7293b9cec44": {
+                                    "id": "141ff175-680a-bcd4-9f52-c7293b9cec44",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -576,13 +660,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "55debfcd-8910-2445-bd32-474a1c923fd9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "55debfcd-8910-2445-bd32-474a1c923fd9",
+                                    "name": "indexpattern-datasource-layer-14c56d2d-c110-4c27-44b5-c8e6ea1a3118"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "55debfcd-8910-2445-bd32-474a1c923fd9": {
+                                    "id": "55debfcd-8910-2445-bd32-474a1c923fd9",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -717,13 +822,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "508f2120-7df0-f7d1-4beb-301051499124"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "508f2120-7df0-f7d1-4beb-301051499124",
+                                    "name": "indexpattern-datasource-layer-1decbbec-bd91-5ee6-dd54-c2d2da10b755"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "508f2120-7df0-f7d1-4beb-301051499124": {
+                                    "id": "508f2120-7df0-f7d1-4beb-301051499124",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -877,13 +1003,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cf0ebe06-5fa1-8fd7-984f-f03c6c37c844"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cf0ebe06-5fa1-8fd7-984f-f03c6c37c844",
+                                    "name": "indexpattern-datasource-layer-7d567625-ebc1-9ed7-29e6-f8fae6dc5f8e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cf0ebe06-5fa1-8fd7-984f-f03c6c37c844": {
+                                    "id": "cf0ebe06-5fa1-8fd7-984f-f03c6c37c844",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1037,13 +1184,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0c2b23a9-6460-e846-3246-6a617a130cd9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0c2b23a9-6460-e846-3246-6a617a130cd9",
+                                    "name": "indexpattern-datasource-layer-881bf086-c5bb-75b1-689b-dd51f6bdfb09"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0c2b23a9-6460-e846-3246-6a617a130cd9": {
+                                    "id": "0c2b23a9-6460-e846-3246-6a617a130cd9",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1204,13 +1372,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "54a89738-fd83-db57-5dbd-90b1a50561e2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "54a89738-fd83-db57-5dbd-90b1a50561e2",
+                                    "name": "indexpattern-datasource-layer-fc785524-593d-1253-0d92-f4755ff7a00f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "54a89738-fd83-db57-5dbd-90b1a50561e2": {
+                                    "id": "54a89738-fd83-db57-5dbd-90b1a50561e2",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1348,13 +1537,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "383c3d33-d44e-3363-faf0-7ede3481261a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "383c3d33-d44e-3363-faf0-7ede3481261a",
+                                    "name": "indexpattern-datasource-layer-736b977f-1767-c560-b198-8545dbefe953"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "383c3d33-d44e-3363-faf0-7ede3481261a": {
+                                    "id": "383c3d33-d44e-3363-faf0-7ede3481261a",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1547,13 +1757,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b0e2177a-9720-4973-ccfc-65648f92bd15"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b0e2177a-9720-4973-ccfc-65648f92bd15",
+                                    "name": "indexpattern-datasource-layer-14917540-a83c-dda3-6345-c7f3af112d0a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b0e2177a-9720-4973-ccfc-65648f92bd15": {
+                                    "id": "b0e2177a-9720-4973-ccfc-65648f92bd15",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1707,13 +1938,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bf6216d0-193f-4922-5891-c6ef5876c985"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bf6216d0-193f-4922-5891-c6ef5876c985",
+                                    "name": "indexpattern-datasource-layer-11c82413-7074-acf4-2377-68431e2cc550"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bf6216d0-193f-4922-5891-c6ef5876c985": {
+                                    "id": "bf6216d0-193f-4922-5891-c6ef5876c985",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1867,13 +2119,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4e490824-2e5f-c544-7b14-fefd3197540a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4e490824-2e5f-c544-7b14-fefd3197540a",
+                                    "name": "indexpattern-datasource-layer-79ba4b62-ce88-7e25-d02b-5f396a5581b3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4e490824-2e5f-c544-7b14-fefd3197540a": {
+                                    "id": "4e490824-2e5f-c544-7b14-fefd3197540a",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2024,13 +2297,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f9d4906e-1e9d-29c7-ab49-b072cac5cf25"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f9d4906e-1e9d-29c7-ab49-b072cac5cf25",
+                                    "name": "indexpattern-datasource-layer-95561bbc-f2af-7bfe-43b4-1b4bde4424c9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f9d4906e-1e9d-29c7-ab49-b072cac5cf25": {
+                                    "id": "f9d4906e-1e9d-29c7-ab49-b072cac5cf25",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2223,13 +2517,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "825241c7-6f94-8ad9-efe0-270dcfba64ad"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "825241c7-6f94-8ad9-efe0-270dcfba64ad",
+                                    "name": "indexpattern-datasource-layer-dfb59a85-6f45-1177-d362-1f2e8934cb52"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "825241c7-6f94-8ad9-efe0-270dcfba64ad": {
+                                    "id": "825241c7-6f94-8ad9-efe0-270dcfba64ad",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2431,13 +2746,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "49401c47-31ba-8ea7-064b-0161245f6edc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "49401c47-31ba-8ea7-064b-0161245f6edc",
+                                    "name": "indexpattern-datasource-layer-f4488541-c361-ede2-3964-18ef938184aa"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "49401c47-31ba-8ea7-064b-0161245f6edc": {
+                                    "id": "49401c47-31ba-8ea7-064b-0161245f6edc",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/activemq_otel/kibana/dashboard/activemq_otel-destinations.json
+++ b/packages/activemq_otel/kibana/dashboard/activemq_otel-destinations.json
@@ -170,13 +170,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8bd66300-e3ae-092a-e39f-7e37d6716c06"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8bd66300-e3ae-092a-e39f-7e37d6716c06",
+                                    "name": "indexpattern-datasource-layer-23c78476-ed14-0ccb-7705-c585c34d96bd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8bd66300-e3ae-092a-e39f-7e37d6716c06": {
+                                    "id": "8bd66300-e3ae-092a-e39f-7e37d6716c06",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -274,13 +295,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "61664273-09c3-250d-9ea1-4a17635c9b28"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "61664273-09c3-250d-9ea1-4a17635c9b28",
+                                    "name": "indexpattern-datasource-layer-6c5c52af-8534-56e7-1e2f-bcdd62a13d50"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "61664273-09c3-250d-9ea1-4a17635c9b28": {
+                                    "id": "61664273-09c3-250d-9ea1-4a17635c9b28",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -378,13 +420,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0d29c5b1-3830-d2c7-c26e-6a5e5773b3e0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0d29c5b1-3830-d2c7-c26e-6a5e5773b3e0",
+                                    "name": "indexpattern-datasource-layer-cd292a98-d96d-edd9-8211-33dc856db926"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0d29c5b1-3830-d2c7-c26e-6a5e5773b3e0": {
+                                    "id": "0d29c5b1-3830-d2c7-c26e-6a5e5773b3e0",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -551,13 +614,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "69489693-c283-8688-17e6-3675336b1fd9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "69489693-c283-8688-17e6-3675336b1fd9",
+                                    "name": "indexpattern-datasource-layer-8cd86c89-8714-5bcd-e06f-a83526356832"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "69489693-c283-8688-17e6-3675336b1fd9": {
+                                    "id": "69489693-c283-8688-17e6-3675336b1fd9",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -724,13 +808,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5c24d237-4aae-4395-13f1-329528965d85"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5c24d237-4aae-4395-13f1-329528965d85",
+                                    "name": "indexpattern-datasource-layer-ce484978-422f-d85b-82df-9beb819459f0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5c24d237-4aae-4395-13f1-329528965d85": {
+                                    "id": "5c24d237-4aae-4395-13f1-329528965d85",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -897,13 +1002,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e0d9da31-8679-9ffc-ad94-6782e5ec5858"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e0d9da31-8679-9ffc-ad94-6782e5ec5858",
+                                    "name": "indexpattern-datasource-layer-b53b9a15-e44c-7e61-2ec4-ecebf0479f63"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e0d9da31-8679-9ffc-ad94-6782e5ec5858": {
+                                    "id": "e0d9da31-8679-9ffc-ad94-6782e5ec5858",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1070,13 +1196,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "060816ae-43e7-ecb7-dded-ef5ef70bce11"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "060816ae-43e7-ecb7-dded-ef5ef70bce11",
+                                    "name": "indexpattern-datasource-layer-fe7dee46-5ab2-8bd1-3ad3-20e877e7bf74"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "060816ae-43e7-ecb7-dded-ef5ef70bce11": {
+                                    "id": "060816ae-43e7-ecb7-dded-ef5ef70bce11",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1243,13 +1390,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5373f8b5-6372-2da3-dfb9-5067d1430d7b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5373f8b5-6372-2da3-dfb9-5067d1430d7b",
+                                    "name": "indexpattern-datasource-layer-ad6c62e0-5431-23bf-2d3b-5f891c2dd750"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5373f8b5-6372-2da3-dfb9-5067d1430d7b": {
+                                    "id": "5373f8b5-6372-2da3-dfb9-5067d1430d7b",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1403,13 +1571,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f231a2fc-453b-9cf6-3e23-960d3cffb1fc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f231a2fc-453b-9cf6-3e23-960d3cffb1fc",
+                                    "name": "indexpattern-datasource-layer-320c837e-fa84-8666-451f-31a35e3faa54"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f231a2fc-453b-9cf6-3e23-960d3cffb1fc": {
+                                    "id": "f231a2fc-453b-9cf6-3e23-960d3cffb1fc",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1560,13 +1749,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8b48b41a-dac9-f05b-d4b3-6af129731333"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8b48b41a-dac9-f05b-d4b3-6af129731333",
+                                    "name": "indexpattern-datasource-layer-654d4934-4768-19e9-4bf7-b5a960f428c3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8b48b41a-dac9-f05b-d4b3-6af129731333": {
+                                    "id": "8b48b41a-dac9-f05b-d4b3-6af129731333",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1717,13 +1927,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "97fff8f9-60cb-7e73-be8d-a6deeaaab05a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "97fff8f9-60cb-7e73-be8d-a6deeaaab05a",
+                                    "name": "indexpattern-datasource-layer-1fe75635-f6fe-143d-a282-4ab1699085cd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "97fff8f9-60cb-7e73-be8d-a6deeaaab05a": {
+                                    "id": "97fff8f9-60cb-7e73-be8d-a6deeaaab05a",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1823,13 +2054,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "826d1baf-ffd4-73d1-89a7-31078205f7e9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "826d1baf-ffd4-73d1-89a7-31078205f7e9",
+                                    "name": "indexpattern-datasource-layer-8f5c541c-6494-b8bd-c150-ed3c8785be2f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "826d1baf-ffd4-73d1-89a7-31078205f7e9": {
+                                    "id": "826d1baf-ffd4-73d1-89a7-31078205f7e9",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1929,13 +2181,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "39f4dcf6-6f7e-3659-eff0-b63117955d73"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "39f4dcf6-6f7e-3659-eff0-b63117955d73",
+                                    "name": "indexpattern-datasource-layer-13dd65ce-f1f1-a54b-3a9e-7addf81549a8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "39f4dcf6-6f7e-3659-eff0-b63117955d73": {
+                                    "id": "39f4dcf6-6f7e-3659-eff0-b63117955d73",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/activemq_otel/kibana/dashboard/activemq_otel-overview.json
+++ b/packages/activemq_otel/kibana/dashboard/activemq_otel-overview.json
@@ -168,13 +168,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4aaa2100-c027-d470-b372-f73bc9328c49"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4aaa2100-c027-d470-b372-f73bc9328c49",
+                                    "name": "indexpattern-datasource-layer-a2d3035a-37dc-0111-ff44-78fc37fad19e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4aaa2100-c027-d470-b372-f73bc9328c49": {
+                                    "id": "4aaa2100-c027-d470-b372-f73bc9328c49",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -270,13 +291,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e",
+                                    "name": "indexpattern-datasource-layer-aac5154e-4e4b-9447-5d5c-aacd238eb44f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e": {
+                                    "id": "5f4c48d8-8ad2-8e07-b8a6-5b9ecce8a89e",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -372,13 +414,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3",
+                                    "name": "indexpattern-datasource-layer-0d807522-0497-0018-7002-60d884c68000"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3": {
+                                    "id": "8c6c5402-29ab-71a5-c0c3-c6b4505f08d3",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -476,13 +539,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1b826171-18bf-c1b5-533f-f4ef45fba38b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1b826171-18bf-c1b5-533f-f4ef45fba38b",
+                                    "name": "indexpattern-datasource-layer-99706da4-35c4-cb31-5982-254c88b6b41e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1b826171-18bf-c1b5-533f-f4ef45fba38b": {
+                                    "id": "1b826171-18bf-c1b5-533f-f4ef45fba38b",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -679,13 +763,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a535da6b-ee40-29a8-ddc1-c6a5b2c52db6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a535da6b-ee40-29a8-ddc1-c6a5b2c52db6",
+                                    "name": "indexpattern-datasource-layer-5f0869ac-269f-93f9-d33a-3f30752a87b9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a535da6b-ee40-29a8-ddc1-c6a5b2c52db6": {
+                                    "id": "a535da6b-ee40-29a8-ddc1-c6a5b2c52db6",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -878,13 +983,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f23ad0fd-e8c5-b083-d3ef-fde6e23e3ab7"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f23ad0fd-e8c5-b083-d3ef-fde6e23e3ab7",
+                                    "name": "indexpattern-datasource-layer-ed8ffc31-9ecb-6534-7d8d-bda4b161afe5"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f23ad0fd-e8c5-b083-d3ef-fde6e23e3ab7": {
+                                    "id": "f23ad0fd-e8c5-b083-d3ef-fde6e23e3ab7",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -984,13 +1110,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "db38a1e2-ff7e-88ca-0fc4-6522800ac488"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "db38a1e2-ff7e-88ca-0fc4-6522800ac488",
+                                    "name": "indexpattern-datasource-layer-a52d894a-4139-60ab-7fbf-2d478b6ff44b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "db38a1e2-ff7e-88ca-0fc4-6522800ac488": {
+                                    "id": "db38a1e2-ff7e-88ca-0fc4-6522800ac488",
+                                    "type": "esql",
+                                    "name": "metrics-activemq.otel-*",
+                                    "title": "metrics-activemq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/activemq_otel/manifest.yml
+++ b/packages/activemq_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.5
 name: activemq_otel
 title: "ActiveMQ OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "ActiveMQ Assets for OpenTelemetry Collector"

--- a/packages/apache_tomcat_otel/changelog.yml
+++ b/packages/apache_tomcat_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/apache_tomcat_otel/changelog.yml
+++ b/packages/apache_tomcat_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20378
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-jvm-memory-gc.json
+++ b/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-jvm-memory-gc.json
@@ -189,13 +189,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5ddadc7a-fa60-b4b9-d76b-16961ad923ad"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5ddadc7a-fa60-b4b9-d76b-16961ad923ad",
+                                    "name": "indexpattern-datasource-layer-5c70fb75-4b0b-ce59-fa09-fead4d159bfa"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5ddadc7a-fa60-b4b9-d76b-16961ad923ad": {
+                                    "id": "5ddadc7a-fa60-b4b9-d76b-16961ad923ad",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -291,13 +312,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a125f008-0bb6-5d8a-085f-815b91e84d2c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a125f008-0bb6-5d8a-085f-815b91e84d2c",
+                                    "name": "indexpattern-datasource-layer-5ae9bc18-4cc6-4bec-2628-b316ad64605f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a125f008-0bb6-5d8a-085f-815b91e84d2c": {
+                                    "id": "a125f008-0bb6-5d8a-085f-815b91e84d2c",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -393,13 +435,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "23cfef2c-afc0-d190-4cd9-dbe2e0b88b85"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "23cfef2c-afc0-d190-4cd9-dbe2e0b88b85",
+                                    "name": "indexpattern-datasource-layer-becfbb5b-526b-c43f-3ded-de34575eeb5a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "23cfef2c-afc0-d190-4cd9-dbe2e0b88b85": {
+                                    "id": "23cfef2c-afc0-d190-4cd9-dbe2e0b88b85",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -536,13 +599,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c",
+                                    "name": "indexpattern-datasource-layer-6a261722-8393-b8ba-0d0a-571df89afef1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c": {
+                                    "id": "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -640,13 +724,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "188dd43b-f15c-85fe-e6e4-2aa86338aeaf"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "188dd43b-f15c-85fe-e6e4-2aa86338aeaf",
+                                    "name": "indexpattern-datasource-layer-e14d35f3-e53e-a844-334f-4563fceb8e92"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "188dd43b-f15c-85fe-e6e4-2aa86338aeaf": {
+                                    "id": "188dd43b-f15c-85fe-e6e4-2aa86338aeaf",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -744,13 +849,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "894db2fe-9e28-ae88-8068-c10f5f9c6a3d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "894db2fe-9e28-ae88-8068-c10f5f9c6a3d",
+                                    "name": "indexpattern-datasource-layer-96466c36-89ad-658e-644d-821f906ea78e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "894db2fe-9e28-ae88-8068-c10f5f9c6a3d": {
+                                    "id": "894db2fe-9e28-ae88-8068-c10f5f9c6a3d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -848,13 +974,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e71bb72c-0112-2b7e-f7f6-5b8790990e58"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e71bb72c-0112-2b7e-f7f6-5b8790990e58",
+                                    "name": "indexpattern-datasource-layer-63107ea8-1225-548d-856f-c32600f472f9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e71bb72c-0112-2b7e-f7f6-5b8790990e58": {
+                                    "id": "e71bb72c-0112-2b7e-f7f6-5b8790990e58",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -952,13 +1099,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3ea3b009-0eeb-a9ae-29b1-dc2e42e4a5c1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3ea3b009-0eeb-a9ae-29b1-dc2e42e4a5c1",
+                                    "name": "indexpattern-datasource-layer-82085c94-2a56-c04a-d9d4-6ba8ad8ee731"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3ea3b009-0eeb-a9ae-29b1-dc2e42e4a5c1": {
+                                    "id": "3ea3b009-0eeb-a9ae-29b1-dc2e42e4a5c1",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1224,13 +1392,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7845dfea-d5cb-f4da-827d-91c0dbb8388a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7845dfea-d5cb-f4da-827d-91c0dbb8388a",
+                                    "name": "indexpattern-datasource-layer-f0d9ecde-6012-17e7-9365-b158efe98961"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7845dfea-d5cb-f4da-827d-91c0dbb8388a": {
+                                    "id": "7845dfea-d5cb-f4da-827d-91c0dbb8388a",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1416,13 +1605,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d04a4926-c834-db7d-a222-f0caa340eee8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d04a4926-c834-db7d-a222-f0caa340eee8",
+                                    "name": "indexpattern-datasource-layer-0d589d42-0ddb-d4b6-91b6-165cc2e2cccc"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d04a4926-c834-db7d-a222-f0caa340eee8": {
+                                    "id": "d04a4926-c834-db7d-a222-f0caa340eee8",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1702,13 +1912,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "98d62e6e-62c6-963e-28ec-331eeacd36d0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "98d62e6e-62c6-963e-28ec-331eeacd36d0",
+                                    "name": "indexpattern-datasource-layer-242f5019-a0e4-4d05-c848-b6f97722297a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "98d62e6e-62c6-963e-28ec-331eeacd36d0": {
+                                    "id": "98d62e6e-62c6-963e-28ec-331eeacd36d0",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1947,13 +2178,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "750bb49a-349a-df8d-31de-842f51210714"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "750bb49a-349a-df8d-31de-842f51210714",
+                                    "name": "indexpattern-datasource-layer-0aabdb2c-7b32-4923-3ffc-41f288cfb109"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "750bb49a-349a-df8d-31de-842f51210714": {
+                                    "id": "750bb49a-349a-df8d-31de-842f51210714",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2180,13 +2432,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cc03eecc-6166-df7f-3ea6-6bf0143bb5d6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cc03eecc-6166-df7f-3ea6-6bf0143bb5d6",
+                                    "name": "indexpattern-datasource-layer-1af0960a-f116-2f2d-b9cd-0dd29aec3ae6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cc03eecc-6166-df7f-3ea6-6bf0143bb5d6": {
+                                    "id": "cc03eecc-6166-df7f-3ea6-6bf0143bb5d6",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2372,13 +2645,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ce2a80bf-466a-b67f-8e5a-9eff3e49f8bc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ce2a80bf-466a-b67f-8e5a-9eff3e49f8bc",
+                                    "name": "indexpattern-datasource-layer-94da83fd-50c4-0c4b-4368-2dbeace6f342"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ce2a80bf-466a-b67f-8e5a-9eff3e49f8bc": {
+                                    "id": "ce2a80bf-466a-b67f-8e5a-9eff3e49f8bc",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2564,13 +2858,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ff9e334c-3fd7-9add-e56c-135af0322e4f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ff9e334c-3fd7-9add-e56c-135af0322e4f",
+                                    "name": "indexpattern-datasource-layer-c5c53960-cba2-ad0e-a4e0-2d674234a6ed"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ff9e334c-3fd7-9add-e56c-135af0322e4f": {
+                                    "id": "ff9e334c-3fd7-9add-e56c-135af0322e4f",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2822,13 +3137,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3e7b3677-431b-1765-a037-1ac39d268d4e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3e7b3677-431b-1765-a037-1ac39d268d4e",
+                                    "name": "indexpattern-datasource-layer-60bdb82c-4134-8954-af16-c502b958b74c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3e7b3677-431b-1765-a037-1ac39d268d4e": {
+                                    "id": "3e7b3677-431b-1765-a037-1ac39d268d4e",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3039,13 +3375,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b5741d1b-0c78-6a28-3031-6215a48fb908"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b5741d1b-0c78-6a28-3031-6215a48fb908",
+                                    "name": "indexpattern-datasource-layer-aa9f8a37-b3dc-7331-fe8f-11b3024e450a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b5741d1b-0c78-6a28-3031-6215a48fb908": {
+                                    "id": "b5741d1b-0c78-6a28-3031-6215a48fb908",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-jvm-os-resources.json
+++ b/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-jvm-os-resources.json
@@ -189,13 +189,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "52391a9b-c709-d892-32ad-45f352aa1dbf"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "52391a9b-c709-d892-32ad-45f352aa1dbf",
+                                    "name": "indexpattern-datasource-layer-abdfcaed-bfe1-6d2d-1d2c-c4ace98d942d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "52391a9b-c709-d892-32ad-45f352aa1dbf": {
+                                    "id": "52391a9b-c709-d892-32ad-45f352aa1dbf",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -291,13 +312,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "12198abf-ebc6-8407-50ab-ed9155a38bc1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "12198abf-ebc6-8407-50ab-ed9155a38bc1",
+                                    "name": "indexpattern-datasource-layer-8390384a-755b-08b8-df56-809e8735c0da"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "12198abf-ebc6-8407-50ab-ed9155a38bc1": {
+                                    "id": "12198abf-ebc6-8407-50ab-ed9155a38bc1",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -393,13 +435,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "81517733-a1ed-3da1-5826-3dbbf3f90096"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "81517733-a1ed-3da1-5826-3dbbf3f90096",
+                                    "name": "indexpattern-datasource-layer-486df89f-7dca-c86b-35ab-bacc5190fed4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "81517733-a1ed-3da1-5826-3dbbf3f90096": {
+                                    "id": "81517733-a1ed-3da1-5826-3dbbf3f90096",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -495,13 +558,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f5bcb9a7-5129-a111-cef1-6b57d4abf1a5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f5bcb9a7-5129-a111-cef1-6b57d4abf1a5",
+                                    "name": "indexpattern-datasource-layer-0c41927d-da34-cc41-3f46-a0156770e0d2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f5bcb9a7-5129-a111-cef1-6b57d4abf1a5": {
+                                    "id": "f5bcb9a7-5129-a111-cef1-6b57d4abf1a5",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -597,13 +681,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3d0491db-ad9e-492d-c1dc-8bbe9b698a88"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3d0491db-ad9e-492d-c1dc-8bbe9b698a88",
+                                    "name": "indexpattern-datasource-layer-d54e2441-ded6-afef-4e70-a7fc3b367770"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3d0491db-ad9e-492d-c1dc-8bbe9b698a88": {
+                                    "id": "3d0491db-ad9e-492d-c1dc-8bbe9b698a88",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -699,13 +804,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d8b0be7d-59d5-4771-8a72-cdf5c561b976"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d8b0be7d-59d5-4771-8a72-cdf5c561b976",
+                                    "name": "indexpattern-datasource-layer-74754ed0-64ad-201f-b37a-e3b0b17c2369"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d8b0be7d-59d5-4771-8a72-cdf5c561b976": {
+                                    "id": "d8b0be7d-59d5-4771-8a72-cdf5c561b976",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -801,13 +927,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "66e24fb0-a75f-4d7d-584b-249484c90ae2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "66e24fb0-a75f-4d7d-584b-249484c90ae2",
+                                    "name": "indexpattern-datasource-layer-eef0e741-1128-a636-bf1c-9e4dd8561872"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "66e24fb0-a75f-4d7d-584b-249484c90ae2": {
+                                    "id": "66e24fb0-a75f-4d7d-584b-249484c90ae2",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -903,13 +1050,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8a57bc96-30df-1b46-1cef-5eb44f964897"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8a57bc96-30df-1b46-1cef-5eb44f964897",
+                                    "name": "indexpattern-datasource-layer-517430b5-3f21-f280-ab55-2f2fb6a7981f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8a57bc96-30df-1b46-1cef-5eb44f964897": {
+                                    "id": "8a57bc96-30df-1b46-1cef-5eb44f964897",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1140,13 +1308,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ad183740-dcd3-5f2b-dd27-956093a241a1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ad183740-dcd3-5f2b-dd27-956093a241a1",
+                                    "name": "indexpattern-datasource-layer-1cfa2aec-0117-fe5d-b061-1a5d1e1d043a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ad183740-dcd3-5f2b-dd27-956093a241a1": {
+                                    "id": "ad183740-dcd3-5f2b-dd27-956093a241a1",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1332,13 +1521,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b6f89c14-a4be-9a65-2675-48926feafd19"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b6f89c14-a4be-9a65-2675-48926feafd19",
+                                    "name": "indexpattern-datasource-layer-04f3b7b9-c2a6-ecd9-cf94-3db2b5617c50"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b6f89c14-a4be-9a65-2675-48926feafd19": {
+                                    "id": "b6f89c14-a4be-9a65-2675-48926feafd19",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1565,13 +1775,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9e24e560-1c33-eb93-4492-899550efec60"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9e24e560-1c33-eb93-4492-899550efec60",
+                                    "name": "indexpattern-datasource-layer-13d1237c-caa6-43bc-fcb8-410e254f8514"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9e24e560-1c33-eb93-4492-899550efec60": {
+                                    "id": "9e24e560-1c33-eb93-4492-899550efec60",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1782,13 +2013,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9425c8d3-84ba-3aa9-8858-9d4096f9b00e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9425c8d3-84ba-3aa9-8858-9d4096f9b00e",
+                                    "name": "indexpattern-datasource-layer-53be9313-1cdb-4feb-efd6-72ff380e876b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9425c8d3-84ba-3aa9-8858-9d4096f9b00e": {
+                                    "id": "9425c8d3-84ba-3aa9-8858-9d4096f9b00e",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2054,13 +2306,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e2694ee0-4074-3734-c08e-e8446e0a8fe9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e2694ee0-4074-3734-c08e-e8446e0a8fe9",
+                                    "name": "indexpattern-datasource-layer-260396c2-3dd1-0bc4-2a89-23e318f9b280"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e2694ee0-4074-3734-c08e-e8446e0a8fe9": {
+                                    "id": "e2694ee0-4074-3734-c08e-e8446e0a8fe9",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2207,13 +2480,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8bb2acd6-91ca-25cd-1392-f3edf5b9a629"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8bb2acd6-91ca-25cd-1392-f3edf5b9a629",
+                                    "name": "indexpattern-datasource-layer-f5cf7490-c5db-d48b-d004-00420520b050"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8bb2acd6-91ca-25cd-1392-f3edf5b9a629": {
+                                    "id": "8bb2acd6-91ca-25cd-1392-f3edf5b9a629",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2440,13 +2734,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ecb97c35-e3f0-3940-c6bb-f8f3993d9feb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ecb97c35-e3f0-3940-c6bb-f8f3993d9feb",
+                                    "name": "indexpattern-datasource-layer-f4993135-07b9-6231-8794-d03c8269a60e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ecb97c35-e3f0-3940-c6bb-f8f3993d9feb": {
+                                    "id": "ecb97c35-e3f0-3940-c6bb-f8f3993d9feb",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2632,13 +2947,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c428f0bd-a7b4-8f1c-3bf1-b24f4a55676d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c428f0bd-a7b4-8f1c-3bf1-b24f4a55676d",
+                                    "name": "indexpattern-datasource-layer-d77a313d-fd29-3e42-bf39-c7617a4a65a7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c428f0bd-a7b4-8f1c-3bf1-b24f4a55676d": {
+                                    "id": "c428f0bd-a7b4-8f1c-3bf1-b24f4a55676d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2869,13 +3205,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a88f9d5e-8b48-234b-1b3c-431f581179bc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a88f9d5e-8b48-234b-1b3c-431f581179bc",
+                                    "name": "indexpattern-datasource-layer-3618e2c1-21a9-ad7e-c421-eb27e8ff86ab"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a88f9d5e-8b48-234b-1b3c-431f581179bc": {
+                                    "id": "a88f9d5e-8b48-234b-1b3c-431f581179bc",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3061,13 +3418,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0eb5c4b5-5969-fca5-281c-18350e8e54ac"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0eb5c4b5-5969-fca5-281c-18350e8e54ac",
+                                    "name": "indexpattern-datasource-layer-db20819f-8897-63a6-c2a7-cd53fcbff03e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0eb5c4b5-5969-fca5-281c-18350e8e54ac": {
+                                    "id": "0eb5c4b5-5969-fca5-281c-18350e8e54ac",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3214,13 +3592,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0a40087f-2897-aea4-1f14-f5e99687bc40"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0a40087f-2897-aea4-1f14-f5e99687bc40",
+                                    "name": "indexpattern-datasource-layer-bb4ef8c4-a1b8-9f32-1bfb-2162d85095ae"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0a40087f-2897-aea4-1f14-f5e99687bc40": {
+                                    "id": "0a40087f-2897-aea4-1f14-f5e99687bc40",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3318,13 +3717,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4699c34f-6d9d-45f2-4ec5-14453c07354b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4699c34f-6d9d-45f2-4ec5-14453c07354b",
+                                    "name": "indexpattern-datasource-layer-bbc528c9-c50c-1bdb-4270-241cfe4b7779"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4699c34f-6d9d-45f2-4ec5-14453c07354b": {
+                                    "id": "4699c34f-6d9d-45f2-4ec5-14453c07354b",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3420,13 +3840,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "82328da4-84a9-34ee-3a28-c3cce0821f9b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "82328da4-84a9-34ee-3a28-c3cce0821f9b",
+                                    "name": "indexpattern-datasource-layer-6bec6577-17c1-4861-6b16-8f22d6df8e60"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "82328da4-84a9-34ee-3a28-c3cce0821f9b": {
+                                    "id": "82328da4-84a9-34ee-3a28-c3cce0821f9b",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-overview.json
+++ b/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-overview.json
@@ -191,13 +191,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "48466aaa-2619-3dea-064b-58ea56fa1e1d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "48466aaa-2619-3dea-064b-58ea56fa1e1d",
+                                    "name": "indexpattern-datasource-layer-a3add44f-304e-8f9c-419d-12d64c0af768"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "48466aaa-2619-3dea-064b-58ea56fa1e1d": {
+                                    "id": "48466aaa-2619-3dea-064b-58ea56fa1e1d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -293,13 +314,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "18d2d11c-80b2-f4ec-7888-6dc6129c5849"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "18d2d11c-80b2-f4ec-7888-6dc6129c5849",
+                                    "name": "indexpattern-datasource-layer-33757f64-a90b-340b-f653-eacf1040e265"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "18d2d11c-80b2-f4ec-7888-6dc6129c5849": {
+                                    "id": "18d2d11c-80b2-f4ec-7888-6dc6129c5849",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -397,13 +439,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2532cf06-bfca-bfbd-1ebb-ce998b343c96"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2532cf06-bfca-bfbd-1ebb-ce998b343c96",
+                                    "name": "indexpattern-datasource-layer-de5a57b6-b002-cb9e-721b-98abb1e3de55"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2532cf06-bfca-bfbd-1ebb-ce998b343c96": {
+                                    "id": "2532cf06-bfca-bfbd-1ebb-ce998b343c96",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -501,13 +564,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2b4bf0a1-243c-7795-bbb4-d8e361835625"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2b4bf0a1-243c-7795-bbb4-d8e361835625",
+                                    "name": "indexpattern-datasource-layer-f7855997-9e22-aaf0-2d3c-34ce11985f51"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2b4bf0a1-243c-7795-bbb4-d8e361835625": {
+                                    "id": "2b4bf0a1-243c-7795-bbb4-d8e361835625",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -603,13 +687,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d487e99d-d643-d5dd-7413-705f54775ab8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d487e99d-d643-d5dd-7413-705f54775ab8",
+                                    "name": "indexpattern-datasource-layer-d7247a85-b0b5-305d-a758-3f023fab171d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d487e99d-d643-d5dd-7413-705f54775ab8": {
+                                    "id": "d487e99d-d643-d5dd-7413-705f54775ab8",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -705,13 +810,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c",
+                                    "name": "indexpattern-datasource-layer-6a261722-8393-b8ba-0d0a-571df89afef1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c": {
+                                    "id": "baa2d4e8-bb80-3c33-08cc-f4b79a40ff7c",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -809,13 +935,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "20bb114b-cf10-aa17-e7b6-4d11f1ca7b3f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "20bb114b-cf10-aa17-e7b6-4d11f1ca7b3f",
+                                    "name": "indexpattern-datasource-layer-1a1bd199-f9d4-c60b-3394-0d79e58b8aa6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "20bb114b-cf10-aa17-e7b6-4d11f1ca7b3f": {
+                                    "id": "20bb114b-cf10-aa17-e7b6-4d11f1ca7b3f",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -911,13 +1058,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ef9c5538-5e04-0984-1e99-8db8e7fabc3d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ef9c5538-5e04-0984-1e99-8db8e7fabc3d",
+                                    "name": "indexpattern-datasource-layer-754c1d09-bfff-98ff-f622-85d1007498e4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ef9c5538-5e04-0984-1e99-8db8e7fabc3d": {
+                                    "id": "ef9c5538-5e04-0984-1e99-8db8e7fabc3d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1118,13 +1286,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e6583a9d-fc67-5e8d-a75f-8534a9b84152"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e6583a9d-fc67-5e8d-a75f-8534a9b84152",
+                                    "name": "indexpattern-datasource-layer-e9800d59-f83c-7102-689e-1de6541fb15e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e6583a9d-fc67-5e8d-a75f-8534a9b84152": {
+                                    "id": "e6583a9d-fc67-5e8d-a75f-8534a9b84152",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1284,13 +1473,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "75283aec-6dbb-e4df-406c-8631be44ac9d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "75283aec-6dbb-e4df-406c-8631be44ac9d",
+                                    "name": "indexpattern-datasource-layer-313ee559-1b17-0ec9-caf5-c3e97676b11a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "75283aec-6dbb-e4df-406c-8631be44ac9d": {
+                                    "id": "75283aec-6dbb-e4df-406c-8631be44ac9d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1493,13 +1703,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9d89f5c5-ee51-7916-13a9-2404089d75eb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9d89f5c5-ee51-7916-13a9-2404089d75eb",
+                                    "name": "indexpattern-datasource-layer-8a0e3c22-725d-edbb-4426-29b11fc3bc69"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9d89f5c5-ee51-7916-13a9-2404089d75eb": {
+                                    "id": "9d89f5c5-ee51-7916-13a9-2404089d75eb",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1724,13 +1955,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7845dfea-d5cb-f4da-827d-91c0dbb8388a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7845dfea-d5cb-f4da-827d-91c0dbb8388a",
+                                    "name": "indexpattern-datasource-layer-f0d9ecde-6012-17e7-9365-b158efe98961"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7845dfea-d5cb-f4da-827d-91c0dbb8388a": {
+                                    "id": "7845dfea-d5cb-f4da-827d-91c0dbb8388a",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1941,13 +2193,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9bea65d7-9d63-585d-3c82-e23f4826c9ab"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9bea65d7-9d63-585d-3c82-e23f4826c9ab",
+                                    "name": "indexpattern-datasource-layer-1ecb1349-6796-1d25-665e-7ff255e452c3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9bea65d7-9d63-585d-3c82-e23f4826c9ab": {
+                                    "id": "9bea65d7-9d63-585d-3c82-e23f4826c9ab",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2158,13 +2431,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5",
+                                    "name": "indexpattern-datasource-layer-191e0c64-d9ea-9c47-0027-0d40eb2c0398"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5": {
+                                    "id": "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2375,13 +2669,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3e7b3677-431b-1765-a037-1ac39d268d4e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3e7b3677-431b-1765-a037-1ac39d268d4e",
+                                    "name": "indexpattern-datasource-layer-60bdb82c-4134-8954-af16-c502b958b74c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3e7b3677-431b-1765-a037-1ac39d268d4e": {
+                                    "id": "3e7b3677-431b-1765-a037-1ac39d268d4e",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2798,13 +3113,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "65d80497-3c1a-d236-40cf-bde0d544a19e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "65d80497-3c1a-d236-40cf-bde0d544a19e",
+                                    "name": "indexpattern-datasource-layer-30f30488-a430-82da-7398-5454c259ad34"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "65d80497-3c1a-d236-40cf-bde0d544a19e": {
+                                    "id": "65d80497-3c1a-d236-40cf-bde0d544a19e",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-request-processing.json
+++ b/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-request-processing.json
@@ -191,13 +191,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "48466aaa-2619-3dea-064b-58ea56fa1e1d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "48466aaa-2619-3dea-064b-58ea56fa1e1d",
+                                    "name": "indexpattern-datasource-layer-a3add44f-304e-8f9c-419d-12d64c0af768"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "48466aaa-2619-3dea-064b-58ea56fa1e1d": {
+                                    "id": "48466aaa-2619-3dea-064b-58ea56fa1e1d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -295,13 +316,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ec2c9359-e1ac-f077-4a2d-5ca765232b3f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ec2c9359-e1ac-f077-4a2d-5ca765232b3f",
+                                    "name": "indexpattern-datasource-layer-8f6e6bb0-6eaa-cb19-db9e-c47eeee29d94"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ec2c9359-e1ac-f077-4a2d-5ca765232b3f": {
+                                    "id": "ec2c9359-e1ac-f077-4a2d-5ca765232b3f",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -397,13 +439,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f0f8cbf1-620e-c66c-bc29-18cac9141451"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f0f8cbf1-620e-c66c-bc29-18cac9141451",
+                                    "name": "indexpattern-datasource-layer-2a843243-a171-10fb-01b2-11fbee13c73b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f0f8cbf1-620e-c66c-bc29-18cac9141451": {
+                                    "id": "f0f8cbf1-620e-c66c-bc29-18cac9141451",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -499,13 +562,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8ed0feb1-30d0-7ac8-b680-8ab8c05f2c1c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8ed0feb1-30d0-7ac8-b680-8ab8c05f2c1c",
+                                    "name": "indexpattern-datasource-layer-bb69ddd5-d900-870a-d80e-103b1dbd144c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8ed0feb1-30d0-7ac8-b680-8ab8c05f2c1c": {
+                                    "id": "8ed0feb1-30d0-7ac8-b680-8ab8c05f2c1c",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -601,13 +685,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "18d2d11c-80b2-f4ec-7888-6dc6129c5849"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "18d2d11c-80b2-f4ec-7888-6dc6129c5849",
+                                    "name": "indexpattern-datasource-layer-33757f64-a90b-340b-f653-eacf1040e265"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "18d2d11c-80b2-f4ec-7888-6dc6129c5849": {
+                                    "id": "18d2d11c-80b2-f4ec-7888-6dc6129c5849",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -705,13 +810,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6d50f08a-6e87-aa54-95b2-fd5f1ba679ec"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6d50f08a-6e87-aa54-95b2-fd5f1ba679ec",
+                                    "name": "indexpattern-datasource-layer-3e9c5d2b-988c-c8f4-ec8c-b7169e6883ec"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6d50f08a-6e87-aa54-95b2-fd5f1ba679ec": {
+                                    "id": "6d50f08a-6e87-aa54-95b2-fd5f1ba679ec",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -809,13 +935,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2dfddf6d-3da2-bd50-f587-26f8ae5c82ab"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2dfddf6d-3da2-bd50-f587-26f8ae5c82ab",
+                                    "name": "indexpattern-datasource-layer-43b93f7c-f8e7-1c51-a414-85966abbe531"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2dfddf6d-3da2-bd50-f587-26f8ae5c82ab": {
+                                    "id": "2dfddf6d-3da2-bd50-f587-26f8ae5c82ab",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -911,13 +1058,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3ad7aa22-68c8-1294-45db-747850fe9deb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3ad7aa22-68c8-1294-45db-747850fe9deb",
+                                    "name": "indexpattern-datasource-layer-f73b5500-a552-bf13-9b90-e96cc1886d5d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3ad7aa22-68c8-1294-45db-747850fe9deb": {
+                                    "id": "3ad7aa22-68c8-1294-45db-747850fe9deb",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1118,13 +1286,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e6583a9d-fc67-5e8d-a75f-8534a9b84152"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e6583a9d-fc67-5e8d-a75f-8534a9b84152",
+                                    "name": "indexpattern-datasource-layer-e9800d59-f83c-7102-689e-1de6541fb15e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e6583a9d-fc67-5e8d-a75f-8534a9b84152": {
+                                    "id": "e6583a9d-fc67-5e8d-a75f-8534a9b84152",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1310,13 +1499,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d862d3f1-710e-7e4f-efbe-084d99454f56"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d862d3f1-710e-7e4f-efbe-084d99454f56",
+                                    "name": "indexpattern-datasource-layer-43bea42c-8e9a-164c-1cde-bae08841b697"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d862d3f1-710e-7e4f-efbe-084d99454f56": {
+                                    "id": "d862d3f1-710e-7e4f-efbe-084d99454f56",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1519,13 +1729,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a967424b-5966-63ab-b2f9-f69ed584115f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a967424b-5966-63ab-b2f9-f69ed584115f",
+                                    "name": "indexpattern-datasource-layer-3162f3cd-00fd-c7ea-74b9-218bb3ac39bd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a967424b-5966-63ab-b2f9-f69ed584115f": {
+                                    "id": "a967424b-5966-63ab-b2f9-f69ed584115f",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1687,13 +1918,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5c4faecc-647f-a995-4be7-44fccd65f447"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5c4faecc-647f-a995-4be7-44fccd65f447",
+                                    "name": "indexpattern-datasource-layer-50d64306-bb2a-a3d2-a064-ee664b650ba3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5c4faecc-647f-a995-4be7-44fccd65f447": {
+                                    "id": "5c4faecc-647f-a995-4be7-44fccd65f447",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1894,13 +2146,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "75283aec-6dbb-e4df-406c-8631be44ac9d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "75283aec-6dbb-e4df-406c-8631be44ac9d",
+                                    "name": "indexpattern-datasource-layer-313ee559-1b17-0ec9-caf5-c3e97676b11a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "75283aec-6dbb-e4df-406c-8631be44ac9d": {
+                                    "id": "75283aec-6dbb-e4df-406c-8631be44ac9d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2062,13 +2335,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2d6e3c5b-3023-b40e-4949-8092651bbed7"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2d6e3c5b-3023-b40e-4949-8092651bbed7",
+                                    "name": "indexpattern-datasource-layer-a4d1b13a-79b3-f9d7-b93c-a3d1bf92d401"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2d6e3c5b-3023-b40e-4949-8092651bbed7": {
+                                    "id": "2d6e3c5b-3023-b40e-4949-8092651bbed7",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2416,13 +2710,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4e05de81-5b59-0bba-ccb2-a0476f1c4af9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4e05de81-5b59-0bba-ccb2-a0476f1c4af9",
+                                    "name": "indexpattern-datasource-layer-621515ca-ced2-2553-5815-8c13a469ddae"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4e05de81-5b59-0bba-ccb2-a0476f1c4af9": {
+                                    "id": "4e05de81-5b59-0bba-ccb2-a0476f1c4af9",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2755,13 +3070,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "643bb495-3611-e1dc-647f-827f7b6be594"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "643bb495-3611-e1dc-647f-827f7b6be594",
+                                    "name": "indexpattern-datasource-layer-c23064e7-32f7-c8d2-f20d-289e73cb53d9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "643bb495-3611-e1dc-647f-827f7b6be594": {
+                                    "id": "643bb495-3611-e1dc-647f-827f7b6be594",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-sessions-servlets.json
+++ b/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-sessions-servlets.json
@@ -191,13 +191,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2b4bf0a1-243c-7795-bbb4-d8e361835625"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2b4bf0a1-243c-7795-bbb4-d8e361835625",
+                                    "name": "indexpattern-datasource-layer-f7855997-9e22-aaf0-2d3c-34ce11985f51"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2b4bf0a1-243c-7795-bbb4-d8e361835625": {
+                                    "id": "2b4bf0a1-243c-7795-bbb4-d8e361835625",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -295,13 +316,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a240bf25-0636-203b-78b4-7945fc534a3d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a240bf25-0636-203b-78b4-7945fc534a3d",
+                                    "name": "indexpattern-datasource-layer-c66fa715-47ca-60c6-a0f9-5682acf2083e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a240bf25-0636-203b-78b4-7945fc534a3d": {
+                                    "id": "a240bf25-0636-203b-78b4-7945fc534a3d",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -399,13 +441,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fc023fe6-c3f2-8d63-ba91-624255b8999f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fc023fe6-c3f2-8d63-ba91-624255b8999f",
+                                    "name": "indexpattern-datasource-layer-ead75d74-042c-bb3e-4c24-554e5c3900c1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fc023fe6-c3f2-8d63-ba91-624255b8999f": {
+                                    "id": "fc023fe6-c3f2-8d63-ba91-624255b8999f",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -503,13 +566,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bf9c1b51-bcad-39d6-155a-f3fe1c40c560"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bf9c1b51-bcad-39d6-155a-f3fe1c40c560",
+                                    "name": "indexpattern-datasource-layer-08d2a378-41cf-a125-51be-b1f1de656360"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bf9c1b51-bcad-39d6-155a-f3fe1c40c560": {
+                                    "id": "bf9c1b51-bcad-39d6-155a-f3fe1c40c560",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -607,13 +691,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c748ea43-bf3b-ba28-8a2a-6ec541c0b469"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c748ea43-bf3b-ba28-8a2a-6ec541c0b469",
+                                    "name": "indexpattern-datasource-layer-7ff8f149-eb29-8199-6cb4-7673c2ee9f1b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c748ea43-bf3b-ba28-8a2a-6ec541c0b469": {
+                                    "id": "c748ea43-bf3b-ba28-8a2a-6ec541c0b469",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -711,13 +816,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "40cdbb19-b33b-eccf-009c-d97b43c8a9e0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "40cdbb19-b33b-eccf-009c-d97b43c8a9e0",
+                                    "name": "indexpattern-datasource-layer-10877fbb-7fe8-207f-28cb-7eb52f5f36af"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "40cdbb19-b33b-eccf-009c-d97b43c8a9e0": {
+                                    "id": "40cdbb19-b33b-eccf-009c-d97b43c8a9e0",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -815,13 +941,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f9d979b8-b3b9-22ae-5639-f5a489be1542"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f9d979b8-b3b9-22ae-5639-f5a489be1542",
+                                    "name": "indexpattern-datasource-layer-1f033986-e77c-23c8-0855-90196f63bd89"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f9d979b8-b3b9-22ae-5639-f5a489be1542": {
+                                    "id": "f9d979b8-b3b9-22ae-5639-f5a489be1542",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -919,13 +1066,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f61d7bde-e316-a532-8abc-6569bf9943a8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f61d7bde-e316-a532-8abc-6569bf9943a8",
+                                    "name": "indexpattern-datasource-layer-834b974e-19e6-e623-d75c-9b654080a2ca"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f61d7bde-e316-a532-8abc-6569bf9943a8": {
+                                    "id": "f61d7bde-e316-a532-8abc-6569bf9943a8",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1152,13 +1320,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f419b0e3-5bb2-0472-0452-48ab25ed51e0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f419b0e3-5bb2-0472-0452-48ab25ed51e0",
+                                    "name": "indexpattern-datasource-layer-d0d63c2b-e6af-fe1c-4124-f129af19a784"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f419b0e3-5bb2-0472-0452-48ab25ed51e0": {
+                                    "id": "f419b0e3-5bb2-0472-0452-48ab25ed51e0",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1344,13 +1533,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2dbd57b5-3c6b-6d91-9419-05b5c052cc44"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2dbd57b5-3c6b-6d91-9419-05b5c052cc44",
+                                    "name": "indexpattern-datasource-layer-29b38f9d-1728-08dc-67c8-1290159f37af"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2dbd57b5-3c6b-6d91-9419-05b5c052cc44": {
+                                    "id": "2dbd57b5-3c6b-6d91-9419-05b5c052cc44",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1589,13 +1799,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e73191ea-d46f-127d-e45b-f0c82433ef53"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e73191ea-d46f-127d-e45b-f0c82433ef53",
+                                    "name": "indexpattern-datasource-layer-35c593e3-33c4-4f7f-478e-624c4f4ab69c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e73191ea-d46f-127d-e45b-f0c82433ef53": {
+                                    "id": "e73191ea-d46f-127d-e45b-f0c82433ef53",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1785,13 +2016,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fa83bdaa-44e5-df96-4760-16c5f158f7bd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fa83bdaa-44e5-df96-4760-16c5f158f7bd",
+                                    "name": "indexpattern-datasource-layer-b1feaa32-f97d-986c-46e7-62fd68588e8f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fa83bdaa-44e5-df96-4760-16c5f158f7bd": {
+                                    "id": "fa83bdaa-44e5-df96-4760-16c5f158f7bd",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2223,13 +2475,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4a1d6f05-1803-8153-19ab-065b1bc1326a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4a1d6f05-1803-8153-19ab-065b1bc1326a",
+                                    "name": "indexpattern-datasource-layer-7b50a51b-a07a-ac4e-ceac-c8b3eac13bed"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4a1d6f05-1803-8153-19ab-065b1bc1326a": {
+                                    "id": "4a1d6f05-1803-8153-19ab-065b1bc1326a",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2430,13 +2703,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4ed7922c-b394-b6b4-b00d-325122512ce3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4ed7922c-b394-b6b4-b00d-325122512ce3",
+                                    "name": "indexpattern-datasource-layer-825754ae-00cd-6324-aea1-5079184cfa75"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4ed7922c-b394-b6b4-b00d-325122512ce3": {
+                                    "id": "4ed7922c-b394-b6b4-b00d-325122512ce3",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2596,13 +2890,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f02a0a70-88a8-7b9f-f814-b1226b72d4d0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f02a0a70-88a8-7b9f-f814-b1226b72d4d0",
+                                    "name": "indexpattern-datasource-layer-a313149f-0529-af00-e619-2e27e7ec38ec"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f02a0a70-88a8-7b9f-f814-b1226b72d4d0": {
+                                    "id": "f02a0a70-88a8-7b9f-f814-b1226b72d4d0",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3038,13 +3353,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "77441f31-a109-73f8-33e7-6000e1cd9dcb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "77441f31-a109-73f8-33e7-6000e1cd9dcb",
+                                    "name": "indexpattern-datasource-layer-fef0e892-a306-0ca8-0c83-5d6938294b9c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "77441f31-a109-73f8-33e7-6000e1cd9dcb": {
+                                    "id": "77441f31-a109-73f8-33e7-6000e1cd9dcb",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3181,13 +3517,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8d1bfa87-4ed6-36c3-5640-4e5d5b753df5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8d1bfa87-4ed6-36c3-5640-4e5d5b753df5",
+                                    "name": "indexpattern-datasource-layer-2e6f1aec-3fce-ed5c-b78f-25d45f8e3ff9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8d1bfa87-4ed6-36c3-5640-4e5d5b753df5": {
+                                    "id": "8d1bfa87-4ed6-36c3-5640-4e5d5b753df5",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3283,13 +3640,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "68a3e57d-3131-555b-4b1f-81a809b7ab6a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "68a3e57d-3131-555b-4b1f-81a809b7ab6a",
+                                    "name": "indexpattern-datasource-layer-556e46d8-81e5-d073-cc6c-4d3d64252739"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "68a3e57d-3131-555b-4b1f-81a809b7ab6a": {
+                                    "id": "68a3e57d-3131-555b-4b1f-81a809b7ab6a",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3436,13 +3814,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "88ca2d40-4404-a26b-144c-88bc227c18ca"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "88ca2d40-4404-a26b-144c-88bc227c18ca",
+                                    "name": "indexpattern-datasource-layer-f698683e-1759-0e99-9178-d6f5e397fc5b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "88ca2d40-4404-a26b-144c-88bc227c18ca": {
+                                    "id": "88ca2d40-4404-a26b-144c-88bc227c18ca",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-thread-pool-connections.json
+++ b/packages/apache_tomcat_otel/kibana/dashboard/apache_tomcat_otel-thread-pool-connections.json
@@ -189,13 +189,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a2e475bd-c039-452a-3b6d-2ab20a42e9f0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a2e475bd-c039-452a-3b6d-2ab20a42e9f0",
+                                    "name": "indexpattern-datasource-layer-d45fe8ac-9a3a-f135-d1d8-5d640ee18a79"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a2e475bd-c039-452a-3b6d-2ab20a42e9f0": {
+                                    "id": "a2e475bd-c039-452a-3b6d-2ab20a42e9f0",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -291,13 +312,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "298f518c-01bd-fbc7-1a4b-b4c1e5e39595"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "298f518c-01bd-fbc7-1a4b-b4c1e5e39595",
+                                    "name": "indexpattern-datasource-layer-85bf3df5-e81d-b9c0-8375-608f72421178"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "298f518c-01bd-fbc7-1a4b-b4c1e5e39595": {
+                                    "id": "298f518c-01bd-fbc7-1a4b-b4c1e5e39595",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -393,13 +435,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "65a9aad6-793c-4a5e-f8b3-648a7078ea6c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "65a9aad6-793c-4a5e-f8b3-648a7078ea6c",
+                                    "name": "indexpattern-datasource-layer-cca0f63b-7dbc-2560-0055-e5b15bc9ca87"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "65a9aad6-793c-4a5e-f8b3-648a7078ea6c": {
+                                    "id": "65a9aad6-793c-4a5e-f8b3-648a7078ea6c",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -495,13 +558,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d487e99d-d643-d5dd-7413-705f54775ab8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d487e99d-d643-d5dd-7413-705f54775ab8",
+                                    "name": "indexpattern-datasource-layer-d7247a85-b0b5-305d-a758-3f023fab171d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d487e99d-d643-d5dd-7413-705f54775ab8": {
+                                    "id": "d487e99d-d643-d5dd-7413-705f54775ab8",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -597,13 +681,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bedb2a8a-f5f3-b4b1-b4e6-4fa9aece1280"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bedb2a8a-f5f3-b4b1-b4e6-4fa9aece1280",
+                                    "name": "indexpattern-datasource-layer-f16a49f1-b805-f42c-6a8f-008862b03ac6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bedb2a8a-f5f3-b4b1-b4e6-4fa9aece1280": {
+                                    "id": "bedb2a8a-f5f3-b4b1-b4e6-4fa9aece1280",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -701,13 +806,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1e3f6c93-7ebf-9f83-dc75-89023211d170"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1e3f6c93-7ebf-9f83-dc75-89023211d170",
+                                    "name": "indexpattern-datasource-layer-4519fb32-13b3-410b-9274-d03b2de1892b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1e3f6c93-7ebf-9f83-dc75-89023211d170": {
+                                    "id": "1e3f6c93-7ebf-9f83-dc75-89023211d170",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -803,13 +929,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9c09bc71-b83e-8823-3cc7-12843122662a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9c09bc71-b83e-8823-3cc7-12843122662a",
+                                    "name": "indexpattern-datasource-layer-662dcc24-d4b6-69f2-df68-e81142a787ce"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9c09bc71-b83e-8823-3cc7-12843122662a": {
+                                    "id": "9c09bc71-b83e-8823-3cc7-12843122662a",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -905,13 +1052,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "faeb5794-f7a5-6cd4-32cc-d19f50e3e054"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "faeb5794-f7a5-6cd4-32cc-d19f50e3e054",
+                                    "name": "indexpattern-datasource-layer-25f8f582-7941-e1be-100f-5b62ff8b75cd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "faeb5794-f7a5-6cd4-32cc-d19f50e3e054": {
+                                    "id": "faeb5794-f7a5-6cd4-32cc-d19f50e3e054",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1177,13 +1345,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0696e2fb-630e-eaa7-91b1-bbef38f1df83"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0696e2fb-630e-eaa7-91b1-bbef38f1df83",
+                                    "name": "indexpattern-datasource-layer-dc77e285-4195-9b3e-eec5-0683addd961a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0696e2fb-630e-eaa7-91b1-bbef38f1df83": {
+                                    "id": "0696e2fb-630e-eaa7-91b1-bbef38f1df83",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1386,13 +1575,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9d89f5c5-ee51-7916-13a9-2404089d75eb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9d89f5c5-ee51-7916-13a9-2404089d75eb",
+                                    "name": "indexpattern-datasource-layer-8a0e3c22-725d-edbb-4426-29b11fc3bc69"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9d89f5c5-ee51-7916-13a9-2404089d75eb": {
+                                    "id": "9d89f5c5-ee51-7916-13a9-2404089d75eb",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1658,13 +1868,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b1a13838-71a6-2c4b-2834-97a92ce0a5d7"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b1a13838-71a6-2c4b-2834-97a92ce0a5d7",
+                                    "name": "indexpattern-datasource-layer-126074cc-3358-58be-875b-b9863889f25d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b1a13838-71a6-2c4b-2834-97a92ce0a5d7": {
+                                    "id": "b1a13838-71a6-2c4b-2834-97a92ce0a5d7",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1826,13 +2057,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "88b120b2-e289-3d3f-5840-91d3f197bba8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "88b120b2-e289-3d3f-5840-91d3f197bba8",
+                                    "name": "indexpattern-datasource-layer-f86abdaa-bea0-6412-12e6-401071fcf9e1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "88b120b2-e289-3d3f-5840-91d3f197bba8": {
+                                    "id": "88b120b2-e289-3d3f-5840-91d3f197bba8",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2084,13 +2336,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9bea65d7-9d63-585d-3c82-e23f4826c9ab"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9bea65d7-9d63-585d-3c82-e23f4826c9ab",
+                                    "name": "indexpattern-datasource-layer-1ecb1349-6796-1d25-665e-7ff255e452c3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9bea65d7-9d63-585d-3c82-e23f4826c9ab": {
+                                    "id": "9bea65d7-9d63-585d-3c82-e23f4826c9ab",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2301,13 +2574,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5",
+                                    "name": "indexpattern-datasource-layer-191e0c64-d9ea-9c47-0027-0d40eb2c0398"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5": {
+                                    "id": "5d79c2f5-9507-5da4-6c64-dfe715cf7bc5",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2814,13 +3108,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "51537a50-16b4-4d95-6fde-f65c81dad330"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "51537a50-16b4-4d95-6fde-f65c81dad330",
+                                    "name": "indexpattern-datasource-layer-b5ab9d59-1727-8d6e-bb70-6abac8cf7304"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "51537a50-16b4-4d95-6fde-f65c81dad330": {
+                                    "id": "51537a50-16b4-4d95-6fde-f65c81dad330",
+                                    "type": "esql",
+                                    "name": "metrics-tomcat.otel-*",
+                                    "title": "metrics-tomcat.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/apache_tomcat_otel/manifest.yml
+++ b/packages/apache_tomcat_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: apache_tomcat_otel
 title: "Apache Tomcat OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Apache Tomcat Assets from OpenTelemetry Collector"

--- a/packages/haproxy_otel/changelog.yml
+++ b/packages/haproxy_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/haproxy_otel/changelog.yml
+++ b/packages/haproxy_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20378
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/haproxy_otel/kibana/dashboard/haproxy_otel-backend.json
+++ b/packages/haproxy_otel/kibana/dashboard/haproxy_otel-backend.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "56ed5807-dce4-cd51-d590-262c9872e2c0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "56ed5807-dce4-cd51-d590-262c9872e2c0",
+                                    "name": "indexpattern-datasource-layer-63573808-62cc-7573-18b5-4df870b54376"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "56ed5807-dce4-cd51-d590-262c9872e2c0": {
+                                    "id": "56ed5807-dce4-cd51-d590-262c9872e2c0",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "72068fc9-02a4-83df-cb8c-6d701d99d7bf"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "72068fc9-02a4-83df-cb8c-6d701d99d7bf",
+                                    "name": "indexpattern-datasource-layer-de8d5c4e-7de2-f980-f012-f6114287a992"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "72068fc9-02a4-83df-cb8c-6d701d99d7bf": {
+                                    "id": "72068fc9-02a4-83df-cb8c-6d701d99d7bf",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -383,13 +425,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8d71d6cf-8bb6-8b47-52b0-a82e70ba33b0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8d71d6cf-8bb6-8b47-52b0-a82e70ba33b0",
+                                    "name": "indexpattern-datasource-layer-eefeb3fc-7581-ca9b-a60d-4209550824c4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8d71d6cf-8bb6-8b47-52b0-a82e70ba33b0": {
+                                    "id": "8d71d6cf-8bb6-8b47-52b0-a82e70ba33b0",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -487,13 +550,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4535bf96-dc5c-abb4-7a51-022314f864cc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4535bf96-dc5c-abb4-7a51-022314f864cc",
+                                    "name": "indexpattern-datasource-layer-1f355ee7-ad1f-b012-c7ab-45ca808ba81d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4535bf96-dc5c-abb4-7a51-022314f864cc": {
+                                    "id": "4535bf96-dc5c-abb4-7a51-022314f864cc",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -770,13 +854,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5ac1c675-9f9a-500c-435b-e563c5fcf759"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5ac1c675-9f9a-500c-435b-e563c5fcf759",
+                                    "name": "indexpattern-datasource-layer-3313d40c-3bd6-4a88-e130-cbb7141662fc"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5ac1c675-9f9a-500c-435b-e563c5fcf759": {
+                                    "id": "5ac1c675-9f9a-500c-435b-e563c5fcf759",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1014,13 +1119,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d5149091-17bc-d6eb-14f5-c30a06c7c5ec"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d5149091-17bc-d6eb-14f5-c30a06c7c5ec",
+                                    "name": "indexpattern-datasource-layer-9bc80485-edce-1319-a5c5-75d183c41a5d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d5149091-17bc-d6eb-14f5-c30a06c7c5ec": {
+                                    "id": "d5149091-17bc-d6eb-14f5-c30a06c7c5ec",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1180,13 +1306,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cfacb710-7c12-c1a8-c33d-5716c6f5983f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cfacb710-7c12-c1a8-c33d-5716c6f5983f",
+                                    "name": "indexpattern-datasource-layer-fa2530fd-07f8-06ee-078d-32527b0a554e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cfacb710-7c12-c1a8-c33d-5716c6f5983f": {
+                                    "id": "cfacb710-7c12-c1a8-c33d-5716c6f5983f",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1346,13 +1493,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4a3a9f4b-4a8d-8229-d017-ef39735de259"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4a3a9f4b-4a8d-8229-d017-ef39735de259",
+                                    "name": "indexpattern-datasource-layer-04ea1f9e-5198-57d7-4cff-9c7f1306ff24"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4a3a9f4b-4a8d-8229-d017-ef39735de259": {
+                                    "id": "4a3a9f4b-4a8d-8229-d017-ef39735de259",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1551,13 +1719,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9f761a78-8d46-e4c6-5382-22f31672ae21"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9f761a78-8d46-e4c6-5382-22f31672ae21",
+                                    "name": "indexpattern-datasource-layer-5ef65069-6f9f-9be1-b76f-2ef090250041"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9f761a78-8d46-e4c6-5382-22f31672ae21": {
+                                    "id": "9f761a78-8d46-e4c6-5382-22f31672ae21",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1995,13 +2184,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "795f6119-238a-fba1-b855-a061a1540720"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "795f6119-238a-fba1-b855-a061a1540720",
+                                    "name": "indexpattern-datasource-layer-75c62d75-6f4f-3bab-ccb4-b576bbb4e3a4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "795f6119-238a-fba1-b855-a061a1540720": {
+                                    "id": "795f6119-238a-fba1-b855-a061a1540720",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/haproxy_otel/kibana/dashboard/haproxy_otel-frontend.json
+++ b/packages/haproxy_otel/kibana/dashboard/haproxy_otel-frontend.json
@@ -177,13 +177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a",
+                                    "name": "indexpattern-datasource-layer-737d5f1c-e4b5-bced-df13-f856e5fa3136"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a": {
+                                    "id": "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -281,13 +302,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2fb7250d-3d47-565f-cfa6-2418f399f214"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2fb7250d-3d47-565f-cfa6-2418f399f214",
+                                    "name": "indexpattern-datasource-layer-31c999df-2406-ef59-67a1-87153a12760b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2fb7250d-3d47-565f-cfa6-2418f399f214": {
+                                    "id": "2fb7250d-3d47-565f-cfa6-2418f399f214",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -385,13 +427,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5fc03517-a4a3-6716-05c2-d1ded0a07ef9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5fc03517-a4a3-6716-05c2-d1ded0a07ef9",
+                                    "name": "indexpattern-datasource-layer-de400575-cc5b-91ab-325b-3be06add7d89"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5fc03517-a4a3-6716-05c2-d1ded0a07ef9": {
+                                    "id": "5fc03517-a4a3-6716-05c2-d1ded0a07ef9",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -489,13 +552,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "84643fc3-285b-55b6-f670-172e50f1da6b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "84643fc3-285b-55b6-f670-172e50f1da6b",
+                                    "name": "indexpattern-datasource-layer-38a4e8b4-9226-6fad-26d2-24bc8e85375c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "84643fc3-285b-55b6-f670-172e50f1da6b": {
+                                    "id": "84643fc3-285b-55b6-f670-172e50f1da6b",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -655,13 +739,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b58eb1ad-7d66-43d7-f466-4a23bccd7576"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b58eb1ad-7d66-43d7-f466-4a23bccd7576",
+                                    "name": "indexpattern-datasource-layer-3313ff0a-17f1-bb07-2830-b24d30257faf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b58eb1ad-7d66-43d7-f466-4a23bccd7576": {
+                                    "id": "b58eb1ad-7d66-43d7-f466-4a23bccd7576",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -821,13 +926,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cfac5f39-3c0c-078c-5d18-f6e9ed72342a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cfac5f39-3c0c-078c-5d18-f6e9ed72342a",
+                                    "name": "indexpattern-datasource-layer-35809150-e401-c2a9-1d84-1f215346ddfe"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cfac5f39-3c0c-078c-5d18-f6e9ed72342a": {
+                                    "id": "cfac5f39-3c0c-078c-5d18-f6e9ed72342a",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -865,7 +991,7 @@
                             "visualization": {
                                 "layers": [
                                     {
-                                        "layerId": "a730c4f3-0680-f794-ca0b-daa82f24a712",
+                                        "layerId": "e37c552e-b002-81c3-c74b-ff4ec5893a23",
                                         "layerType": "data",
                                         "colorMapping": {
                                             "assignments": [
@@ -947,6 +1073,7 @@
                                         "numberDisplay": "percent",
                                         "categoryDisplay": "default",
                                         "legendDisplay": "show",
+                                        "legendPosition": "right",
                                         "nestedLegend": false,
                                         "emptySizeRatio": 0.5
                                     }
@@ -960,7 +1087,7 @@
                             "datasourceStates": {
                                 "textBased": {
                                     "layers": {
-                                        "a730c4f3-0680-f794-ca0b-daa82f24a712": {
+                                        "e37c552e-b002-81c3-c74b-ff4ec5893a23": {
                                             "query": {
                                                 "esql": "TS metrics-haproxyreceiver.otel-*\n| WHERE haproxy.service_name == \"FRONTEND\" AND haproxy.requests.total IS NOT NULL AND attributes.status_code IS NOT NULL\n| STATS requests = SUM(RATE(haproxy.requests.total)) BY attributes.status_code\n| SORT requests DESC\n| LIMIT 6"
                                             },
@@ -1002,13 +1129,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b33441c2-9cb5-32a2-2424-aea2c1c5344c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b33441c2-9cb5-32a2-2424-aea2c1c5344c",
+                                    "name": "indexpattern-datasource-layer-e37c552e-b002-81c3-c74b-ff4ec5893a23"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b33441c2-9cb5-32a2-2424-aea2c1c5344c": {
+                                    "id": "b33441c2-9cb5-32a2-2424-aea2c1c5344c",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1207,13 +1355,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4cb44590-2a57-ed77-0f75-4a1915ab6d26"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4cb44590-2a57-ed77-0f75-4a1915ab6d26",
+                                    "name": "indexpattern-datasource-layer-12e0d1d0-c076-b36c-d4ac-80cdf49e58ca"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4cb44590-2a57-ed77-0f75-4a1915ab6d26": {
+                                    "id": "4cb44590-2a57-ed77-0f75-4a1915ab6d26",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1373,13 +1542,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "17625185-8cde-4780-5a3c-ab4356d128de"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "17625185-8cde-4780-5a3c-ab4356d128de",
+                                    "name": "indexpattern-datasource-layer-827f2c8a-2641-fa20-2978-789a80e63a54"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "17625185-8cde-4780-5a3c-ab4356d128de": {
+                                    "id": "17625185-8cde-4780-5a3c-ab4356d128de",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1688,13 +1878,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cd6f5995-4943-05dd-a5fe-055d25c14374"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cd6f5995-4943-05dd-a5fe-055d25c14374",
+                                    "name": "indexpattern-datasource-layer-43b232ce-d886-27b8-c50c-a95529e7ca3c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cd6f5995-4943-05dd-a5fe-055d25c14374": {
+                                    "id": "cd6f5995-4943-05dd-a5fe-055d25c14374",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/haproxy_otel/kibana/dashboard/haproxy_otel-overview.json
+++ b/packages/haproxy_otel/kibana/dashboard/haproxy_otel-overview.json
@@ -1,7 +1,7 @@
 {
     "attributes": {
         "title": "[HAProxy OTel] Overview",
-        "description": "Top-level health across all proxies \u2014 error rates, traffic volume, latency summary, session saturation, server availability.",
+        "description": "Top-level health across all proxies — error rates, traffic volume, latency summary, session saturation, server availability.",
         "panelsJSON": [
             {
                 "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
@@ -116,7 +116,7 @@
                         "references": [],
                         "state": {
                             "visualization": {
-                                "layerId": "bf791024-2047-3cc5-4ce0-ba2bb558fd5c",
+                                "layerId": "737d5f1c-e4b5-bced-df13-f856e5fa3136",
                                 "layerType": "data",
                                 "metricAccessor": "add1b5db-6cde-6603-e764-93623cd42282",
                                 "showBar": false,
@@ -129,7 +129,7 @@
                             "datasourceStates": {
                                 "textBased": {
                                     "layers": {
-                                        "bf791024-2047-3cc5-4ce0-ba2bb558fd5c": {
+                                        "737d5f1c-e4b5-bced-df13-f856e5fa3136": {
                                             "query": {
                                                 "esql": "TS metrics-haproxyreceiver.otel-*\n| WHERE haproxy.service_name == \"FRONTEND\" AND haproxy.requests.total IS NOT NULL\n| STATS req_rate = SUM(RATE(haproxy.requests.total))"
                                             },
@@ -177,13 +177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a",
+                                    "name": "indexpattern-datasource-layer-737d5f1c-e4b5-bced-df13-f856e5fa3136"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a": {
+                                    "id": "1fd956fe-a6cd-e4ab-d545-1cc387db8f0a",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -281,13 +302,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5688b009-baa2-cbbd-aa6e-4a51fd426951"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5688b009-baa2-cbbd-aa6e-4a51fd426951",
+                                    "name": "indexpattern-datasource-layer-fe62bcae-26b1-6808-d314-603faa441253"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5688b009-baa2-cbbd-aa6e-4a51fd426951": {
+                                    "id": "5688b009-baa2-cbbd-aa6e-4a51fd426951",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -385,13 +427,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "aa1e2a50-6ed6-d291-864d-c47dd97b2d25"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "aa1e2a50-6ed6-d291-864d-c47dd97b2d25",
+                                    "name": "indexpattern-datasource-layer-1b253d56-7cf1-91ec-4b31-8246efd942ae"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "aa1e2a50-6ed6-d291-864d-c47dd97b2d25": {
+                                    "id": "aa1e2a50-6ed6-d291-864d-c47dd97b2d25",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -489,13 +552,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ae6da09c-7f5f-8d19-995f-6aea333dc13e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ae6da09c-7f5f-8d19-995f-6aea333dc13e",
+                                    "name": "indexpattern-datasource-layer-53469bdb-5ef7-81c8-24ac-57cf27b966dd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ae6da09c-7f5f-8d19-995f-6aea333dc13e": {
+                                    "id": "ae6da09c-7f5f-8d19-995f-6aea333dc13e",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -593,13 +677,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2fe2a442-6256-f714-3dcd-fdc03992878d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2fe2a442-6256-f714-3dcd-fdc03992878d",
+                                    "name": "indexpattern-datasource-layer-df3a27c6-103c-ba9a-288e-9d13918740cf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2fe2a442-6256-f714-3dcd-fdc03992878d": {
+                                    "id": "2fe2a442-6256-f714-3dcd-fdc03992878d",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -695,13 +800,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "56ed5807-dce4-cd51-d590-262c9872e2c0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "56ed5807-dce4-cd51-d590-262c9872e2c0",
+                                    "name": "indexpattern-datasource-layer-63573808-62cc-7573-18b5-4df870b54376"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "56ed5807-dce4-cd51-d590-262c9872e2c0": {
+                                    "id": "56ed5807-dce4-cd51-d590-262c9872e2c0",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -739,7 +865,7 @@
                             "visualization": {
                                 "layers": [
                                     {
-                                        "layerId": "ade712df-860f-2e75-8082-c7ae7544c958",
+                                        "layerId": "94ddc587-cd88-e836-d1e6-8600c54a5552",
                                         "accessors": [
                                             "507c821e-c46e-7d92-6c38-c87580c4424b"
                                         ],
@@ -862,7 +988,7 @@
                             "datasourceStates": {
                                 "textBased": {
                                     "layers": {
-                                        "ade712df-860f-2e75-8082-c7ae7544c958": {
+                                        "94ddc587-cd88-e836-d1e6-8600c54a5552": {
                                             "query": {
                                                 "esql": "TS metrics-haproxyreceiver.otel-*\n| WHERE haproxy.service_name == \"FRONTEND\" AND haproxy.requests.total IS NOT NULL AND attributes.status_code IS NOT NULL\n| STATS requests = SUM(RATE(haproxy.requests.total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.status_code\n| SORT time_bucket ASC"
                                             },
@@ -940,13 +1066,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2276665b-7754-0a21-2820-b6087985c93a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2276665b-7754-0a21-2820-b6087985c93a",
+                                    "name": "indexpattern-datasource-layer-94ddc587-cd88-e836-d1e6-8600c54a5552"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2276665b-7754-0a21-2820-b6087985c93a": {
+                                    "id": "2276665b-7754-0a21-2820-b6087985c93a",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1171,13 +1318,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "89a5aaf7-5e2a-a16f-b3fe-d5e5bf0bd2af"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "89a5aaf7-5e2a-a16f-b3fe-d5e5bf0bd2af",
+                                    "name": "indexpattern-datasource-layer-fa7557d7-3cb3-3eac-7bef-89f1f6c22bcf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "89a5aaf7-5e2a-a16f-b3fe-d5e5bf0bd2af": {
+                                    "id": "89a5aaf7-5e2a-a16f-b3fe-d5e5bf0bd2af",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1324,13 +1492,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "749c9660-f807-8c44-eb5e-13b76523eb3b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "749c9660-f807-8c44-eb5e-13b76523eb3b",
+                                    "name": "indexpattern-datasource-layer-90fe0466-f187-3228-bf5d-17c7b52c309c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "749c9660-f807-8c44-eb5e-13b76523eb3b": {
+                                    "id": "749c9660-f807-8c44-eb5e-13b76523eb3b",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1516,13 +1705,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c0bccceb-d03e-246d-5706-fe0644e78247"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c0bccceb-d03e-246d-5706-fe0644e78247",
+                                    "name": "indexpattern-datasource-layer-640b35ac-43c6-fe14-83c7-13dc33e017e9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c0bccceb-d03e-246d-5706-fe0644e78247": {
+                                    "id": "c0bccceb-d03e-246d-5706-fe0644e78247",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1560,7 +1770,7 @@
                             "visualization": {
                                 "layers": [
                                     {
-                                        "layerId": "a965cc26-76f7-5e5f-5ecb-69781b634c38",
+                                        "layerId": "14061932-d51c-2cc9-ec5c-dc5091386824",
                                         "accessors": [
                                             "63568547-199c-c0da-de33-15d7f382bb75",
                                             "a203f8b1-4749-f4b0-97a3-1a6759d28363"
@@ -1604,7 +1814,7 @@
                             "datasourceStates": {
                                 "textBased": {
                                     "layers": {
-                                        "a965cc26-76f7-5e5f-5ecb-69781b634c38": {
+                                        "14061932-d51c-2cc9-ec5c-dc5091386824": {
                                             "query": {
                                                 "esql": "TS metrics-haproxyreceiver.otel-*\n| WHERE haproxy.service_name == \"FRONTEND\" AND (haproxy.bytes.input IS NOT NULL OR haproxy.bytes.output IS NOT NULL)\n| STATS bytes_in = SUM(RATE(haproxy.bytes.input)), bytes_out = SUM(RATE(haproxy.bytes.output)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bytes_in = COALESCE(bytes_in, 0)\n| EVAL bytes_out = COALESCE(bytes_out, 0)\n| SORT time_bucket ASC"
                                             },
@@ -1708,13 +1918,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "116b1f73-af76-7fea-a385-8e442459beae"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "116b1f73-af76-7fea-a385-8e442459beae",
+                                    "name": "indexpattern-datasource-layer-14061932-d51c-2cc9-ec5c-dc5091386824"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "116b1f73-af76-7fea-a385-8e442459beae": {
+                                    "id": "116b1f73-af76-7fea-a385-8e442459beae",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1851,13 +2082,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4ae8d69b-bd32-17e0-e493-7df636f64fce"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4ae8d69b-bd32-17e0-e493-7df636f64fce",
+                                    "name": "indexpattern-datasource-layer-71cf919c-9482-020b-df94-3b9162d72c3d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4ae8d69b-bd32-17e0-e493-7df636f64fce": {
+                                    "id": "4ae8d69b-bd32-17e0-e493-7df636f64fce",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/haproxy_otel/kibana/dashboard/haproxy_otel-server.json
+++ b/packages/haproxy_otel/kibana/dashboard/haproxy_otel-server.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "36da9a0b-3bc8-95f6-ef38-5486bd5c7f3f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "36da9a0b-3bc8-95f6-ef38-5486bd5c7f3f",
+                                    "name": "indexpattern-datasource-layer-de7bc617-38d3-6f18-a2d1-b8f2f1a5661f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "36da9a0b-3bc8-95f6-ef38-5486bd5c7f3f": {
+                                    "id": "36da9a0b-3bc8-95f6-ef38-5486bd5c7f3f",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a3c19755-2008-00d2-7d49-175f722daa9b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a3c19755-2008-00d2-7d49-175f722daa9b",
+                                    "name": "indexpattern-datasource-layer-4308c38f-aab7-0b81-5b20-8a84b066ff4e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a3c19755-2008-00d2-7d49-175f722daa9b": {
+                                    "id": "a3c19755-2008-00d2-7d49-175f722daa9b",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -383,13 +425,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6578ba13-9f41-97c9-2105-662de2c52563"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6578ba13-9f41-97c9-2105-662de2c52563",
+                                    "name": "indexpattern-datasource-layer-36274718-7911-21a2-9ba0-34ff87d9d38d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6578ba13-9f41-97c9-2105-662de2c52563": {
+                                    "id": "6578ba13-9f41-97c9-2105-662de2c52563",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -487,13 +550,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2b2db9b6-6f67-6f01-c965-526753d985da"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2b2db9b6-6f67-6f01-c965-526753d985da",
+                                    "name": "indexpattern-datasource-layer-d9fc9e5e-3314-9f43-d4b9-31758e395818"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2b2db9b6-6f67-6f01-c965-526753d985da": {
+                                    "id": "2b2db9b6-6f67-6f01-c965-526753d985da",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -653,13 +737,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "53e4df5f-6a73-4d05-cb87-18c2e6a99652"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "53e4df5f-6a73-4d05-cb87-18c2e6a99652",
+                                    "name": "indexpattern-datasource-layer-f9afd162-9a67-ba52-b64d-7e458231c171"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "53e4df5f-6a73-4d05-cb87-18c2e6a99652": {
+                                    "id": "53e4df5f-6a73-4d05-cb87-18c2e6a99652",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -810,13 +915,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ede4332d-e259-544e-fd01-9d7f1fbaf71a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ede4332d-e259-544e-fd01-9d7f1fbaf71a",
+                                    "name": "indexpattern-datasource-layer-c269d13d-d311-adbe-d020-f0254ad495af"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ede4332d-e259-544e-fd01-9d7f1fbaf71a": {
+                                    "id": "ede4332d-e259-544e-fd01-9d7f1fbaf71a",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1045,13 +1171,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "84012b44-9601-a68a-19cc-484d66dd58a2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "84012b44-9601-a68a-19cc-484d66dd58a2",
+                                    "name": "indexpattern-datasource-layer-96f1b31c-f0bf-563d-465d-8f96d3edcab7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "84012b44-9601-a68a-19cc-484d66dd58a2": {
+                                    "id": "84012b44-9601-a68a-19cc-484d66dd58a2",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1211,13 +1358,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "044ab24f-46df-fabf-bb37-678d3006db78"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "044ab24f-46df-fabf-bb37-678d3006db78",
+                                    "name": "indexpattern-datasource-layer-3a0f9bc9-c932-48a2-0c94-0d3e80e94c4d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "044ab24f-46df-fabf-bb37-678d3006db78": {
+                                    "id": "044ab24f-46df-fabf-bb37-678d3006db78",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1672,13 +1840,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "469841e0-0fdd-3cb4-3f84-33c3d16ccfa2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "469841e0-0fdd-3cb4-3f84-33c3d16ccfa2",
+                                    "name": "indexpattern-datasource-layer-5ddd1123-94c9-bfd5-63b7-a101e91fd66d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "469841e0-0fdd-3cb4-3f84-33c3d16ccfa2": {
+                                    "id": "469841e0-0fdd-3cb4-3f84-33c3d16ccfa2",
+                                    "type": "esql",
+                                    "name": "metrics-haproxyreceiver.otel-*",
+                                    "title": "metrics-haproxyreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/haproxy_otel/manifest.yml
+++ b/packages/haproxy_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.5
 name: haproxy_otel
 title: "Haproxy OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Haproxy Assets for OpenTelemetry Collector"

--- a/packages/ibmmq_otel/changelog.yml
+++ b/packages/ibmmq_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/ibmmq_otel/changelog.yml
+++ b/packages/ibmmq_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20378
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-error-analysis.json
+++ b/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-error-analysis.json
@@ -179,13 +179,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1dcdc8b2-095e-c69d-6402-def5e45576a0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1dcdc8b2-095e-c69d-6402-def5e45576a0",
+                                    "name": "indexpattern-datasource-layer-96e0bea8-4834-8b90-16fd-b6d4164580f9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1dcdc8b2-095e-c69d-6402-def5e45576a0": {
+                                    "id": "1dcdc8b2-095e-c69d-6402-def5e45576a0",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -285,13 +306,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c6091d45-2d81-76a4-ea2b-4bc2db10c1ce"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c6091d45-2d81-76a4-ea2b-4bc2db10c1ce",
+                                    "name": "indexpattern-datasource-layer-e6ac1411-22ae-9590-b713-f834d8a81c36"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c6091d45-2d81-76a4-ea2b-4bc2db10c1ce": {
+                                    "id": "c6091d45-2d81-76a4-ea2b-4bc2db10c1ce",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -391,13 +433,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "21b090fe-de83-4fb8-6e0b-01b9d1cf02c1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "21b090fe-de83-4fb8-6e0b-01b9d1cf02c1",
+                                    "name": "indexpattern-datasource-layer-48040175-13ec-9139-6d80-8b04117d3626"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "21b090fe-de83-4fb8-6e0b-01b9d1cf02c1": {
+                                    "id": "21b090fe-de83-4fb8-6e0b-01b9d1cf02c1",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -497,13 +560,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "77f113fa-c8ab-d76e-f0fd-46104d341aa0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "77f113fa-c8ab-d76e-f0fd-46104d341aa0",
+                                    "name": "indexpattern-datasource-layer-75e00e5c-2f0a-731c-5011-155a5de5921a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "77f113fa-c8ab-d76e-f0fd-46104d341aa0": {
+                                    "id": "77f113fa-c8ab-d76e-f0fd-46104d341aa0",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -603,13 +687,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9a440157-36b5-7025-1c8f-464fa209886b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9a440157-36b5-7025-1c8f-464fa209886b",
+                                    "name": "indexpattern-datasource-layer-c5c867fa-751c-d43f-ec0e-d2eaaba592c2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9a440157-36b5-7025-1c8f-464fa209886b": {
+                                    "id": "9a440157-36b5-7025-1c8f-464fa209886b",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -705,13 +810,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "99b29e58-cd78-2e91-a853-2739d2c0a65d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "99b29e58-cd78-2e91-a853-2739d2c0a65d",
+                                    "name": "indexpattern-datasource-layer-28fdf49b-daa6-ab01-2a61-433dfe5b428c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "99b29e58-cd78-2e91-a853-2739d2c0a65d": {
+                                    "id": "99b29e58-cd78-2e91-a853-2739d2c0a65d",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -811,13 +937,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7f7a47e5-9114-f3d8-3422-e17f5ee17517"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7f7a47e5-9114-f3d8-3422-e17f5ee17517",
+                                    "name": "indexpattern-datasource-layer-f93cdacb-6827-7078-25d6-7fd7dbc3d6e4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7f7a47e5-9114-f3d8-3422-e17f5ee17517": {
+                                    "id": "7f7a47e5-9114-f3d8-3422-e17f5ee17517",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -917,13 +1064,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "70c7d9d5-65c2-fa4b-edac-b00653be682c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "70c7d9d5-65c2-fa4b-edac-b00653be682c",
+                                    "name": "indexpattern-datasource-layer-684a7c61-fbf6-b83f-9db9-8527a4eb41a4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "70c7d9d5-65c2-fa4b-edac-b00653be682c": {
+                                    "id": "70c7d9d5-65c2-fa4b-edac-b00653be682c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1123,13 +1291,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "45cf7a2b-d4d1-584c-54c4-59006b73fd51"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "45cf7a2b-d4d1-584c-54c4-59006b73fd51",
+                                    "name": "indexpattern-datasource-layer-c1207fc7-da87-a189-cafa-cd5ac9d8a264"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "45cf7a2b-d4d1-584c-54c4-59006b73fd51": {
+                                    "id": "45cf7a2b-d4d1-584c-54c4-59006b73fd51",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1306,13 +1495,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "95075991-a00d-6d90-0bae-0101c8ae9209"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "95075991-a00d-6d90-0bae-0101c8ae9209",
+                                    "name": "indexpattern-datasource-layer-be8e15ee-15c1-c9e6-43f1-03386b993bca"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "95075991-a00d-6d90-0bae-0101c8ae9209": {
+                                    "id": "95075991-a00d-6d90-0bae-0101c8ae9209",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1489,13 +1699,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1e31be85-0161-e804-9945-40e4f8ab79e9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1e31be85-0161-e804-9945-40e4f8ab79e9",
+                                    "name": "indexpattern-datasource-layer-1350e9bf-f56e-0ffa-5b4b-c751ac082faa"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1e31be85-0161-e804-9945-40e4f8ab79e9": {
+                                    "id": "1e31be85-0161-e804-9945-40e4f8ab79e9",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1695,13 +1926,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9ed3ebcc-463c-5da0-43a5-3c9859336af9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9ed3ebcc-463c-5da0-43a5-3c9859336af9",
+                                    "name": "indexpattern-datasource-layer-d2cdcd67-2a3d-00cf-d222-9193b566e9ce"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9ed3ebcc-463c-5da0-43a5-3c9859336af9": {
+                                    "id": "9ed3ebcc-463c-5da0-43a5-3c9859336af9",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1918,13 +2170,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9d647e7a-c8b7-0b97-f7b4-642fac7d500d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9d647e7a-c8b7-0b97-f7b4-642fac7d500d",
+                                    "name": "indexpattern-datasource-layer-29674102-6a61-9132-dd2f-a894cf9d2b6f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9d647e7a-c8b7-0b97-f7b4-642fac7d500d": {
+                                    "id": "9d647e7a-c8b7-0b97-f7b4-642fac7d500d",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2112,13 +2385,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "169508f9-2114-b776-73b8-1dd4ef1cc66f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "169508f9-2114-b776-73b8-1dd4ef1cc66f",
+                                    "name": "indexpattern-datasource-layer-e2514c51-e3d8-e9e2-c31e-e186645b638d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "169508f9-2114-b776-73b8-1dd4ef1cc66f": {
+                                    "id": "169508f9-2114-b776-73b8-1dd4ef1cc66f",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2504,13 +2798,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5dd085f3-bf0f-7c95-aad5-9e12de7afd70"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5dd085f3-bf0f-7c95-aad5-9e12de7afd70",
+                                    "name": "indexpattern-datasource-layer-8bd3bc75-dab4-6757-2520-850e41198a28"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5dd085f3-bf0f-7c95-aad5-9e12de7afd70": {
+                                    "id": "5dd085f3-bf0f-7c95-aad5-9e12de7afd70",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-message-traffic.json
+++ b/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-message-traffic.json
@@ -179,13 +179,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "767f2099-ce64-6ecd-f36b-c4699f038984"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "767f2099-ce64-6ecd-f36b-c4699f038984",
+                                    "name": "indexpattern-datasource-layer-4090b9b7-ab6e-4b13-28f6-373b3403ebd3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "767f2099-ce64-6ecd-f36b-c4699f038984": {
+                                    "id": "767f2099-ce64-6ecd-f36b-c4699f038984",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -285,13 +306,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "00e3a58e-c323-a5b2-d29f-585e4127ef5c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "00e3a58e-c323-a5b2-d29f-585e4127ef5c",
+                                    "name": "indexpattern-datasource-layer-a62a876d-8754-d90e-038b-eb7992ccfbb7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "00e3a58e-c323-a5b2-d29f-585e4127ef5c": {
+                                    "id": "00e3a58e-c323-a5b2-d29f-585e4127ef5c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -389,13 +431,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fdca1141-a259-2e5b-615b-25bb0042d01d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fdca1141-a259-2e5b-615b-25bb0042d01d",
+                                    "name": "indexpattern-datasource-layer-719f9ea0-1ed7-e2e4-1680-369958a8675f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fdca1141-a259-2e5b-615b-25bb0042d01d": {
+                                    "id": "fdca1141-a259-2e5b-615b-25bb0042d01d",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -493,13 +556,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9cb83b13-f745-4a68-2c2c-319b037fc45b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9cb83b13-f745-4a68-2c2c-319b037fc45b",
+                                    "name": "indexpattern-datasource-layer-b8a2c0d3-6313-28ba-4264-703f1227f4f1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9cb83b13-f745-4a68-2c2c-319b037fc45b": {
+                                    "id": "9cb83b13-f745-4a68-2c2c-319b037fc45b",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -599,13 +683,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fdff3d66-564c-84a1-f328-194cc6bc7d36"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fdff3d66-564c-84a1-f328-194cc6bc7d36",
+                                    "name": "indexpattern-datasource-layer-1af63e96-11b9-b10c-c305-85bc99eb7c0a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fdff3d66-564c-84a1-f328-194cc6bc7d36": {
+                                    "id": "fdff3d66-564c-84a1-f328-194cc6bc7d36",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -705,13 +810,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "24e11ebb-9913-1349-9f0f-1b61fa33596c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "24e11ebb-9913-1349-9f0f-1b61fa33596c",
+                                    "name": "indexpattern-datasource-layer-57b7e39d-8181-3c7f-46f4-6deee4887ad5"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "24e11ebb-9913-1349-9f0f-1b61fa33596c": {
+                                    "id": "24e11ebb-9913-1349-9f0f-1b61fa33596c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -811,13 +937,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c289c139-ae68-5dca-6d7e-fa285a8046db"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c289c139-ae68-5dca-6d7e-fa285a8046db",
+                                    "name": "indexpattern-datasource-layer-230e766c-cdda-4069-71ef-728a3f6aa33b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c289c139-ae68-5dca-6d7e-fa285a8046db": {
+                                    "id": "c289c139-ae68-5dca-6d7e-fa285a8046db",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -917,13 +1064,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "403f8be2-84e0-24df-ae88-a1daf95da50a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "403f8be2-84e0-24df-ae88-a1daf95da50a",
+                                    "name": "indexpattern-datasource-layer-011b9715-4ee2-f664-76dc-b480396aa4c3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "403f8be2-84e0-24df-ae88-a1daf95da50a": {
+                                    "id": "403f8be2-84e0-24df-ae88-a1daf95da50a",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1085,13 +1253,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6e74231a-abcb-8cde-1509-b75aa3d18e37"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6e74231a-abcb-8cde-1509-b75aa3d18e37",
+                                    "name": "indexpattern-datasource-layer-d7a647d4-27d2-e450-605d-f8ca04320b16"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6e74231a-abcb-8cde-1509-b75aa3d18e37": {
+                                    "id": "6e74231a-abcb-8cde-1509-b75aa3d18e37",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1253,13 +1442,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f224cdff-d2c6-9158-f09a-a4419ee77179"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f224cdff-d2c6-9158-f09a-a4419ee77179",
+                                    "name": "indexpattern-datasource-layer-26a40c7f-5169-bfb9-be0b-129f95e521b2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f224cdff-d2c6-9158-f09a-a4419ee77179": {
+                                    "id": "f224cdff-d2c6-9158-f09a-a4419ee77179",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1449,13 +1659,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9044d3be-270f-d436-0682-87706f4dc1d9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9044d3be-270f-d436-0682-87706f4dc1d9",
+                                    "name": "indexpattern-datasource-layer-6d8d8ead-00a1-d063-0fc6-d32423a4719d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9044d3be-270f-d436-0682-87706f4dc1d9": {
+                                    "id": "9044d3be-270f-d436-0682-87706f4dc1d9",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1645,13 +1876,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7c18c8eb-d4d4-3719-df3a-a45c25bc1521"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7c18c8eb-d4d4-3719-df3a-a45c25bc1521",
+                                    "name": "indexpattern-datasource-layer-fa202345-9a30-279f-ad40-36cb306614d0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7c18c8eb-d4d4-3719-df3a-a45c25bc1521": {
+                                    "id": "7c18c8eb-d4d4-3719-df3a-a45c25bc1521",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1841,13 +2093,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7f38f398-ecca-8636-0f40-145450f7a9bd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7f38f398-ecca-8636-0f40-145450f7a9bd",
+                                    "name": "indexpattern-datasource-layer-69f86248-d746-7205-1594-9450b0b8f8cf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7f38f398-ecca-8636-0f40-145450f7a9bd": {
+                                    "id": "7f38f398-ecca-8636-0f40-145450f7a9bd",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2037,13 +2310,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a0c78d0b-095f-0117-3e66-a66b4d0a6a27"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a0c78d0b-095f-0117-3e66-a66b4d0a6a27",
+                                    "name": "indexpattern-datasource-layer-219a3204-1faf-0e44-aa9c-11eafe44224a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a0c78d0b-095f-0117-3e66-a66b4d0a6a27": {
+                                    "id": "a0c78d0b-095f-0117-3e66-a66b4d0a6a27",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2274,13 +2568,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "87ef153f-36ee-d0ee-1fd8-d2ebda85e82f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "87ef153f-36ee-d0ee-1fd8-d2ebda85e82f",
+                                    "name": "indexpattern-datasource-layer-7d397e2c-9b57-b1d0-68ea-a564c741beeb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "87ef153f-36ee-d0ee-1fd8-d2ebda85e82f": {
+                                    "id": "87ef153f-36ee-d0ee-1fd8-d2ebda85e82f",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2480,13 +2795,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "62296605-5119-f707-2a69-bf0e5032797b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "62296605-5119-f707-2a69-bf0e5032797b",
+                                    "name": "indexpattern-datasource-layer-eb295e19-740c-ebf0-8201-f36cf386eea6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "62296605-5119-f707-2a69-bf0e5032797b": {
+                                    "id": "62296605-5119-f707-2a69-bf0e5032797b",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2870,13 +3206,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4ea1353a-3337-05f9-5938-4acf45cabec6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4ea1353a-3337-05f9-5938-4acf45cabec6",
+                                    "name": "indexpattern-datasource-layer-79edd81a-d168-0f99-aa2b-49f92f4646d0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4ea1353a-3337-05f9-5938-4acf45cabec6": {
+                                    "id": "4ea1353a-3337-05f9-5938-4acf45cabec6",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-overview.json
+++ b/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-overview.json
@@ -179,13 +179,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "767f2099-ce64-6ecd-f36b-c4699f038984"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "767f2099-ce64-6ecd-f36b-c4699f038984",
+                                    "name": "indexpattern-datasource-layer-4090b9b7-ab6e-4b13-28f6-373b3403ebd3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "767f2099-ce64-6ecd-f36b-c4699f038984": {
+                                    "id": "767f2099-ce64-6ecd-f36b-c4699f038984",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -285,13 +306,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "00e3a58e-c323-a5b2-d29f-585e4127ef5c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "00e3a58e-c323-a5b2-d29f-585e4127ef5c",
+                                    "name": "indexpattern-datasource-layer-a62a876d-8754-d90e-038b-eb7992ccfbb7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "00e3a58e-c323-a5b2-d29f-585e4127ef5c": {
+                                    "id": "00e3a58e-c323-a5b2-d29f-585e4127ef5c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -391,13 +433,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c289c139-ae68-5dca-6d7e-fa285a8046db"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c289c139-ae68-5dca-6d7e-fa285a8046db",
+                                    "name": "indexpattern-datasource-layer-230e766c-cdda-4069-71ef-728a3f6aa33b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c289c139-ae68-5dca-6d7e-fa285a8046db": {
+                                    "id": "c289c139-ae68-5dca-6d7e-fa285a8046db",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -497,13 +560,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7e89a785-5278-f0dc-1808-11bbd3102e29"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7e89a785-5278-f0dc-1808-11bbd3102e29",
+                                    "name": "indexpattern-datasource-layer-0308dd0c-785e-f62a-4cb4-b85a13c56c84"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7e89a785-5278-f0dc-1808-11bbd3102e29": {
+                                    "id": "7e89a785-5278-f0dc-1808-11bbd3102e29",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -603,13 +687,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3ac28bee-9f4c-0894-fb7e-f918cde70f4c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3ac28bee-9f4c-0894-fb7e-f918cde70f4c",
+                                    "name": "indexpattern-datasource-layer-a7a9c12d-3b23-6224-476e-1f0de7d54cdd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3ac28bee-9f4c-0894-fb7e-f918cde70f4c": {
+                                    "id": "3ac28bee-9f4c-0894-fb7e-f918cde70f4c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -707,13 +812,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6c961b42-d674-1487-0f69-4e0112053887"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6c961b42-d674-1487-0f69-4e0112053887",
+                                    "name": "indexpattern-datasource-layer-56bdcd99-82d0-bf77-2a6c-5e73bb664bd4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6c961b42-d674-1487-0f69-4e0112053887": {
+                                    "id": "6c961b42-d674-1487-0f69-4e0112053887",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -811,13 +937,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6e766d55-72d8-9e61-6183-ad184ecc0a8a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6e766d55-72d8-9e61-6183-ad184ecc0a8a",
+                                    "name": "indexpattern-datasource-layer-686e6b88-829d-aa64-cbfa-24da3e7c3259"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6e766d55-72d8-9e61-6183-ad184ecc0a8a": {
+                                    "id": "6e766d55-72d8-9e61-6183-ad184ecc0a8a",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -913,13 +1060,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "99b29e58-cd78-2e91-a853-2739d2c0a65d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "99b29e58-cd78-2e91-a853-2739d2c0a65d",
+                                    "name": "indexpattern-datasource-layer-28fdf49b-daa6-ab01-2a61-433dfe5b428c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "99b29e58-cd78-2e91-a853-2739d2c0a65d": {
+                                    "id": "99b29e58-cd78-2e91-a853-2739d2c0a65d",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1109,13 +1277,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "aa5b5d10-0550-7220-8c92-b4c45ef59e89"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "aa5b5d10-0550-7220-8c92-b4c45ef59e89",
+                                    "name": "indexpattern-datasource-layer-4694524e-7a5b-7488-2ba5-a9b3a19ee7e0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "aa5b5d10-0550-7220-8c92-b4c45ef59e89": {
+                                    "id": "aa5b5d10-0550-7220-8c92-b4c45ef59e89",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1332,13 +1521,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9d647e7a-c8b7-0b97-f7b4-642fac7d500d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9d647e7a-c8b7-0b97-f7b4-642fac7d500d",
+                                    "name": "indexpattern-datasource-layer-29674102-6a61-9132-dd2f-a894cf9d2b6f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9d647e7a-c8b7-0b97-f7b4-642fac7d500d": {
+                                    "id": "9d647e7a-c8b7-0b97-f7b4-642fac7d500d",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1538,13 +1748,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4d7b5900-ace1-ae81-aec8-95cffa4d1c4e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4d7b5900-ace1-ae81-aec8-95cffa4d1c4e",
+                                    "name": "indexpattern-datasource-layer-fb74f617-a3c7-d084-7d55-9710440f6393"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4d7b5900-ace1-ae81-aec8-95cffa4d1c4e": {
+                                    "id": "4d7b5900-ace1-ae81-aec8-95cffa4d1c4e",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1706,13 +1937,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2e9acea1-b153-24d6-f495-40adcd8a9bb0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2e9acea1-b153-24d6-f495-40adcd8a9bb0",
+                                    "name": "indexpattern-datasource-layer-34b497fd-240d-408e-aeac-498753a9e267"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2e9acea1-b153-24d6-f495-40adcd8a9bb0": {
+                                    "id": "2e9acea1-b153-24d6-f495-40adcd8a9bb0",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1984,13 +2236,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "30cdba30-1d86-2d44-ae34-5b22a3b48373"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "30cdba30-1d86-2d44-ae34-5b22a3b48373",
+                                    "name": "indexpattern-datasource-layer-6ab58690-1b90-c528-8496-35fe60477091"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "30cdba30-1d86-2d44-ae34-5b22a3b48373": {
+                                    "id": "30cdba30-1d86-2d44-ae34-5b22a3b48373",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2221,13 +2494,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c",
+                                    "name": "indexpattern-datasource-layer-7a9c2a55-4938-8d03-fc32-15efafbda7e7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c": {
+                                    "id": "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2660,13 +2954,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "86ea6077-e91e-8632-2f75-624b4b94c390"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "86ea6077-e91e-8632-2f75-624b4b94c390",
+                                    "name": "indexpattern-datasource-layer-6ae034e3-653d-53e7-2412-74bb04377cf0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "86ea6077-e91e-8632-2f75-624b4b94c390": {
+                                    "id": "86ea6077-e91e-8632-2f75-624b4b94c390",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-resources.json
+++ b/packages/ibmmq_otel/kibana/dashboard/ibmmq_otel-resources.json
@@ -267,13 +267,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0dd706e2-c231-1bdc-c352-d562be108fac"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0dd706e2-c231-1bdc-c352-d562be108fac",
+                                    "name": "indexpattern-datasource-layer-bcd2a5f9-22df-42ae-48fc-1556764d4577"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0dd706e2-c231-1bdc-c352-d562be108fac": {
+                                    "id": "0dd706e2-c231-1bdc-c352-d562be108fac",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -461,13 +482,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cc5667a5-b129-3f4f-a90f-ca27ab62ab54"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cc5667a5-b129-3f4f-a90f-ca27ab62ab54",
+                                    "name": "indexpattern-datasource-layer-820cd189-2c7d-f020-5309-2410e32e8f1c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cc5667a5-b129-3f4f-a90f-ca27ab62ab54": {
+                                    "id": "cc5667a5-b129-3f4f-a90f-ca27ab62ab54",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -655,13 +697,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d85cde18-f6c6-311d-e65a-5ef9a5281313"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d85cde18-f6c6-311d-e65a-5ef9a5281313",
+                                    "name": "indexpattern-datasource-layer-975ec949-d5ff-01eb-d9f6-8cee76f92ea0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d85cde18-f6c6-311d-e65a-5ef9a5281313": {
+                                    "id": "d85cde18-f6c6-311d-e65a-5ef9a5281313",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -849,13 +912,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e43e6d32-4520-4656-bbcd-d9eac0bf4329"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e43e6d32-4520-4656-bbcd-d9eac0bf4329",
+                                    "name": "indexpattern-datasource-layer-48bab4b5-e788-1b08-35f4-f151dc3aa729"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e43e6d32-4520-4656-bbcd-d9eac0bf4329": {
+                                    "id": "e43e6d32-4520-4656-bbcd-d9eac0bf4329",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1058,13 +1142,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2e9acea1-b153-24d6-f495-40adcd8a9bb0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2e9acea1-b153-24d6-f495-40adcd8a9bb0",
+                                    "name": "indexpattern-datasource-layer-34b497fd-240d-408e-aeac-498753a9e267"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2e9acea1-b153-24d6-f495-40adcd8a9bb0": {
+                                    "id": "2e9acea1-b153-24d6-f495-40adcd8a9bb0",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1226,13 +1331,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1f465df1-8105-a591-a890-bb245f29b5d6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1f465df1-8105-a591-a890-bb245f29b5d6",
+                                    "name": "indexpattern-datasource-layer-f2c0d737-6cad-a741-30bd-6f1773cd6085"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1f465df1-8105-a591-a890-bb245f29b5d6": {
+                                    "id": "1f465df1-8105-a591-a890-bb245f29b5d6",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1422,13 +1548,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "879b6bff-586e-74b1-a03d-dd488eaff355"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "879b6bff-586e-74b1-a03d-dd488eaff355",
+                                    "name": "indexpattern-datasource-layer-bd1f7bd2-af28-a5df-d805-0a71438d0eb0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "879b6bff-586e-74b1-a03d-dd488eaff355": {
+                                    "id": "879b6bff-586e-74b1-a03d-dd488eaff355",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1588,13 +1735,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a8a6ba23-5f90-fe07-9e4b-cea038538f6c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a8a6ba23-5f90-fe07-9e4b-cea038538f6c",
+                                    "name": "indexpattern-datasource-layer-e8fae731-4496-b9bd-920d-dca2b68a8577"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a8a6ba23-5f90-fe07-9e4b-cea038538f6c": {
+                                    "id": "a8a6ba23-5f90-fe07-9e4b-cea038538f6c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1907,13 +2075,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "30cdba30-1d86-2d44-ae34-5b22a3b48373"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "30cdba30-1d86-2d44-ae34-5b22a3b48373",
+                                    "name": "indexpattern-datasource-layer-6ab58690-1b90-c528-8496-35fe60477091"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "30cdba30-1d86-2d44-ae34-5b22a3b48373": {
+                                    "id": "30cdba30-1d86-2d44-ae34-5b22a3b48373",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2103,13 +2292,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "87c88942-fc7a-c5df-c19e-c6b7c0975fb9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "87c88942-fc7a-c5df-c19e-c6b7c0975fb9",
+                                    "name": "indexpattern-datasource-layer-80d2e292-d9f5-aa49-346e-745f00544807"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "87c88942-fc7a-c5df-c19e-c6b7c0975fb9": {
+                                    "id": "87c88942-fc7a-c5df-c19e-c6b7c0975fb9",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2269,13 +2479,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f47f6835-17c3-af13-89e1-deef85893038"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f47f6835-17c3-af13-89e1-deef85893038",
+                                    "name": "indexpattern-datasource-layer-05669400-31f3-5385-9ce8-ad96e2580303"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f47f6835-17c3-af13-89e1-deef85893038": {
+                                    "id": "f47f6835-17c3-af13-89e1-deef85893038",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2435,13 +2666,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9e95a3b6-8b9b-36d2-8a9f-5ed957c0f3af"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9e95a3b6-8b9b-36d2-8a9f-5ed957c0f3af",
+                                    "name": "indexpattern-datasource-layer-f0c84676-1845-d740-63a9-aef9f07ac31d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9e95a3b6-8b9b-36d2-8a9f-5ed957c0f3af": {
+                                    "id": "9e95a3b6-8b9b-36d2-8a9f-5ed957c0f3af",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2713,13 +2965,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c",
+                                    "name": "indexpattern-datasource-layer-7a9c2a55-4938-8d03-fc32-15efafbda7e7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c": {
+                                    "id": "eaf0b7f9-45d3-af9f-95a1-f57fdb52700c",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2991,13 +3264,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "24f0ccb1-c2e6-7460-bf99-4f8638db6a46"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "24f0ccb1-c2e6-7460-bf99-4f8638db6a46",
+                                    "name": "indexpattern-datasource-layer-c91bb2c6-8785-1ffe-b17c-d6c0e8d7fd76"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "24f0ccb1-c2e6-7460-bf99-4f8638db6a46": {
+                                    "id": "24f0ccb1-c2e6-7460-bf99-4f8638db6a46",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3159,13 +3453,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "43553c0b-db60-7236-c80d-353db7820c01"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "43553c0b-db60-7236-c80d-353db7820c01",
+                                    "name": "indexpattern-datasource-layer-1cb97c50-798f-2e2d-89f4-781cfa51edeb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "43553c0b-db60-7236-c80d-353db7820c01": {
+                                    "id": "43553c0b-db60-7236-c80d-353db7820c01",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3325,13 +3640,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "17d1a519-b231-9c12-e9fc-d4d716e5fb78"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "17d1a519-b231-9c12-e9fc-d4d716e5fb78",
+                                    "name": "indexpattern-datasource-layer-b8c57dfa-6498-40dd-ac1b-8b810b5c8218"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "17d1a519-b231-9c12-e9fc-d4d716e5fb78": {
+                                    "id": "17d1a519-b231-9c12-e9fc-d4d716e5fb78",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3725,13 +4061,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c767ee94-dc84-1a17-e6b4-30df0dba37fa"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c767ee94-dc84-1a17-e6b4-30df0dba37fa",
+                                    "name": "indexpattern-datasource-layer-0a6e2b99-9ca4-5b8f-f4d2-686764f7d29d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c767ee94-dc84-1a17-e6b4-30df0dba37fa": {
+                                    "id": "c767ee94-dc84-1a17-e6b4-30df0dba37fa",
+                                    "type": "esql",
+                                    "name": "metrics-ibmmq.otel-*",
+                                    "title": "metrics-ibmmq.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/ibmmq_otel/manifest.yml
+++ b/packages/ibmmq_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: ibmmq_otel
 title: "IBM MQ OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "IBM MQ Assets from OpenTelemetry Collector"

--- a/packages/iis_otel/changelog.yml
+++ b/packages/iis_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20378
 - version: "0.5.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/iis_otel/changelog.yml
+++ b/packages/iis_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.5.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/iis_otel/kibana/dashboard/iis_otel-overview.json
+++ b/packages/iis_otel/kibana/dashboard/iis_otel-overview.json
@@ -1,59 +1,3696 @@
 {
-  "attributes": {
-    "title": "[IIS OTel] Overview",
-    "description": "Comprehensive operational visibility for IIS web servers instrumented via OpenTelemetry iisreceiver. Tracks application pool health, request handling capacity, traffic patterns, and resource utilization.",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"311e2098-d3cb-e8f4-bf13-b097739154c3\", \"order\": 1, \"label\": \"Sites & Pools\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [IIS OTel] Overview\\n\\nThis dashboard provides operational visibility for **IIS** instrumented via the OpenTelemetry **iisreceiver** (collector-contrib):\\n\\n- **Pool health** \\u2014 State and uptime; any pool not Running = outage\\n- **Request handling** \\u2014 Queue depth, age, rejections (primary saturation/error signals)\\n- **Traffic** \\u2014 Request rate by method, connections, network throughput\\n- **Resources** \\u2014 Active threads, bandwidth throttling\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"813ddedf-a285-d443-e8ec-de7939b683e7\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"813ddedf-a285-d443-e8ec-de7939b683e7\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Unhealthy Pools\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e80039e9-1eb2-1829-e8f7-0ee07c079cf9\", \"layerType\": \"data\", \"metricAccessor\": \"0f9b7569-7ec6-4688-7d61-877cae7188af\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e80039e9-1eb2-1829-e8f7-0ee07c079cf9\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\\n\"}, \"columns\": [{\"fieldName\": \"unhealthy\", \"columnId\": \"0f9b7569-7ec6-4688-7d61-877cae7188af\", \"label\": \"unhealthy\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"unhealthy\", \"columnId\": \"0f9b7569-7ec6-4688-7d61-877cae7188af\", \"label\": \"unhealthy\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"95fa3c06-c2bd-c69a-db35-556c2f3c71d6\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"95fa3c06-c2bd-c69a-db35-556c2f3c71d6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Pools Running\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"84f43c43-73a5-ce07-eae5-2a869bc01c39\", \"layerType\": \"data\", \"metricAccessor\": \"d4e02019-b446-715f-69d5-ee2e746edb50\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"84f43c43-73a5-ce07-eae5-2a869bc01c39\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\\n\"}, \"columns\": [{\"fieldName\": \"pools_running\", \"columnId\": \"d4e02019-b446-715f-69d5-ee2e746edb50\", \"label\": \"pools_running\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"pools_running\", \"columnId\": \"d4e02019-b446-715f-69d5-ee2e746edb50\", \"label\": \"pools_running\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ab63f3d4-0787-0d45-2876-5028b2132cce\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"ab63f3d4-0787-0d45-2876-5028b2132cce\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"c924c3f4-3bec-ecd5-7532-09f9f09b8c7e\", \"layerType\": \"data\", \"metricAccessor\": \"b8b4df96-d61b-76cf-3ae0-10119f5ec31b\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`))\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c924c3f4-3bec-ecd5-7532-09f9f09b8c7e\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`))\\n\"}, \"columns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b8b4df96-d61b-76cf-3ae0-10119f5ec31b\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b8b4df96-d61b-76cf-3ae0-10119f5ec31b\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"eac7ed13-3f78-1d43-4da3-b28d55f68ed9\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"eac7ed13-3f78-1d43-4da3-b28d55f68ed9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejected Requests\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"ec129854-26b4-acf0-4ac7-c3a259bbbc3d\", \"layerType\": \"data\", \"metricAccessor\": \"582f7d34-b4d5-a6c9-e48b-d06157a6ef74\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ec129854-26b4-acf0-4ac7-c3a259bbbc3d\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\\n\"}, \"columns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"582f7d34-b4d5-a6c9-e48b-d06157a6ef74\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"582f7d34-b4d5-a6c9-e48b-d06157a6ef74\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f6254395-a5b0-089a-6a73-298a6896dbc2\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"f6254395-a5b0-089a-6a73-298a6896dbc2\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Max Queue Depth\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"86cec1c4-9f7d-c98c-88a1-2f0bd5a3d0eb\", \"layerType\": \"data\", \"metricAccessor\": \"7c6337ab-977d-1114-3e7c-0f9d4f55b9b6\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"86cec1c4-9f7d-c98c-88a1-2f0bd5a3d0eb\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`)\\n\"}, \"columns\": [{\"fieldName\": \"max_queue\", \"columnId\": \"7c6337ab-977d-1114-3e7c-0f9d4f55b9b6\", \"label\": \"max_queue\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"max_queue\", \"columnId\": \"7c6337ab-977d-1114-3e7c-0f9d4f55b9b6\", \"label\": \"max_queue\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"b20d2603-819c-4c4f-762e-406a5009f675\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"b20d2603-819c-4c4f-762e-406a5009f675\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Max Queue Age\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"5b35ce18-ec94-aa56-07e0-cac121ebde99\", \"layerType\": \"data\", \"metricAccessor\": \"a7734371-c6e7-4544-62cf-a6c05723924a\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"5b35ce18-ec94-aa56-07e0-cac121ebde99\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`)\\n\"}, \"columns\": [{\"fieldName\": \"max_age\", \"columnId\": \"a7734371-c6e7-4544-62cf-a6c05723924a\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"max_age\", \"columnId\": \"a7734371-c6e7-4544-62cf-a6c05723924a\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"90a8c058-4a5c-8e56-a4d8-44db0887cca7\", \"gridData\": {\"x\": 32, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"90a8c058-4a5c-8e56-a4d8-44db0887cca7\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"dcbdf011-f9ca-49fe-12f1-02c33cc0bc00\", \"layerType\": \"data\", \"metricAccessor\": \"2b3b5ebb-85ad-68e5-6139-59d7a2f18460\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"dcbdf011-f9ca-49fe-12f1-02c33cc0bc00\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`)\\n\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"2b3b5ebb-85ad-68e5-6139-59d7a2f18460\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"2b3b5ebb-85ad-68e5-6139-59d7a2f18460\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7c65e231-552e-caaa-87a5-2e4e5ed1f96e\", \"gridData\": {\"x\": 40, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"7c65e231-552e-caaa-87a5-2e4e5ed1f96e\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Threads\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e5ceceeb-8f86-9072-6e06-f82b575829e1\", \"layerType\": \"data\", \"metricAccessor\": \"50916375-279e-ffde-d978-76b56fcb2241\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e5ceceeb-8f86-9072-6e06-f82b575829e1\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`)\\n\"}, \"columns\": [{\"fieldName\": \"threads\", \"columnId\": \"50916375-279e-ffde-d978-76b56fcb2241\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"threads\", \"columnId\": \"50916375-279e-ffde-d978-76b56fcb2241\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"98dd998b-7197-65f6-2395-6f3b86cdb1e8\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 48, \"h\": 3, \"i\": \"98dd998b-7197-65f6-2395-6f3b86cdb1e8\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Application Pool Health & State\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"34d9cc5f-7571-24f7-fef6-bd05516fb5b3\", \"gridData\": {\"x\": 0, \"y\": 17, \"w\": 24, \"h\": 12, \"i\": \"34d9cc5f-7571-24f7-fef6-bd05516fb5b3\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Application Pool Health \\u2014 State & Uptime Table\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"ee50b2c7-6646-dc9d-c57c-12e81f6509dd\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ee50b2c7-6646-dc9d-c57c-12e81f6509dd\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"columns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"10d284ec-b188-cdbf-e310-0e39f6e87d33\", \"gridData\": {\"x\": 24, \"y\": 17, \"w\": 24, \"h\": 12, \"i\": \"10d284ec-b188-cdbf-e310-0e39f6e87d33\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Pool Uptime Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cd54e897-9fa3-89a4-ad7a-0c193dbff658\", \"accessors\": [\"44c283a7-8a78-dd3c-5b66-4c7e8ca5defc\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"c915ede9-a7d1-1075-b745-5b72743ca894\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd54e897-9fa3-89a4-ad7a-0c193dbff658\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"uptime\", \"columnId\": \"44c283a7-8a78-dd3c-5b66-4c7e8ca5defc\", \"label\": \"uptime\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"pool\", \"columnId\": \"c915ede9-a7d1-1075-b745-5b72743ca894\", \"label\": \"pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"uptime\", \"columnId\": \"44c283a7-8a78-dd3c-5b66-4c7e8ca5defc\", \"label\": \"uptime\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"pool\", \"columnId\": \"c915ede9-a7d1-1075-b745-5b72743ca894\", \"label\": \"pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f3c72600-acb1-c4be-af9d-1055b48a0a2a\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 48, \"h\": 3, \"i\": \"f3c72600-acb1-c4be-af9d-1055b48a0a2a\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Request Rate & Queue Metrics\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"6fea96a6-f528-9373-2e0e-386184013bbd\", \"gridData\": {\"x\": 0, \"y\": 32, \"w\": 24, \"h\": 12, \"i\": \"6fea96a6-f528-9373-2e0e-386184013bbd\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate by HTTP Method Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"51fe9a4a-6244-7681-e2ab-f521416d6e14\", \"accessors\": [\"b1911db0-e346-dde6-337e-a829f741712f\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"51fe9a4a-6244-7681-e2ab-f521416d6e14\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b1911db0-e346-dde6-337e-a829f741712f\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b1911db0-e346-dde6-337e-a829f741712f\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"4f435521-b3f6-be32-0518-4c26873c5dc9\", \"gridData\": {\"x\": 24, \"y\": 32, \"w\": 24, \"h\": 12, \"i\": \"4f435521-b3f6-be32-0518-4c26873c5dc9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Depth and Rejections Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"893d1400-cdbf-b21f-48b1-b0e98604a831\", \"accessors\": [\"e976855b-f978-6e5c-9596-70700fbfefb7\", \"dafc20a2-21a9-1560-3d32-082ef9c83e85\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\"\\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"893d1400-cdbf-b21f-48b1-b0e98604a831\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\"\\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"eee5aea0-a409-c924-2c9a-6904041a625c\", \"gridData\": {\"x\": 0, \"y\": 44, \"w\": 12, \"h\": 10, \"i\": \"eee5aea0-a409-c924-2c9a-6904041a625c\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Depth Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"c8b86171-f1f3-d287-82ea-c416c4c60863\", \"accessors\": [\"e976855b-f978-6e5c-9596-70700fbfefb7\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"bottom\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c8b86171-f1f3-d287-82ea-c416c4c60863\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"872b997d-1b64-79cb-596e-27e82d85296d\", \"gridData\": {\"x\": 12, \"y\": 44, \"w\": 12, \"h\": 10, \"i\": \"872b997d-1b64-79cb-596e-27e82d85296d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejections Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"a4bed244-493a-e788-e13b-f8d4920a2037\", \"accessors\": [\"dafc20a2-21a9-1560-3d32-082ef9c83e85\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"bottom\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"a4bed244-493a-e788-e13b-f8d4920a2037\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e75467ea-82ca-9f6b-ae93-e22957fe1697\", \"gridData\": {\"x\": 24, \"y\": 44, \"w\": 24, \"h\": 10, \"i\": \"e75467ea-82ca-9f6b-ae93-e22957fe1697\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Age Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"9ea7ce9f-5bb4-72c5-5be9-c8b8f53b727b\", \"accessors\": [\"efce20bc-bdd4-19fc-3289-e7a670ec6e46\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"9ea7ce9f-5bb4-72c5-5be9-c8b8f53b727b\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"max_age\", \"columnId\": \"efce20bc-bdd4-19fc-3289-e7a670ec6e46\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"max_age\", \"columnId\": \"efce20bc-bdd4-19fc-3289-e7a670ec6e46\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"9a325fad-2e84-d2d6-4737-c9d5addbd26e\", \"gridData\": {\"x\": 0, \"y\": 54, \"w\": 48, \"h\": 3, \"i\": \"9a325fad-2e84-d2d6-4737-c9d5addbd26e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Traffic, Method Distribution & Network\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"c43a4883-7cb8-eb95-61e6-152104c9bd11\", \"gridData\": {\"x\": 0, \"y\": 57, \"w\": 12, \"h\": 10, \"i\": \"c43a4883-7cb8-eb95-61e6-152104c9bd11\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Method Distribution\", \"visualizationType\": \"lnsPie\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"672deec4-9160-eea9-ef60-c7e7673edd20\", \"layerType\": \"data\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}, \"primaryGroups\": [\"832a40a5-0d17-20cc-1799-0d4c98b841c4\"], \"metrics\": [\"e43af042-3fa3-61be-f3d7-62e1baefc7e7\"], \"numberDisplay\": \"percent\", \"categoryDisplay\": \"default\", \"legendDisplay\": \"default\", \"nestedLegend\": false}], \"shape\": \"pie\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\\n| SORT total DESC\\n| LIMIT 10\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"672deec4-9160-eea9-ef60-c7e7673edd20\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\\n| SORT total DESC\\n| LIMIT 10\\n\"}, \"columns\": [{\"fieldName\": \"total\", \"columnId\": \"e43af042-3fa3-61be-f3d7-62e1baefc7e7\", \"label\": \"total\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"total\", \"columnId\": \"e43af042-3fa3-61be-f3d7-62e1baefc7e7\", \"label\": \"total\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497\", \"gridData\": {\"x\": 12, \"y\": 57, \"w\": 24, \"h\": 10, \"i\": \"d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Network Throughput by Direction\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"2e13466d-46b0-3fe7-b853-613b5d3f6c5e\", \"accessors\": [\"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"fe86b495-7752-6f2d-44dc-203bce848544\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"2e13466d-46b0-3fe7-b853-613b5d3f6c5e\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.direction\", \"columnId\": \"fe86b495-7752-6f2d-44dc-203bce848544\", \"label\": \"attributes.direction\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.direction\", \"columnId\": \"fe86b495-7752-6f2d-44dc-203bce848544\", \"label\": \"attributes.direction\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"14976295-25a9-0b8c-cdc5-e98753bd2bbe\", \"gridData\": {\"x\": 36, \"y\": 57, \"w\": 12, \"h\": 10, \"i\": \"14976295-25a9-0b8c-cdc5-e98753bd2bbe\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Connection Attempts Rate\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"208be375-a11f-8910-a5ce-e993bdeb4a48\", \"accessors\": [\"0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"bottom\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.attempt.count` IS NOT NULL\\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"208be375-a11f-8910-a5ce-e993bdeb4a48\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.attempt.count` IS NOT NULL\\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"conn_rate\", \"columnId\": \"0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2\", \"label\": \"conn_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"conn_rate\", \"columnId\": \"0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2\", \"label\": \"conn_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"62953700-7a24-57d5-a2a0-ab0aa34c850a\", \"gridData\": {\"x\": 0, \"y\": 67, \"w\": 24, \"h\": 10, \"i\": \"62953700-7a24-57d5-a2a0-ab0aa34c850a\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections and Connection Attempts Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"af83e35f-7589-ecc6-71db-7e9e91d7300a\", \"accessors\": [\"e69a4803-c22b-cba0-e508-01c3fe86ec24\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"af83e35f-7589-ecc6-71db-7e9e91d7300a\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"937f0d95-1ed6-015e-58a6-47b6b543dae8\", \"gridData\": {\"x\": 24, \"y\": 67, \"w\": 24, \"h\": 10, \"i\": \"937f0d95-1ed6-015e-58a6-47b6b543dae8\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Threads Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\", \"accessors\": [\"9285a34b-2f64-b4a4-a660-df6762b1a5ef\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"c601e964-d18c-2c8d-e202-057197d76666\", \"gridData\": {\"x\": 0, \"y\": 77, \"w\": 24, \"h\": 10, \"i\": \"c601e964-d18c-2c8d-e202-057197d76666\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Bandwidth Throttling Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"7e0bb619-2f97-53d1-f665-2da5bec7f452\", \"accessors\": [\"f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.blocked` IS NOT NULL\\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"7e0bb619-2f97-53d1-f665-2da5bec7f452\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.blocked` IS NOT NULL\\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"blocked\", \"columnId\": \"f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6\", \"label\": \"blocked\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"blocked\", \"columnId\": \"f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6\", \"label\": \"blocked\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"33ec49e3-d414-5288-c27e-dd7c855b7ede\", \"gridData\": {\"x\": 0, \"y\": 87, \"w\": 48, \"h\": 3, \"i\": \"33ec49e3-d414-5288-c27e-dd7c855b7ede\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Top Sites & Application Pools\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"4b178876-d6bc-6817-cb95-9410be79a3d5\", \"gridData\": {\"x\": 0, \"y\": 90, \"w\": 24, \"h\": 15, \"i\": \"4b178876-d6bc-6817-cb95-9410be79a3d5\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Sites by Request Rate\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"1146ad2e-b45b-c51e-a472-c2a5df85e06d\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 20\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"1146ad2e-b45b-c51e-a472-c2a5df85e06d\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 20\"}, \"columns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f5caab11-b09c-9683-20ca-e18a4a976389\", \"gridData\": {\"x\": 24, \"y\": 90, \"w\": 24, \"h\": 15, \"i\": \"f5caab11-b09c-9683-20ca-e18a4a976389\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Application Pools \\u2014 State Summary\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"383e53a9-74bd-03a4-5f81-ad611d89e4ab\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"ede5f01c-ef7b-064c-9b87-19ba855dec60\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND iis.application_pool IS NOT NULL\\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ede5f01c-ef7b-064c-9b87-19ba855dec60\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND iis.application_pool IS NOT NULL\\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"columns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"queue\", \"columnId\": \"383e53a9-74bd-03a4-5f81-ad611d89e4ab\", \"label\": \"Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"queue\", \"columnId\": \"383e53a9-74bd-03a4-5f81-ad611d89e4ab\", \"label\": \"Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
-    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"iisreceiver.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"iisreceiver.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+    "attributes": {
+        "title": "[IIS OTel] Overview",
+        "description": "Comprehensive operational visibility for IIS web servers instrumented via OpenTelemetry iisreceiver. Tracks application pool health, request handling capacity, traffic patterns, and resource utilization.",
+        "panelsJSON": [
+            {
+                "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+                "gridData": {
+                    "x": 0,
+                    "y": 0,
+                    "w": 48,
+                    "h": 2,
+                    "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+                },
+                "type": "links",
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "attributes": {
+                        "layout": "horizontal",
+                        "links": [
+                            {
+                                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                                "order": 0,
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+                            },
+                            {
+                                "id": "311e2098-d3cb-e8f4-bf13-b097739154c3",
+                                "order": 1,
+                                "label": "Sites & Pools",
+                                "type": "dashboardLink",
+                                "destinationRefName": "link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+                "gridData": {
+                    "x": 0,
+                    "y": 2,
+                    "w": 16,
+                    "h": 12,
+                    "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## [IIS OTel] Overview\n\nThis dashboard provides operational visibility for **IIS** instrumented via the OpenTelemetry **iisreceiver** (collector-contrib):\n\n- **Pool health** — State and uptime; any pool not Running = outage\n- **Request handling** — Queue depth, age, rejections (primary saturation/error signals)\n- **Traffic** — Request rate by method, connections, network throughput\n- **Resources** — Active threads, bandwidth throttling\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "813ddedf-a285-d443-e8ec-de7939b683e7",
+                "gridData": {
+                    "x": 16,
+                    "y": 2,
+                    "w": 8,
+                    "h": 4,
+                    "i": "813ddedf-a285-d443-e8ec-de7939b683e7"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Unhealthy Pools",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "bda3162c-dbfd-0ca0-0ee3-54facd6d8374",
+                                "layerType": "data",
+                                "metricAccessor": "bf33d9f0-8c74-9c20-7eaa-64ec1274d785",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "bda3162c-dbfd-0ca0-0ee3-54facd6d8374": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "unhealthy",
+                                                    "columnId": "bf33d9f0-8c74-9c20-7eaa-64ec1274d785",
+                                                    "label": "unhealthy",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "unhealthy",
+                                                    "columnId": "bf33d9f0-8c74-9c20-7eaa-64ec1274d785",
+                                                    "label": "unhealthy",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "fa7fc00e-10f4-d95c-fee4-8f735303518a"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fa7fc00e-10f4-d95c-fee4-8f735303518a",
+                                    "name": "indexpattern-datasource-layer-bda3162c-dbfd-0ca0-0ee3-54facd6d8374"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fa7fc00e-10f4-d95c-fee4-8f735303518a": {
+                                    "id": "fa7fc00e-10f4-d95c-fee4-8f735303518a",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "95fa3c06-c2bd-c69a-db35-556c2f3c71d6",
+                "gridData": {
+                    "x": 24,
+                    "y": 2,
+                    "w": 8,
+                    "h": 4,
+                    "i": "95fa3c06-c2bd-c69a-db35-556c2f3c71d6"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Pools Running",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "e6764449-b92a-8a14-a667-376f9670da69",
+                                "layerType": "data",
+                                "metricAccessor": "4646b428-dd78-79e2-1f8c-8f227f5882cd",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "e6764449-b92a-8a14-a667-376f9670da69": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "pools_running",
+                                                    "columnId": "4646b428-dd78-79e2-1f8c-8f227f5882cd",
+                                                    "label": "pools_running",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "pools_running",
+                                                    "columnId": "4646b428-dd78-79e2-1f8c-8f227f5882cd",
+                                                    "label": "pools_running",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "0ee137d3-a163-8296-ca68-d7174aa02aef"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0ee137d3-a163-8296-ca68-d7174aa02aef",
+                                    "name": "indexpattern-datasource-layer-e6764449-b92a-8a14-a667-376f9670da69"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0ee137d3-a163-8296-ca68-d7174aa02aef": {
+                                    "id": "0ee137d3-a163-8296-ca68-d7174aa02aef",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "ab63f3d4-0787-0d45-2876-5028b2132cce",
+                "gridData": {
+                    "x": 32,
+                    "y": 2,
+                    "w": 8,
+                    "h": 4,
+                    "i": "ab63f3d4-0787-0d45-2876-5028b2132cce"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Request Rate",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "4e22bdc8-38c8-a45e-1c51-e32343a8b1ea",
+                                "layerType": "data",
+                                "metricAccessor": "81965363-fb67-2557-4505-b22cb301863c",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`))\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "4e22bdc8-38c8-a45e-1c51-e32343a8b1ea": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`))\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "81965363-fb67-2557-4505-b22cb301863c",
+                                                    "label": "req_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "81965363-fb67-2557-4505-b22cb301863c",
+                                                    "label": "req_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "1674350b-2d08-cbe0-6112-0970d8f78ee7"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1674350b-2d08-cbe0-6112-0970d8f78ee7",
+                                    "name": "indexpattern-datasource-layer-4e22bdc8-38c8-a45e-1c51-e32343a8b1ea"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1674350b-2d08-cbe0-6112-0970d8f78ee7": {
+                                    "id": "1674350b-2d08-cbe0-6112-0970d8f78ee7",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "eac7ed13-3f78-1d43-4da3-b28d55f68ed9",
+                "gridData": {
+                    "x": 40,
+                    "y": 2,
+                    "w": 8,
+                    "h": 4,
+                    "i": "eac7ed13-3f78-1d43-4da3-b28d55f68ed9"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Rejected Requests",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "8dc33f88-2789-7e4b-52dc-50009119fcb8",
+                                "layerType": "data",
+                                "metricAccessor": "9a0e1840-102e-630c-ad19-9772a5954598",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "8dc33f88-2789-7e4b-52dc-50009119fcb8": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "rej_rate",
+                                                    "columnId": "9a0e1840-102e-630c-ad19-9772a5954598",
+                                                    "label": "rej_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "rej_rate",
+                                                    "columnId": "9a0e1840-102e-630c-ad19-9772a5954598",
+                                                    "label": "rej_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "8c5c168f-0b73-ebae-faa9-a9a3223993ee"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8c5c168f-0b73-ebae-faa9-a9a3223993ee",
+                                    "name": "indexpattern-datasource-layer-8dc33f88-2789-7e4b-52dc-50009119fcb8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8c5c168f-0b73-ebae-faa9-a9a3223993ee": {
+                                    "id": "8c5c168f-0b73-ebae-faa9-a9a3223993ee",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "f6254395-a5b0-089a-6a73-298a6896dbc2",
+                "gridData": {
+                    "x": 16,
+                    "y": 6,
+                    "w": 8,
+                    "h": 4,
+                    "i": "f6254395-a5b0-089a-6a73-298a6896dbc2"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Max Queue Depth",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "442bbb0a-3b70-b4fc-464e-59783c5735ac",
+                                "layerType": "data",
+                                "metricAccessor": "ff79665d-2ebc-ced3-506e-52f66eae4e6b",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`)\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "442bbb0a-3b70-b4fc-464e-59783c5735ac": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`)\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "max_queue",
+                                                    "columnId": "ff79665d-2ebc-ced3-506e-52f66eae4e6b",
+                                                    "label": "max_queue",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "max_queue",
+                                                    "columnId": "ff79665d-2ebc-ced3-506e-52f66eae4e6b",
+                                                    "label": "max_queue",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "44c8ea64-3f4f-8170-ece1-b5b7e5601953"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "44c8ea64-3f4f-8170-ece1-b5b7e5601953",
+                                    "name": "indexpattern-datasource-layer-442bbb0a-3b70-b4fc-464e-59783c5735ac"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "44c8ea64-3f4f-8170-ece1-b5b7e5601953": {
+                                    "id": "44c8ea64-3f4f-8170-ece1-b5b7e5601953",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "b20d2603-819c-4c4f-762e-406a5009f675",
+                "gridData": {
+                    "x": 24,
+                    "y": 6,
+                    "w": 8,
+                    "h": 4,
+                    "i": "b20d2603-819c-4c4f-762e-406a5009f675"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Max Queue Age",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "7ede041e-21a1-5906-36bf-8ecda7b3e71a",
+                                "layerType": "data",
+                                "metricAccessor": "2b930ad7-aabc-3c27-a4cb-1ac40e558e2b",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`)\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "7ede041e-21a1-5906-36bf-8ecda7b3e71a": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`)\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "max_age",
+                                                    "columnId": "2b930ad7-aabc-3c27-a4cb-1ac40e558e2b",
+                                                    "label": "max_age",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "max_age",
+                                                    "columnId": "2b930ad7-aabc-3c27-a4cb-1ac40e558e2b",
+                                                    "label": "max_age",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "7abf2984-cae7-2536-2fd3-592cd8659a0c"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7abf2984-cae7-2536-2fd3-592cd8659a0c",
+                                    "name": "indexpattern-datasource-layer-7ede041e-21a1-5906-36bf-8ecda7b3e71a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7abf2984-cae7-2536-2fd3-592cd8659a0c": {
+                                    "id": "7abf2984-cae7-2536-2fd3-592cd8659a0c",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "90a8c058-4a5c-8e56-a4d8-44db0887cca7",
+                "gridData": {
+                    "x": 32,
+                    "y": 6,
+                    "w": 8,
+                    "h": 4,
+                    "i": "90a8c058-4a5c-8e56-a4d8-44db0887cca7"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Active Connections",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "3e1b6254-52f9-e647-e5ef-244c5bd4fc8b",
+                                "layerType": "data",
+                                "metricAccessor": "61342c3c-90c1-d070-c42d-993ff9c4b41b",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`)\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "3e1b6254-52f9-e647-e5ef-244c5bd4fc8b": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`)\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "connections",
+                                                    "columnId": "61342c3c-90c1-d070-c42d-993ff9c4b41b",
+                                                    "label": "connections",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "connections",
+                                                    "columnId": "61342c3c-90c1-d070-c42d-993ff9c4b41b",
+                                                    "label": "connections",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "e135a8f6-bc77-e825-d073-4c8e18c60ce3"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e135a8f6-bc77-e825-d073-4c8e18c60ce3",
+                                    "name": "indexpattern-datasource-layer-3e1b6254-52f9-e647-e5ef-244c5bd4fc8b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e135a8f6-bc77-e825-d073-4c8e18c60ce3": {
+                                    "id": "e135a8f6-bc77-e825-d073-4c8e18c60ce3",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "7c65e231-552e-caaa-87a5-2e4e5ed1f96e",
+                "gridData": {
+                    "x": 40,
+                    "y": 6,
+                    "w": 8,
+                    "h": 4,
+                    "i": "7c65e231-552e-caaa-87a5-2e4e5ed1f96e"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Active Threads",
+                        "visualizationType": "lnsMetric",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layerId": "91ac654e-12ab-51ba-bdc6-56a6a696bc0e",
+                                "layerType": "data",
+                                "metricAccessor": "26af5da4-63a5-b237-af12-13a66ce6a012",
+                                "showBar": false,
+                                "applyColorTo": "background"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`)\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "91ac654e-12ab-51ba-bdc6-56a6a696bc0e": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`)\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "threads",
+                                                    "columnId": "26af5da4-63a5-b237-af12-13a66ce6a012",
+                                                    "label": "threads",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "threads",
+                                                    "columnId": "26af5da4-63a5-b237-af12-13a66ce6a012",
+                                                    "label": "threads",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "f342ac2e-5022-4878-1793-295d6ce6e30f"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f342ac2e-5022-4878-1793-295d6ce6e30f",
+                                    "name": "indexpattern-datasource-layer-91ac654e-12ab-51ba-bdc6-56a6a696bc0e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f342ac2e-5022-4878-1793-295d6ce6e30f": {
+                                    "id": "f342ac2e-5022-4878-1793-295d6ce6e30f",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "98dd998b-7197-65f6-2395-6f3b86cdb1e8",
+                "gridData": {
+                    "x": 0,
+                    "y": 14,
+                    "w": 48,
+                    "h": 3,
+                    "i": "98dd998b-7197-65f6-2395-6f3b86cdb1e8"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## Application Pool Health & State\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "34d9cc5f-7571-24f7-fef6-bd05516fb5b3",
+                "gridData": {
+                    "x": 0,
+                    "y": 17,
+                    "w": 24,
+                    "h": 12,
+                    "i": "34d9cc5f-7571-24f7-fef6-bd05516fb5b3"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Application Pool Health — State & Uptime Table",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "f74a569d-7f26-747b-8223-c7483b3b95d2",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "dd0c94d5-837e-18b9-5c5f-7e743e86b835",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "cc79f498-21ab-d51a-8917-38ac86fdad03",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "c6f1a666-cd4f-d9be-5670-44ad3ec15c00",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "c6f1a666-cd4f-d9be-5670-44ad3ec15c00": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "host",
+                                                    "columnId": "f74a569d-7f26-747b-8223-c7483b3b95d2",
+                                                    "label": "Host",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "state_label",
+                                                    "columnId": "dd0c94d5-837e-18b9-5c5f-7e743e86b835",
+                                                    "label": "State",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "uptime",
+                                                    "columnId": "cc79f498-21ab-d51a-8917-38ac86fdad03",
+                                                    "label": "Uptime (ms)",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "host",
+                                                    "columnId": "f74a569d-7f26-747b-8223-c7483b3b95d2",
+                                                    "label": "Host",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "state_label",
+                                                    "columnId": "dd0c94d5-837e-18b9-5c5f-7e743e86b835",
+                                                    "label": "State",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "uptime",
+                                                    "columnId": "cc79f498-21ab-d51a-8917-38ac86fdad03",
+                                                    "label": "Uptime (ms)",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "76df2ebe-ce1e-cc2c-715d-62c1d3d911e1"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "76df2ebe-ce1e-cc2c-715d-62c1d3d911e1",
+                                    "name": "indexpattern-datasource-layer-c6f1a666-cd4f-d9be-5670-44ad3ec15c00"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "76df2ebe-ce1e-cc2c-715d-62c1d3d911e1": {
+                                    "id": "76df2ebe-ce1e-cc2c-715d-62c1d3d911e1",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "10d284ec-b188-cdbf-e310-0e39f6e87d33",
+                "gridData": {
+                    "x": 24,
+                    "y": 17,
+                    "w": 24,
+                    "h": 12,
+                    "i": "10d284ec-b188-cdbf-e310-0e39f6e87d33"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Pool Uptime Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "c154d920-2ffa-5de9-4e4c-77864d437ce7",
+                                        "accessors": [
+                                            "44c283a7-8a78-dd3c-5b66-4c7e8ca5defc"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "858047d9-f6df-9e41-3f05-349c16cdfb25",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "c154d920-2ffa-5de9-4e4c-77864d437ce7": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "uptime",
+                                                    "columnId": "44c283a7-8a78-dd3c-5b66-4c7e8ca5defc",
+                                                    "label": "uptime",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "858047d9-f6df-9e41-3f05-349c16cdfb25",
+                                                    "label": "pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "uptime",
+                                                    "columnId": "44c283a7-8a78-dd3c-5b66-4c7e8ca5defc",
+                                                    "label": "uptime",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "858047d9-f6df-9e41-3f05-349c16cdfb25",
+                                                    "label": "pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "9d37012e-373c-ef3a-0724-b8683da643fa"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9d37012e-373c-ef3a-0724-b8683da643fa",
+                                    "name": "indexpattern-datasource-layer-c154d920-2ffa-5de9-4e4c-77864d437ce7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9d37012e-373c-ef3a-0724-b8683da643fa": {
+                                    "id": "9d37012e-373c-ef3a-0724-b8683da643fa",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "f3c72600-acb1-c4be-af9d-1055b48a0a2a",
+                "gridData": {
+                    "x": 0,
+                    "y": 29,
+                    "w": 48,
+                    "h": 3,
+                    "i": "f3c72600-acb1-c4be-af9d-1055b48a0a2a"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## Request Rate & Queue Metrics\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "6fea96a6-f528-9373-2e0e-386184013bbd",
+                "gridData": {
+                    "x": 0,
+                    "y": 32,
+                    "w": 24,
+                    "h": 12,
+                    "i": "6fea96a6-f528-9373-2e0e-386184013bbd"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Request Rate by HTTP Method Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "7ede10ca-1940-fffe-68ce-565170287dba",
+                                        "accessors": [
+                                            "b1911db0-e346-dde6-337e-a829f741712f"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "area",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c0ec0d2c-81da-043d-c55e-0717297d84c5",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "area",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "7ede10ca-1940-fffe-68ce-565170287dba": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "b1911db0-e346-dde6-337e-a829f741712f",
+                                                    "label": "req_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "attributes.request",
+                                                    "columnId": "c0ec0d2c-81da-043d-c55e-0717297d84c5",
+                                                    "label": "attributes.request",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "b1911db0-e346-dde6-337e-a829f741712f",
+                                                    "label": "req_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "attributes.request",
+                                                    "columnId": "c0ec0d2c-81da-043d-c55e-0717297d84c5",
+                                                    "label": "attributes.request",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "2073f5f5-db63-3f5c-a16a-b367e181dd5f"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2073f5f5-db63-3f5c-a16a-b367e181dd5f",
+                                    "name": "indexpattern-datasource-layer-7ede10ca-1940-fffe-68ce-565170287dba"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2073f5f5-db63-3f5c-a16a-b367e181dd5f": {
+                                    "id": "2073f5f5-db63-3f5c-a16a-b367e181dd5f",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "4f435521-b3f6-be32-0518-4c26873c5dc9",
+                "gridData": {
+                    "x": 24,
+                    "y": 32,
+                    "w": 24,
+                    "h": 12,
+                    "i": "4f435521-b3f6-be32-0518-4c26873c5dc9"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Queue Depth and Rejections Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "f8520190-940c-e7c1-f994-ee2b31ad94ed",
+                                        "accessors": [
+                                            "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                            "dafc20a2-21a9-1560-3d32-082ef9c83e85"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\"\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "f8520190-940c-e7c1-f994-ee2b31ad94ed": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\"\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "queue_depth",
+                                                    "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                                    "label": "queue_depth",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "rej_rate",
+                                                    "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                                                    "label": "rej_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "queue_depth",
+                                                    "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                                    "label": "queue_depth",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "rej_rate",
+                                                    "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                                                    "label": "rej_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "9c372f87-02cb-4511-4dd1-94ddb774c58d"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9c372f87-02cb-4511-4dd1-94ddb774c58d",
+                                    "name": "indexpattern-datasource-layer-f8520190-940c-e7c1-f994-ee2b31ad94ed"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9c372f87-02cb-4511-4dd1-94ddb774c58d": {
+                                    "id": "9c372f87-02cb-4511-4dd1-94ddb774c58d",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "eee5aea0-a409-c924-2c9a-6904041a625c",
+                "gridData": {
+                    "x": 0,
+                    "y": 44,
+                    "w": 12,
+                    "h": 10,
+                    "i": "eee5aea0-a409-c924-2c9a-6904041a625c"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Queue Depth Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "b19928ff-34f8-fef9-90e1-6497f9aff44e",
+                                        "accessors": [
+                                            "e976855b-f978-6e5c-9596-70700fbfefb7"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "bottom"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "b19928ff-34f8-fef9-90e1-6497f9aff44e": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "queue_depth",
+                                                    "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                                    "label": "queue_depth",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "queue_depth",
+                                                    "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                                    "label": "queue_depth",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "1a87ea9e-fc9c-8ad2-68ab-678e63f58f73"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1a87ea9e-fc9c-8ad2-68ab-678e63f58f73",
+                                    "name": "indexpattern-datasource-layer-b19928ff-34f8-fef9-90e1-6497f9aff44e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1a87ea9e-fc9c-8ad2-68ab-678e63f58f73": {
+                                    "id": "1a87ea9e-fc9c-8ad2-68ab-678e63f58f73",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "872b997d-1b64-79cb-596e-27e82d85296d",
+                "gridData": {
+                    "x": 12,
+                    "y": 44,
+                    "w": 12,
+                    "h": 10,
+                    "i": "872b997d-1b64-79cb-596e-27e82d85296d"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Rejections Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "aba5e35c-5613-11a7-4076-7c9716f0b87c",
+                                        "accessors": [
+                                            "dafc20a2-21a9-1560-3d32-082ef9c83e85"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "bottom"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "aba5e35c-5613-11a7-4076-7c9716f0b87c": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "rej_rate",
+                                                    "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                                                    "label": "rej_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "rej_rate",
+                                                    "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                                                    "label": "rej_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "93da3e3e-4fdf-a8f8-28ee-581451eeff7b"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "93da3e3e-4fdf-a8f8-28ee-581451eeff7b",
+                                    "name": "indexpattern-datasource-layer-aba5e35c-5613-11a7-4076-7c9716f0b87c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "93da3e3e-4fdf-a8f8-28ee-581451eeff7b": {
+                                    "id": "93da3e3e-4fdf-a8f8-28ee-581451eeff7b",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "e75467ea-82ca-9f6b-ae93-e22957fe1697",
+                "gridData": {
+                    "x": 24,
+                    "y": 44,
+                    "w": 24,
+                    "h": 10,
+                    "i": "e75467ea-82ca-9f6b-ae93-e22957fe1697"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Queue Age Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "63dcbb45-1c5f-8565-7a1e-bf4ef2be6206",
+                                        "accessors": [
+                                            "efce20bc-bdd4-19fc-3289-e7a670ec6e46"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "63dcbb45-1c5f-8565-7a1e-bf4ef2be6206": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "max_age",
+                                                    "columnId": "efce20bc-bdd4-19fc-3289-e7a670ec6e46",
+                                                    "label": "max_age",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "max_age",
+                                                    "columnId": "efce20bc-bdd4-19fc-3289-e7a670ec6e46",
+                                                    "label": "max_age",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "e8f87ac9-9e99-30dd-d76f-8368d7d749c2"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e8f87ac9-9e99-30dd-d76f-8368d7d749c2",
+                                    "name": "indexpattern-datasource-layer-63dcbb45-1c5f-8565-7a1e-bf4ef2be6206"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e8f87ac9-9e99-30dd-d76f-8368d7d749c2": {
+                                    "id": "e8f87ac9-9e99-30dd-d76f-8368d7d749c2",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "9a325fad-2e84-d2d6-4737-c9d5addbd26e",
+                "gridData": {
+                    "x": 0,
+                    "y": 54,
+                    "w": 48,
+                    "h": 3,
+                    "i": "9a325fad-2e84-d2d6-4737-c9d5addbd26e"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## Traffic, Method Distribution & Network\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "c43a4883-7cb8-eb95-61e6-152104c9bd11",
+                "gridData": {
+                    "x": 0,
+                    "y": 57,
+                    "w": 12,
+                    "h": 10,
+                    "i": "c43a4883-7cb8-eb95-61e6-152104c9bd11"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Request Method Distribution",
+                        "visualizationType": "lnsPie",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "b46a9114-989f-99a7-82bc-f89bf10bc833",
+                                        "layerType": "data",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        },
+                                        "primaryGroups": [
+                                            "6c9d0e9d-e0f1-0086-c6ad-1527a89e832e"
+                                        ],
+                                        "metrics": [
+                                            "e43af042-3fa3-61be-f3d7-62e1baefc7e7"
+                                        ],
+                                        "numberDisplay": "percent",
+                                        "categoryDisplay": "default",
+                                        "legendDisplay": "default",
+                                        "legendPosition": "right",
+                                        "nestedLegend": false
+                                    }
+                                ],
+                                "shape": "pie"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\n| SORT total DESC\n| LIMIT 10\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "b46a9114-989f-99a7-82bc-f89bf10bc833": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\n| SORT total DESC\n| LIMIT 10\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "total",
+                                                    "columnId": "e43af042-3fa3-61be-f3d7-62e1baefc7e7",
+                                                    "label": "total",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "attributes.request",
+                                                    "columnId": "6c9d0e9d-e0f1-0086-c6ad-1527a89e832e",
+                                                    "label": "attributes.request",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "total",
+                                                    "columnId": "e43af042-3fa3-61be-f3d7-62e1baefc7e7",
+                                                    "label": "total",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "attributes.request",
+                                                    "columnId": "6c9d0e9d-e0f1-0086-c6ad-1527a89e832e",
+                                                    "label": "attributes.request",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "292fdc16-2db9-2e92-c29a-662205d45317"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "292fdc16-2db9-2e92-c29a-662205d45317",
+                                    "name": "indexpattern-datasource-layer-b46a9114-989f-99a7-82bc-f89bf10bc833"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "292fdc16-2db9-2e92-c29a-662205d45317": {
+                                    "id": "292fdc16-2db9-2e92-c29a-662205d45317",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497",
+                "gridData": {
+                    "x": 12,
+                    "y": 57,
+                    "w": 24,
+                    "h": 10,
+                    "i": "d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Network Throughput by Direction",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "6d3e97de-f450-3d4b-0837-5642c0eb4973",
+                                        "accessors": [
+                                            "d17d0e31-7edb-b976-81cb-d9a16f07f2a2"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "area",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "130f59f2-2282-28a4-b90a-1a9cb52ebd27",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "area",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "6d3e97de-f450-3d4b-0837-5642c0eb4973": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "throughput",
+                                                    "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                                                    "label": "throughput",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "attributes.direction",
+                                                    "columnId": "130f59f2-2282-28a4-b90a-1a9cb52ebd27",
+                                                    "label": "attributes.direction",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "throughput",
+                                                    "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                                                    "label": "throughput",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "attributes.direction",
+                                                    "columnId": "130f59f2-2282-28a4-b90a-1a9cb52ebd27",
+                                                    "label": "attributes.direction",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "1d7622c1-fd97-e0de-bed5-29380a55a5c2"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1d7622c1-fd97-e0de-bed5-29380a55a5c2",
+                                    "name": "indexpattern-datasource-layer-6d3e97de-f450-3d4b-0837-5642c0eb4973"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1d7622c1-fd97-e0de-bed5-29380a55a5c2": {
+                                    "id": "1d7622c1-fd97-e0de-bed5-29380a55a5c2",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "14976295-25a9-0b8c-cdc5-e98753bd2bbe",
+                "gridData": {
+                    "x": 36,
+                    "y": 57,
+                    "w": 12,
+                    "h": 10,
+                    "i": "14976295-25a9-0b8c-cdc5-e98753bd2bbe"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Connection Attempts Rate",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "42eaf28f-d711-4491-f351-c86e1a823e9f",
+                                        "accessors": [
+                                            "0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "bottom"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.attempt.count` IS NOT NULL\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "42eaf28f-d711-4491-f351-c86e1a823e9f": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.attempt.count` IS NOT NULL\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "conn_rate",
+                                                    "columnId": "0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2",
+                                                    "label": "conn_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "conn_rate",
+                                                    "columnId": "0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2",
+                                                    "label": "conn_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "2f6678f2-dc7a-2258-268e-1c0acf9e2f8f"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2f6678f2-dc7a-2258-268e-1c0acf9e2f8f",
+                                    "name": "indexpattern-datasource-layer-42eaf28f-d711-4491-f351-c86e1a823e9f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2f6678f2-dc7a-2258-268e-1c0acf9e2f8f": {
+                                    "id": "2f6678f2-dc7a-2258-268e-1c0acf9e2f8f",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "62953700-7a24-57d5-a2a0-ab0aa34c850a",
+                "gridData": {
+                    "x": 0,
+                    "y": 67,
+                    "w": 24,
+                    "h": 10,
+                    "i": "62953700-7a24-57d5-a2a0-ab0aa34c850a"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Active Connections and Connection Attempts Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "716739a7-b9e1-296e-8ccc-1c1ab269c401",
+                                        "accessors": [
+                                            "e69a4803-c22b-cba0-e508-01c3fe86ec24"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "716739a7-b9e1-296e-8ccc-1c1ab269c401": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "connections",
+                                                    "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                                                    "label": "connections",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "connections",
+                                                    "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                                                    "label": "connections",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "449d0757-96ac-ac43-761d-be05224901e2"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "449d0757-96ac-ac43-761d-be05224901e2",
+                                    "name": "indexpattern-datasource-layer-716739a7-b9e1-296e-8ccc-1c1ab269c401"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "449d0757-96ac-ac43-761d-be05224901e2": {
+                                    "id": "449d0757-96ac-ac43-761d-be05224901e2",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "937f0d95-1ed6-015e-58a6-47b6b543dae8",
+                "gridData": {
+                    "x": 24,
+                    "y": 67,
+                    "w": 24,
+                    "h": 10,
+                    "i": "937f0d95-1ed6-015e-58a6-47b6b543dae8"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Active Threads Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "f3b0db06-7131-2aa2-674e-5b90e4b68a07",
+                                        "accessors": [
+                                            "9285a34b-2f64-b4a4-a660-df6762b1a5ef"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "f3b0db06-7131-2aa2-674e-5b90e4b68a07": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "threads",
+                                                    "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                                                    "label": "threads",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "threads",
+                                                    "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                                                    "label": "threads",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "5c57d522-f506-a1f3-8bba-1ff5290fe912"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5c57d522-f506-a1f3-8bba-1ff5290fe912",
+                                    "name": "indexpattern-datasource-layer-f3b0db06-7131-2aa2-674e-5b90e4b68a07"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5c57d522-f506-a1f3-8bba-1ff5290fe912": {
+                                    "id": "5c57d522-f506-a1f3-8bba-1ff5290fe912",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "c601e964-d18c-2c8d-e202-057197d76666",
+                "gridData": {
+                    "x": 0,
+                    "y": 77,
+                    "w": 24,
+                    "h": 10,
+                    "i": "c601e964-d18c-2c8d-e202-057197d76666"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Bandwidth Throttling Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "b2e812b8-7135-9743-4add-dc205f9b8803",
+                                        "accessors": [
+                                            "f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.blocked` IS NOT NULL\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "b2e812b8-7135-9743-4add-dc205f9b8803": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.blocked` IS NOT NULL\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "blocked",
+                                                    "columnId": "f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6",
+                                                    "label": "blocked",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "blocked",
+                                                    "columnId": "f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6",
+                                                    "label": "blocked",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "0b009d3a-bdf7-3a3a-ee50-cdc3fc04fa45"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0b009d3a-bdf7-3a3a-ee50-cdc3fc04fa45",
+                                    "name": "indexpattern-datasource-layer-b2e812b8-7135-9743-4add-dc205f9b8803"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0b009d3a-bdf7-3a3a-ee50-cdc3fc04fa45": {
+                                    "id": "0b009d3a-bdf7-3a3a-ee50-cdc3fc04fa45",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "33ec49e3-d414-5288-c27e-dd7c855b7ede",
+                "gridData": {
+                    "x": 0,
+                    "y": 87,
+                    "w": 48,
+                    "h": 3,
+                    "i": "33ec49e3-d414-5288-c27e-dd7c855b7ede"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## Top Sites & Application Pools\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "4b178876-d6bc-6817-cb95-9410be79a3d5",
+                "gridData": {
+                    "x": 0,
+                    "y": 90,
+                    "w": 24,
+                    "h": 15,
+                    "i": "4b178876-d6bc-6817-cb95-9410be79a3d5"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Top Sites by Request Rate",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "7c03b6e0-7fef-84a4-b979-70d4bded8a9f",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "e8db2ae0-f306-b3ea-502c-1bf2361907c6",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 20"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "e8db2ae0-f306-b3ea-502c-1bf2361907c6": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 20"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                                    "label": "Site",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "7c03b6e0-7fef-84a4-b979-70d4bded8a9f",
+                                                    "label": "Requests/sec",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                                    "label": "Site",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "7c03b6e0-7fef-84a4-b979-70d4bded8a9f",
+                                                    "label": "Requests/sec",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "692e9053-0df5-d68e-18c9-b55d8cab43ce"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "692e9053-0df5-d68e-18c9-b55d8cab43ce",
+                                    "name": "indexpattern-datasource-layer-e8db2ae0-f306-b3ea-502c-1bf2361907c6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "692e9053-0df5-d68e-18c9-b55d8cab43ce": {
+                                    "id": "692e9053-0df5-d68e-18c9-b55d8cab43ce",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "f5caab11-b09c-9683-20ca-e18a4a976389",
+                "gridData": {
+                    "x": 24,
+                    "y": 90,
+                    "w": 24,
+                    "h": 15,
+                    "i": "f5caab11-b09c-9683-20ca-e18a4a976389"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Application Pools — State Summary",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "dd0c94d5-837e-18b9-5c5f-7e743e86b835",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "3290b03d-8ec9-9e8b-a1dd-ca32c17656ae",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    },
+                                    {
+                                        "columnId": "cc79f498-21ab-d51a-8917-38ac86fdad03",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "52490a81-a7eb-917a-01a1-7877423aa43c",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND iis.application_pool IS NOT NULL\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "52490a81-a7eb-917a-01a1-7877423aa43c": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND iis.application_pool IS NOT NULL\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "state_label",
+                                                    "columnId": "dd0c94d5-837e-18b9-5c5f-7e743e86b835",
+                                                    "label": "State",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "queue",
+                                                    "columnId": "3290b03d-8ec9-9e8b-a1dd-ca32c17656ae",
+                                                    "label": "Queue Depth",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "uptime",
+                                                    "columnId": "cc79f498-21ab-d51a-8917-38ac86fdad03",
+                                                    "label": "Uptime (ms)",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "state_label",
+                                                    "columnId": "dd0c94d5-837e-18b9-5c5f-7e743e86b835",
+                                                    "label": "State",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "queue",
+                                                    "columnId": "3290b03d-8ec9-9e8b-a1dd-ca32c17656ae",
+                                                    "label": "Queue Depth",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "uptime",
+                                                    "columnId": "cc79f498-21ab-d51a-8917-38ac86fdad03",
+                                                    "label": "Uptime (ms)",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "26523ead-b30a-af92-3c83-d145b9d49504"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "26523ead-b30a-af92-3c83-d145b9d49504",
+                                    "name": "indexpattern-datasource-layer-52490a81-a7eb-917a-01a1-7877423aa43c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "26523ead-b30a-af92-3c83-d145b9d49504": {
+                                    "id": "26523ead-b30a-af92-3c83-d145b9d49504",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            }
+        ],
+        "optionsJSON": {
+            "useMargins": true,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "hidePanelTitles": false
+        },
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "disabled": false,
+                            "negate": false,
+                            "alias": null,
+                            "type": "phrase",
+                            "key": "data_stream.dataset",
+                            "field": "data_stream.dataset",
+                            "params": {
+                                "query": "iisreceiver.otel"
+                            }
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iisreceiver.otel"
+                            }
+                        }
+                    }
+                ],
+                "query": {
+                    "query": "",
+                    "language": "kuery"
+                }
+            }
+        },
+        "timeRestore": true,
+        "timeFrom": "now-1h",
+        "timeTo": "now",
+        "version": 1,
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "ba14dd38-3256-313e-2eb9-8a73fea4ed25": {
+                    "grow": false,
+                    "order": 0,
+                    "width": "medium",
+                    "type": "optionsListControl",
+                    "explicitInput": {
+                        "id": "ba14dd38-3256-313e-2eb9-8a73fea4ed25",
+                        "dataViewId": "metrics-*",
+                        "fieldName": "resource.attributes.host.name",
+                        "title": "Host",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        }
+                    }
+                },
+                "a710b1ce-97f3-66d6-b2c5-09c5b73a4568": {
+                    "grow": false,
+                    "order": 1,
+                    "width": "medium",
+                    "type": "optionsListControl",
+                    "explicitInput": {
+                        "id": "a710b1ce-97f3-66d6-b2c5-09c5b73a4568",
+                        "dataViewId": "metrics-*",
+                        "fieldName": "iis.site",
+                        "title": "Site",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        }
+                    }
+                },
+                "2aa79284-fddb-46b6-64a3-983d23b2dd43": {
+                    "grow": false,
+                    "order": 2,
+                    "width": "medium",
+                    "type": "optionsListControl",
+                    "explicitInput": {
+                        "id": "2aa79284-fddb-46b6-64a3-983d23b2dd43",
+                        "dataViewId": "metrics-*",
+                        "fieldName": "iis.application_pool",
+                        "title": "Application Pool",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        }
+                    }
+                }
+            },
+            "showApplySelections": false
+        }
     },
-    "timeRestore": true,
-    "timeFrom": "now-1h",
-    "timeTo": "now",
-    "version": 1,
-    "controlGroupInput": {
-      "chainingSystem": "HIERARCHICAL",
-      "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"resource.attributes.host.name\",\"title\":\"Host\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.site\",\"title\":\"Site\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"2aa79284-fddb-46b6-64a3-983d23b2dd43\":{\"grow\":false,\"order\":2,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2aa79284-fddb-46b6-64a3-983d23b2dd43\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.application_pool\",\"title\":\"Application Pool\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
-      "showApplySelections": false
-    }
-  },
-  "coreMigrationVersion": "8.8.0",
-  "created_at": "2023-10-01T00:00:00Z",
-  "created_by": "admin",
-  "id": "iis_otel-overview",
-  "managed": false,
-  "references": [
-    {
-      "type": "dashboard",
-      "id": "iis_otel-overview",
-      "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
-    },
-    {
-      "type": "dashboard",
-      "id": "iis_otel-sites",
-      "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
-    },
-    {
-      "type": "index-pattern",
-      "id": "metrics-*",
-      "name": "controlGroup_ba14dd38-3256-313e-2eb9-8a73fea4ed25:optionsListDataView"
-    },
-    {
-      "type": "index-pattern",
-      "id": "metrics-*",
-      "name": "controlGroup_a710b1ce-97f3-66d6-b2c5-09c5b73a4568:optionsListDataView"
-    },
-    {
-      "type": "index-pattern",
-      "id": "metrics-*",
-      "name": "controlGroup_2aa79284-fddb-46b6-64a3-983d23b2dd43:optionsListDataView"
-    }
-  ],
-  "type": "dashboard",
-  "typeMigrationVersion": "10.2.0",
-  "updated_at": "2023-10-01T00:00:00Z",
-  "updated_by": "admin",
-  "version": "1"
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-10-01T00:00:00Z",
+    "created_by": "admin",
+    "id": "iis_otel-overview",
+    "managed": false,
+    "references": [
+        {
+            "type": "dashboard",
+            "id": "iis_otel-overview",
+            "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+        },
+        {
+            "type": "dashboard",
+            "id": "iis_otel-sites",
+            "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "controlGroup_ba14dd38-3256-313e-2eb9-8a73fea4ed25:optionsListDataView"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "controlGroup_a710b1ce-97f3-66d6-b2c5-09c5b73a4568:optionsListDataView"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "controlGroup_2aa79284-fddb-46b6-64a3-983d23b2dd43:optionsListDataView"
+        }
+    ],
+    "type": "dashboard",
+    "typeMigrationVersion": "10.2.0",
+    "updated_at": "2023-10-01T00:00:00Z",
+    "updated_by": "admin",
+    "version": "1"
 }

--- a/packages/iis_otel/kibana/dashboard/iis_otel-sites.json
+++ b/packages/iis_otel/kibana/dashboard/iis_otel-sites.json
@@ -1,59 +1,2056 @@
 {
-  "attributes": {
-    "title": "[IIS OTel] Sites & Pools",
-    "description": "Per-site and per-application-pool breakdown of request rate, network throughput, connections, queue metrics, and rejections. Supports capacity planning and per-tenant analysis.",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"311e2098-d3cb-e8f4-bf13-b097739154c3\", \"order\": 1, \"label\": \"Sites & Pools\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [IIS OTel] Sites & Pools\\n\\nThis dashboard provides per-site and per-application-pool breakdowns:\\n\\n- **Per-site** \\u2014 Request rate, network throughput, active connections\\n- **Per-pool** \\u2014 Queue depth, rejection rate, queue age, active threads\\n- **Detail tables** \\u2014 Top sites and pools by traffic and health\\n\\nUse the Host, Site, and Application Pool filters to narrow the view.\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"1c7012df-5cc7-34a1-5597-5373fcecbff6\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 32, \"h\": 12, \"i\": \"1c7012df-5cc7-34a1-5597-5373fcecbff6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate by Site\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"0c465483-dfd4-e2d3-507f-67f1b821efaa\", \"accessors\": [\"3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"0c465483-dfd4-e2d3-507f-67f1b821efaa\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af\", \"label\": \"request_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af\", \"label\": \"request_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"6fbdbb87-fb45-c3da-aed7-bea514676e1f\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 24, \"h\": 12, \"i\": \"6fbdbb87-fb45-c3da-aed7-bea514676e1f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Network Throughput by Site\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"6ea955e7-32d8-1231-d0d9-a5040c1dd5f0\", \"accessors\": [\"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"6ea955e7-32d8-1231-d0d9-a5040c1dd5f0\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"b9979009-5578-7141-2933-4fa0583cd882\", \"gridData\": {\"x\": 24, \"y\": 14, \"w\": 24, \"h\": 12, \"i\": \"b9979009-5578-7141-2933-4fa0583cd882\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections by Site\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"72f89635-d20b-efff-66a2-17c249116451\", \"accessors\": [\"e69a4803-c22b-cba0-e508-01c3fe86ec24\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"72f89635-d20b-efff-66a2-17c249116451\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2c63b4bb-844a-bad3-6fff-536f2d1f4b6e\", \"gridData\": {\"x\": 0, \"y\": 26, \"w\": 48, \"h\": 3, \"i\": \"2c63b4bb-844a-bad3-6fff-536f2d1f4b6e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Per-Application-Pool Metrics\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 24, \"h\": 12, \"i\": \"ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Depth by Pool\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"e30e9523-c233-3c51-155a-4582b0abed2d\", \"accessors\": [\"e976855b-f978-6e5c-9596-70700fbfefb7\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e30e9523-c233-3c51-155a-4582b0abed2d\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"05b2f9df-5188-db1e-2796-18cb493beef6\", \"gridData\": {\"x\": 24, \"y\": 29, \"w\": 24, \"h\": 12, \"i\": \"05b2f9df-5188-db1e-2796-18cb493beef6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejection Rate by Pool\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"ff033aca-ef68-7e0f-4374-669704a4af74\", \"accessors\": [\"94c16f55-bfe3-3609-6bad-10f1b6d92e7c\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ff033aca-ef68-7e0f-4374-669704a4af74\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"rejection_rate\", \"columnId\": \"94c16f55-bfe3-3609-6bad-10f1b6d92e7c\", \"label\": \"rejection_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rejection_rate\", \"columnId\": \"94c16f55-bfe3-3609-6bad-10f1b6d92e7c\", \"label\": \"rejection_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7c4344c7-425f-c9c2-aa97-4009ea1b4b5d\", \"gridData\": {\"x\": 0, \"y\": 41, \"w\": 24, \"h\": 12, \"i\": \"7c4344c7-425f-c9c2-aa97-4009ea1b4b5d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Age by Pool\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"869b4ddf-26c4-1055-1214-36de11156f9e\", \"accessors\": [\"034b560f-b710-abfb-87aa-04700d0fac5e\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"869b4ddf-26c4-1055-1214-36de11156f9e\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_age_ms\", \"columnId\": \"034b560f-b710-abfb-87aa-04700d0fac5e\", \"label\": \"queue_age_ms\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"queue_age_ms\", \"columnId\": \"034b560f-b710-abfb-87aa-04700d0fac5e\", \"label\": \"queue_age_ms\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"dd819480-c9aa-d638-ee8e-ff0aa6b3d934\", \"gridData\": {\"x\": 24, \"y\": 41, \"w\": 24, \"h\": 12, \"i\": \"dd819480-c9aa-d638-ee8e-ff0aa6b3d934\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Threads Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\", \"accessors\": [\"9285a34b-2f64-b4a4-a660-df6762b1a5ef\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"25facd50-b4a8-7a8c-60c5-d653f5f8b3e9\", \"gridData\": {\"x\": 0, \"y\": 53, \"w\": 48, \"h\": 3, \"i\": \"25facd50-b4a8-7a8c-60c5-d653f5f8b3e9\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Top Sites & Application Pools\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"0fffa92b-02c5-f0c4-d098-ba89a3915abb\", \"gridData\": {\"x\": 0, \"y\": 56, \"w\": 24, \"h\": 15, \"i\": \"0fffa92b-02c5-f0c4-d098-ba89a3915abb\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Sites by Request Count\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"be420b5c-0eaa-3390-b377-822f4d268b24\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"6afb878c-1dc6-f565-27b8-7b350df39dd1\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\\n| SORT total_requests DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"6afb878c-1dc6-f565-27b8-7b350df39dd1\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\\n| SORT total_requests DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"total_requests\", \"columnId\": \"be420b5c-0eaa-3390-b377-822f4d268b24\", \"label\": \"Total Requests\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"total_requests\", \"columnId\": \"be420b5c-0eaa-3390-b377-822f4d268b24\", \"label\": \"Total Requests\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"8e745e07-81c8-1aaf-6552-35e44b95ff33\", \"gridData\": {\"x\": 24, \"y\": 56, \"w\": 24, \"h\": 15, \"i\": \"8e745e07-81c8-1aaf-6552-35e44b95ff33\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Pools by Rejection Rate\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"9da88212-7b99-6af6-4b0e-060c74a32bba\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"4b4146c2-44db-ccfd-b6a0-33eb34faa0b0\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\\n| SORT rejection_rate DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"4b4146c2-44db-ccfd-b6a0-33eb34faa0b0\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\\n| SORT rejection_rate DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"iis.application_pool\", \"columnId\": \"9da88212-7b99-6af6-4b0e-060c74a32bba\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c\", \"label\": \"Rejections/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"iis.application_pool\", \"columnId\": \"9da88212-7b99-6af6-4b0e-060c74a32bba\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c\", \"label\": \"Rejections/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e5bc9ecd-4d83-a600-8a4a-3667f9a37642\", \"gridData\": {\"x\": 0, \"y\": 71, \"w\": 24, \"h\": 15, \"i\": \"e5bc9ecd-4d83-a600-8a4a-3667f9a37642\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Sites by Request Rate\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"907abc74-5aaa-8841-ac4d-e2e37c13de57\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"907abc74-5aaa-8841-ac4d-e2e37c13de57\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3df009d1-4950-6747-bfa1-958aac238cbd\", \"gridData\": {\"x\": 24, \"y\": 71, \"w\": 24, \"h\": 15, \"i\": \"3df009d1-4950-6747-bfa1-958aac238cbd\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Pools by Queue Depth\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"679f83c2-0608-6f7b-366c-d6be08613c7e\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"1372e37d-1581-a2d4-ee1e-0b9385a98a54\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\\n| SORT max_queue DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"1372e37d-1581-a2d4-ee1e-0b9385a98a54\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\\n| SORT max_queue DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"max_queue\", \"columnId\": \"679f83c2-0608-6f7b-366c-d6be08613c7e\", \"label\": \"Max Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"max_queue\", \"columnId\": \"679f83c2-0608-6f7b-366c-d6be08613c7e\", \"label\": \"Max Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
-    "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"iisreceiver.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"iisreceiver.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+    "attributes": {
+        "title": "[IIS OTel] Sites & Pools",
+        "description": "Per-site and per-application-pool breakdown of request rate, network throughput, connections, queue metrics, and rejections. Supports capacity planning and per-tenant analysis.",
+        "panelsJSON": [
+            {
+                "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+                "gridData": {
+                    "x": 0,
+                    "y": 0,
+                    "w": 48,
+                    "h": 2,
+                    "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+                },
+                "type": "links",
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "attributes": {
+                        "layout": "horizontal",
+                        "links": [
+                            {
+                                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                                "order": 0,
+                                "label": "Overview",
+                                "type": "dashboardLink",
+                                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+                            },
+                            {
+                                "id": "311e2098-d3cb-e8f4-bf13-b097739154c3",
+                                "order": 1,
+                                "label": "Sites & Pools",
+                                "type": "dashboardLink",
+                                "destinationRefName": "link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+                "gridData": {
+                    "x": 0,
+                    "y": 2,
+                    "w": 16,
+                    "h": 12,
+                    "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## [IIS OTel] Sites & Pools\n\nThis dashboard provides per-site and per-application-pool breakdowns:\n\n- **Per-site** — Request rate, network throughput, active connections\n- **Per-pool** — Queue depth, rejection rate, queue age, active threads\n- **Detail tables** — Top sites and pools by traffic and health\n\nUse the Host, Site, and Application Pool filters to narrow the view.\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "1c7012df-5cc7-34a1-5597-5373fcecbff6",
+                "gridData": {
+                    "x": 16,
+                    "y": 2,
+                    "w": 32,
+                    "h": 12,
+                    "i": "1c7012df-5cc7-34a1-5597-5373fcecbff6"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Request Rate by Site",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "9585d56f-e865-438a-6da8-dfcf4f735705",
+                                        "accessors": [
+                                            "3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "area",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "area",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "9585d56f-e865-438a-6da8-dfcf4f735705": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "request_rate",
+                                                    "columnId": "3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af",
+                                                    "label": "request_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                                    "label": "iis.site",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "request_rate",
+                                                    "columnId": "3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af",
+                                                    "label": "request_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                                    "label": "iis.site",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "e6129498-befd-dcd9-96a4-7288c0be098f"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e6129498-befd-dcd9-96a4-7288c0be098f",
+                                    "name": "indexpattern-datasource-layer-9585d56f-e865-438a-6da8-dfcf4f735705"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e6129498-befd-dcd9-96a4-7288c0be098f": {
+                                    "id": "e6129498-befd-dcd9-96a4-7288c0be098f",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "6fbdbb87-fb45-c3da-aed7-bea514676e1f",
+                "gridData": {
+                    "x": 0,
+                    "y": 14,
+                    "w": 24,
+                    "h": 12,
+                    "i": "6fbdbb87-fb45-c3da-aed7-bea514676e1f"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Network Throughput by Site",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "df752061-9b83-548b-65c2-bcd89d8f7789",
+                                        "accessors": [
+                                            "d17d0e31-7edb-b976-81cb-d9a16f07f2a2"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "area",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "area",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "df752061-9b83-548b-65c2-bcd89d8f7789": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "throughput",
+                                                    "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                                                    "label": "throughput",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                                    "label": "iis.site",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "throughput",
+                                                    "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                                                    "label": "throughput",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                                    "label": "iis.site",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "648ee4e0-bd12-641d-1b0d-e44183878ddd"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "648ee4e0-bd12-641d-1b0d-e44183878ddd",
+                                    "name": "indexpattern-datasource-layer-df752061-9b83-548b-65c2-bcd89d8f7789"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "648ee4e0-bd12-641d-1b0d-e44183878ddd": {
+                                    "id": "648ee4e0-bd12-641d-1b0d-e44183878ddd",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "b9979009-5578-7141-2933-4fa0583cd882",
+                "gridData": {
+                    "x": 24,
+                    "y": 14,
+                    "w": 24,
+                    "h": 12,
+                    "i": "b9979009-5578-7141-2933-4fa0583cd882"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Active Connections by Site",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "d5104778-f143-d87b-13f1-e0a56b595156",
+                                        "accessors": [
+                                            "e69a4803-c22b-cba0-e508-01c3fe86ec24"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "d5104778-f143-d87b-13f1-e0a56b595156": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "connections",
+                                                    "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                                                    "label": "connections",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                                    "label": "iis.site",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "connections",
+                                                    "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                                                    "label": "connections",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "4e138b02-ec44-26d1-ddf1-4da997743461",
+                                                    "label": "iis.site",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "81709912-7c58-563c-f5c7-4848184b2aa7"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "81709912-7c58-563c-f5c7-4848184b2aa7",
+                                    "name": "indexpattern-datasource-layer-d5104778-f143-d87b-13f1-e0a56b595156"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "81709912-7c58-563c-f5c7-4848184b2aa7": {
+                                    "id": "81709912-7c58-563c-f5c7-4848184b2aa7",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "2c63b4bb-844a-bad3-6fff-536f2d1f4b6e",
+                "gridData": {
+                    "x": 0,
+                    "y": 26,
+                    "w": 48,
+                    "h": 3,
+                    "i": "2c63b4bb-844a-bad3-6fff-536f2d1f4b6e"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## Per-Application-Pool Metrics\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9",
+                "gridData": {
+                    "x": 0,
+                    "y": 29,
+                    "w": 24,
+                    "h": 12,
+                    "i": "ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Queue Depth by Pool",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "a6dc9826-8a54-91d9-f6ac-765d864a82b0",
+                                        "accessors": [
+                                            "e976855b-f978-6e5c-9596-70700fbfefb7"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "a6dc9826-8a54-91d9-f6ac-765d864a82b0": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "queue_depth",
+                                                    "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                                    "label": "queue_depth",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                                    "label": "iis.application_pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "queue_depth",
+                                                    "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                                                    "label": "queue_depth",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                                    "label": "iis.application_pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "2d3b5318-aea9-2193-1f62-7e95aa66d4ee"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2d3b5318-aea9-2193-1f62-7e95aa66d4ee",
+                                    "name": "indexpattern-datasource-layer-a6dc9826-8a54-91d9-f6ac-765d864a82b0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2d3b5318-aea9-2193-1f62-7e95aa66d4ee": {
+                                    "id": "2d3b5318-aea9-2193-1f62-7e95aa66d4ee",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "05b2f9df-5188-db1e-2796-18cb493beef6",
+                "gridData": {
+                    "x": 24,
+                    "y": 29,
+                    "w": 24,
+                    "h": 12,
+                    "i": "05b2f9df-5188-db1e-2796-18cb493beef6"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Rejection Rate by Pool",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "e770efa8-36b3-eb0e-bcb9-f5d95c602d28",
+                                        "accessors": [
+                                            "94c16f55-bfe3-3609-6bad-10f1b6d92e7c"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "e770efa8-36b3-eb0e-bcb9-f5d95c602d28": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "rejection_rate",
+                                                    "columnId": "94c16f55-bfe3-3609-6bad-10f1b6d92e7c",
+                                                    "label": "rejection_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                                    "label": "iis.application_pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "rejection_rate",
+                                                    "columnId": "94c16f55-bfe3-3609-6bad-10f1b6d92e7c",
+                                                    "label": "rejection_rate",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                                    "label": "iis.application_pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "33dcf534-ca1c-4678-4b52-8dff377c14b8"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "33dcf534-ca1c-4678-4b52-8dff377c14b8",
+                                    "name": "indexpattern-datasource-layer-e770efa8-36b3-eb0e-bcb9-f5d95c602d28"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "33dcf534-ca1c-4678-4b52-8dff377c14b8": {
+                                    "id": "33dcf534-ca1c-4678-4b52-8dff377c14b8",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "7c4344c7-425f-c9c2-aa97-4009ea1b4b5d",
+                "gridData": {
+                    "x": 0,
+                    "y": 41,
+                    "w": 24,
+                    "h": 12,
+                    "i": "7c4344c7-425f-c9c2-aa97-4009ea1b4b5d"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Queue Age by Pool",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "f903b0b9-47c2-ec63-cb28-199228fce9b6",
+                                        "accessors": [
+                                            "034b560f-b710-abfb-87aa-04700d0fac5e"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "splitAccessor": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "f903b0b9-47c2-ec63-cb28-199228fce9b6": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "queue_age_ms",
+                                                    "columnId": "034b560f-b710-abfb-87aa-04700d0fac5e",
+                                                    "label": "queue_age_ms",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                                    "label": "iis.application_pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "queue_age_ms",
+                                                    "columnId": "034b560f-b710-abfb-87aa-04700d0fac5e",
+                                                    "label": "queue_age_ms",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "755bdb96-330e-cb72-5ec3-c28e2c587ddb",
+                                                    "label": "iis.application_pool",
+                                                    "customLabel": false
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "619cd8f7-b797-27c9-ad73-c52626ef8268"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "619cd8f7-b797-27c9-ad73-c52626ef8268",
+                                    "name": "indexpattern-datasource-layer-f903b0b9-47c2-ec63-cb28-199228fce9b6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "619cd8f7-b797-27c9-ad73-c52626ef8268": {
+                                    "id": "619cd8f7-b797-27c9-ad73-c52626ef8268",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "dd819480-c9aa-d638-ee8e-ff0aa6b3d934",
+                "gridData": {
+                    "x": 24,
+                    "y": 41,
+                    "w": 24,
+                    "h": 12,
+                    "i": "dd819480-c9aa-d638-ee8e-ff0aa6b3d934"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Active Threads Over Time",
+                        "visualizationType": "lnsXY",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "layerId": "f3b0db06-7131-2aa2-674e-5b90e4b68a07",
+                                        "accessors": [
+                                            "9285a34b-2f64-b4a4-a660-df6762b1a5ef"
+                                        ],
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "xAccessor": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                        "position": "top",
+                                        "showGridlines": false,
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "specialAssignments": [
+                                                {
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ],
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "preferredSeriesType": "line",
+                                "legend": {
+                                    "position": "right"
+                                },
+                                "valueLabels": "hide"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "f3b0db06-7131-2aa2-674e-5b90e4b68a07": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "threads",
+                                                    "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                                                    "label": "threads",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "threads",
+                                                    "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                                                    "label": "threads",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true
+                                                },
+                                                {
+                                                    "fieldName": "time_bucket",
+                                                    "columnId": "42a876a0-15e3-395a-0a00-b1577942ad2f",
+                                                    "label": "time_bucket",
+                                                    "customLabel": false,
+                                                    "meta": {
+                                                        "type": "date",
+                                                        "esType": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "5c57d522-f506-a1f3-8bba-1ff5290fe912"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5c57d522-f506-a1f3-8bba-1ff5290fe912",
+                                    "name": "indexpattern-datasource-layer-f3b0db06-7131-2aa2-674e-5b90e4b68a07"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5c57d522-f506-a1f3-8bba-1ff5290fe912": {
+                                    "id": "5c57d522-f506-a1f3-8bba-1ff5290fe912",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "25facd50-b4a8-7a8c-60c5-d653f5f8b3e9",
+                "gridData": {
+                    "x": 0,
+                    "y": 53,
+                    "w": 48,
+                    "h": 3,
+                    "i": "25facd50-b4a8-7a8c-60c5-d653f5f8b3e9"
+                },
+                "type": "visualization",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "savedVis": {
+                        "type": "markdown",
+                        "id": "",
+                        "title": "",
+                        "description": "",
+                        "params": {
+                            "fontSize": 12,
+                            "openLinksInNewTab": false,
+                            "markdown": "## Top Sites & Application Pools\n"
+                        },
+                        "uiState": {},
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "query": {
+                                    "query": "",
+                                    "language": "kuery"
+                                },
+                                "filter": []
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "panelIndex": "0fffa92b-02c5-f0c4-d098-ba89a3915abb",
+                "gridData": {
+                    "x": 0,
+                    "y": 56,
+                    "w": 24,
+                    "h": 15,
+                    "i": "0fffa92b-02c5-f0c4-d098-ba89a3915abb"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Top Sites by Request Count",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "ddb966a4-abf6-3127-74aa-09fc61093e9e",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "bf652d74-8b2d-9767-1e48-b21858b0c4f1",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\n| SORT total_requests DESC\n| LIMIT 50"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "bf652d74-8b2d-9767-1e48-b21858b0c4f1": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\n| SORT total_requests DESC\n| LIMIT 50"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                                    "label": "Site",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "total_requests",
+                                                    "columnId": "ddb966a4-abf6-3127-74aa-09fc61093e9e",
+                                                    "label": "Total Requests",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                                    "label": "Site",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "total_requests",
+                                                    "columnId": "ddb966a4-abf6-3127-74aa-09fc61093e9e",
+                                                    "label": "Total Requests",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "0e61d09b-11a3-ca35-a51a-faf43674cd7b"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0e61d09b-11a3-ca35-a51a-faf43674cd7b",
+                                    "name": "indexpattern-datasource-layer-bf652d74-8b2d-9767-1e48-b21858b0c4f1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0e61d09b-11a3-ca35-a51a-faf43674cd7b": {
+                                    "id": "0e61d09b-11a3-ca35-a51a-faf43674cd7b",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "8e745e07-81c8-1aaf-6552-35e44b95ff33",
+                "gridData": {
+                    "x": 24,
+                    "y": 56,
+                    "w": 24,
+                    "h": 15,
+                    "i": "8e745e07-81c8-1aaf-6552-35e44b95ff33"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Top Pools by Rejection Rate",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "68fca49c-69d3-dcc4-79fa-9583c2fff60c",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "c0dc0136-8e08-5b17-9613-ed1c44a6d74c",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "9f67b687-d93d-1699-2970-33f5fa309ebd",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\n| SORT rejection_rate DESC\n| LIMIT 50"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "9f67b687-d93d-1699-2970-33f5fa309ebd": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\n| SORT rejection_rate DESC\n| LIMIT 50"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "68fca49c-69d3-dcc4-79fa-9583c2fff60c",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "rejection_rate",
+                                                    "columnId": "c0dc0136-8e08-5b17-9613-ed1c44a6d74c",
+                                                    "label": "Rejections/sec",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "iis.application_pool",
+                                                    "columnId": "68fca49c-69d3-dcc4-79fa-9583c2fff60c",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "rejection_rate",
+                                                    "columnId": "c0dc0136-8e08-5b17-9613-ed1c44a6d74c",
+                                                    "label": "Rejections/sec",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "17f56d66-fd4f-3a97-974e-9209ce8749b3"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "17f56d66-fd4f-3a97-974e-9209ce8749b3",
+                                    "name": "indexpattern-datasource-layer-9f67b687-d93d-1699-2970-33f5fa309ebd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "17f56d66-fd4f-3a97-974e-9209ce8749b3": {
+                                    "id": "17f56d66-fd4f-3a97-974e-9209ce8749b3",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "e5bc9ecd-4d83-a600-8a4a-3667f9a37642",
+                "gridData": {
+                    "x": 0,
+                    "y": 71,
+                    "w": 24,
+                    "h": 15,
+                    "i": "e5bc9ecd-4d83-a600-8a4a-3667f9a37642"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Top Sites by Request Rate",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "7c03b6e0-7fef-84a4-b979-70d4bded8a9f",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "bf980fca-db78-946e-b9b7-b50095ca8f7d",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 50"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "bf980fca-db78-946e-b9b7-b50095ca8f7d": {
+                                            "query": {
+                                                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 50"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                                    "label": "Site",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "7c03b6e0-7fef-84a4-b979-70d4bded8a9f",
+                                                    "label": "Requests/sec",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "iis.site",
+                                                    "columnId": "f7f02f2e-d94a-68c8-a0fa-7f16845672e2",
+                                                    "label": "Site",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "req_rate",
+                                                    "columnId": "7c03b6e0-7fef-84a4-b979-70d4bded8a9f",
+                                                    "label": "Requests/sec",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "e21290aa-77d3-87b6-f4ea-783769e8a335"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e21290aa-77d3-87b6-f4ea-783769e8a335",
+                                    "name": "indexpattern-datasource-layer-bf980fca-db78-946e-b9b7-b50095ca8f7d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e21290aa-77d3-87b6-f4ea-783769e8a335": {
+                                    "id": "e21290aa-77d3-87b6-f4ea-783769e8a335",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            },
+            {
+                "panelIndex": "3df009d1-4950-6747-bfa1-958aac238cbd",
+                "gridData": {
+                    "x": 24,
+                    "y": 71,
+                    "w": 24,
+                    "h": 15,
+                    "i": "3df009d1-4950-6747-bfa1-958aac238cbd"
+                },
+                "type": "lens",
+                "embeddableConfig": {
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "attributes": {
+                        "title": "Top Pools by Queue Depth",
+                        "visualizationType": "lnsDatatable",
+                        "type": "lens",
+                        "references": [],
+                        "state": {
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                        "isTransposed": false,
+                                        "isMetric": false
+                                    },
+                                    {
+                                        "columnId": "f0a76a36-4c7b-52d5-03d7-0b1ecfbadea9",
+                                        "isTransposed": false,
+                                        "isMetric": true
+                                    }
+                                ],
+                                "layerId": "482791ee-ca97-f037-f5c4-e6252cc90734",
+                                "layerType": "data"
+                            },
+                            "query": {
+                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\n| SORT max_queue DESC\n| LIMIT 50"
+                            },
+                            "filters": [],
+                            "datasourceStates": {
+                                "textBased": {
+                                    "layers": {
+                                        "482791ee-ca97-f037-f5c4-e6252cc90734": {
+                                            "query": {
+                                                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\n| SORT max_queue DESC\n| LIMIT 50"
+                                            },
+                                            "columns": [
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "max_queue",
+                                                    "columnId": "f0a76a36-4c7b-52d5-03d7-0b1ecfbadea9",
+                                                    "label": "Max Queue Depth",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "allColumns": [
+                                                {
+                                                    "fieldName": "pool",
+                                                    "columnId": "d8fa6443-2959-c180-e407-58f1aca51b33",
+                                                    "label": "Application Pool",
+                                                    "customLabel": true
+                                                },
+                                                {
+                                                    "fieldName": "max_queue",
+                                                    "columnId": "f0a76a36-4c7b-52d5-03d7-0b1ecfbadea9",
+                                                    "label": "Max Queue Depth",
+                                                    "customLabel": true,
+                                                    "meta": {
+                                                        "type": "number",
+                                                        "esType": "long"
+                                                    },
+                                                    "inMetricDimension": true,
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "timeField": "@timestamp",
+                                            "index": "ddbb9aa0-cddc-58b6-4d69-785de0bfd985"
+                                        }
+                                    }
+                                }
+                            },
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ddbb9aa0-cddc-58b6-4d69-785de0bfd985",
+                                    "name": "indexpattern-datasource-layer-482791ee-ca97-f037-f5c4-e6252cc90734"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ddbb9aa0-cddc-58b6-4d69-785de0bfd985": {
+                                    "id": "ddbb9aa0-cddc-58b6-4d69-785de0bfd985",
+                                    "type": "esql",
+                                    "name": "metrics-iisreceiver.otel-*",
+                                    "title": "metrics-iisreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
+                        }
+                    },
+                    "syncTooltips": false,
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "filters": [],
+                    "query": {
+                        "query": "",
+                        "language": "kuery"
+                    }
+                }
+            }
+        ],
+        "optionsJSON": {
+            "useMargins": true,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "hidePanelTitles": false
+        },
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "disabled": false,
+                            "negate": false,
+                            "alias": null,
+                            "type": "phrase",
+                            "key": "data_stream.dataset",
+                            "field": "data_stream.dataset",
+                            "params": {
+                                "query": "iisreceiver.otel"
+                            }
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iisreceiver.otel"
+                            }
+                        }
+                    }
+                ],
+                "query": {
+                    "query": "",
+                    "language": "kuery"
+                }
+            }
+        },
+        "timeRestore": true,
+        "timeFrom": "now-1h",
+        "timeTo": "now",
+        "version": 1,
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "ba14dd38-3256-313e-2eb9-8a73fea4ed25": {
+                    "grow": false,
+                    "order": 0,
+                    "width": "medium",
+                    "type": "optionsListControl",
+                    "explicitInput": {
+                        "id": "ba14dd38-3256-313e-2eb9-8a73fea4ed25",
+                        "dataViewId": "metrics-*",
+                        "fieldName": "resource.attributes.host.name",
+                        "title": "Host",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        }
+                    }
+                },
+                "a710b1ce-97f3-66d6-b2c5-09c5b73a4568": {
+                    "grow": false,
+                    "order": 1,
+                    "width": "medium",
+                    "type": "optionsListControl",
+                    "explicitInput": {
+                        "id": "a710b1ce-97f3-66d6-b2c5-09c5b73a4568",
+                        "dataViewId": "metrics-*",
+                        "fieldName": "iis.site",
+                        "title": "Site",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        }
+                    }
+                },
+                "2aa79284-fddb-46b6-64a3-983d23b2dd43": {
+                    "grow": false,
+                    "order": 2,
+                    "width": "medium",
+                    "type": "optionsListControl",
+                    "explicitInput": {
+                        "id": "2aa79284-fddb-46b6-64a3-983d23b2dd43",
+                        "dataViewId": "metrics-*",
+                        "fieldName": "iis.application_pool",
+                        "title": "Application Pool",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        }
+                    }
+                }
+            },
+            "showApplySelections": false
+        }
     },
-    "timeRestore": true,
-    "timeFrom": "now-1h",
-    "timeTo": "now",
-    "version": 1,
-    "controlGroupInput": {
-      "chainingSystem": "HIERARCHICAL",
-      "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"resource.attributes.host.name\",\"title\":\"Host\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.site\",\"title\":\"Site\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"2aa79284-fddb-46b6-64a3-983d23b2dd43\":{\"grow\":false,\"order\":2,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2aa79284-fddb-46b6-64a3-983d23b2dd43\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.application_pool\",\"title\":\"Application Pool\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
-      "showApplySelections": false
-    }
-  },
-  "coreMigrationVersion": "8.8.0",
-  "created_at": "2023-10-01T00:00:00Z",
-  "created_by": "admin",
-  "id": "iis_otel-sites",
-  "managed": false,
-  "references": [
-    {
-      "type": "dashboard",
-      "id": "iis_otel-overview",
-      "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
-    },
-    {
-      "type": "dashboard",
-      "id": "iis_otel-sites",
-      "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
-    },
-    {
-      "type": "index-pattern",
-      "id": "metrics-*",
-      "name": "controlGroup_ba14dd38-3256-313e-2eb9-8a73fea4ed25:optionsListDataView"
-    },
-    {
-      "type": "index-pattern",
-      "id": "metrics-*",
-      "name": "controlGroup_a710b1ce-97f3-66d6-b2c5-09c5b73a4568:optionsListDataView"
-    },
-    {
-      "type": "index-pattern",
-      "id": "metrics-*",
-      "name": "controlGroup_2aa79284-fddb-46b6-64a3-983d23b2dd43:optionsListDataView"
-    }
-  ],
-  "type": "dashboard",
-  "typeMigrationVersion": "10.2.0",
-  "updated_at": "2023-10-01T00:00:00Z",
-  "updated_by": "admin",
-  "version": "1"
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-10-01T00:00:00Z",
+    "created_by": "admin",
+    "id": "iis_otel-sites",
+    "managed": false,
+    "references": [
+        {
+            "type": "dashboard",
+            "id": "iis_otel-overview",
+            "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+        },
+        {
+            "type": "dashboard",
+            "id": "iis_otel-sites",
+            "name": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d:link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "controlGroup_ba14dd38-3256-313e-2eb9-8a73fea4ed25:optionsListDataView"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "controlGroup_a710b1ce-97f3-66d6-b2c5-09c5b73a4568:optionsListDataView"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "controlGroup_2aa79284-fddb-46b6-64a3-983d23b2dd43:optionsListDataView"
+        }
+    ],
+    "type": "dashboard",
+    "typeMigrationVersion": "10.2.0",
+    "updated_at": "2023-10-01T00:00:00Z",
+    "updated_by": "admin",
+    "version": "1"
 }

--- a/packages/iis_otel/manifest.yml
+++ b/packages/iis_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: iis_otel
 title: "IIS OpenTelemetry assets"
-version: 0.5.0
+version: 0.5.1
 source:
   license: "Elastic-2.0"
 description: "IIS Assets for OpenTelemetry Collector"

--- a/packages/traefik_otel/changelog.yml
+++ b/packages/traefik_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/traefik_otel/changelog.yml
+++ b/packages/traefik_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20378
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-overview.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-overview.json
@@ -177,13 +177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ce11a074-2a81-5e88-4cee-d7c20bbd9b7b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ce11a074-2a81-5e88-4cee-d7c20bbd9b7b",
+                                    "name": "indexpattern-datasource-layer-d2a62428-55bf-f397-73d8-ef8de23036f1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ce11a074-2a81-5e88-4cee-d7c20bbd9b7b": {
+                                    "id": "ce11a074-2a81-5e88-4cee-d7c20bbd9b7b",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e4f4ce42-905a-fac9-9c91-ec51d3d9c80f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e4f4ce42-905a-fac9-9c91-ec51d3d9c80f",
+                                    "name": "indexpattern-datasource-layer-213e51a5-bb57-44e4-426a-2bc6c1156e30"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e4f4ce42-905a-fac9-9c91-ec51d3d9c80f": {
+                                    "id": "e4f4ce42-905a-fac9-9c91-ec51d3d9c80f",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -381,13 +423,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3026386a-4e41-0e73-409d-d1d14ab405c3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3026386a-4e41-0e73-409d-d1d14ab405c3",
+                                    "name": "indexpattern-datasource-layer-981dc043-f3c6-e068-e2a8-26e6e2211a2e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3026386a-4e41-0e73-409d-d1d14ab405c3": {
+                                    "id": "3026386a-4e41-0e73-409d-d1d14ab405c3",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -483,13 +546,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3cc08590-95d3-d483-2ae1-84858d618181"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3cc08590-95d3-d483-2ae1-84858d618181",
+                                    "name": "indexpattern-datasource-layer-2534cb18-a368-812b-8ac0-4cb2e45438bf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3cc08590-95d3-d483-2ae1-84858d618181": {
+                                    "id": "3cc08590-95d3-d483-2ae1-84858d618181",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -649,13 +733,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fe92e415-25cb-3216-4258-477ad5bc7aa6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fe92e415-25cb-3216-4258-477ad5bc7aa6",
+                                    "name": "indexpattern-datasource-layer-bc49e397-7457-6be1-83ca-ef806fe774b2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fe92e415-25cb-3216-4258-477ad5bc7aa6": {
+                                    "id": "fe92e415-25cb-3216-4258-477ad5bc7aa6",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -861,13 +966,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fdb5c22c-c0d8-355d-0173-f26ccbbba19a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fdb5c22c-c0d8-355d-0173-f26ccbbba19a",
+                                    "name": "indexpattern-datasource-layer-fc4791a2-fdd7-95dc-c139-4017b43935a5"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fdb5c22c-c0d8-355d-0173-f26ccbbba19a": {
+                                    "id": "fdb5c22c-c0d8-355d-0173-f26ccbbba19a",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1027,13 +1153,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "67223601-26eb-1ff5-a2f0-3ac6efcd1452"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "67223601-26eb-1ff5-a2f0-3ac6efcd1452",
+                                    "name": "indexpattern-datasource-layer-b38574cf-a2bf-193c-3091-e5eb68984ac4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "67223601-26eb-1ff5-a2f0-3ac6efcd1452": {
+                                    "id": "67223601-26eb-1ff5-a2f0-3ac6efcd1452",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1156,13 +1303,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "84954e9e-b336-1f04-9258-806e02d39343"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "84954e9e-b336-1f04-9258-806e02d39343",
+                                    "name": "indexpattern-datasource-layer-2fcc441e-f741-8c78-e998-0e6222cb3954"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "84954e9e-b336-1f04-9258-806e02d39343": {
+                                    "id": "84954e9e-b336-1f04-9258-806e02d39343",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1309,13 +1477,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7ade0080-a557-9426-3528-275eb0b1f34d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7ade0080-a557-9426-3528-275eb0b1f34d",
+                                    "name": "indexpattern-datasource-layer-6bfaabfd-9472-2da5-b24d-481c2447686c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7ade0080-a557-9426-3528-275eb0b1f34d": {
+                                    "id": "7ade0080-a557-9426-3528-275eb0b1f34d",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1433,13 +1622,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a00209b9-2099-3911-139c-07026e668edd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a00209b9-2099-3911-139c-07026e668edd",
+                                    "name": "indexpattern-datasource-layer-3e200d8b-03be-0ace-8618-ce0ca3000a92"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a00209b9-2099-3911-139c-07026e668edd": {
+                                    "id": "a00209b9-2099-3911-139c-07026e668edd",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-process.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-process.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cf6cd73f-73dd-11ce-0e81-432b387541a4"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cf6cd73f-73dd-11ce-0e81-432b387541a4",
+                                    "name": "indexpattern-datasource-layer-358e8389-7a01-dd37-26a4-babb648d2d1c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cf6cd73f-73dd-11ce-0e81-432b387541a4": {
+                                    "id": "cf6cd73f-73dd-11ce-0e81-432b387541a4",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -277,13 +298,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c1a5b090-1bb2-5abd-f653-2af227be80e7"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c1a5b090-1bb2-5abd-f653-2af227be80e7",
+                                    "name": "indexpattern-datasource-layer-ce34f717-7835-4ba3-7ab2-c7086cb8718c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c1a5b090-1bb2-5abd-f653-2af227be80e7": {
+                                    "id": "c1a5b090-1bb2-5abd-f653-2af227be80e7",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -379,13 +421,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "14281640-dbdb-19ff-b912-a0321212e872"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "14281640-dbdb-19ff-b912-a0321212e872",
+                                    "name": "indexpattern-datasource-layer-63e26b92-9aa9-8fc3-13a9-737266aa8623"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "14281640-dbdb-19ff-b912-a0321212e872": {
+                                    "id": "14281640-dbdb-19ff-b912-a0321212e872",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -481,13 +544,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "456bfbab-e6ce-a378-57ec-64d7860477b6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "456bfbab-e6ce-a378-57ec-64d7860477b6",
+                                    "name": "indexpattern-datasource-layer-63b1e765-8c20-e04e-3a8a-54f086feea29"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "456bfbab-e6ce-a378-57ec-64d7860477b6": {
+                                    "id": "456bfbab-e6ce-a378-57ec-64d7860477b6",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -629,13 +713,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e83f8954-dfbe-83d4-f1e8-f1a002f49dca"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e83f8954-dfbe-83d4-f1e8-f1a002f49dca",
+                                    "name": "indexpattern-datasource-layer-4f769601-40f8-b52d-7cc3-bcf8cdea886c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e83f8954-dfbe-83d4-f1e8-f1a002f49dca": {
+                                    "id": "e83f8954-dfbe-83d4-f1e8-f1a002f49dca",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -782,13 +887,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9c672c6a-7012-af4e-e0de-37e24dc594a6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9c672c6a-7012-af4e-e0de-37e24dc594a6",
+                                    "name": "indexpattern-datasource-layer-a9a510cf-e039-a3aa-b81e-9caa3ec63df9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9c672c6a-7012-af4e-e0de-37e24dc594a6": {
+                                    "id": "9c672c6a-7012-af4e-e0de-37e24dc594a6",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -974,13 +1100,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "93d67932-cff1-18a8-5bac-b50434662860"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "93d67932-cff1-18a8-5bac-b50434662860",
+                                    "name": "indexpattern-datasource-layer-f0cefcd9-b601-2945-8022-1f2ea88e8e40"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "93d67932-cff1-18a8-5bac-b50434662860": {
+                                    "id": "93d67932-cff1-18a8-5bac-b50434662860",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1126,13 +1273,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "90a19172-9356-177e-870a-cf19446d6ecd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "90a19172-9356-177e-870a-cf19446d6ecd",
+                                    "name": "indexpattern-datasource-layer-09346ed4-ea66-cdc5-4df7-e5480b63e7c6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "90a19172-9356-177e-870a-cf19446d6ecd": {
+                                    "id": "90a19172-9356-177e-870a-cf19446d6ecd",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1318,13 +1486,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bb57ca30-f2e2-40cd-a894-aac7d6f3bf31"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bb57ca30-f2e2-40cd-a894-aac7d6f3bf31",
+                                    "name": "indexpattern-datasource-layer-fbd961b2-7276-2579-283e-91c31b4abe4a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bb57ca30-f2e2-40cd-a894-aac7d6f3bf31": {
+                                    "id": "bb57ca30-f2e2-40cd-a894-aac7d6f3bf31",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-services.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-services.json
@@ -177,13 +177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "84ed4e31-1d9b-744f-f681-a342712d3059"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "84ed4e31-1d9b-744f-f681-a342712d3059",
+                                    "name": "indexpattern-datasource-layer-24923788-bf95-415f-a024-b10aeec210c3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "84ed4e31-1d9b-744f-f681-a342712d3059": {
+                                    "id": "84ed4e31-1d9b-744f-f681-a342712d3059",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2c18f3f1-8f32-6e1c-2a27-5a2d22fe1bbd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2c18f3f1-8f32-6e1c-2a27-5a2d22fe1bbd",
+                                    "name": "indexpattern-datasource-layer-bee789bd-d827-5064-2fc1-d13cd64237d4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2c18f3f1-8f32-6e1c-2a27-5a2d22fe1bbd": {
+                                    "id": "2c18f3f1-8f32-6e1c-2a27-5a2d22fe1bbd",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -381,13 +423,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5adec298-7cbe-c331-9076-9d6450b7dff5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5adec298-7cbe-c331-9076-9d6450b7dff5",
+                                    "name": "indexpattern-datasource-layer-b5ca809b-946f-8488-f0f2-4ebfab996d19"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5adec298-7cbe-c331-9076-9d6450b7dff5": {
+                                    "id": "5adec298-7cbe-c331-9076-9d6450b7dff5",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -483,13 +546,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "63153df6-4c30-2a58-e85b-841120f72de8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "63153df6-4c30-2a58-e85b-841120f72de8",
+                                    "name": "indexpattern-datasource-layer-d8699402-679b-8c07-f4c7-ad960cb00522"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "63153df6-4c30-2a58-e85b-841120f72de8": {
+                                    "id": "63153df6-4c30-2a58-e85b-841120f72de8",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -649,13 +733,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a68567bb-85f3-78a9-0e27-5a83199d6690"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a68567bb-85f3-78a9-0e27-5a83199d6690",
+                                    "name": "indexpattern-datasource-layer-a8d28977-5fc1-8b65-8dff-c809a5b6b327"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a68567bb-85f3-78a9-0e27-5a83199d6690": {
+                                    "id": "a68567bb-85f3-78a9-0e27-5a83199d6690",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -815,13 +920,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "01c5fc6b-f3b4-7619-a120-af3926cc4dbc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "01c5fc6b-f3b4-7619-a120-af3926cc4dbc",
+                                    "name": "indexpattern-datasource-layer-95b39c83-08b6-e6ce-2504-7801e818b803"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "01c5fc6b-f3b4-7619-a120-af3926cc4dbc": {
+                                    "id": "01c5fc6b-f3b4-7619-a120-af3926cc4dbc",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1011,13 +1137,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "65e1710d-c668-49ce-11ee-19bf344f533c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "65e1710d-c668-49ce-11ee-19bf344f533c",
+                                    "name": "indexpattern-datasource-layer-9204b3d6-aa38-79b2-b713-6e782b5302f5"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "65e1710d-c668-49ce-11ee-19bf344f533c": {
+                                    "id": "65e1710d-c668-49ce-11ee-19bf344f533c",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1178,13 +1325,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1f75f3be-bda6-8abc-0d92-b0a377793f50"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1f75f3be-bda6-8abc-0d92-b0a377793f50",
+                                    "name": "indexpattern-datasource-layer-9ebe9a80-3080-c144-8823-ed1688de4f6f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1f75f3be-bda6-8abc-0d92-b0a377793f50": {
+                                    "id": "1f75f3be-bda6-8abc-0d92-b0a377793f50",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1345,13 +1513,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "99cccc41-8ee7-2a08-e65e-67abf1ebbedb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "99cccc41-8ee7-2a08-e65e-67abf1ebbedb",
+                                    "name": "indexpattern-datasource-layer-52dc3ccb-8cd0-9c15-a55f-3715f8968516"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "99cccc41-8ee7-2a08-e65e-67abf1ebbedb": {
+                                    "id": "99cccc41-8ee7-2a08-e65e-67abf1ebbedb",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-tls-config.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-tls-config.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e064abeb-0faf-fa20-a054-943f8370e3e3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e064abeb-0faf-fa20-a054-943f8370e3e3",
+                                    "name": "indexpattern-datasource-layer-7eeb3065-b873-4697-6fb7-c4ba6e319183"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e064abeb-0faf-fa20-a054-943f8370e3e3": {
+                                    "id": "e064abeb-0faf-fa20-a054-943f8370e3e3",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "05b0464f-f0ab-bf1d-c3c5-c944710475fa"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "05b0464f-f0ab-bf1d-c3c5-c944710475fa",
+                                    "name": "indexpattern-datasource-layer-83931d67-3b12-4680-0e38-897455a8a794"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "05b0464f-f0ab-bf1d-c3c5-c944710475fa": {
+                                    "id": "05b0464f-f0ab-bf1d-c3c5-c944710475fa",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -381,13 +423,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "489e101f-9976-8831-68db-98dfabf85cc8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "489e101f-9976-8831-68db-98dfabf85cc8",
+                                    "name": "indexpattern-datasource-layer-f6c244a6-782e-f1af-fe1d-f3ed703ef826"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "489e101f-9976-8831-68db-98dfabf85cc8": {
+                                    "id": "489e101f-9976-8831-68db-98dfabf85cc8",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -483,13 +546,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "150d871d-6abd-96f3-225f-ca6dec805982"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "150d871d-6abd-96f3-225f-ca6dec805982",
+                                    "name": "indexpattern-datasource-layer-f297594d-393a-04b7-5e04-981297e6f133"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "150d871d-6abd-96f3-225f-ca6dec805982": {
+                                    "id": "150d871d-6abd-96f3-225f-ca6dec805982",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -649,13 +733,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c00b9156-da8a-3989-e20f-6a57f6930da9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c00b9156-da8a-3989-e20f-6a57f6930da9",
+                                    "name": "indexpattern-datasource-layer-ed8695b1-edbe-072d-2c19-ac236ed70386"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c00b9156-da8a-3989-e20f-6a57f6930da9": {
+                                    "id": "c00b9156-da8a-3989-e20f-6a57f6930da9",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -778,13 +883,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6121f6e1-93c8-2bc8-3968-d403349a4db6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6121f6e1-93c8-2bc8-3968-d403349a4db6",
+                                    "name": "indexpattern-datasource-layer-da970c0b-a67d-96d3-5bc5-5316b772090d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6121f6e1-93c8-2bc8-3968-d403349a4db6": {
+                                    "id": "6121f6e1-93c8-2bc8-3968-d403349a4db6",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -917,13 +1043,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "487bbaa7-007b-21d3-4c67-8f50b215972d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "487bbaa7-007b-21d3-4c67-8f50b215972d",
+                                    "name": "indexpattern-datasource-layer-467ad8ac-e351-a0c7-e7de-2a6b43473960"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "487bbaa7-007b-21d3-4c67-8f50b215972d": {
+                                    "id": "487bbaa7-007b-21d3-4c67-8f50b215972d",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1069,13 +1216,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f030c7bf-db46-fb9c-8871-ed8471f182b5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f030c7bf-db46-fb9c-8871-ed8471f182b5",
+                                    "name": "indexpattern-datasource-layer-8303432c-9414-c7f0-f513-9fd97a332047"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f030c7bf-db46-fb9c-8871-ed8471f182b5": {
+                                    "id": "f030c7bf-db46-fb9c-8871-ed8471f182b5",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1198,13 +1366,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2fcc79cb-1c3b-0455-1dab-12bac52d75f8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2fcc79cb-1c3b-0455-1dab-12bac52d75f8",
+                                    "name": "indexpattern-datasource-layer-7c67f00e-37fa-3890-f8b2-95d6010eb9b4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2fcc79cb-1c3b-0455-1dab-12bac52d75f8": {
+                                    "id": "2fcc79cb-1c3b-0455-1dab-12bac52d75f8",
+                                    "type": "esql",
+                                    "name": "metrics-traefik.otel-*",
+                                    "title": "metrics-traefik.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/traefik_otel/manifest.yml
+++ b/packages/traefik_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: traefik_otel
 title: "Traefik OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Traefik Assets for OpenTelemetry Collector"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Regenerate the compiled Kibana dashboards for six OTel packages (`iis_otel`, `traefik_otel`, `apache_tomcat_otel`, `haproxy_otel`, `activemq_otel`, `ibmmq_otel`) by recompiling their YAML sources with the Elastic fork of the dashboard compiler (`elastic/kb-yaml-to-lens`, which adds `adHocDataViews` to compiled objects).

- WHAT: every ES|QL Lens layer in the shipped dashboard JSON now carries a populated `adHocDataViews`, `internalReferences`, and per-layer `index`. No queries, titles, visualization types, dimensions, filters, controls, or layout change — the only intentional diff is those additions (plus an occasional benign `legendPosition`).
- WHY: the previously pinned compiler (`kb-dashboard-cli==0.4.1`) emitted `"adHocDataViews": {}` and omitted the per-layer `index`/`internalReferences`. On Kibana 9.3+ this breaks the panel "Explore in Discover" action (elastic/obs-integration-team#1014). Repopulating those fields restores it.

`iis_otel` is JSON-only: its `_dev` YAML source is intentionally left unchanged so the pinned `validate-dashboards` CI compiler does not recompile empty `adHocDataViews` and fail CI; only its compiled JSON is updated.

Each package gets a patch version bump and a `bugfix` changelog entry.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm the only diff vs. the previously compiled dashboards is `adHocDataViews`, `internalReferences`, and per-layer `index` (plus occasional `legendPosition`) — no query/title/viz-type/layout drift.
- [ ] Confirm `iis_otel` is intentionally JSON-only (its `_dev/shared/kibana` YAML is unchanged) so the pinned dashboard-compiler CI check stays green.
- [ ] Spot-check "Explore in Discover" on a rendered ES|QL panel on a Kibana 9.3+ stack.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Executed by the author on a Kibana 9.5 stack (issue #1014 reproduces on 9.3+):

- Installed all six regenerated packages via Fleet and queried every dashboard saved object. All 23 dashboards return HTTP 200, panel counts are unchanged vs. `main`, and every ES|QL panel now has a populated `adHocDataViews`:
  - `iis_otel` — 2 dashboards / 34 ES|QL panels / 34 with adHocDataViews
  - `traefik_otel` — 4 / 37 / 37
  - `apache_tomcat_otel` — 6 / 104 / 104
  - `haproxy_otel` — 4 / 41 / 41
  - `activemq_otel` — 3 / 36 / 36
  - `ibmmq_otel` — 4 / 64 / 64
- Before/after on `traefik_otel` (with sample data ingested so panels render): on the `main` build the panel menu exposed no "Explore in Discover" and the dashboard JSON had empty `adHocDataViews`; on this build "Explore in Discover" appears, opens Discover with the panel's ES|QL query / index pattern / columns / time range preserved, and no `Cannot read properties of undefined (reading 'id')` (#1014) console error.

Reviewer steps:
- Install any of these packages on a Kibana >= 9.3 stack, open a dashboard with a rendering ES|QL panel, use the panel menu -> "Explore in Discover", and confirm it opens cleanly with the query preserved and no console error.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/obs-integration-team#1148
- Relates elastic/obs-integration-team#1014

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
This PR changes only compiled dashboard JSON (no UI/config forms). The before/after "Explore in Discover" behavior on `traefik_otel` was verified live on Kibana 9.5; a summary is posted on the tracking issue elastic/obs-integration-team#1148.