### PR TITLE
ti_opencti: fix incremental polling missing UI-edited indicators

### DIFF
--- a/packages/ti_opencti/_dev/build/docs/README.md
+++ b/packages/ti_opencti/_dev/build/docs/README.md
@@ -94,9 +94,9 @@ All filters work together using AND logic at the top level. Within each multi-va
 
 The OpenCTI integration supports running on multiple Elastic Agents for high availability. When multiple agents fetch the same indicators:
 
-- **Automatic Deduplication**: The integration uses a fingerprint-based document ID to prevent duplicates. Each indicator gets a consistent ID based on its `standard_id` and `modified` timestamp.
+- **Automatic Deduplication**: The integration uses a fingerprint-based document ID to prevent duplicates. Each indicator version gets a consistent ID based on its `standard_id`, `modified` and `updated_at` timestamps.
 - **No Manual Configuration Needed**: Deduplication works automatically - just deploy the integration to multiple agents.
-- **Update Handling**: When an indicator is updated in OpenCTI, the new version replaces the old one in Elasticsearch.
+- **Update Handling**: When an indicator is updated in OpenCTI, a new document is indexed alongside the previous version in `logs-ti_opencti.indicator-*`. The `latest_ioc` transform keeps only the most recent version per indicator in `logs-ti_opencti_latest.indicator`, which is the index detection rules and dashboards should query.
 
 #### Best Practices for HA Setup
 
@@ -164,6 +164,7 @@ Timestamps are mapped as follows:
 | -           | event.ingested                | Time the event arrived in the central data store |
 | created     | event.created                 | Time of the indicator's creation |
 | modified    | threat.indicator.modified_at  | Time of the indicator's last modification |
+| updated_at  | opencti.indicator.updated_at  | Time the indicator record was last updated in the OpenCTI platform, including UI edits, enrichment and scoring changes |
 | valid_from  | opencti.indicator.valid_from  | Time from which this indicator is considered a valid indicator of the behaviors it is related to or represents |
 | valid_until | opencti.indicator.valid_until | Time at which this indicator should no longer be considered a valid indicator of the behaviors it is related to or represents |
 | -           | opencti.indicator.invalid_or_revoked_from | The earliest time at which an indicator reaches its `valid_until` time or is marked as revoked |

--- a/packages/ti_opencti/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_opencti/_dev/deploy/docker/files/config.yml
@@ -4,7 +4,7 @@ rules:
     request_headers:
       Authorization: "Bearer test_api_key"
       Content-Type: application/json
-    request_body: '/"variables":\{"after":null,"filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\}\],"mode":"and"\},"first":3,"orderBy":"modified","orderMode":"asc"\}/'
+    request_body: '/"variables":\{"after":null,"filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
     responses:
       - status_code: 200
         body: |-
@@ -22,6 +22,7 @@ rules:
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
                       "modified": "2023-01-17T05:53:42.851Z",
+                      "updated_at": "2023-01-17T05:53:43.100Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']",
@@ -83,6 +84,7 @@ rules:
                       "lang": "en",
                       "created": "2020-08-03T06:40:58.000Z",
                       "modified": "2023-01-17T05:53:43.702Z",
+                      "updated_at": "2023-01-17T05:53:44.200Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[ipv4-addr:value = '216.59.38.123']",
@@ -144,6 +146,7 @@ rules:
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
                       "modified": "2023-01-17T05:53:45.716Z",
+                      "updated_at": "2023-01-17T05:53:46.716Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'ec2-54-213-146-215.us-west-2.compute.amazonaws.com']",
@@ -209,7 +212,7 @@ rules:
     request_headers:
       Authorization: "Bearer test_api_key"
       Content-Type: application/json
-    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4MjU3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:53:45.716Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"modified","orderMode":"asc"\}/'
+    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4MjU3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:53:46.716Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
     responses:
       - status_code: 200
         body: |-
@@ -227,6 +230,7 @@ rules:
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
                       "modified": "2023-01-17T05:54:00.005Z",
+                      "updated_at": "2023-01-17T05:54:00.500Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'u.qurl.f.360.cn']",
@@ -288,6 +292,7 @@ rules:
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
                       "modified": "2023-01-17T05:54:00.557Z",
+                      "updated_at": "2023-01-17T05:54:01.111Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'ec2-184-73-167-20.compute-1.amazonaws.com']",
@@ -349,6 +354,7 @@ rules:
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
                       "modified": "2023-01-17T05:54:00.810Z",
+                      "updated_at": "2023-01-17T05:54:01.810Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'ec2-52-28-3-6.eu-central-1.compute.amazonaws.com']",
@@ -414,7 +420,7 @@ rules:
     request_headers:
       Authorization: "Bearer test_api_key"
       Content-Type: application/json
-    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4NDA4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:54:00.81Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"modified","orderMode":"asc"\}/'
+    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4NDA4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:54:01.81Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
     responses:
       - status_code: 200
         body: |-
@@ -432,6 +438,7 @@ rules:
                       "lang": "en",
                       "created": "2020-08-03T06:40:55.000Z",
                       "modified": "2023-01-17T05:54:02.636Z",
+                      "updated_at": "2023-01-17T05:54:03.636Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[ipv4-addr:value = '67.215.253.139']",
@@ -493,6 +500,7 @@ rules:
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
                       "modified": "2023-01-17T05:54:07.310Z",
+                      "updated_at": "2023-01-17T05:54:08.310Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'ec2-184-73-214-203.compute-1.amazonaws.com']",
@@ -556,7 +564,8 @@ rules:
                       "confidence": 15,
                       "lang": "en",
                       "created": "2018-02-05T08:04:53.000Z",
-                      "modified": "2023-01-17T05:54:07.355Z",
+                      "modified": "2023-01-10T00:00:00.000Z",
+                      "updated_at": "2023-01-17T05:54:09.355Z",
                       "pattern_type": "stix",
                       "pattern_version": "2.1",
                       "pattern": "[hostname:value = 'ec2-52-28-249-128.eu-central-1.compute.amazonaws.com']",

--- a/packages/ti_opencti/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_opencti/_dev/deploy/docker/files/config.yml
@@ -72,7 +72,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4MjI4NTEsImluZGljYXRvci0tY2RlMGE2ZTEtYzYyMi01MmM0LWI4NTctZTlhZWFjNTYxMzFiIl0="
+                    "cursor": "WzE2NzM5MzQ4MjMxMDAsImluZGljYXRvci0tY2RlMGE2ZTEtYzYyMi01MmM0LWI4NTctZTlhZWFjNTYxMzFiIl0="
                   },
                   {
                     "node": {
@@ -134,7 +134,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4MjM3MDIsImluZGljYXRvci0tYzcyMWI4MWEtNmMzYy01NWFiLTliZjMtMDM4NjQyZThhZGQ4Il0="
+                    "cursor": "WzE2NzM5MzQ4MjQyMDAsImluZGljYXRvci0tYzcyMWI4MWEtNmMzYy01NWFiLTliZjMtMDM4NjQyZThhZGQ4Il0="
                   },
                   {
                     "node": {
@@ -196,11 +196,11 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4MjU3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0="
+                    "cursor": "WzE2NzM5MzQ4MjY3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0="
                   }
                 ],
                 "pageInfo": {
-                  "endCursor": "WzE2NzM5MzQ4MjU3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0=",
+                  "endCursor": "WzE2NzM5MzQ4MjY3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0=",
                   "hasNextPage": true,
                   "globalCount": 1233582
                 }
@@ -212,7 +212,7 @@ rules:
     request_headers:
       Authorization: "Bearer test_api_key"
       Content-Type: application/json
-    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4MjU3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:53:46.716Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
+    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4MjY3MTYsImluZGljYXRvci0tYmM2MjJhNjEtNTJlMC01Nzg1LTkxZDMtYzczNzFmMDdmMTVkIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:53:46.716Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
     responses:
       - status_code: 200
         body: |-
@@ -280,7 +280,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4NDAwMDUsImluZGljYXRvci0tNjVlOTY4ODAtMzY1Mi01YWE3LWI2MjUtYjdiMGY3MTAzYTM3Il0="
+                    "cursor": "WzE2NzM5MzQ4NDA1MDAsImluZGljYXRvci0tNjVlOTY4ODAtMzY1Mi01YWE3LWI2MjUtYjdiMGY3MTAzYTM3Il0="
                   },
                   {
                     "node": {
@@ -342,7 +342,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4NDA1NTcsImluZGljYXRvci0tNjIzMzdhYzktM2UxNy01MGRiLThjNjctNGE0OTljYmNhMGE0Il0="
+                    "cursor": "WzE2NzM5MzQ4NDExMTEsImluZGljYXRvci0tNjIzMzdhYzktM2UxNy01MGRiLThjNjctNGE0OTljYmNhMGE0Il0="
                   },
                   {
                     "node": {
@@ -404,11 +404,11 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4NDA4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0="
+                    "cursor": "WzE2NzM5MzQ4NDE4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0="
                   }
                 ],
                 "pageInfo": {
-                  "endCursor": "WzE2NzM5MzQ4NDA4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0=",
+                  "endCursor": "WzE2NzM5MzQ4NDE4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0=",
                   "hasNextPage": true,
                   "globalCount": 1233582
                 }
@@ -420,7 +420,7 @@ rules:
     request_headers:
       Authorization: "Bearer test_api_key"
       Content-Type: application/json
-    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4NDA4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:54:01.81Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
+    request_body: '/"variables":\{"after":"WzE2NzM5MzQ4NDE4MTAsImluZGljYXRvci0tNWY5NWEyNmEtZjlmMC01ZjhkLTlkMzctYzkxMjUzOTQ2MmUzIl0=","filters":\{"filterGroups":\[\],"filters":\[\{"key":"entity_type","operator":"eq","values":\["Indicator"\]\},\{"key":"revoked","operator":"eq","values":\["false"\]\},\{"key":"updated_at","operator":"gt","values":\["2023-01-17T05:54:01.81Z"\]\}\],"mode":"and"\},"first":3,"orderBy":"updated_at","orderMode":"asc"\}/'
     responses:
       - status_code: 200
         body: |-
@@ -488,7 +488,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4NDI2MzYsImluZGljYXRvci0tNTJmZDllN2EtMmVhOS01ZTlhLTlhYTAtOWJlYTUzNGM1MTU4Il0="
+                    "cursor": "WzE2NzM5MzQ4NDM2MzYsImluZGljYXRvci0tNTJmZDllN2EtMmVhOS01ZTlhLTlhYTAtOWJlYTUzNGM1MTU4Il0="
                   },
                   {
                     "node": {
@@ -553,7 +553,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4NDczMTAsImluZGljYXRvci0tMzYzYWNjYzYtYWI5Yi01Nzc2LWJiODAtMjFhYmU0YTA0OWNlIl0="
+                    "cursor": "WzE2NzM5MzQ4NDgzMTAsImluZGljYXRvci0tMzYzYWNjYzYtYWI5Yi01Nzc2LWJiODAtMjFhYmU0YTA0OWNlIl0="
                   },
                   {
                     "node": {
@@ -615,7 +615,7 @@ rules:
                         }
                       }
                     },
-                    "cursor": "WzE2NzM5MzQ4NDczNTUsImluZGljYXRvci0tMzVlOTU4ZjMtOTc4ZS01NmE5LTk4MDEtMTIxYzkyYTcxNDJlIl0="
+                    "cursor": "WzE2NzM5MzQ4NDkzNTUsImluZGljYXRvci0tMzVlOTU4ZjMtOTc4ZS01NmE5LTk4MDEtMTIxYzkyYTcxNDJlIl0="
                   }
                 ],
                 "pageInfo": {

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.2"
+  changes:
+    - description: Fix incremental polling missing UI-edited indicators.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.15.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix incremental polling missing UI-edited indicators.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20382
 - version: "2.15.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-hostname.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-hostname.json
@@ -9,6 +9,7 @@
             "lang": "en",
             "created": "2023-01-17T06:44:52.954Z",
             "modified": "2023-01-17T09:30:06.920Z",
+            "updated_at": "2023-01-17T09:35:00.000Z",
             "pattern_type": "stix",
             "pattern_version": "2.1",
             "pattern": "[hostname:value = 'news.googmail.org']",

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-hostname.json-expected.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-hostname.json-expected.json
@@ -29,6 +29,7 @@
                     "revoked": true,
                     "score": 50,
                     "standard_id": "indicator--a4d5ef8d-0b00-5241-bf3a-856e2fc01e9a",
+                    "updated_at": "2023-01-17T09:35:00.000Z",
                     "valid_from": "2017-08-23T14:00:35.000Z",
                     "valid_until": "2018-08-23T14:00:35.000Z"
                 },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-default.expected
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-default.expected
@@ -36,7 +36,7 @@ inputs:
                 "variables": {
                   "after": has(state.cursor) && has(state.cursor.value) ? state.cursor.value : null,
                   "first": state.page_size,
-                  "orderBy": "modified",
+                  "orderBy": "updated_at",
                   "orderMode": "asc",
                   "filters": {
                     "mode": "and",
@@ -166,10 +166,9 @@ inputs:
                     )),
                     "want_more": body.data.indicators.pageInfo.hasNextPage,
                     "cursor": { "value": body.data.indicators.pageInfo.endCursor },
-                    "last_modified": has(body.data.indicators.edges) && body.data.indicators.edges.size() > 0 ?
-                      body.data.indicators.edges.map(e, timestamp(e.node.modified)).max()
-                    :
-                      state.?last_modified.orValue(null)
+                    "last_modified": body.data.indicators.edges
+                      .map(e, has(e.node.updated_at) && e.node.updated_at != null, timestamp(e.node.updated_at))
+                      .as(ts, ts.size() > 0 ? ts.max() : state.?last_modified.orValue(null))
                   })
                 )
               )
@@ -228,6 +227,7 @@ inputs:
                   lang
                   created
                   modified
+                  updated_at
                   pattern_type
                   pattern_version
                   pattern

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-multi-values.expected
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-multi-values.expected
@@ -36,7 +36,7 @@ inputs:
                 "variables": {
                   "after": has(state.cursor) && has(state.cursor.value) ? state.cursor.value : null,
                   "first": state.page_size,
-                  "orderBy": "modified",
+                  "orderBy": "updated_at",
                   "orderMode": "asc",
                   "filters": {
                     "mode": "and",
@@ -166,10 +166,9 @@ inputs:
                     )),
                     "want_more": body.data.indicators.pageInfo.hasNextPage,
                     "cursor": { "value": body.data.indicators.pageInfo.endCursor },
-                    "last_modified": has(body.data.indicators.edges) && body.data.indicators.edges.size() > 0 ?
-                      body.data.indicators.edges.map(e, timestamp(e.node.modified)).max()
-                    :
-                      state.?last_modified.orValue(null)
+                    "last_modified": body.data.indicators.edges
+                      .map(e, has(e.node.updated_at) && e.node.updated_at != null, timestamp(e.node.updated_at))
+                      .as(ts, ts.size() > 0 ? ts.max() : state.?last_modified.orValue(null))
                   })
                 )
               )
@@ -249,6 +248,7 @@ inputs:
                   lang
                   created
                   modified
+                  updated_at
                   pattern_type
                   pattern_version
                   pattern

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -184,10 +184,9 @@ program: |
           )),
           "want_more": body.data.indicators.pageInfo.hasNextPage,
           "cursor": { "value": body.data.indicators.pageInfo.endCursor },
-          "last_modified": has(body.data.indicators.edges) && body.data.indicators.edges.size() > 0 ?
-            body.data.indicators.edges.map(e, timestamp(e.node.updated_at)).max()
-          :
-            state.?last_modified.orValue(null)
+          "last_modified": body.data.indicators.edges
+            .map(e, has(e.node.updated_at) && e.node.updated_at != null, timestamp(e.node.updated_at))
+            .as(ts, ts.size() > 0 ? ts.max() : state.?last_modified.orValue(null))
         })
       )
     )

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -54,7 +54,7 @@ program: |
       "variables": {
         "after": has(state.cursor) && has(state.cursor.value) ? state.cursor.value : null,
         "first": state.page_size,
-        "orderBy": "modified",
+        "orderBy": "updated_at",
         "orderMode": "asc",
         "filters": {
           "mode": "and",
@@ -185,7 +185,7 @@ program: |
           "want_more": body.data.indicators.pageInfo.hasNextPage,
           "cursor": { "value": body.data.indicators.pageInfo.endCursor },
           "last_modified": has(body.data.indicators.edges) && body.data.indicators.edges.size() > 0 ?
-            body.data.indicators.edges.map(e, timestamp(e.node.modified)).max()
+            body.data.indicators.edges.map(e, timestamp(e.node.updated_at)).max()
           :
             state.?last_modified.orValue(null)
         })
@@ -298,6 +298,7 @@ state:
       lang
       created
       modified
+      updated_at
       pattern_type
       pattern_version
       pattern

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -925,6 +925,7 @@ processors:
       fields:
         - opencti.indicator.standard_id  # STIX ID is globally unique and consistent
         - threat.indicator.modified_at
+        - opencti.indicator.updated_at
       target_field: _id
       ignore_missing: true
       description: Generate consistent document ID for deduplication

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -99,6 +99,10 @@ processors:
       field: modified
       target_field: threat.indicator.modified_at
   - rename:
+      field: updated_at
+      target_field: opencti.indicator.updated_at
+      ignore_missing: true
+  - rename:
       field: pattern_type
       target_field: opencti.indicator.pattern_type
   - rename:

--- a/packages/ti_opencti/data_stream/indicator/fields/opencti.yml
+++ b/packages/ti_opencti/data_stream/indicator/fields/opencti.yml
@@ -36,6 +36,9 @@
         - name: invalid_or_revoked_from
           type: date
           description: A time from which this indicator should be considered invalid or revoked.
+        - name: updated_at
+          type: date
+          description: The date and time the indicator was last updated in the OpenCTI platform (including UI edits, enrichment, and scoring changes). Distinct from threat.indicator.modified_at, which reflects the source-supplied STIX modified timestamp.
         - name: score
           type: long
           description: An integer score for the indicator.

--- a/packages/ti_opencti/data_stream/indicator/sample_event.json
+++ b/packages/ti_opencti/data_stream/indicator/sample_event.json
@@ -1,22 +1,22 @@
 {
-    "@timestamp": "2026-07-28T14:15:05.406Z",
+    "@timestamp": "2026-07-28T16:24:27.251Z",
     "agent": {
-        "ephemeral_id": "3f642561-30af-4aea-968c-0686506c2e0b",
-        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
-        "name": "elastic-agent-68782",
+        "ephemeral_id": "1ea3af6c-e057-40ba-a374-d7c64b9c2d98",
+        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
+        "name": "elastic-agent-28477",
         "type": "filebeat",
         "version": "9.4.3"
     },
     "data_stream": {
         "dataset": "ti_opencti.indicator",
-        "namespace": "95413",
+        "namespace": "56867",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
+        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
         "snapshot": false,
         "version": "9.4.3"
     },
@@ -28,7 +28,7 @@
         "created": "2018-02-05T08:04:53.000Z",
         "dataset": "ti_opencti.indicator",
         "id": "d019b01c-b637-4eb2-af53-6d527be3193d",
-        "ingested": "2026-07-28T14:15:08Z",
+        "ingested": "2026-07-28T16:24:30Z",
         "kind": "enrichment",
         "module": "ti_opencti",
         "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"updated_at\":\"2023-01-17T05:53:43.100Z\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",

--- a/packages/ti_opencti/data_stream/indicator/sample_event.json
+++ b/packages/ti_opencti/data_stream/indicator/sample_event.json
@@ -1,22 +1,22 @@
 {
-    "@timestamp": "2026-07-28T16:24:27.251Z",
+    "@timestamp": "2026-07-29T12:09:03.572Z",
     "agent": {
-        "ephemeral_id": "1ea3af6c-e057-40ba-a374-d7c64b9c2d98",
-        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
-        "name": "elastic-agent-28477",
+        "ephemeral_id": "f2c072b7-7955-4811-9ae3-9c6fe3f315c4",
+        "id": "83d99a75-f67a-4fa0-a55e-3dcaf28762bd",
+        "name": "elastic-agent-82823",
         "type": "filebeat",
         "version": "9.4.3"
     },
     "data_stream": {
         "dataset": "ti_opencti.indicator",
-        "namespace": "56867",
+        "namespace": "14780",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
+        "id": "83d99a75-f67a-4fa0-a55e-3dcaf28762bd",
         "snapshot": false,
         "version": "9.4.3"
     },
@@ -28,7 +28,7 @@
         "created": "2018-02-05T08:04:53.000Z",
         "dataset": "ti_opencti.indicator",
         "id": "d019b01c-b637-4eb2-af53-6d527be3193d",
-        "ingested": "2026-07-28T16:24:30Z",
+        "ingested": "2026-07-29T12:09:06Z",
         "kind": "enrichment",
         "module": "ti_opencti",
         "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"updated_at\":\"2023-01-17T05:53:43.100Z\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",

--- a/packages/ti_opencti/data_stream/indicator/sample_event.json
+++ b/packages/ti_opencti/data_stream/indicator/sample_event.json
@@ -1,24 +1,24 @@
 {
-    "@timestamp": "2025-11-05T11:37:38.726Z",
+    "@timestamp": "2026-07-28T14:15:05.406Z",
     "agent": {
-        "ephemeral_id": "638d123f-09b5-4d0f-aa84-168b3e311640",
-        "id": "d9bcb055-c833-401c-836b-698a37b90613",
-        "name": "elastic-agent-20893",
+        "ephemeral_id": "3f642561-30af-4aea-968c-0686506c2e0b",
+        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
+        "name": "elastic-agent-68782",
         "type": "filebeat",
-        "version": "9.1.3"
+        "version": "9.4.3"
     },
     "data_stream": {
         "dataset": "ti_opencti.indicator",
-        "namespace": "26786",
+        "namespace": "95413",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "d9bcb055-c833-401c-836b-698a37b90613",
+        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
         "snapshot": false,
-        "version": "9.1.3"
+        "version": "9.4.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -28,10 +28,10 @@
         "created": "2018-02-05T08:04:53.000Z",
         "dataset": "ti_opencti.indicator",
         "id": "d019b01c-b637-4eb2-af53-6d527be3193d",
-        "ingested": "2025-11-05T11:37:41Z",
+        "ingested": "2026-07-28T14:15:08Z",
         "kind": "enrichment",
         "module": "ti_opencti",
-        "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",
+        "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"updated_at\":\"2023-01-17T05:53:43.100Z\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",
         "type": [
             "indicator"
         ]
@@ -56,6 +56,7 @@
             "revoked": false,
             "score": 40,
             "standard_id": "indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b",
+            "updated_at": "2023-01-17T05:53:43.100Z",
             "valid_from": "2018-02-05T08:04:53.000Z",
             "valid_until": "2019-02-05T08:04:53.000Z"
         },

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -94,9 +94,9 @@ All filters work together using AND logic at the top level. Within each multi-va
 
 The OpenCTI integration supports running on multiple Elastic Agents for high availability. When multiple agents fetch the same indicators:
 
-- **Automatic Deduplication**: The integration uses a fingerprint-based document ID to prevent duplicates. Each indicator gets a consistent ID based on its `standard_id` and `modified` timestamp.
+- **Automatic Deduplication**: The integration uses a fingerprint-based document ID to prevent duplicates. Each indicator version gets a consistent ID based on its `standard_id`, `modified` and `updated_at` timestamps.
 - **No Manual Configuration Needed**: Deduplication works automatically - just deploy the integration to multiple agents.
-- **Update Handling**: When an indicator is updated in OpenCTI, the new version replaces the old one in Elasticsearch.
+- **Update Handling**: When an indicator is updated in OpenCTI, a new document is indexed alongside the previous version in `logs-ti_opencti.indicator-*`. The `latest_ioc` transform keeps only the most recent version per indicator in `logs-ti_opencti_latest.indicator`, which is the index detection rules and dashboards should query.
 
 #### Best Practices for HA Setup
 
@@ -150,24 +150,24 @@ An example event for `indicator` looks as following:
 
 ```json
 {
-    "@timestamp": "2026-07-28T16:24:27.251Z",
+    "@timestamp": "2026-07-29T12:09:03.572Z",
     "agent": {
-        "ephemeral_id": "1ea3af6c-e057-40ba-a374-d7c64b9c2d98",
-        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
-        "name": "elastic-agent-28477",
+        "ephemeral_id": "f2c072b7-7955-4811-9ae3-9c6fe3f315c4",
+        "id": "83d99a75-f67a-4fa0-a55e-3dcaf28762bd",
+        "name": "elastic-agent-82823",
         "type": "filebeat",
         "version": "9.4.3"
     },
     "data_stream": {
         "dataset": "ti_opencti.indicator",
-        "namespace": "56867",
+        "namespace": "14780",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
+        "id": "83d99a75-f67a-4fa0-a55e-3dcaf28762bd",
         "snapshot": false,
         "version": "9.4.3"
     },
@@ -179,7 +179,7 @@ An example event for `indicator` looks as following:
         "created": "2018-02-05T08:04:53.000Z",
         "dataset": "ti_opencti.indicator",
         "id": "d019b01c-b637-4eb2-af53-6d527be3193d",
-        "ingested": "2026-07-28T16:24:30Z",
+        "ingested": "2026-07-29T12:09:06Z",
         "kind": "enrichment",
         "module": "ti_opencti",
         "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"updated_at\":\"2023-01-17T05:53:43.100Z\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",
@@ -276,6 +276,7 @@ Timestamps are mapped as follows:
 | -           | event.ingested                | Time the event arrived in the central data store |
 | created     | event.created                 | Time of the indicator's creation |
 | modified    | threat.indicator.modified_at  | Time of the indicator's last modification |
+| updated_at  | opencti.indicator.updated_at  | Time the indicator record was last updated in the OpenCTI platform, including UI edits, enrichment and scoring changes |
 | valid_from  | opencti.indicator.valid_from  | Time from which this indicator is considered a valid indicator of the behaviors it is related to or represents |
 | valid_until | opencti.indicator.valid_until | Time at which this indicator should no longer be considered a valid indicator of the behaviors it is related to or represents |
 | -           | opencti.indicator.invalid_or_revoked_from | The earliest time at which an indicator reaches its `valid_until` time or is marked as revoked |

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -150,26 +150,26 @@ An example event for `indicator` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-11-05T11:37:38.726Z",
+    "@timestamp": "2026-07-28T14:15:05.406Z",
     "agent": {
-        "ephemeral_id": "638d123f-09b5-4d0f-aa84-168b3e311640",
-        "id": "d9bcb055-c833-401c-836b-698a37b90613",
-        "name": "elastic-agent-20893",
+        "ephemeral_id": "3f642561-30af-4aea-968c-0686506c2e0b",
+        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
+        "name": "elastic-agent-68782",
         "type": "filebeat",
-        "version": "9.1.3"
+        "version": "9.4.3"
     },
     "data_stream": {
         "dataset": "ti_opencti.indicator",
-        "namespace": "26786",
+        "namespace": "95413",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "d9bcb055-c833-401c-836b-698a37b90613",
+        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
         "snapshot": false,
-        "version": "9.1.3"
+        "version": "9.4.3"
     },
     "event": {
         "agent_id_status": "verified",
@@ -179,10 +179,10 @@ An example event for `indicator` looks as following:
         "created": "2018-02-05T08:04:53.000Z",
         "dataset": "ti_opencti.indicator",
         "id": "d019b01c-b637-4eb2-af53-6d527be3193d",
-        "ingested": "2025-11-05T11:37:41Z",
+        "ingested": "2026-07-28T14:15:08Z",
         "kind": "enrichment",
         "module": "ti_opencti",
-        "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",
+        "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"updated_at\":\"2023-01-17T05:53:43.100Z\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",
         "type": [
             "indicator"
         ]
@@ -207,6 +207,7 @@ An example event for `indicator` looks as following:
             "revoked": false,
             "score": 40,
             "standard_id": "indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b",
+            "updated_at": "2023-01-17T05:53:43.100Z",
             "valid_from": "2018-02-05T08:04:53.000Z",
             "valid_until": "2019-02-05T08:04:53.000Z"
         },
@@ -317,6 +318,7 @@ The documentation for ECS fields can be found at:
 | opencti.indicator.rule_compatible | Whether the indicator is compatible with detection rules. | boolean |
 | opencti.indicator.score | An integer score for the indicator. | long |
 | opencti.indicator.standard_id | A predictable STIX ID, generated based on one or multiple attributes of the indicator. | keyword |
+| opencti.indicator.updated_at | The date and time the indicator was last updated in the OpenCTI platform (including UI edits, enrichment, and scoring changes). Distinct from threat.indicator.modified_at, which reflects the source-supplied STIX modified timestamp. | date |
 | opencti.indicator.valid_from | The time from which this indicator is considered a valid indicator of the behaviors it is related to or represents. | date |
 | opencti.indicator.valid_until | The time at which this indicator should no longer be considered a valid indicator of the behaviors it is related to or represents. | date |
 | opencti.observable.artifact.additional_names | Additional names of the artifact. | keyword |

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -150,24 +150,24 @@ An example event for `indicator` looks as following:
 
 ```json
 {
-    "@timestamp": "2026-07-28T14:15:05.406Z",
+    "@timestamp": "2026-07-28T16:24:27.251Z",
     "agent": {
-        "ephemeral_id": "3f642561-30af-4aea-968c-0686506c2e0b",
-        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
-        "name": "elastic-agent-68782",
+        "ephemeral_id": "1ea3af6c-e057-40ba-a374-d7c64b9c2d98",
+        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
+        "name": "elastic-agent-28477",
         "type": "filebeat",
         "version": "9.4.3"
     },
     "data_stream": {
         "dataset": "ti_opencti.indicator",
-        "namespace": "95413",
+        "namespace": "56867",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "305feae0-accd-49c0-a6b7-c3b360934a03",
+        "id": "196b7587-7693-43c5-9416-bae4e95dcba2",
         "snapshot": false,
         "version": "9.4.3"
     },
@@ -179,7 +179,7 @@ An example event for `indicator` looks as following:
         "created": "2018-02-05T08:04:53.000Z",
         "dataset": "ti_opencti.indicator",
         "id": "d019b01c-b637-4eb2-af53-6d527be3193d",
-        "ingested": "2026-07-28T14:15:08Z",
+        "ingested": "2026-07-28T16:24:30Z",
         "kind": "enrichment",
         "module": "ti_opencti",
         "original": "{\"confidence\":15,\"created\":\"2018-02-05T08:04:53.000Z\",\"createdBy\":{\"identity_class\":\"organization\",\"name\":\"CthulhuSPRL.be\"},\"description\":\"\",\"externalReferences\":{\"edges\":[]},\"id\":\"d019b01c-b637-4eb2-af53-6d527be3193d\",\"is_inferred\":false,\"killChainPhases\":[],\"lang\":\"en\",\"modified\":\"2023-01-17T05:53:42.851Z\",\"name\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"objectLabel\":[{\"value\":\"information-credibility-6\"},{\"value\":\"osint\"}],\"objectMarking\":[{\"definition\":\"TLP:GREEN\",\"definition_type\":\"TLP\"}],\"observables\":{\"edges\":[{\"node\":{\"entity_type\":\"Hostname\",\"id\":\"b0a91059-5637-4050-8dce-a976a607f75c\",\"observable_value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\",\"standard_id\":\"hostname--2047cd44-ffae-5b34-b912-5856add59b59\",\"value\":\"ec2-23-21-172-164.compute-1.amazonaws.com\"}}],\"pageInfo\":{\"globalCount\":1}},\"pattern\":\"[hostname:value = 'ec2-23-21-172-164.compute-1.amazonaws.com']\",\"pattern_type\":\"stix\",\"pattern_version\":\"2.1\",\"revoked\":false,\"standard_id\":\"indicator--cde0a6e1-c622-52c4-b857-e9aeac56131b\",\"updated_at\":\"2023-01-17T05:53:43.100Z\",\"valid_from\":\"2018-02-05T08:04:53.000Z\",\"valid_until\":\"2019-02-05T08:04:53.000Z\",\"x_opencti_detection\":false,\"x_opencti_main_observable_type\":\"Hostname\",\"x_opencti_score\":40}",

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/opencti.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/fields/opencti.yml
@@ -36,6 +36,9 @@
         - name: invalid_or_revoked_from
           type: date
           description: A time from which this indicator should be considered invalid or revoked.
+        - name: updated_at
+          type: date
+          description: The date and time the indicator was last updated in the OpenCTI platform (including UI edits, enrichment, and scoring changes). Distinct from threat.indicator.modified_at, which reflects the source-supplied STIX modified timestamp.
         - name: score
           type: long
           description: An integer score for the indicator.

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
@@ -15,7 +15,7 @@ source:
 # that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_opencti_latest.dest_indicator-5"
+  index: "logs-ti_opencti_latest.dest_indicator-6"
   aliases:
     - alias: "logs-ti_opencti_latest.indicator"
       move_on_creation: true
@@ -41,6 +41,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.8.0
+  fleet_transform_version: 0.9.0
 settings:
   num_failure_retries: -1

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: ti_opencti
 title: OpenCTI
-version: "2.15.1"
+version: "2.15.2"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
## Proposed commit message

```
ti_opencti: fix incremental polling missing UI-edited indicators

The CEL program ordered results and tracked the polling cursor using
the STIX modified field, which is controlled by the upstream feed
supplier. The incremental filter, however, compared against
updated_at, OpenCTI's internal platform timestamp that advances on
every platform-side change — including UI edits, enrichment, and
scoring updates. This mismatch meant any indicator edited directly
in OpenCTI would never be re-ingested: its modified timestamp
remained in the already-processed range, so keyset pagination by
modified order would never return it again.

Per the OpenCTI documentation, modified reflects the original update
timestamp from the source, while updated_at represents the most
recent update to the entity in the platform. The two fields are
analogous to the created/created_at distinction. See:
https://docs.opencti.io/latest/usage/dates/

Align all three operations on updated_at: change orderBy from
"modified" to "updated_at", update the cursor to track
max(node.updated_at) instead of max(node.modified), and add
updated_at to the GraphQL fragment so the field is fetched.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
