### PR TITLE
Update agentless release mode to ga for security packages

### DIFF
--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.16.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/abnormal_security/manifest.yml
+++ b/packages/abnormal_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: abnormal_security
 title: Abnormal AI
-version: "1.16.0"
+version: "1.16.1"
 description: Collect logs from Abnormal AI with Elastic Agent.
 type: integration
 categories:
@@ -59,7 +59,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/admin_by_request_epm/changelog.yml
+++ b/packages/admin_by_request_epm/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.4.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/admin_by_request_epm/manifest.yml
+++ b/packages/admin_by_request_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: admin_by_request_epm
 title: Admin By Request EPM
-version: "1.4.0"
+version: "1.4.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Admin By Request EPM with Elastic Agent."
@@ -40,7 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.10.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "2.10.0"
+version: "2.10.1"
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration
 categories:
@@ -24,7 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.33.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.33.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.33.0"
+version: "1.33.1"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:
@@ -24,6 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.34.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.34.0"
+version: "1.34.1"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:
@@ -24,6 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.26.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: auth0
 title: "Auth0"
-version: "1.26.0"
+version: "1.26.1"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:
@@ -29,7 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/authentik/changelog.yml
+++ b/packages/authentik/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.11.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/authentik/manifest.yml
+++ b/packages/authentik/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: authentik
 title: authentik
-version: "1.11.0"
+version: "1.11.1"
 description: Collect logs from authentik with Elastic Agent.
 type: integration
 categories:
@@ -36,7 +36,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.2.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_securityhub
 title: "AWS Security Hub"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Elastic-2.0"
 description: Collect logs from AWS Security Hub with Elastic Agent.
@@ -35,7 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.3.1"
   changes:
     - description: Send the PS-Auth Authorization header on all data collection requests instead of only on sign-in, so collection works against API registrations that validate authentication on every call.

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "1.3.1"
+version: "1.3.2"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.
@@ -40,7 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/beyondtrust_pra/changelog.yml
+++ b/packages/beyondtrust_pra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.2.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/beyondtrust_pra/manifest.yml
+++ b/packages/beyondtrust_pra/manifest.yml
@@ -1,6 +1,6 @@
 name: beyondtrust_pra
 title: "BeyondTrust PRA"
-version: 1.2.0
+version: 1.2.1
 description: "Collect logs from BeyondTrust PRA with Elastic Agent."
 type: integration
 format_version: 3.3.2
@@ -34,7 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.12.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.12.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: bitdefender
 title: "BitDefender"
-version: "2.12.0"
+version: "2.12.1"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"
@@ -38,7 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/bitwarden/changelog.yml
+++ b/packages/bitwarden/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.21.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/bitwarden/manifest.yml
+++ b/packages/bitwarden/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitwarden
 title: Bitwarden
-version: "1.21.0"
+version: "1.21.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Bitwarden with Elastic Agent.
@@ -45,7 +45,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/blacklens/changelog.yml
+++ b/packages/blacklens/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.3.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/blacklens/manifest.yml
+++ b/packages/blacklens/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: blacklens
 title: "blacklens.io"
-version: "1.3.0"
+version: "1.3.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from blacklens.io with Elastic Agent"
@@ -34,7 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "3.5.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.6.1"
 name: box_events
 title: Box Events
-version: "3.5.0"
+version: "3.5.1"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:
@@ -102,7 +102,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.4.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "4.4.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "4.4.0"
+version: "4.4.1"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:
@@ -29,7 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/checkpoint_email/changelog.yml
+++ b/packages/checkpoint_email/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.6.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/checkpoint_email/manifest.yml
+++ b/packages/checkpoint_email/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_email
 title: Check Point Harmony Email & Collaboration
-version: "1.6.0"
+version: "1.6.1"
 description: Collect logs from Check Point Harmony Email & Collaboration with Elastic Agent.
 type: integration
 categories:
@@ -32,7 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.4.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "1.4.0"
+version: "1.4.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"
@@ -38,7 +38,7 @@ policy_templates:
         enabled: true 
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cisa_kevs/changelog.yml
+++ b/packages/cisa_kevs/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.10.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/cisa_kevs/manifest.yml
+++ b/packages/cisa_kevs/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cisa_kevs
 title: "CISA Known Exploited Vulnerabilities"
-version: "1.10.0"
+version: "1.10.1"
 description: "This package allows the ingest of known exploited vulnerabilities according to the Cybersecurity and Infrastructure Security Agency of the United States of America. This information could be used to enrich or track exisiting vulnerabilities that are known to be exploited in the wild."
 type: integration
 categories:
@@ -30,7 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.11.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.11.0"
+version: "2.11.1"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:
@@ -53,7 +53,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.36.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.36.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: "2.36.0"
+version: "2.36.1"
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration
 categories:
@@ -29,7 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.5.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/claroty_ctd/manifest.yml
+++ b/packages/claroty_ctd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: claroty_ctd
 title: Claroty CTD
-version: "1.5.0"
+version: "1.5.1"
 description: Collect logs from Claroty CTD using Elastic Agent.
 type: integration
 categories:
@@ -58,7 +58,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/claroty_xdome/changelog.yml
+++ b/packages/claroty_xdome/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.2.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/claroty_xdome/manifest.yml
+++ b/packages/claroty_xdome/manifest.yml
@@ -1,6 +1,6 @@
 name: claroty_xdome
 title: "Claroty xDome"
-version: 1.2.0
+version: 1.2.1
 description: "Collect logs from Claroty xDome with Elastic Agent."
 type: integration
 format_version: 3.3.2
@@ -39,7 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.36.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.36.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.36.0"
+version: "2.36.1"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -35,7 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cyberark_epm/changelog.yml
+++ b/packages/cyberark_epm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.5.1"
   changes:
     - description: Fix login failure when username or password contains quotes, slashes, or backslashes.

--- a/packages/cyberark_epm/manifest.yml
+++ b/packages/cyberark_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyberark_epm
 title: CyberArk EPM
-version: "1.5.1"
+version: "1.5.2"
 description: Collect logs from CyberArk EPM with Elastic Agent.
 type: integration
 categories:
@@ -38,7 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cybereason/changelog.yml
+++ b/packages/cybereason/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.8.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/cybereason/manifest.yml
+++ b/packages/cybereason/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cybereason
 title: Cybereason
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs from Cybereason with Elastic Agent.
 type: integration
 categories:
@@ -51,7 +51,7 @@ policy_templates:
        enabled: true
      agentless:
        enabled: true
-       release: beta
+       release: ga
        organization: security
        division: engineering
        team: security-service-integrations

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.3.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: darktrace
 title: Darktrace
-version: "2.3.0"
+version: "2.3.1"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:
@@ -29,7 +29,7 @@ policy_templates:
        enabled: true
      agentless:
        enabled: true
-       release: beta
+       release: ga
        organization: security
        division: engineering
        team: security-service-integrations

--- a/packages/digital_guardian/changelog.yml
+++ b/packages/digital_guardian/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.11.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/digital_guardian/manifest.yml
+++ b/packages/digital_guardian/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: digital_guardian
 title: Digital Guardian
-version: "1.11.0"
+version: "1.11.1"
 description: Collect logs from Digital Guardian with Elastic Agent.
 type: integration
 categories:
@@ -33,7 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -1,4 +1,9 @@
 
+- version: "1.0.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.0.0"
   changes:
     - description: Promote integration to GA.

--- a/packages/doppel/manifest.yml
+++ b/packages/doppel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: doppel
 title: "Doppel"
-version: 1.0.0
+version: 1.0.1
 description: "Collects Doppel alerts and sends them to Elastic"
 type: integration
 source:
@@ -32,7 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.5.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: eset_protect
 title: ESET PROTECT
-version: "2.5.1"
+version: "2.5.2"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:
@@ -40,7 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/first_epss/changelog.yml
+++ b/packages/first_epss/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/first_epss/manifest.yml
+++ b/packages/first_epss/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: first_epss
 title: First EPSS
-version: "1.4.0"
+version: "1.4.1"
 description: Collect exploit prediction score data from the First EPSS API with Elastic Agent.
 type: integration
 categories:
@@ -31,7 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.24.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/forgerock/manifest.yml
+++ b/packages/forgerock/manifest.yml
@@ -1,6 +1,6 @@
 name: forgerock
 title: "ForgeRock"
-version: "1.24.0"
+version: "1.24.1"
 description: Collect audit logs from ForgeRock with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -22,7 +22,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/google_scc/changelog.yml
+++ b/packages/google_scc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.6.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/google_scc/manifest.yml
+++ b/packages/google_scc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.2.3"
 name: google_scc
 title: Google Security Command Center
-version: "2.6.0"
+version: "2.6.1"
 description: Collect logs from Google Security Command Center with Elastic Agent.
 type: integration
 categories:
@@ -50,7 +50,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/google_secops/changelog.yml
+++ b/packages/google_secops/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/google_secops/manifest.yml
+++ b/packages/google_secops/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: google_secops
 title: Google SecOps
-version: 1.3.0
+version: 1.3.1
 description: Collect alerts from Google SecOps with Elastic Agent.
 type: integration
 categories:
@@ -32,7 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ibm_qradar/changelog.yml
+++ b/packages/ibm_qradar/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.1"
   changes:
     - description: Handle offense rules not present in the rules dictionary during enrichment.

--- a/packages/ibm_qradar/manifest.yml
+++ b/packages/ibm_qradar/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ibm_qradar
 title: IBM QRadar
-version: 1.1.1
+version: 1.1.2
 description: Collect logs from IBM QRadar with Elastic Agent.
 type: integration
 categories:
@@ -31,7 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.15.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.15.0"
+version: "1.15.1"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:
@@ -30,7 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.23.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/infoblox_bloxone_ddi/manifest.yml
+++ b/packages/infoblox_bloxone_ddi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: infoblox_bloxone_ddi
 title: Infoblox BloxOne DDI
-version: "1.23.0"
+version: "1.23.1"
 description: Collect logs from Infoblox BloxOne DDI with Elastic Agent.
 type: integration
 categories:
@@ -30,7 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/island_browser/changelog.yml
+++ b/packages/island_browser/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.2"
   changes:
     - description: Fix device ingest pipeline to parse `internalIpAddress` values that contain multiple NIC entries.

--- a/packages/island_browser/manifest.yml
+++ b/packages/island_browser/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: island_browser
 title: Island Browser
-version: 1.1.2
+version: 1.1.3
 description: Collect logs from Island Browser with Elastic Agent.
 type: integration
 categories:
@@ -46,7 +46,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.3.1"
   changes:
     - description: Add ECS event categorization fields to the events data stream.

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: jamf_pro
 title: "Jamf Pro"
-version: "1.3.1"
+version: "1.3.2"
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"
@@ -49,7 +49,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.22.1"
   changes:
     - description: Fix ingestion failure when an event contains both `@version` and `version` fields by retaining both fields.

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: jumpcloud
 title: "JumpCloud"
-version: "1.22.1"
+version: "1.22.2"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:
@@ -31,7 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/jupiter_one/changelog.yml
+++ b/packages/jupiter_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.1"
   changes:
     - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.

--- a/packages/jupiter_one/manifest.yml
+++ b/packages/jupiter_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: jupiter_one
 title: JupiterOne
-version: 1.1.1
+version: 1.1.2
 description: Collect logs from JupiterOne with Elastic Agent.
 type: integration
 categories:
@@ -34,7 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.23.1"
   changes:
     - description: Fix serialisation of detailed_shared_folder data stream response.

--- a/packages/lastpass/manifest.yml
+++ b/packages/lastpass/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: lastpass
 title: LastPass
-version: "1.23.1"
+version: "1.23.2"
 description: Collect logs from LastPass with Elastic Agent.
 type: integration
 categories:
@@ -31,7 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.8.1"
   changes:
     - description: Fix activity logs cursor so incremental collection filters requests by the stored timestamp instead of replaying the full history each interval.

--- a/packages/lumos/manifest.yml
+++ b/packages/lumos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: lumos
 title: "Lumos"
-version: "1.8.1"
+version: "1.8.2"
 description: "An integration with Lumos to ship your Activity logs to your Elastic instance."
 type: integration
 categories:
@@ -34,7 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/menlo/changelog.yml
+++ b/packages/menlo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.8.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/menlo/manifest.yml
+++ b/packages/menlo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: menlo
 title: "Menlo Security"
-version: "1.8.0"
+version: "1.8.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Menlo Security products with Elastic Agent"
@@ -33,7 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_defender_cloud/changelog.yml
+++ b/packages/microsoft_defender_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "3.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/microsoft_defender_cloud/manifest.yml
+++ b/packages/microsoft_defender_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: '3.3.2'
 name: microsoft_defender_cloud
 title: Microsoft Defender for Cloud
-version: '3.5.0'
+version: '3.5.1'
 description: Collect logs from Microsoft Defender for Cloud with Elastic Agent.
 type: integration
 categories:
@@ -33,7 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.9.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "4.9.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "4.9.0"
+version: "4.9.1"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - security
@@ -23,7 +23,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.5"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.2.4"
   changes:
     - description: Use case-insensitive comparison when matching source.domain and destination.domain against local domains for mailflow direction calculation.

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "2.2.4"
+version: "2.2.5"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:
@@ -30,7 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_sentinel/changelog.yml
+++ b/packages/microsoft_sentinel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/microsoft_sentinel/manifest.yml
+++ b/packages/microsoft_sentinel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: microsoft_sentinel
 title: Microsoft Sentinel
-version: "1.4.0"
+version: "1.4.1"
 description: Collect logs from Microsoft Sentinel with Elastic Agent.
 type: integration
 categories:
@@ -40,7 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "3.5.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: mimecast
 title: "Mimecast"
-version: "3.5.0"
+version: "3.5.1"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]
@@ -27,7 +27,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/miniflux/changelog.yml
+++ b/packages/miniflux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/miniflux/manifest.yml
+++ b/packages/miniflux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: miniflux
 title: "Miniflux RSS reader"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Elastic-2.0"
 description: Collect RSS feed content from the Miniflux API with Elastic Agent.
@@ -38,7 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.8"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "3.10.7"
   changes:
     - description: Fix document_parsing_exception on o365.audit.Message for AIInteractionCreatedNotification events by moving object-typed values to o365.audit.MessageObject.

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.10.7"
+version: "3.10.8"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"
@@ -41,7 +41,7 @@ policy_templates:
         enabled: true 
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.7.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "2.7.0"
+version: "2.7.1"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
 format_version: "3.4.0"
@@ -37,7 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.24.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: ping_one
 title: PingOne
-version: "1.24.0"
+version: "1.24.1"
 description: Collect logs from PingOne with Elastic-Agent.
 type: integration
 categories:
@@ -29,7 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.2.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "4.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "4.2.0"
+version: "4.2.1"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:
@@ -57,7 +57,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/proofpoint_essentials/changelog.yml
+++ b/packages/proofpoint_essentials/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/proofpoint_essentials/manifest.yml
+++ b/packages/proofpoint_essentials/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: proofpoint_essentials
 title: Proofpoint Essentials
-version: 1.1.1
+version: 1.1.2
 description: Collect logs from Proofpoint Essentials with Elastic Agent.
 type: integration
 categories:
@@ -34,7 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/proofpoint_itm/changelog.yml
+++ b/packages/proofpoint_itm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/proofpoint_itm/manifest.yml
+++ b/packages/proofpoint_itm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: proofpoint_itm
 title: Proofpoint ITM
-version: "1.1.0"
+version: "1.1.1"
 description: Collect logs from Proofpoint ITM using Elastic Agent.
 type: integration
 categories:
@@ -30,7 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.31.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.31.1"
+version: "1.31.2"
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration
 categories:
@@ -29,7 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.19.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "6.19.1"
   changes:
     - description: Record missing KB entries in `knowledge_base.status` instead of `error.message`, so they no longer mark documents as `pipeline_error`.

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.19.1"
+version: "6.19.2"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:
@@ -41,7 +41,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/rapid7_insightvm/changelog.yml
+++ b/packages/rapid7_insightvm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.9.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/rapid7_insightvm/manifest.yml
+++ b/packages/rapid7_insightvm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: rapid7_insightvm
 title: Rapid7 InsightVM
-version: "2.9.0"
+version: "2.9.1"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Rapid7 InsightVM with Elastic Agent.
@@ -39,7 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sailpoint_identity_sc/changelog.yml
+++ b/packages/sailpoint_identity_sc/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.3.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/sailpoint_identity_sc/manifest.yml
+++ b/packages/sailpoint_identity_sc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: sailpoint_identity_sc
 title: Sailpoint Identity Security Cloud
-version: "1.3.0"
+version: "1.3.1"
 source:
   license: "Elastic-2.0"
 description: "Sailpoint identity security cloud provides enterprise identity governance and security capabilities. The integration allows users to extract audit information from their identity security cloud tenant using the ISC's AuditEvent API."
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.11.1"
   changes:
     - description: Add time watermark and fingerprint deduplication to the threat event data stream to prevent duplicate ingestion.

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.11.1"
+version: "2.11.2"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:
@@ -61,7 +61,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/servicenow/changelog.yml
+++ b/packages/servicenow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.1.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/servicenow/manifest.yml
+++ b/packages/servicenow/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: servicenow
 title: "ServiceNow"
-version: "2.1.0"
+version: "2.1.1"
 description: "Collect logs from ServiceNow with Elastic Agent."
 type: integration
 categories:
@@ -74,6 +74,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.30.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: slack
 title: "Slack Logs"
-version: "1.30.0"
+version: "1.30.1"
 description: "Slack Logs Integration"
 type: integration
 categories:
@@ -24,7 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         is_default: true
         organization: security
         division: engineering

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "3.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: snyk
 title: "Snyk"
-version: "3.5.0"
+version: "3.5.1"
 description: Collect logs from Snyk with Elastic Agent.
 type: integration
 categories:
@@ -26,7 +26,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.23.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: sophos_central
 title: Sophos Central
-version: "1.23.0"
+version: "1.23.1"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:
@@ -35,7 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/splunk/changelog.yml
+++ b/packages/splunk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.2"
   changes:
     - description: Map alert `proto` to ECS `network.transport` and `network.iana_number` instead of failing on protocol names.

--- a/packages/splunk/manifest.yml
+++ b/packages/splunk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: splunk
 title: Splunk
-version: "1.1.2"
+version: "1.1.3"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Splunk with Elastic Agent.
@@ -33,7 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/spycloud/changelog.yml
+++ b/packages/spycloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.7.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/spycloud/manifest.yml
+++ b/packages/spycloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: spycloud
 title: SpyCloud Enterprise Protection
-version: "1.7.0"
+version: "1.7.1"
 description: Collect data from SpyCloud Enterprise Protection with Elastic Agent.
 type: integration
 categories:
@@ -38,7 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.12.2"
   changes:
     - description: Add ECS event categorization fields to the audit data stream.

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: sublime_security
 title: Sublime Security
-version: "1.12.2"
+version: "1.12.3"
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:
@@ -44,7 +44,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/symantec_endpoint_security/changelog.yml
+++ b/packages/symantec_endpoint_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.15.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/symantec_endpoint_security/manifest.yml
+++ b/packages/symantec_endpoint_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: symantec_endpoint_security
 title: Symantec Endpoint Security
-version: "1.15.0"
+version: "1.15.1"
 description: Collect logs from Symantec Endpoint Security with Elastic Agent.
 type: integration
 categories:
@@ -55,7 +55,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sysdig/changelog.yml
+++ b/packages/sysdig/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.4.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/sysdig/manifest.yml
+++ b/packages/sysdig/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: sysdig
 title: "Sysdig"
-version: "2.4.0"
+version: "2.4.1"
 description: "Collect logs from Sysdig using Elastic Agent."
 type: integration
 categories:
@@ -47,7 +47,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.12.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "4.12.1"
   changes:
     - description: Replace the scan details endpoint with GET /scans/{id} and remap the scan_details fields to the standard VM scan-details schema.

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "4.12.1"
+version: "4.12.2"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:
@@ -31,7 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/tenable_ot_security/changelog.yml
+++ b/packages/tenable_ot_security/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.1.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.1.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/tenable_ot_security/manifest.yml
+++ b/packages/tenable_ot_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: tenable_ot_security
 title: Tenable OT Security
-version: 2.1.0
+version: 2.1.1
 source:
   license: "Elastic-2.0"
 description: Tenable OT Security
@@ -36,6 +36,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -2,7 +2,7 @@ format_version: "3.3.2"
 name: tenable_sc
 title: Tenable Security Center
 # The version must be updated in the input configuration templates as well, in order to set the correct User-Agent header. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "2.3.0"
+version: "2.3.1"
 description: |
   Collect data from Tenable Security Center with Elastic Agent.
 type: integration
@@ -31,7 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.8.2"
   changes:
     - description: Fix pagination when using an advanced search query. The integration now follows the API's next URL for pagination instead of reconstructing the request, which failed when the API used a different cursor format (e.g. search_after) with advanced queries.

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali ThreatStream
-version: "2.8.2"
+version: "2.8.3"
 description: Ingest threat intelligence indicators from Anomali ThreatStream with Elastic Agent.
 type: integration
 format_version: 3.3.2
@@ -45,7 +45,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_anyrun/changelog.yml
+++ b/packages/ti_anyrun/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.2.2"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_anyrun/manifest.yml
+++ b/packages/ti_anyrun/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: ti_anyrun
 title: ANY.RUN Threat Intelligence Feeds
-version: 1.2.2
+version: 1.2.3
 source:
   license: Elastic-2.0
 description: Ingest Threat Intelligence indicators from ANY.RUN TI Feeds with Elastic Agent
@@ -37,7 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.20.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.20.1"
+version: "1.20.2"
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:
@@ -24,7 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.9.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "2.9.0"
+version: "2.9.1"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:
@@ -35,7 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.8.2"
   changes:
     - description: Preserve `added_after` with `next` when paginating TAXII 2.1 requests.

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: "1.8.2"
+version: "1.8.3"
 categories:
   - custom
   - security
@@ -30,7 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.36.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.36.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.36.1"
+version: "1.36.2"
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
 format_version: 3.3.2
@@ -19,7 +19,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_domaintools/changelog.yml
+++ b/packages/ti_domaintools/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.6.0"
   changes:
     - description: Use header-based authentication for DomainTools API.

--- a/packages/ti_domaintools/manifest.yml
+++ b/packages/ti_domaintools/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_domaintools
 title: "DomainTools Feeds"
-version: "1.6.0"
+version: "1.6.1"
 source:
   license: "Elastic-2.0"
 description: "DomainTools Feeds provide data on the different stages of the domain lifecycle: from first-observed in the wild, to newly re-activated after a period of quiet."
@@ -33,7 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.7.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_eclecticiq
 title: EclecticIQ
-version: "1.7.1"
+version: "1.7.2"
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:
@@ -26,7 +26,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_eset/changelog.yml
+++ b/packages/ti_eset/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.11.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: "1.11.1"
+version: "1.11.2"
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:
@@ -39,7 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.1.2"
   changes:
     - description: Prevent the IOC Stream data stream from indefinitely replaying a request that the API persistently rejects. On errors the stale pagination cursor is now discarded, and after three consecutive HTTP 400 responses for the same collection window the window is skipped and the skip is surfaced as an error event.

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "1.1.2"
+version: "1.1.3"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:
@@ -49,7 +49,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_maltiverse/changelog.yml
+++ b/packages/ti_maltiverse/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.8.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_maltiverse/manifest.yml
+++ b/packages/ti_maltiverse/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_maltiverse
 title: Maltiverse
-version: "1.8.1"
+version: "1.8.2"
 description: Ingest threat intelligence indicators from Maltiverse feeds with Elastic Agent
 type: integration
 format_version: 3.3.2
@@ -24,7 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_mandiant_advantage/changelog.yml
+++ b/packages/ti_mandiant_advantage/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.11.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/ti_mandiant_advantage/manifest.yml
+++ b/packages/ti_mandiant_advantage/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_mandiant_advantage
 title: "Mandiant Advantage"
-version: "1.11.0"
+version: "1.11.1"
 source:
   license: "Elastic-2.0"
 description: "Collect Threat Intelligence from products within the Mandiant Advantage platform."
@@ -41,7 +41,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.44.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.44.2"
   changes:
     - description: Fix `daily_refetch` never re-triggering after the first poll. The `last_daily_refetch` cursor value template could not read its own previous value (httpjson evaluates cursor templates with an empty cursor context), so it was reset to the current time on every poll and the 24h elapsed-time check never fired. The refetch marker is now carried through the request's url.params so it survives cursor evaluation.

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.44.2"
+version: "1.44.3"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -33,7 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.15.2"
   changes:
     - description: Fix incremental polling missing UI-edited indicators.

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: ti_opencti
 title: OpenCTI
-version: "2.15.2"
+version: "2.15.3"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:
@@ -43,7 +43,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.32.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.32.1"
+version: "1.32.2"
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
 format_version: 3.3.2
@@ -24,7 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.10.2"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.10.2"
+version: "2.10.3"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories:
@@ -50,7 +50,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.7.2"
   changes:
     - description: Drop the redundant `[Logs RecordedFuture]` suffix from dashboard panel titles.

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "2.7.2"
+version: "2.7.3"
 description: Ingest threat intelligence and alert data from Recorded Future with Elastic Agent.
 type: integration
 format_version: 3.3.2
@@ -49,7 +49,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.3.0"
   changes:
     - description: Set 'elastic' owner type.

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.3.2
 name: ti_threatconnect
 title: ThreatConnect
-version: "2.3.0"
+version: "2.3.1"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:
@@ -32,7 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.39.3"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.39.2"
   changes:
     - description: Restores `sources` and `attributes` fields after recent updates to the ThreatQ Platform's API.

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.39.2"
+version: "1.39.3"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.3.1"
@@ -37,7 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.17.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: tines
 title: "Tines"
-version: "1.17.0"
+version: "1.17.1"
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:
@@ -35,7 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/trellix_epo_cloud/changelog.yml
+++ b/packages/trellix_epo_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.16.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/trellix_epo_cloud/manifest.yml
+++ b/packages/trellix_epo_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: trellix_epo_cloud
 title: Trellix ePO Cloud
-version: "1.16.0"
+version: "1.16.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Trellix ePO Cloud with Elastic Agent.
@@ -44,7 +44,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.13.2"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "2.13.1"
   changes:
     - description: Fix detection pipeline marking events as pipeline_error when risk_level is non-numeric or request URL is malformed.

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: trend_micro_vision_one
 title: TrendAI Vision One
-version: "2.13.1"
+version: "2.13.2"
 description: Collect logs from TrendAI Vision One with Elastic Agent.
 type: integration
 categories:
@@ -53,7 +53,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.6.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "4.6.0"
   changes:
     - description: Add defend_v2 data stream for Wiz Detections API v2.

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: wiz
 title: Wiz
-version: "4.6.0"
+version: "4.6.1"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:
@@ -69,7 +69,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/zerofox/changelog.yml
+++ b/packages/zerofox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.30.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/zerofox/manifest.yml
+++ b/packages/zerofox/manifest.yml
@@ -1,6 +1,6 @@
 name: zerofox
 title: ZeroFox
-version: "1.30.0"
+version: "1.30.1"
 description: Collect logs from ZeroFox with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -27,7 +27,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/zeronetworks/changelog.yml
+++ b/packages/zeronetworks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.20.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/zeronetworks/manifest.yml
+++ b/packages/zeronetworks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: zeronetworks
 title: "Zero Networks"
-version: "1.20.0"
+version: "1.20.1"
 source:
   license: "Elastic-2.0"
 description: "Zero Networks Logs integration"
@@ -40,7 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/zoom/changelog.yml
+++ b/packages/zoom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "1.27.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/zoom/manifest.yml
+++ b/packages/zoom/manifest.yml
@@ -1,6 +1,6 @@
 name: zoom
 title: Zoom
-version: "1.27.0"
+version: "1.27.1"
 description: Collect logs from Zoom with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -39,7 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.2.1"
+  changes:
+    - description: Set agentless deployment mode `release` field to `ga`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20421
 - version: "4.2.0"
   changes:
     - description: Add support for Sandbox Verdict data stream.

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -4,7 +4,7 @@ title: Zscaler Internet Access
 # When updating version, make sure the pkg_version parameter in
 # the check_template_version script in ingest pipelines is
 # updated to match.
-version: "4.2.0"
+version: "4.2.1"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:
@@ -86,7 +86,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Sets `deployment_modes.agentless.release: ga` for **99** integrations that are eligible to graduate now: all `security-service-integrations`-owned packages that are already GA (`version >= 1.0.0`) and not in the top-10 most-deployed list, plus `o365` (top-10 but its ORR is complete).

- **94** are `beta` → `ga` edits.
- **5** add the `release` field (previously absent, so Kibana defaulted to platform maturity): `atlassian_confluence`, `atlassian_jira`, `sailpoint_identity_sc`, `servicenow`, `tenable_ot_security`.

Each package gets a patch version bump and a changelog entry.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
