### PR TITLE
aws: track Amazon Inspector findings per namespace in vulnerability latest transform

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "7.1.1"
   changes:
-    - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index.
+    - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20427
 - version: "7.1.0"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "7.1.1"
+  changes:
+    - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19918
 - version: "7.1.0"
   changes:
     - description: "Stop storing the assumed-role ARN session name in `user.changes.*`. The session name is now added to `related.user` for cross-source correlation; when it is an email, both the full email and the local-part prefix are added. `user.name` continues to hold the IAM role name for detection rules."

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/19918
+      link: https://github.com/elastic/integrations/pull/20427
 - version: "7.1.0"
   changes:
     - description: "Stop storing the assumed-role ARN session name in `user.changes.*`. The session name is now added to `related.user` for cross-source correlation; when it is an email, both the full email and the local-part prefix are added. `user.name` continues to hold the IAM role name for detection rules."

--- a/packages/aws/elasticsearch/transform/latest_cdr_vulnerabilities_awsinspector/transform.yml
+++ b/packages/aws/elasticsearch/transform/latest_cdr_vulnerabilities_awsinspector/transform.yml
@@ -27,6 +27,7 @@ dest:
 latest:
   unique_key:
     - aws.inspector.transform_unique_id
+    - data_stream.namespace
   sort: "@timestamp"
 description: Latest Vulnerabilities Findings from Amazon Inspector.
 settings:
@@ -44,4 +45,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/aws/elasticsearch/transform/latest_cdr_vulnerabilities_awsinspector/transform.yml
+++ b/packages/aws/elasticsearch/transform/latest_cdr_vulnerabilities_awsinspector/transform.yml
@@ -20,7 +20,7 @@ source:
               - data_frozen
               - data_cold
 dest:
-  index: "security_solution-awsinspector.vulnerability_latest-v1"
+  index: "security_solution-awsinspector.vulnerability_latest-v2"
   aliases:
     - alias: "security_solution-awsinspector.vulnerability_latest"
       move_on_creation: true

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.1.0
+version: 7.1.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws: track Amazon Inspector findings per namespace in vulnerability latest transform

The Inspector vulnerability latest transform grouped only on
aws.inspector.transform_unique_id, so findings sharing a unique id across
different data_stream namespaces collapsed into a single latest document,
and findings from non-default namespaces could not be compared. Add
data_stream.namespace to the transform's unique key so findings are tracked
per namespace, matching the other CDR vulnerability transforms.

Adding a field to the unique key re-keys every destination document _id.
Since a fleet_transform_version bump reinstalls the transform but keeps the
existing destination index, the re-keyed documents would otherwise coexist
with the old-keyed ones under the vulnerability_latest alias for up to 90
days. Move the destination index to
security_solution-awsinspector.vulnerability_latest-v2 so the re-keyed
documents land in a clean index and the alias moves with it.

Bump fleet_transform_version to 0.4.0 so existing deployments delete and
reinstall the transform on upgrade.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
