### PR TITLE
Crowdstrike.fdr: raise FDR index total_fields limit to prevent upgrade failures

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Raise FDR `total_fields.limit` from 2000 to 5000 to prevent upgrade failures after latest field additions.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20395
 - version: "4.4.3"
   changes:
     - description: Add `ignore_above` for flattened attribute blobs in the falcon, fdr, and alert data streams to avoid dropping events. Requires Kibana 8.19.8+ or 9.1.8+ so Fleet applies the mapping option.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.4.4"
+  changes:
+    - description: Raise FDR `total_fields.limit` from 2000 to 5000 to prevent upgrade failures after latest field additions.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "4.4.3"
   changes:
     - description: Add `ignore_above` for flattened attribute blobs in the falcon, fdr, and alert data streams to avoid dropping events. Requires Kibana 8.19.8+ or 9.1.8+ so Fleet applies the mapping option.

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -6,7 +6,7 @@ elasticsearch:
       index:
         mapping:
           total_fields:
-            limit: 2000
+            limit: 5000
 streams:
   - input: aws-s3
     template_path: aws-s3.yml.hbs

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "4.4.3"
+version: "4.4.4"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
## Proposed commit message

```
crowdstrike: raise FDR index total_fields limit to prevent upgrade failures

The FDR data stream's explicitly-declared field count has grown past
the limit the package set on its own index template, causing mapping
update failures on upgrade. Raise the limit to give adequate headroom
for continued field growth.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
