### PR TITLE
[Synthetics] Add policy tests (requires Kibana 9.6.0)

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Add policy tests for the http, tcp and icmp data streams verifying that default monitor fields are omitted from the compiled agent stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20412
+    - description: Raise the minimum Kibana version to 9.6.0, which includes the Fleet agent-policy YAML serialization fix (elastic/kibana#280669) required to compile these policies.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20412
 - version: "1.9.0"
   changes:
     - description: Only emit monitor fields in the agent stream when they differ from the Heartbeat default (http, tcp, icmp), reducing the size of the generated policy.

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-custom.expected
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-custom.expected
@@ -1,0 +1,48 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-custom-synthetics
+      streams:
+        - check.request.method: POST
+          data_stream:
+            dataset: http
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          max_redirects: 5
+          name: null
+          response.include_body: always
+          response.include_headers: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          timeout: 30s
+          type: http
+          urls: https://www.elastic.co
+      type: synthetics/http
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-http-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-custom.yml
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-custom.yml
@@ -1,0 +1,8 @@
+input: synthetics/http
+data_stream:
+  vars:
+    urls: https://www.elastic.co
+    timeout: 30s
+    max_redirects: 5
+    response.include_body: always
+    check.request.method: POST

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-defaults.expected
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-defaults.expected
@@ -1,0 +1,44 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-defaults-synthetics
+      streams:
+        - data_stream:
+            dataset: http
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          name: null
+          response.include_headers: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          type: http
+          urls: https://www.elastic.co
+      type: synthetics/http
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-http-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-defaults.yml
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-defaults.yml
@@ -1,0 +1,4 @@
+input: synthetics/http
+data_stream:
+  vars:
+    urls: https://www.elastic.co

--- a/packages/synthetics/data_stream/icmp/_dev/test/policy/test-custom.expected
+++ b/packages/synthetics/data_stream/icmp/_dev/test/policy/test-custom.expected
@@ -1,0 +1,45 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-custom-synthetics
+      streams:
+        - data_stream:
+            dataset: icmp
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          hosts: localhost
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          name: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          timeout: 30s
+          type: icmp
+          wait: 5s
+      type: synthetics/icmp
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-icmp-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/icmp/_dev/test/policy/test-custom.yml
+++ b/packages/synthetics/data_stream/icmp/_dev/test/policy/test-custom.yml
@@ -1,0 +1,6 @@
+input: synthetics/icmp
+data_stream:
+  vars:
+    hosts: localhost
+    timeout: 30s
+    wait: 5s

--- a/packages/synthetics/data_stream/icmp/_dev/test/policy/test-defaults.expected
+++ b/packages/synthetics/data_stream/icmp/_dev/test/policy/test-defaults.expected
@@ -1,0 +1,43 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-defaults-synthetics
+      streams:
+        - data_stream:
+            dataset: icmp
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          hosts: localhost
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          name: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          type: icmp
+      type: synthetics/icmp
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-icmp-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/icmp/_dev/test/policy/test-defaults.yml
+++ b/packages/synthetics/data_stream/icmp/_dev/test/policy/test-defaults.yml
@@ -1,0 +1,4 @@
+input: synthetics/icmp
+data_stream:
+  vars:
+    hosts: localhost

--- a/packages/synthetics/data_stream/tcp/_dev/test/policy/test-custom.expected
+++ b/packages/synthetics/data_stream/tcp/_dev/test/policy/test-custom.expected
@@ -1,0 +1,45 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-custom-synthetics
+      streams:
+        - data_stream:
+            dataset: tcp
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          hosts: localhost:9200
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          name: null
+          proxy_use_local_resolver: true
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          timeout: 30s
+          type: tcp
+      type: synthetics/tcp
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-tcp-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/tcp/_dev/test/policy/test-custom.yml
+++ b/packages/synthetics/data_stream/tcp/_dev/test/policy/test-custom.yml
@@ -1,0 +1,6 @@
+input: synthetics/tcp
+data_stream:
+  vars:
+    hosts: localhost:9200
+    timeout: 30s
+    proxy_use_local_resolver: true

--- a/packages/synthetics/data_stream/tcp/_dev/test/policy/test-defaults.expected
+++ b/packages/synthetics/data_stream/tcp/_dev/test/policy/test-defaults.expected
@@ -1,0 +1,43 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-defaults-synthetics
+      streams:
+        - data_stream:
+            dataset: tcp
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          hosts: localhost:9200
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          name: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          type: tcp
+      type: synthetics/tcp
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-tcp-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/tcp/_dev/test/policy/test-defaults.yml
+++ b/packages/synthetics/data_stream/tcp/_dev/test/policy/test-defaults.yml
@@ -1,0 +1,4 @@
+input: synthetics/tcp
+data_stream:
+  vars:
+    hosts: localhost:9200

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.9.0
+version: 1.10.0
 categories:
   - observability
   # Added monitoring category as Synthetics provides synthetic monitoring capabilities
@@ -33,7 +33,7 @@ conditions:
       - "uptime"
     subscription: "basic"
   kibana:
-    version: "^9.5.0"
+    version: "^9.6.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16


### PR DESCRIPTION
## Summary

Follow-up to #20342. Adds `elastic-package` policy tests for the **http**, **tcp** and **icmp** data streams, verifying that default monitor fields are omitted from the compiled agent stream (and still emitted when a non-default value is configured).

These tests are split out of #20342 because they can only pass on a stack that includes the Fleet agent-policy YAML serialization fix ([elastic/kibana#280669](https://github.com/elastic/kibana/pull/280669), *"Fix agent policy YAML serialization for shared object references"*). Without it, downloading the compiled policy fails with:

```
API status code = 500; message: "Unresolved alias (the anchor must be set before the alias): a1"
```

That fix shipped in **9.6.0 / 9.5.1**, so this PR raises the package's minimum Kibana version.

## Changes

- Add policy test fixtures under `data_stream/{http,tcp,icmp}/_dev/test/policy/` (`test-defaults` and `test-custom`).
- Raise `conditions.kibana.version` `^9.5.0` → `^9.6.0` so CI resolves to a stack (`9.6.0-SNAPSHOT`) containing the Fleet fix.
- Bump package version `1.9.0` → `1.10.0`.

## Notes

- **Base branch:** targets `synthetics-omit-default-values` (the #20342 branch) so the diff shows only the test additions. It will auto-retarget `main` once #20342 merges.
- The feature itself (#20342) ships independently on 9.5.0; only these tests require the newer stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)