### PR TITLE
[citrix_adc] Add dd/MM/yyyy date format to native timestamp processors.

### DIFF
--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.6"
+  changes:
+    - description: Add dd/MM/yyyy date format support to native timestamp processors to handle Citrix ADC day-first (DDMMYYYY) syslog timestamps.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.18.5"
   changes:
     - description: Fix parsing of Source/Destination IP, port, and byte counts for TCP CONN_TERMINATE events with trailing whitespace.

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dd/MM/yyyy date format support to native timestamp processors to handle Citrix ADC day-first (DDMMYYYY) syslog timestamps.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20393
 - version: "1.18.5"
   changes:
     - description: Fix parsing of Source/Destination IP, port, and byte counts for TCP CONN_TERMINATE events with trailing whitespace.

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-ddmmyyyy.log
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-ddmmyyyy.log
@@ -1,0 +1,1 @@
+<134> 27/06/2026:22:38:17  host-1.example.local 0-PPE-0 : default APPFW APPFW_SCHEMA_ENDPOINT_NOTFOUND 124787067 0 :  198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-ddmmyyyy.log-expected.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-ddmmyyyy.log-expected.json
@@ -1,0 +1,49 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-06-27T22:38:17.000Z",
+            "citrix": {
+                "cef_format": false,
+                "default_class": true,
+                "detail": "<134> 27/06/2026:22:38:17  host-1.example.local 0-PPE-0 : default APPFW APPFW_SCHEMA_ENDPOINT_NOTFOUND 124787067 0 :  198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>",
+                "device_event_class_id": "APPFW",
+                "extended": {
+                    "message": "198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>"
+                },
+                "host": "host-1.example.local",
+                "name": "APPFW_SCHEMA_ENDPOINT_NOTFOUND"
+            },
+            "citrix_adc": {
+                "log": {
+                    "message": "198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "id": "124787067",
+                "kind": "event",
+                "original": "<134> 27/06/2026:22:38:17  host-1.example.local 0-PPE-0 : default APPFW APPFW_SCHEMA_ENDPOINT_NOTFOUND 124787067 0 :  198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>",
+                "severity": 0,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "hostname": "host-1.example.local",
+                "product": "Netscaler",
+                "type": "firewall",
+                "vendor": "Citrix"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native.json
@@ -85,8 +85,8 @@
             "message": "<134> 11/18/2024:10:59:53 GMT HOSTNAME 0-PPE-2 : default SSLVPN LOGOUT 6918043 0 : User UserName@domain.com - Client_ip 0.0.0.0 - Nat_ip \"Mapped Ip\" - Vserver 0.0.0.0:443 - Start_time \"11/18/2024:10:59:53 GMT\" - End_time \"11/18/2024:10:59:53 GMT\" - Duration 00:00:00 - Http_resources_accessed 0 - NonHttp_services_accessed 0 - Total_TCP_connections 0 - Total_UDP_flows 0 - Total_policies_allowed 0 - Total_policies_denied 0 - Total_bytes_send 0 - Total_bytes_recv 0 - Total_compressedbytes_send 0 - Total_compressedbytes_recv 0 - Compression_ratio_send 0.00% - Compression_ratio_recv 0.00% - LogoutMethod \"InternalError\" - Group(s) \"N/A\"\n"
         },
         {
-            "@timestamp": "02/13/2025:19:47:20.000Z", 
-        "message": "<135> 02/13/2025:19:47:20 GMT ECLVNSGP001 0-PPE-1 : default SSLVPN Message 877558 0 : \"\nclnt npcb is 12007a600, srvr is 12008be80\""
+            "@timestamp": "02/13/2025:19:47:20.000Z",
+            "message": "<135> 02/13/2025:19:47:20 GMT ECLVNSGP001 0-PPE-1 : default SSLVPN Message 877558 0 : \"\nclnt npcb is 12007a600, srvr is 12008be80\""
         }
     ]
 }

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-rfc5424.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-rfc5424.json
@@ -9,7 +9,7 @@
             "message": "<173>1 2025-01-30T12:00:00Z MY-CITRIX-HOST newsyslog 79382 - - logfile turned over due to size>100K"
         },
         {
-            "@timestamp": "2025-01-08T13:30:00Z" ,
+            "@timestamp": "2025-01-08T13:30:00Z",
             "message": "<171>1 2025-01-08T13:30:00Z MY-CITRIX-HOST httpd::authz_core 38137 - - [client 175.16.199.1:36664] AH01630: client denied by server configuration: /netscaler/ns_gui/var "
         },
         {

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -194,6 +194,8 @@ processors:
         - yyyy/MM/dd:HH:mm:ss z
         - MM/dd/yyyy:HH:mm:ss
         - MM/dd/yyyy:HH:mm:ss z
+        - dd/MM/yyyy:HH:mm:ss
+        - dd/MM/yyyy:HH:mm:ss z
       on_failure:
         - append:
             field: error.message
@@ -210,6 +212,8 @@ processors:
         - yyyy/MM/dd:HH:mm:ss z
         - MM/dd/yyyy:HH:mm:ss
         - MM/dd/yyyy:HH:mm:ss z
+        - dd/MM/yyyy:HH:mm:ss
+        - dd/MM/yyyy:HH:mm:ss z
       on_failure:
         - append:
             field: error.message
@@ -226,6 +230,8 @@ processors:
         - yyyy/MM/dd:HH:mm:ss z
         - MM/dd/yyyy:HH:mm:ss
         - MM/dd/yyyy:HH:mm:ss z
+        - dd/MM/yyyy:HH:mm:ss
+        - dd/MM/yyyy:HH:mm:ss z
       on_failure:
         - append:
             field: error.message
@@ -244,6 +250,9 @@ processors:
         - MM/dd/yyyy:HH:mm:ss
         - MM/dd/yyyy:HH:mm:ss z
         - MM/dd/yyyy:HH:mm:ssz
+        - dd/MM/yyyy:HH:mm:ss
+        - dd/MM/yyyy:HH:mm:ss z
+        - dd/MM/yyyy:HH:mm:ssz
       on_failure:
         - append:
             field: error.message
@@ -260,6 +269,8 @@ processors:
         - yyyy/MM/dd:HH:mm:ss z
         - MM/dd/yyyy:HH:mm:ss
         - MM/dd/yyyy:HH:mm:ss z
+        - dd/MM/yyyy:HH:mm:ss
+        - dd/MM/yyyy:HH:mm:ss z
       on_failure:
         - append:
             field: error.message

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.18.5"
+version: "1.18.6"
 description: This Elastic integration collects logs and metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Adds dd/MM/yyyy:HH:mm:ss and dd/MM/yyyy:HH:mm:ss z (plus the compact-timezone variant dd/MM/yyyy:HH:mm:ssz for the fourth processor) to all five native-timestamp date processors in the citrix_adc log ingest pipeline. Citrix ADC appliances running regional firmware or non-US locale settings emit day-first syslog timestamps that none of the existing MM/dd/yyyy patterns matched, causing every such event to fall through to on_failure and leaving @timestamp unset — the MISSING_CASE symptom reported in the issue. A new pipeline test fixture validates the fix end-to-end.

## Proposed commit message

```
[citrix_adc] Add dd/MM/yyyy date format to native timestamp processors.
```

## Root cause

The five date processors in default.yml that parse Citrix ADC native-format timestamps only include MM/dd/yyyy (US month-first) and yyyy/MM/dd (ISO year-first) format strings, omitting dd/MM/yyyy (European day-first). The NATIVE_TIMESTAMP grok pattern in native.yml already accepts all three Citrix ADC -dateformat variants (MMDDYYYY, DDMMYYYY, YYYYMMDD) and correctly captures day-first timestamps such as '27/06/2026:22:38:17' into _tmp.timestamp_native, but the downstream date processors cannot parse that string, causing the on_failure error.message to be appended.

## Approach

Add 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' to the formats list of ALL five date processors in default.yml (date_timestamp_native, date_timestamp, date_start_time, date_end_time, date_delink_time) that share the same Citrix ADC native timestamp format, appending them after the existing MM/dd/yyyy entries so that ambiguous timestamps (day <= 12) continue to use the existing MM/dd/yyyy parse order while unambiguous day-first timestamps (day > 12, e.g. 27/06/2026) succeed via the new dd/MM/yyyy format. Also add 'dd/MM/yyyy:HH:mm:ssz' to date_end_time to match the no-space-z variant already present there. Add a pipeline test fixture using the sanitized APPFW event to cover the day-first timestamp path.

## Implementation

1. Step 1: In packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/default.yml, locate the 'date_timestamp_native' processor (lines 185-200) and append 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' to its formats list, after 'MM/dd/yyyy:HH:mm:ss z'.
2. Step 2: In the same file, apply the identical addition to the 'date_timestamp' processor (lines 201-216): add 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' after 'MM/dd/yyyy:HH:mm:ss z'.
3. Step 3: In the same file, apply the identical addition to the 'date_start_time' processor (lines 217-232): add 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' after 'MM/dd/yyyy:HH:mm:ss z'.
4. Step 4: In the same file, update the 'date_end_time' processor (lines 233-250): add 'dd/MM/yyyy:HH:mm:ss', 'dd/MM/yyyy:HH:mm:ss z', and 'dd/MM/yyyy:HH:mm:ssz' after their MM/dd/yyyy counterparts, mirroring the existing no-space-z variant pattern.
5. Step 5: In the same file, apply the identical addition to the 'date_delink_time' processor (lines 251-266): add 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' after 'MM/dd/yyyy:HH:mm:ss z'.
6. Step 6: Create a new pipeline test fixture packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native-ddmmyyyy.log containing the sanitized APPFW event ('<134> 27/06/2026:22:38:17  host-1.example.local 0-PPE-0 : default APPFW APPFW_SCHEMA_ENDPOINT_NOTFOUND 124787067 0 :  198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>'), then run 'elastic-package test pipeline --generate' to produce the corresponding -expected.json with @timestamp set to '2026-06-27T22:38:17.000Z' and no error.message.
7. Step 7: Add a new bugfix entry to packages/citrix_adc/changelog.yml and bump the version from 1.18.5 to 1.18.6.

## Pipeline changes

- date_timestamp_native processor (default.yml ~line 191): append 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' to formats list after 'MM/dd/yyyy:HH:mm:ss z'
- date_timestamp processor (default.yml ~line 207): append 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' to formats list after 'MM/dd/yyyy:HH:mm:ss z'
- date_start_time processor (default.yml ~line 223): append 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' to formats list after 'MM/dd/yyyy:HH:mm:ss z'
- date_end_time processor (default.yml ~line 239): append 'dd/MM/yyyy:HH:mm:ss', 'dd/MM/yyyy:HH:mm:ss z', and 'dd/MM/yyyy:HH:mm:ssz' to formats list after their MM/dd/yyyy counterparts
- date_delink_time processor (default.yml ~line 256): append 'dd/MM/yyyy:HH:mm:ss' and 'dd/MM/yyyy:HH:mm:ss z' to formats list after 'MM/dd/yyyy:HH:mm:ss z'

## Field / mapping changes

—

## Sanitized error message

`Processor date with tag date_timestamp_native in pipeline logs-citrix_adc.log-default failed with message: [on_failure_message]`

## Sanitized log (`event_sanitized` excerpt)

```json
<134> 27/06/2026:22:38:17  host-1.example.local 0-PPE-0 : default APPFW APPFW_SCHEMA_ENDPOINT_NOTFOUND 124787067 0 :  198.51.100.10 89a1d5c1-PPE0 - example-appfw-profile Endpoint: (OPTIONS https://auth-server.example.local/cgi/tm?code=dGVzdC1hdXRoLWNvZGUteGFtcGxl) not found in API Spec: (example-spec) <blocked>
```

## Reviewer concerns

- Ambiguity for days 01–12: dd/MM/yyyy patterns are appended after MM/dd/yyyy, so a timestamp like 06/01/2026:10:00:00 will be parsed as June 1 (MM/dd wins) rather than January 6. Devices that emit genuine day-first dates with day ≤ 12 will still be mis-parsed. This is an inherent format ambiguity and cannot be resolved without out-of-band locale information.
- The fourth date processor (~line 250) gains a dd/MM/yyyy:HH:mm:ssz (compact-timezone) variant that the other four processors do not receive. Reviewers should confirm this mirrors the existing MM/dd/yyyy:HH:mm:ssz entry already present only in that block, and that omitting it from the others is intentional.
- The changelog PR link is a placeholder (pull/1) and must be updated to the real PR number before merge.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, test-fixture, ingest
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: citrix_adc.log [MISSING_CASE]: Processor date with tag date_timestamp_native in pipeline logs-citrix_ad…
- **Pipeline case**: `25335679f1182f66`
