### PR TITLE
Skip security_detection_engine from backport checklist comment

### DIFF
--- a/.backports.yml
+++ b/.backports.yml
@@ -12,6 +12,12 @@
 # manually reviewed and corrected (base_commit / base_version values for several
 # branches were adjusted after the automated seed).
 # Do not re-run the bootstrap — update this file directly.
+# Packages listed here are excluded from the backport checklist comment
+# (they will not appear as checkboxes for PR authors) but are still processed
+# for changelog syncing and other automated backport flows.
+skip_checklist_packages:
+  - security_detection_engine
+
 backports:
   - package: apm
     branch: backport-apm-8.15

--- a/dev/backports/inventory.go
+++ b/dev/backports/inventory.go
@@ -20,7 +20,8 @@ import (
 )
 
 type inventory struct {
-	Backports []entry `yaml:"backports"`
+	SkipChecklistPackages []string `yaml:"skip_checklist_packages"`
+	Backports             []entry  `yaml:"backports"`
 }
 
 type entry struct {
@@ -107,6 +108,17 @@ func ListAllActiveBackportBranches(path string, packages []string, now time.Time
 		}
 	}
 	return result, nil
+}
+
+// ListSkipChecklistPackages returns the package names that should be excluded
+// from the backport checklist comment. These packages still participate in
+// changelog syncing and other automated backport flows.
+func ListSkipChecklistPackages(path string) ([]string, error) {
+	inv, err := loadInventory(path)
+	if err != nil {
+		return nil, err
+	}
+	return inv.SkipChecklistPackages, nil
 }
 
 // CheckActive looks up branch in the inventory at path and reports whether it

--- a/dev/backports/inventory_test.go
+++ b/dev/backports/inventory_test.go
@@ -850,6 +850,32 @@ func readInventory(t *testing.T, path string) inventory {
 	return inv
 }
 
+func TestListSkipChecklistPackages(t *testing.T) {
+	t.Run("returns listed packages", func(t *testing.T) {
+		path := writeTemp(t, `skip_checklist_packages:
+  - security_detection_engine
+  - other_pkg
+backports: []
+`)
+		got, err := ListSkipChecklistPackages(path)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"security_detection_engine", "other_pkg"}, got)
+	})
+
+	t.Run("returns nil when field is absent", func(t *testing.T) {
+		path := writeTemp(t, "backports: []\n")
+		got, err := ListSkipChecklistPackages(path)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("file not found returns error", func(t *testing.T) {
+		_, err := ListSkipChecklistPackages("/no/such/file.yml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading inventory")
+	})
+}
+
 func TestValidateBranchFormat(t *testing.T) {
 	tests := []struct {
 		branch      string

--- a/magefile.go
+++ b/magefile.go
@@ -508,13 +508,29 @@ func RenderBackportChecklist(artifactPath string) error {
 
 	checked := bpchecklist.ParseCheckedBranches(string(existingBody))
 
-	branchesByPkg, err := backports.ListAllActiveBackportBranches(".backports.yml", artifact.Packages, time.Now().UTC())
+	skipPkgs, err := backports.ListSkipChecklistPackages(".backports.yml")
+	if err != nil {
+		return fmt.Errorf("loading skip checklist packages: %w", err)
+	}
+	skipSet := make(map[string]struct{}, len(skipPkgs))
+	for _, p := range skipPkgs {
+		skipSet[p] = struct{}{}
+	}
+
+	checklistPkgs := make([]string, 0, len(artifact.Packages))
+	for _, pkg := range artifact.Packages {
+		if _, skip := skipSet[pkg]; !skip {
+			checklistPkgs = append(checklistPkgs, pkg)
+		}
+	}
+
+	branchesByPkg, err := backports.ListAllActiveBackportBranches(".backports.yml", checklistPkgs, time.Now().UTC())
 	if err != nil {
 		return fmt.Errorf("listing active backport branches: %w", err)
 	}
 
-	pkgs := make([]bpchecklist.PackageBranches, 0, len(artifact.Packages))
-	for _, pkg := range artifact.Packages {
+	pkgs := make([]bpchecklist.PackageBranches, 0, len(checklistPkgs))
+	for _, pkg := range checklistPkgs {
 		pkgs = append(pkgs, bpchecklist.PackageBranches{
 			Package:  pkg,
 			Branches: branchesByPkg[pkg],


### PR DESCRIPTION
<!-- Enhancement -->

## Proposed commit message

```
Skip security_detection_engine from backport checklist comment

Add a top-level skip_checklist_packages list to .backports.yml.
Packages in this list are excluded from the checklist comment posted
on PRs (no checkboxes shown to authors) but still participate in
changelog syncing and other automated backport flows.
```

## Author's Checklist

- [x] `skip_checklist_packages` in `.backports.yml` is respected by `RenderBackportChecklist`
- [x] Changelog sync for `security_detection_engine` is unaffected

## How to test this PR locally

1. Add `security_detection_engine` to a PR that also touches other packages with active backport branches.
2. Confirm the posted checklist comment does **not** include a section for `security_detection_engine`.
3. Push a changelog change on a `backport-security_detection_engine-*` branch and confirm the sync-changelog workflow still runs normally.

Example of `security_detection_engine` being skipped from the checklist: https://github.com/mrodm/integrations/pull/66

## Related issues

- Relates #19213
- Requires https://github.com/elastic/integrations/pull/20197

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).