### PR TITLE
[aws_securityhub] Add processor tags to ingest pipelines

### DIFF
--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add processor tags to all ingest pipeline processors and include `_ingest.pipeline` in pipeline `on_failure` messages, to satisfy elastic-package linter requirements for format_version 3.6.0 and above.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20435
 - version: "1.2.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Add processor tags to all ingest pipeline processors and include `_ingest.pipeline` in pipeline `on_failure` messages, to satisfy elastic-package linter requirements for format_version 3.6.0 and above.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.2.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/default.yml
@@ -81,9 +81,10 @@ processors:
         processFields(ctx.aws_securityhub.finding);
       on_failure:
         - append:
+            tag: append_error_message_d83dd772
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  
+
   - convert:
       field: aws_securityhub.finding.action_id
       tag: convert_action_id_to_string
@@ -95,6 +96,7 @@ processors:
       type: string
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_anomaly_analyses_42094361
       field: aws_securityhub.finding.anomaly_analyses
       if: ctx.aws_securityhub?.finding?.anomaly_analyses instanceof List
       processor:
@@ -119,6 +121,7 @@ processors:
                         field: error.message
                         value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_anomaly_analyses_25e26cf9
       field: aws_securityhub.finding.anomaly_analyses
       if: ctx.aws_securityhub?.finding?.anomaly_analyses instanceof List
       processor:
@@ -149,30 +152,38 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_api_response_code_020d20a8
             field: aws_securityhub.finding.api.response.code
             ignore_missing: true
         - append:
+            tag: append_error_message_243ed815
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - json:
+      tag: json_aws_securityhub_finding_api_request_data_c0e0d4ab
       field: aws_securityhub.finding.api.request.data
       if: ctx.aws_securityhub?.finding?.api?.request?.data instanceof String
       on_failure:
         - rename:
+            tag: rename_aws_securityhub_finding_api_request_data_to_aws_securityhub_finding_api_request_data_value_7c035954
             field: aws_securityhub.finding.api.request.data
             target_field: aws_securityhub.finding.api.request.data.value
   - rename:
+      tag: rename_aws_securityhub_finding_api_request_data_to_aws_securityhub_finding_api_request_data_value_b4081a90
       field: aws_securityhub.finding.api.request.data
       target_field: aws_securityhub.finding.api.request.data.value
       if: ctx.aws_securityhub?.finding?.api?.request?.data != null && !(ctx.aws_securityhub.finding.api.request.data instanceof Map)
   - json:
+      tag: json_aws_securityhub_finding_api_response_data_90139c39
       field: aws_securityhub.finding.api.response.data
       if: ctx.aws_securityhub?.finding?.api?.response?.data instanceof String
       on_failure:
         - rename:
+            tag: rename_aws_securityhub_finding_api_response_data_to_aws_securityhub_finding_api_response_data_value_35c267c4
             field: aws_securityhub.finding.api.response.data
             target_field: aws_securityhub.finding.api.response.data.value
   - rename:
+      tag: rename_aws_securityhub_finding_api_response_data_to_aws_securityhub_finding_api_response_data_value_c616b66c
       field: aws_securityhub.finding.api.response.data
       target_field: aws_securityhub.finding.api.response.data.value
       if: ctx.aws_securityhub?.finding?.api?.response?.data != null && !(ctx.aws_securityhub.finding.api.response.data instanceof Map)
@@ -188,8 +199,10 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_has_mfa_e1f4e780
             field: aws_securityhub.finding.assignee.has_mfa
         - append:
+            tag: append_error_message_140e48e9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -203,9 +216,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.created_time_dt != null && ctx.aws_securityhub.finding.assignee.ldap_person.created_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_created_time_dt_1f1e56b9
             field: aws_securityhub.finding.assignee.ldap_person.created_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_053809e9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -217,9 +232,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.created_time != null && ctx.aws_securityhub.finding.assignee.ldap_person.created_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_created_time_33e9fa51
             field: aws_securityhub.finding.assignee.ldap_person.created_time
             ignore_missing: true
         - append:
+            tag: append_error_message_7791e972
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -233,9 +250,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.deleted_time_dt != null && ctx.aws_securityhub.finding.assignee.ldap_person.deleted_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_deleted_time_dt_f18a8f84
             field: aws_securityhub.finding.assignee.ldap_person.deleted_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_bd84f2ff
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -247,9 +266,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.deleted_time != null && ctx.aws_securityhub.finding.assignee.ldap_person.deleted_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_deleted_time_606221d8
             field: aws_securityhub.finding.assignee.ldap_person.deleted_time
             ignore_missing: true
         - append:
+            tag: append_error_message_a1b2f988
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -263,9 +284,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.hire_time_dt != null && ctx.aws_securityhub.finding.assignee.ldap_person.hire_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_hire_time_dt_189efd89
             field: aws_securityhub.finding.assignee.ldap_person.hire_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_cc22b535
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -277,9 +300,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.hire_time != null && ctx.aws_securityhub.finding.assignee.ldap_person.hire_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_hire_time_ed1230ed
             field: aws_securityhub.finding.assignee.ldap_person.hire_time
             ignore_missing: true
         - append:
+            tag: append_error_message_b9a1728a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -293,9 +318,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.last_login_time_dt != null && ctx.aws_securityhub.finding.assignee.ldap_person.last_login_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_last_login_time_dt_2beab121
             field: aws_securityhub.finding.assignee.ldap_person.last_login_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_9add4915
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -307,9 +334,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.last_login_time != null && ctx.aws_securityhub.finding.assignee.ldap_person.last_login_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_last_login_time_dd31ba5d
             field: aws_securityhub.finding.assignee.ldap_person.last_login_time
             ignore_missing: true
         - append:
+            tag: append_error_message_31b0fdc2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -323,9 +352,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.leave_time_dt != null && ctx.aws_securityhub.finding.assignee.ldap_person.leave_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_leave_time_dt_d993737e
             field: aws_securityhub.finding.assignee.ldap_person.leave_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_b9840317
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -337,9 +368,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.leave_time != null && ctx.aws_securityhub.finding.assignee.ldap_person.leave_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_leave_time_0a178a52
             field: aws_securityhub.finding.assignee.ldap_person.leave_time
             ignore_missing: true
         - append:
+            tag: append_error_message_80990fa0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -353,9 +386,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.modified_time_dt != null && ctx.aws_securityhub.finding.assignee.ldap_person.modified_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_modified_time_dt_f569ddd6
             field: aws_securityhub.finding.assignee.ldap_person.modified_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_e070431d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -367,9 +402,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.assignee?.ldap_person?.modified_time != null && ctx.aws_securityhub.finding.assignee.ldap_person.modified_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_ldap_person_modified_time_12166af2
             field: aws_securityhub.finding.assignee.ldap_person.modified_time
             ignore_missing: true
         - append:
+            tag: append_error_message_2dfc1dae
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -384,8 +421,10 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_assignee_risk_score_b5346cb8
             field: aws_securityhub.finding.assignee.risk_score
         - append:
+            tag: append_error_message_403e03b0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -409,6 +448,7 @@ processors:
       type: string
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_compliance_assessments_7c7d219c
       field: aws_securityhub.finding.compliance.assessments
       if: ctx.aws_securityhub?.finding?.compliance?.assessments instanceof List
       processor:
@@ -424,6 +464,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_compliance_assessments_21c12d7f
       field: aws_securityhub.finding.compliance.assessments
       if: ctx.aws_securityhub?.finding?.compliance?.assessments instanceof List
       processor:
@@ -439,6 +480,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_compliance_checks_72ea7a28
       field: aws_securityhub.finding.compliance.checks
       if: ctx.aws_securityhub?.finding?.compliance?.checks instanceof List
       processor:
@@ -448,6 +490,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_compliance_checks_7a4142dc
       field: aws_securityhub.finding.compliance.checks
       if: ctx.aws_securityhub?.finding?.compliance?.checks instanceof List
       processor:
@@ -473,8 +516,10 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_confidence_score_f998a04f
             field: aws_securityhub.finding.confidence_score
         - append:
+            tag: append_error_message_69881d49
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -484,8 +529,10 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_count_dd41dc5d
             field: aws_securityhub.finding.count
         - append:
+            tag: append_error_message_7f2218d7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -500,9 +547,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_duration_e54d7af2
             field: aws_securityhub.finding.duration
             ignore_missing: true
         - append:
+            tag: append_error_message_39b6d28f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -516,9 +565,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.end_time_dt != null && ctx.aws_securityhub.finding.end_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_end_time_dt_fe41467c
             field: aws_securityhub.finding.end_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_df5f1975
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -530,12 +581,15 @@ processors:
       if: ctx.aws_securityhub?.finding?.end_time != null && ctx.aws_securityhub.finding.end_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_end_time_b1998704
             field: aws_securityhub.finding.end_time
             ignore_missing: true
         - append:
+            tag: append_error_message_b4535bb2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_enrichments_0b1cfe1a
       field: aws_securityhub.finding.enrichments
       if: ctx.aws_securityhub?.finding?.enrichments instanceof List
       processor:
@@ -551,6 +605,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_enrichments_08d1628f
       field: aws_securityhub.finding.enrichments
       if: ctx.aws_securityhub?.finding?.enrichments instanceof List
       processor:
@@ -560,6 +615,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_enrichments_67a4ee09
       field: aws_securityhub.finding.enrichments
       if: ctx.aws_securityhub?.finding?.enrichments instanceof List
       processor:
@@ -576,6 +632,7 @@ processors:
                 field: _ingest._value.reputation.base_score
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_enrichments_82ca69c1
       field: aws_securityhub.finding.enrichments
       if: ctx.aws_securityhub?.finding?.enrichments instanceof List
       processor:
@@ -596,9 +653,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_firewall_rule_duration_33f45cb7
             field: aws_securityhub.finding.firewall_rule.duration
             ignore_missing: true
         - append:
+            tag: append_error_message_9e1142b5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -608,9 +667,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_firewall_rule_rate_limit_830541b3
             field: aws_securityhub.finding.firewall_rule.rate_limit
             ignore_missing: true
         - append:
+            tag: append_error_message_007cfe57
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -625,9 +686,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_impact_score_dfd13156
             field: aws_securityhub.finding.impact_score
             ignore_missing: true
         - append:
+            tag: append_error_message_32638be8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -637,9 +700,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_is_alert_171ad8ae
             field: aws_securityhub.finding.is_alert
             ignore_missing: true
         - append:
+            tag: append_error_message_22c881ae
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -649,9 +714,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_is_suspected_breach_7de8befe
             field: aws_securityhub.finding.is_suspected_breach
             ignore_missing: true
         - append:
+            tag: append_error_message_b9b04af0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -665,9 +732,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.malware_scan_info?.end_time_dt != null && ctx.aws_securityhub.finding.malware_scan_info.end_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_end_time_dt_1ad8d49a
             field: aws_securityhub.finding.malware_scan_info.end_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_a1b5e831
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -679,9 +748,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.malware_scan_info?.end_time != null && ctx.aws_securityhub.finding.malware_scan_info.end_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_end_time_e84dbc82
             field: aws_securityhub.finding.malware_scan_info.end_time
             ignore_missing: true
         - append:
+            tag: append_error_message_dd432fcc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -691,9 +762,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_num_files_408ae907
             field: aws_securityhub.finding.malware_scan_info.num_files
             ignore_missing: true
         - append:
+            tag: append_error_message_3a9b6b8e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -703,9 +776,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_num_infected_1fc57d6b
             field: aws_securityhub.finding.malware_scan_info.num_infected
             ignore_missing: true
         - append:
+            tag: append_error_message_91bcba63
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -715,9 +790,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_num_volumes_e88a67cf
             field: aws_securityhub.finding.malware_scan_info.num_volumes
             ignore_missing: true
         - append:
+            tag: append_error_message_3233d9f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -727,9 +804,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_size_8c88c163
             field: aws_securityhub.finding.malware_scan_info.size
             ignore_missing: true
         - append:
+            tag: append_error_message_f784cb1f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -743,9 +822,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.malware_scan_info?.start_time_dt != null && ctx.aws_securityhub.finding.malware_scan_info.start_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_start_time_dt_89c3e79d
             field: aws_securityhub.finding.malware_scan_info.start_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_f25a570f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -757,9 +838,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.malware_scan_info?.start_time != null && ctx.aws_securityhub.finding.malware_scan_info.start_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_start_time_8f175c95
             field: aws_securityhub.finding.malware_scan_info.start_time
             ignore_missing: true
         - append:
+            tag: append_error_message_6441eae6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -774,12 +857,15 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_malware_scan_info_unique_malware_count_8254452b
             field: aws_securityhub.finding.malware_scan_info.unique_malware_count
             ignore_missing: true
         - append:
+            tag: append_error_message_74e86de9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_observables_d0e278ae
       field: aws_securityhub.finding.observables
       if: ctx.aws_securityhub?.finding?.observables instanceof List
       processor:
@@ -796,6 +882,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_observables_5c289cc1
       field: aws_securityhub.finding.observables
       if: ctx.aws_securityhub?.finding?.observables instanceof List
       processor:
@@ -805,6 +892,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_observables_21b47d00
       field: aws_securityhub.finding.observables
       if: ctx.aws_securityhub?.finding?.observables instanceof List
       processor:
@@ -820,9 +908,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_policy_is_applied_8b83eaa5
             field: aws_securityhub.finding.policy.is_applied
             ignore_missing: true
         - append:
+            tag: append_error_message_e33f98ca
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -836,6 +926,7 @@ processors:
       tag: json_decoding_raw_data
       on_failure:
         - rename:
+            tag: rename_aws_securityhub_finding_raw_data_to_aws_securityhub_finding_raw_data_keyword_08557e5a
             field: aws_securityhub.finding.raw_data
             target_field: aws_securityhub.finding.raw_data_keyword
             ignore_missing: true
@@ -846,12 +937,15 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_raw_data_size_1610c25a
             field: aws_securityhub.finding.raw_data_size
             ignore_missing: true
         - append:
+            tag: append_error_message_d9fa892c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_remediation_kb_article_list_8e3cb575
       field: aws_securityhub.finding.remediation.kb_article_list
       if: ctx.aws_securityhub?.finding?.remediation?.kb_article_list instanceof List
       processor:
@@ -868,6 +962,7 @@ processors:
                 field: _ingest._value.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_remediation_kb_article_list_491503fa
       field: aws_securityhub.finding.remediation.kb_article_list
       if: ctx.aws_securityhub?.finding?.remediation?.kb_article_list instanceof List
       processor:
@@ -882,6 +977,7 @@ processors:
                 field: _ingest._value.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_remediation_kb_article_list_5892a888
       field: aws_securityhub.finding.remediation.kb_article_list
       if: ctx.aws_securityhub?.finding?.remediation?.kb_article_list instanceof List
       processor:
@@ -891,6 +987,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_remediation_kb_article_list_a0a52ca5
       field: aws_securityhub.finding.remediation.kb_article_list
       if: ctx.aws_securityhub?.finding?.remediation?.kb_article_list instanceof List
       processor:
@@ -907,6 +1004,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_remediation_kb_article_list_c47b3677
       field: aws_securityhub.finding.remediation.kb_article_list
       if: ctx.aws_securityhub?.finding?.remediation?.kb_article_list instanceof List
       processor:
@@ -934,9 +1032,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_risk_score_aea1d60c
             field: aws_securityhub.finding.risk_score
             ignore_missing: true
         - append:
+            tag: append_error_message_ce4e04ab
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -955,9 +1055,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.start_time_dt != null && ctx.aws_securityhub.finding.start_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_start_time_dt_366d8f45
             field: aws_securityhub.finding.start_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_df8e9357
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -969,9 +1071,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.start_time != null && ctx.aws_securityhub.finding.start_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_start_time_7a6260af
             field: aws_securityhub.finding.start_time
             ignore_missing: true
         - append:
+            tag: append_error_message_f333c436
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -980,6 +1084,7 @@ processors:
       type: string
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_tickets_7b659475
       field: aws_securityhub.finding.tickets
       if: ctx.aws_securityhub?.finding?.tickets instanceof List
       processor:
@@ -989,6 +1094,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_tickets_a6ed2ef1
       field: aws_securityhub.finding.tickets
       if: ctx.aws_securityhub?.finding?.tickets instanceof List
       processor:
@@ -1008,9 +1114,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.time_dt != null && ctx.aws_securityhub.finding.time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_time_dt_b3644038
             field: aws_securityhub.finding.time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_8c6de387
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -1022,9 +1130,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.time != null && ctx.aws_securityhub.finding.time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_time_abfb8498
             field: aws_securityhub.finding.time
             ignore_missing: true
         - append:
+            tag: append_error_message_efb42808
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1034,9 +1144,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_timezone_offset_d634548e
             field: aws_securityhub.finding.timezone_offset
             ignore_missing: true
         - append:
+            tag: append_error_message_3dfafd56
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1045,13 +1157,16 @@ processors:
       type: string
       ignore_missing: true
   - json:
+      tag: json_aws_securityhub_finding_unmapped_cd7b265b
       field: aws_securityhub.finding.unmapped
       if: ctx.aws_securityhub?.finding?.unmapped instanceof String
       on_failure:
         - rename:
+            tag: rename_aws_securityhub_finding_unmapped_to_aws_securityhub_finding_unmapped_value_3041ebbc
             field: aws_securityhub.finding.unmapped
             target_field: aws_securityhub.finding.unmapped.value
   - rename:
+      tag: rename_aws_securityhub_finding_unmapped_to_aws_securityhub_finding_unmapped_value_968ed43c
       field: aws_securityhub.finding.unmapped
       target_field: aws_securityhub.finding.unmapped.value
       if: ctx.aws_securityhub?.finding?.unmapped != null && !(ctx.aws_securityhub.finding.unmapped instanceof Map)
@@ -1065,7 +1180,6 @@ processors:
       tag: convert_finding_verdict_id_to_string
       type: string
       ignore_missing: true
-
 
   # convert values
   - pipeline:
@@ -1086,7 +1200,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_object_evidence" }}'
       if: ctx.aws_securityhub?.finding?.class_uid != null && ['2003','2004'].contains(ctx.aws_securityhub.finding.class_uid) && ctx.aws_securityhub.finding.evidences instanceof List
-      tag: pipeline_object_device
+      tag: pipeline_object_evidence
       ignore_missing_pipeline: true
   - pipeline:
       name: '{{ IngestPipeline "pipeline_object_finding" }}'
@@ -1114,8 +1228,8 @@ processors:
       tag: pipeline_object_vulnerabilities
       ignore_missing_pipeline: true
 
-# populate ECS fields
 
+  # populate ECS fields
   - set:
       field: '@timestamp'
       tag: set_@timestamp_from_finding_info_modified_time_dt
@@ -1243,7 +1357,8 @@ processors:
           ctx.aws_securityhub.finding.status_id.equals('3') ||
           ctx.aws_securityhub.finding.status_id.equals('4')
         )
-  
+
+
   - script:
       description: Extract ECS fields from aws.securityhub_findings.resources.
       tag: script_extract_fields_from_resource
@@ -1361,9 +1476,10 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_d0c2e3f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  
+
   # cloud.*
   - set:
       field: cloud.account.id
@@ -1408,13 +1524,13 @@ processors:
       tag: set_organization_name_from_metadata_product_vendor_name
       copy_from: aws_securityhub.finding.metadata.product.vendor_name
       ignore_empty_value: true
-  
+
   # observer.*
   - set:
       field: observer.vendor
       tag: set_observer_vendor
       value: AWS Security Hub
-  
+
   # rule.*
   - set:
       field: rule.id
@@ -1466,9 +1582,10 @@ processors:
         ctx.rule.reference = remediation?.references;
       on_failure:
         - append:
+            tag: append_error_message_1dbb93e7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  
+
   # result.*
   - set:
       field: result.evaluation
@@ -1485,14 +1602,14 @@ processors:
       tag: set_result_evaluation_failed
       value: failed
       if: ctx.aws_securityhub?.finding?.compliance?.status_id == '3'
-    
+
   # url.*
   - set:
       field: url.full
       tag: set_url_full_from_finding_info_src_url
       copy_from: aws_securityhub.finding.finding_info.src_url
       ignore_empty_value: true
-  
+
   # vulnerability.*, package.*
   - script:
       description: Extract fields from aws.securityhub_findings.vulnerabilities with single vulnerability.
@@ -1556,6 +1673,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_63ad53c7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -1585,6 +1703,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_f8e813ce
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -1716,6 +1835,7 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.name != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_13bc6c9f
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -1725,6 +1845,7 @@ processors:
           value: '{{{_ingest._value.hostname}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_9019326d
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -1788,6 +1909,7 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.uid_alt != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_2afadb26
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1797,6 +1919,7 @@ processors:
           value: '{{{_ingest._value.creator.display_name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e322aa42
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1806,6 +1929,7 @@ processors:
           value: '{{{_ingest._value.creator.email_addr}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_445fad00
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1815,6 +1939,7 @@ processors:
           value: '{{{_ingest._value.creator.forward_addr}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_b6f95740
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1824,6 +1949,7 @@ processors:
           value: '{{{_ingest._value.creator.full_name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_05a93408
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1833,6 +1959,7 @@ processors:
           value: '{{{_ingest._value.creator.name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_d6b22d20
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1842,6 +1969,7 @@ processors:
           value: '{{{_ingest._value.creator.uid}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_d39a1d78
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1851,6 +1979,7 @@ processors:
           value: '{{{_ingest._value.creator.uid_alt}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_9bdaa95e
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1860,6 +1989,7 @@ processors:
           value: '{{{_ingest._value.whois.email_addr}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_0aefd522
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -1891,9 +2021,11 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_11999c97
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_c8d21433
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1903,6 +2035,7 @@ processors:
           value: '{{{_ingest._value.hostname}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_6465c54f
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1912,6 +2045,7 @@ processors:
           value: '{{{_ingest._value.ip}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_efa3712e
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1921,6 +2055,7 @@ processors:
           value: '{{{_ingest._value.owner.display_name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_9b498f3a
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1930,6 +2065,7 @@ processors:
           value: '{{{_ingest._value.owner.email_addr}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_5dca1ba0
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1939,6 +2075,7 @@ processors:
           value: '{{{_ingest._value.owner.forward_addr}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_7d6cd902
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1948,6 +2085,7 @@ processors:
           value: '{{{_ingest._value.owner.full_name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_b59f2170
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1957,6 +2095,7 @@ processors:
           value: '{{{_ingest._value.owner.name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_f0cad7ce
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1966,6 +2105,7 @@ processors:
           value: '{{{_ingest._value.owner.uid}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_95cc194e
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1975,6 +2115,7 @@ processors:
           value: '{{{_ingest._value.owner.uid_alt}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_fe7b3e2f
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -1988,6 +2129,7 @@ processors:
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_8b39cb43
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -2000,7 +2142,7 @@ processors:
               tag: append_resources_data_awsEc2InstanceDetails_ipV6Addresses_to_related_ip
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
-  
+
   - set:
       field: aws_securityhub.finding.transform_unique_id
       tag: set_transform_unique_id
@@ -2067,6 +2209,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
@@ -2077,7 +2220,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_actor.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_actor.yml
@@ -9,9 +9,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_idp_has_mfa_0473e85c
             field: aws_securityhub.finding.actor.idp.has_mfa
             ignore_missing: true
         - append:
+            tag: append_error_message_45f9519c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -45,9 +47,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.process?.created_time_dt != null && ctx.aws_securityhub.finding.actor.process.created_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_process_created_time_dt_09ee772f
             field: aws_securityhub.finding.actor.process.created_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_558bfaf1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -59,9 +63,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.process?.created_time != null && ctx.aws_securityhub.finding.actor.process.created_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_process_created_time_339f2a73
             field: aws_securityhub.finding.actor.process.created_time
             ignore_missing: true
         - append:
+            tag: append_error_message_f21e0c92
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -76,9 +82,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_process_namespace_pid_584fdc78
             field: aws_securityhub.finding.actor.process.namespace_pid
             ignore_missing: true
         - append:
+            tag: append_error_message_fe3084b2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -88,9 +96,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_process_pid_43c70568
             field: aws_securityhub.finding.actor.process.pid
             ignore_missing: true
         - append:
+            tag: append_error_message_f98f6b32
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -104,9 +114,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.process?.terminated_time_dt != null && ctx.aws_securityhub.finding.actor.process.terminated_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_process_terminated_time_dt_6e95be78
             field: aws_securityhub.finding.actor.process.terminated_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_dbb3c7ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -118,9 +130,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.process?.terminated_time != null && ctx.aws_securityhub.finding.actor.process.terminated_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_process_terminated_time_666829f4
             field: aws_securityhub.finding.actor.process.terminated_time
             ignore_missing: true
         - append:
+            tag: append_error_message_b7c6425c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -135,9 +149,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_count_46897f8a
             field: aws_securityhub.finding.actor.session.count
             ignore_missing: true
         - append:
+            tag: append_error_message_54dd06dd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -151,9 +167,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.session?.created_time_dt != null && ctx.aws_securityhub.finding.actor.session.created_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_created_time_dt_e4eee88a
             field: aws_securityhub.finding.actor.session.created_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_dbbab837
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -165,9 +183,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.session?.created_time != null && ctx.aws_securityhub.finding.actor.session.created_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_created_time_2afe219e
             field: aws_securityhub.finding.actor.session.created_time
             ignore_missing: true
         - append:
+            tag: append_error_message_18b068d0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -181,9 +201,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.session?.expiration_time_dt != null && ctx.aws_securityhub.finding.actor.session.expiration_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_expiration_time_dt_03288119
             field: aws_securityhub.finding.actor.session.expiration_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_76575d9b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -195,9 +217,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.actor?.session?.expiration_time != null && ctx.aws_securityhub.finding.actor.session.expiration_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_expiration_time_006f8d55
             field: aws_securityhub.finding.actor.session.expiration_time
             ignore_missing: true
         - append:
+            tag: append_error_message_94dcc170
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -207,9 +231,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_is_mfa_0d00ff76
             field: aws_securityhub.finding.actor.session.is_mfa
             ignore_missing: true
         - append:
+            tag: append_error_message_f9578ac1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -219,9 +245,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_is_remote_111419de
             field: aws_securityhub.finding.actor.session.is_remote
             ignore_missing: true
         - append:
+            tag: append_error_message_da207511
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -231,9 +259,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_session_is_vpn_7943641e
             field: aws_securityhub.finding.actor.session.is_vpn
             ignore_missing: true
         - append:
+            tag: append_error_message_0fae2c43
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -243,9 +273,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_user_has_mfa_dabfba3e
             field: aws_securityhub.finding.actor.user.has_mfa
             ignore_missing: true
         - append:
+            tag: append_error_message_21c56c82
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -260,9 +292,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_actor_user_risk_score_2e8bd978
             field: aws_securityhub.finding.actor.user.risk_score
             ignore_missing: true
         - append:
+            tag: append_error_message_2781ed4f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -276,7 +310,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_attack.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_attack.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Attack object.
 # Attack object docs: https://schema.ocsf.io/1.5.0/objects/attack
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_acba7f4a
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -12,6 +13,7 @@ processors:
           tag: append_attacks_tactic_uid_into_threat_tactic_id
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_aed967de
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -21,6 +23,7 @@ processors:
           tag: append_attacks_tactic_name_into_threat_tactic_name
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_f7199c38
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -30,6 +33,7 @@ processors:
           tag: append_attacks_tactic_src_url_into_threat_tactic_reference
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_b7b42044
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -39,6 +43,7 @@ processors:
           tag: append_attacks_technique_uid_into_threat_technique_id
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_b891d100
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -48,6 +53,7 @@ processors:
           tag: append_attacks_technique_name_into_threat_technique_name
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_59be8a52
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -57,6 +63,7 @@ processors:
           tag: append_attacks_technique_src_url_into_threat_technique_reference
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_0d7da6b1
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -66,6 +73,7 @@ processors:
           tag: append_attacks_sub_technique_uid_into_threat_technique_subtechnique_id
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_5847e5a7
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -75,6 +83,7 @@ processors:
           tag: append_attacks_sub_technique_name_into_threat_technique_subtechnique_name
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_securityhub_finding_attacks_b3a53e5b
       field: aws_securityhub.finding.attacks
       if: ctx.aws_securityhub?.finding?.attacks instanceof List
       processor:
@@ -89,7 +98,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_device.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_device.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Device object.
 # Device object docs: https://schema.ocsf.io/1.5.0/objects/device
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_agent_list_f9062e12
       field: aws_securityhub.finding.device.agent_list
       if: ctx.aws_securityhub?.finding?.device?.agent_list instanceof List
       processor:
@@ -22,9 +23,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.boot_time_dt != null && ctx.aws_securityhub.finding.device.boot_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_boot_time_dt_2def1d61
             field: aws_securityhub.finding.device.boot_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_0bd0ede3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -36,9 +39,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.boot_time != null && ctx.aws_securityhub.finding.device.boot_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_boot_time_0de407fd
             field: aws_securityhub.finding.device.boot_time
             ignore_missing: true
         - append:
+            tag: append_error_message_74c0f2f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -48,8 +53,10 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_container_size_6dfc9845
             field: aws_securityhub.finding.device.container.size
         - append:
+            tag: append_error_message_bdefe17a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -63,9 +70,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.created_time_dt != null && ctx.aws_securityhub.finding.device.created_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_created_time_dt_de70fb51
             field: aws_securityhub.finding.device.created_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_aaf66be9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -77,9 +86,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.created_time != null && ctx.aws_securityhub.finding.device.created_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_created_time_96665f61
             field: aws_securityhub.finding.device.created_time
             ignore_missing: true
         - append:
+            tag: append_error_message_01f89738
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -93,9 +104,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.first_seen_time_dt != null && ctx.aws_securityhub.finding.device.first_seen_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_first_seen_time_dt_e349e4f5
             field: aws_securityhub.finding.device.first_seen_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_207c682f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -107,9 +120,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.first_seen_time != null && ctx.aws_securityhub.finding.device.first_seen_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_first_seen_time_c6cb2c05
             field: aws_securityhub.finding.device.first_seen_time
             ignore_missing: true
         - append:
+            tag: append_error_message_f9a2fe32
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -124,9 +139,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_hw_info_cpu_bits_0bff0b24
             field: aws_securityhub.finding.device.hw_info.cpu_bits
             ignore_missing: true
         - append:
+            tag: append_error_message_b64f2d38
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -136,9 +153,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_hw_info_cpu_cores_6b68df48
             field: aws_securityhub.finding.device.hw_info.cpu_cores
             ignore_missing: true
         - append:
+            tag: append_error_message_e868eb80
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -148,9 +167,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_hw_info_cpu_count_63dfa69e
             field: aws_securityhub.finding.device.hw_info.cpu_count
             ignore_missing: true
         - append:
+            tag: append_error_message_449f9961
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -160,9 +181,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_hw_info_cpu_speed_3aef167e
             field: aws_securityhub.finding.device.hw_info.cpu_speed
             ignore_missing: true
         - append:
+            tag: append_error_message_046b2d3d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -172,9 +195,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_hw_info_ram_size_53d666e6
             field: aws_securityhub.finding.device.hw_info.ram_size
             ignore_missing: true
         - append:
+            tag: append_error_message_2828c4a7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -188,9 +213,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_ip_07955299
             field: aws_securityhub.finding.device.ip
             ignore_missing: true
         - append:
+            tag: append_error_message_a4602cc3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -200,9 +227,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_backed_up_7460cb51
             field: aws_securityhub.finding.device.is_backed_up
             ignore_missing: true
         - append:
+            tag: append_error_message_c4508f0b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -212,9 +241,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_compliant_1ad77a53
             field: aws_securityhub.finding.device.is_compliant
             ignore_missing: true
         - append:
+            tag: append_error_message_fda22a74
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -224,9 +255,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_managed_5f06b957
             field: aws_securityhub.finding.device.is_managed
             ignore_missing: true
         - append:
+            tag: append_error_message_e4c4f10c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -236,9 +269,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_mobile_account_active_9cbda0db
             field: aws_securityhub.finding.device.is_mobile_account_active
             ignore_missing: true
         - append:
+            tag: append_error_message_ad2710bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -248,9 +283,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_personal_c399404f
             field: aws_securityhub.finding.device.is_personal
             ignore_missing: true
         - append:
+            tag: append_error_message_9b63e2ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -260,9 +297,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_shared_3e662701
             field: aws_securityhub.finding.device.is_shared
             ignore_missing: true
         - append:
+            tag: append_error_message_bde92a7c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -272,9 +311,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_supervised_d40a229b
             field: aws_securityhub.finding.device.is_supervised
             ignore_missing: true
         - append:
+            tag: append_error_message_95706a01
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -284,9 +325,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_is_trusted_81e9c1e3
             field: aws_securityhub.finding.device.is_trusted
             ignore_missing: true
         - append:
+            tag: append_error_message_e32f7b76
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -300,9 +343,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.last_seen_time_dt != null && ctx.aws_securityhub.finding.device.last_seen_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_last_seen_time_dt_949a865b
             field: aws_securityhub.finding.device.last_seen_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_976b03e1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -314,9 +359,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.last_seen_time != null && ctx.aws_securityhub.finding.device.last_seen_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_last_seen_time_d50c1beb
             field: aws_securityhub.finding.device.last_seen_time
             ignore_missing: true
         - append:
+            tag: append_error_message_6e78e5d4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -326,9 +373,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_location_is_on_premises_36d34278
             field: aws_securityhub.finding.device.location.is_on_premises
             ignore_missing: true
         - append:
+            tag: append_error_message_86aaf8cb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -338,9 +387,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_location_lat_8ea55e40
             field: aws_securityhub.finding.device.location.lat
             ignore_missing: true
         - append:
+            tag: append_error_message_ae185245
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -350,9 +401,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_location_long_2885084e
             field: aws_securityhub.finding.device.location.long
             ignore_missing: true
         - append:
+            tag: append_error_message_db1f79ae
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -373,9 +426,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_mac_0bfeba91
             field: aws_securityhub.finding.device.mac
             ignore_missing: true
         - append:
+            tag: append_error_message_05c4b6db
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
@@ -385,9 +440,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.mac != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_mac_ecef4f38
             field: aws_securityhub.finding.device.mac
             ignore_missing: true
         - append:
+            tag: append_error_message_0b90d902
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -401,9 +458,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.modified_time_dt != null && ctx.aws_securityhub.finding.device.modified_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_modified_time_dt_b8fe8fa0
             field: aws_securityhub.finding.device.modified_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_42df26d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -415,9 +474,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.device?.modified_time != null && ctx.aws_securityhub.finding.device.modified_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_modified_time_74d70e04
             field: aws_securityhub.finding.device.modified_time
             ignore_missing: true
         - append:
+            tag: append_error_message_98dade48
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -427,12 +488,15 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_namespace_pid_ec8ecfeb
             field: aws_securityhub.finding.device.namespace_pid
             ignore_missing: true
         - append:
+            tag: append_error_message_461b9c87
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_2e8ed360
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -449,6 +513,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_e094a9c0
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -466,6 +531,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_812a41ff
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -481,6 +547,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_1a678ac9
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -490,6 +557,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_device_network_interfaces_10620945
       field: aws_securityhub.finding.device.network_interfaces
       if: ctx.aws_securityhub?.finding?.device?.network_interfaces instanceof List
       processor:
@@ -512,9 +580,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_os_cpu_bits_23628c62
             field: aws_securityhub.finding.device.os.cpu_bits
             ignore_missing: true
         - append:
+            tag: append_error_message_e47ed148
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -534,9 +604,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_owner_has_mfa_73f09ef9
             field: aws_securityhub.finding.device.owner.has_mfa
             ignore_missing: true
         - append:
+            tag: append_error_message_31528448
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -551,9 +623,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_owner_risk_score_f121429c
             field: aws_securityhub.finding.device.owner.risk_score
             ignore_missing: true
         - append:
+            tag: append_error_message_40148eee
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -568,9 +642,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_device_risk_score_c69a1067
             field: aws_securityhub.finding.device.risk_score
             ignore_missing: true
         - append:
+            tag: append_error_message_81ae0ad8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -584,7 +660,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_evidence.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_evidence.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Evidence Artifacts object.
 # Evidence object docs: https://schema.ocsf.io/1.5.0/objects/evidences
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_2cfcb411
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -19,6 +20,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_cf2ef4e8
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -28,6 +30,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_071c357c
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -37,6 +40,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_08e8eec4
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -46,6 +50,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_d6394b64
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -55,6 +60,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_94d1f883
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -71,6 +77,7 @@ processors:
                 field: _ingest._value.actor.process.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_96e32212
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -85,6 +92,7 @@ processors:
                 field: _ingest._value.actor.process.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_33bdada4
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -94,6 +102,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_154d7a4b
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -110,6 +119,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_f1c1794b
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -126,6 +136,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_a9f98587
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -145,6 +156,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_6f66441c
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -162,6 +174,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_c9b3ad26
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -171,6 +184,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_c248a82e
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -187,6 +201,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_2919e631
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -206,6 +221,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_d3cdca14
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -223,6 +239,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_731de3d9
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -242,6 +259,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_ba45f2ac
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -259,6 +277,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_25877c82
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -275,6 +294,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_a055f60e
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -291,6 +311,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_87841044
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -307,6 +328,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_a654f27b
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -323,6 +345,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_23d9a90c
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -332,6 +355,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_fe122d64
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -348,6 +372,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_40de1dd4
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -357,6 +382,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_b083db62
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -373,6 +399,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_ca572291
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -382,6 +409,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_95aaea83
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -391,6 +419,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_29ba1baf
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -407,6 +436,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_037633a9
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -416,6 +446,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_c2063977
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -432,6 +463,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_8e97c021
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -448,6 +480,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_6c783354
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -464,6 +497,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_01b7c9f6
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -481,6 +515,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_cad9318d
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -496,6 +531,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_745067ae
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -512,6 +548,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_a7da4b28
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -528,6 +565,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_1ab9f419
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -537,6 +575,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_d6ffd85f
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -546,6 +585,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_7b82ed57
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -555,6 +595,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_69748c67
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -564,6 +605,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_bf977912
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -580,6 +622,7 @@ processors:
                 field: _ingest._value.process.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_3f7e1009
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -594,6 +637,7 @@ processors:
                 field: _ingest._value.process.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_af5032d7
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -603,6 +647,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_b5896d05
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -619,6 +664,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_2b219a35
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -635,6 +681,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_304eba36
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -654,6 +701,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_61eb0d7f
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -671,6 +719,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_3f397f69
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -680,6 +729,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_9c79243d
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -689,6 +739,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_263a6345
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -698,6 +749,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_evidences_2bda9abc
       field: aws_securityhub.finding.evidences
       if: ctx.aws_securityhub?.finding?.evidences instanceof List
       processor:
@@ -712,7 +764,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_finding.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_finding.yml
@@ -18,9 +18,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.created_time_dt != null && ctx.aws_securityhub.finding.finding_info.created_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_created_time_dt_f07a174d
             field: aws_securityhub.finding.finding_info.created_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_fa7fa741
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -32,9 +34,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.created_time != null && ctx.aws_securityhub.finding.finding_info.created_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_created_time_1a99e93d
             field: aws_securityhub.finding.finding_info.created_time
             ignore_missing: true
         - append:
+            tag: append_error_message_5ae2c6d0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -48,9 +52,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.first_seen_time_dt != null && ctx.aws_securityhub.finding.finding_info.first_seen_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_first_seen_time_dt_8710c4a1
             field: aws_securityhub.finding.finding_info.first_seen_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_ac3be137
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -62,9 +68,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.first_seen_time != null && ctx.aws_securityhub.finding.finding_info.first_seen_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_first_seen_time_0a5e1001
             field: aws_securityhub.finding.finding_info.first_seen_time
             ignore_missing: true
         - append:
+            tag: append_error_message_f513d53a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -83,9 +91,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.last_seen_time_dt != null && ctx.aws_securityhub.finding.finding_info.last_seen_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_last_seen_time_dt_b8d06aef
             field: aws_securityhub.finding.finding_info.last_seen_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_f07ec589
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -97,9 +107,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.last_seen_time != null && ctx.aws_securityhub.finding.finding_info.last_seen_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_last_seen_time_0bfb77e7
             field: aws_securityhub.finding.finding_info.last_seen_time
             ignore_missing: true
         - append:
+            tag: append_error_message_58c9271c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -113,9 +125,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.modified_time_dt != null && ctx.aws_securityhub.finding.finding_info.modified_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_modified_time_dt_6941455c
             field: aws_securityhub.finding.finding_info.modified_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_700d4d55
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -127,12 +141,15 @@ processors:
       if: ctx.aws_securityhub?.finding?.finding_info?.modified_time != null && ctx.aws_securityhub.finding.finding_info.modified_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_modified_time_5ac3c690
             field: aws_securityhub.finding.finding_info.modified_time
             ignore_missing: true
         - append:
+            tag: append_error_message_ebd95230
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_finding_info_related_analytics_b9d78805
       field: aws_securityhub.finding.finding_info.related_analytics
       if: ctx.aws_securityhub?.finding?.finding_info?.related_analytics instanceof List
       processor:
@@ -148,8 +165,10 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_finding_info_related_events_count_7d97372e
             field: aws_securityhub.finding.finding_info.related_events_count
         - append:
+            tag: append_error_message_a6faba3e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 on_failure:
@@ -158,7 +177,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_malware.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_malware.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Malware object.
 # Malware object docs: https://schema.ocsf.io/1.5.0/objects/malware
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_38bd8d97
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -12,6 +13,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_c87b621b
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -32,6 +34,7 @@ processors:
                     field: _ingest._value.created_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_17866436
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -50,6 +53,7 @@ processors:
                     field: _ingest._value.created_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_98bfa132
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -73,6 +77,7 @@ processors:
                         field: error.message
                         value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_5b850172
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -96,6 +101,7 @@ processors:
                         field: error.message
                         value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_a48cb9e3
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -116,6 +122,7 @@ processors:
                     field: _ingest._value.modified_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_7fea2486
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -134,6 +141,7 @@ processors:
                     field: _ingest._value.modified_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_954d6123
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -154,6 +162,7 @@ processors:
                     field: _ingest._value.accessed_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_f24123d0
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -172,6 +181,7 @@ processors:
                     field: _ingest._value.accessed_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_d04b5541
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -191,6 +201,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_e2552674
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -204,6 +215,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_f8621bc7
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -224,6 +236,7 @@ processors:
                     field: _ingest._value.created_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_391be640
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -242,6 +255,7 @@ processors:
                     field: _ingest._value.created_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_e70f7d26
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -255,6 +269,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_79cb7356
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -274,6 +289,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_af00a6ff
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -293,6 +309,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_fcd6f6d4
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -312,6 +329,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_386c9bcf
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -332,6 +350,7 @@ processors:
                     field: _ingest._value.modified_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_a0a0b018
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -350,6 +369,7 @@ processors:
                     field: _ingest._value.modified_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_c59eaf6d
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -369,6 +389,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_c53e50aa
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -382,6 +403,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_8a5a9f24
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -397,6 +419,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_malware_a730d01b
       field: aws_securityhub.finding.malware
       if: ctx.aws_securityhub?.finding?.malware instanceof List
       processor:
@@ -411,7 +434,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_metadata.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_metadata.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Metadata object.
 # Metadata object docs: https://schema.ocsf.io/1.5.0/objects/metadata
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_data_classifications_555d59cd
       field: aws_securityhub.finding.metadata.data_classifications
       if: ctx.aws_securityhub?.finding?.metadata?.data_classifications instanceof List
       processor:
@@ -12,6 +13,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_data_classifications_9d60b821
       field: aws_securityhub.finding.metadata.data_classifications
       if: ctx.aws_securityhub?.finding?.metadata?.data_classifications instanceof List
       processor:
@@ -21,6 +23,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_data_classifications_31ada704
       field: aws_securityhub.finding.metadata.data_classifications
       if: ctx.aws_securityhub?.finding?.metadata?.data_classifications instanceof List
       processor:
@@ -37,15 +40,17 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_data_classifications_f3ecb729
       field: aws_securityhub.finding.metadata.data_classifications
       if: ctx.aws_securityhub?.finding?.metadata?.data_classifications instanceof List
       processor:
         convert:
-          field: _ingest._value.status_id	
+          field: _ingest._value.status_id
           tag: convert_finding_metadata_data_classifications_status_id_to_string
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_data_classifications_7eefd7e1
       field: aws_securityhub.finding.metadata.data_classifications
       if: ctx.aws_securityhub?.finding?.metadata?.data_classifications instanceof List
       processor:
@@ -72,9 +77,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.metadata?.logged_time_dt != null && ctx.aws_securityhub.finding.metadata.logged_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_logged_time_dt_f96b8e86
             field: aws_securityhub.finding.metadata.logged_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_b4e4c4c3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -86,12 +93,15 @@ processors:
       if: ctx.aws_securityhub?.finding?.metadata?.logged_time != null && ctx.aws_securityhub.finding.metadata.logged_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_logged_time_2476b072
             field: aws_securityhub.finding.metadata.logged_time
             ignore_missing: true
         - append:
+            tag: append_error_message_5e3157f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_loggers_f4e7e83f
       field: aws_securityhub.finding.metadata.loggers
       if: ctx.aws_securityhub?.finding?.metadata?.loggers instanceof List
       processor:
@@ -108,6 +118,7 @@ processors:
                 field: _ingest._value.logged_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_loggers_dae6fdc8
       field: aws_securityhub.finding.metadata.loggers
       if: ctx.aws_securityhub?.finding?.metadata?.loggers instanceof List
       processor:
@@ -122,6 +133,7 @@ processors:
                 field: _ingest._value.logged_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_loggers_755f154b
       field: aws_securityhub.finding.metadata.loggers
       if: ctx.aws_securityhub?.finding?.metadata?.loggers instanceof List
       processor:
@@ -138,6 +150,7 @@ processors:
                 field: _ingest._value.transmit_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_loggers_0ae0a034
       field: aws_securityhub.finding.metadata.loggers
       if: ctx.aws_securityhub?.finding?.metadata?.loggers instanceof List
       processor:
@@ -162,9 +175,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.metadata?.modified_time_dt != null && ctx.aws_securityhub.finding.metadata.modified_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_modified_time_dt_a2938f11
             field: aws_securityhub.finding.metadata.modified_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_ea5d8909
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -176,9 +191,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.metadata?.modified_time != null && ctx.aws_securityhub.finding.metadata.modified_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_modified_time_3ede13fd
             field: aws_securityhub.finding.metadata.modified_time
             ignore_missing: true
         - append:
+            tag: append_error_message_7483ff98
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -192,9 +209,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.metadata?.processed_time_dt != null && ctx.aws_securityhub.finding.metadata.processed_time_dt != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_processed_time_dt_1662d898
             field: aws_securityhub.finding.metadata.processed_time_dt
             ignore_missing: true
         - append:
+            tag: append_error_message_9001c3a3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -206,9 +225,11 @@ processors:
       if: ctx.aws_securityhub?.finding?.metadata?.processed_time != null && ctx.aws_securityhub.finding.metadata.processed_time != ''
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_processed_time_cd41d5d8
             field: aws_securityhub.finding.metadata.processed_time
             ignore_missing: true
         - append:
+            tag: append_error_message_86a1cff2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -218,12 +239,15 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_aws_securityhub_finding_metadata_sequence_c1e35d75
             field: aws_securityhub.finding.metadata.sequence
             ignore_missing: true
         - append:
+            tag: append_error_message_5b8e2cd4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_transformation_info_list_4553a877
       field: aws_securityhub.finding.metadata.transformation_info_list
       if: ctx.aws_securityhub?.finding?.metadata?.transformation_info_list instanceof List
       processor:
@@ -240,6 +264,7 @@ processors:
                 field: _ingest._value.time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_metadata_transformation_info_list_2731b516
       field: aws_securityhub.finding.metadata.transformation_info_list
       if: ctx.aws_securityhub?.finding?.metadata?.transformation_info_list instanceof List
       processor:
@@ -259,7 +284,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_osint.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_osint.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing OSINT object.
 # OSINT object docs: https://schema.ocsf.io/1.5.0/objects/osint
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_02d45017
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -22,6 +23,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e376f74a
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -35,6 +37,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_8f1e4872
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -48,6 +51,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_b24f25a8
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -63,6 +67,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_6c1fa157
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -72,6 +77,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_c5b93b52
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -88,6 +94,7 @@ processors:
                 field: _ingest._value.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_dbd231cb
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -102,6 +109,7 @@ processors:
                 field: _ingest._value.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_7d606e28
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -117,6 +125,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_40b854a8
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -126,6 +135,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_7bac7373
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -141,6 +151,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_57ecfa74
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -150,6 +161,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_0ee7ca3b
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -159,6 +171,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_bc0cf754
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -174,6 +187,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_7c48ab48
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -189,6 +203,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_049cdcab
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -209,6 +224,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_6f7557c2
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -225,6 +241,7 @@ processors:
                 field: _ingest._value.expiration_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_72224377
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -239,6 +256,7 @@ processors:
                 field: _ingest._value.expiration_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_fcda412d
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -255,6 +273,7 @@ processors:
                 field: _ingest._value.file.accessed_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_c40cc24a
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -269,6 +288,7 @@ processors:
                 field: _ingest._value.file.accessed_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_8eab8ae0
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -284,6 +304,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e0a3cc46
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -293,6 +314,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_7e1a0c19
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -309,6 +331,7 @@ processors:
                 field: _ingest._value.file.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_8ff0a33e
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -323,6 +346,7 @@ processors:
                 field: _ingest._value.file.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_a054f274
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -332,6 +356,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_ae6f41ed
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -347,6 +372,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_a4c84df6
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -362,6 +388,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_4cba3235
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -377,6 +404,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_0bd2b3e1
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -393,6 +421,7 @@ processors:
                 field: _ingest._value.file.modified_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_729764ba
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -407,6 +436,7 @@ processors:
                 field: _ingest._value.file.modified_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_8a03f54e
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -416,6 +446,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_bcf26b2c
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -431,6 +462,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_713620a8
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -444,6 +476,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_53e67749
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -459,6 +492,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_4979dfdd
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -474,6 +508,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_68824284
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -489,6 +524,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_80fcecb6
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -502,6 +538,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_6a21a9c4
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -521,6 +558,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e0768186
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -534,6 +572,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_df005bfe
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -550,6 +589,7 @@ processors:
                 field: _ingest._value.modified_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_92bf7f0f
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -564,6 +604,7 @@ processors:
                 field: _ingest._value.modified_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_cc5fad0c
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -577,6 +618,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_228da076
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -592,6 +634,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e3553a96
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -601,6 +644,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_c5114758
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -616,6 +660,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_c1ee6418
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -625,6 +670,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_d483a93b
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -634,6 +680,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e7d62572
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -647,6 +694,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_c4a16887
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -667,6 +715,7 @@ processors:
                     field: _ingest._value.created_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_8c992552
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -685,6 +734,7 @@ processors:
                     field: _ingest._value.created_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_72610092
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -698,6 +748,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_70c2674a
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -707,6 +758,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_3c802beb
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -716,6 +768,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_e00c5618
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -732,6 +785,7 @@ processors:
                 field: _ingest._value.uploaded_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_f3179e83
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -746,6 +800,7 @@ processors:
                 field: _ingest._value.uploaded_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_66408a1d
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -766,6 +821,7 @@ processors:
                     field: _ingest._value.exploit_last_seen_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_28fbf328
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -784,6 +840,7 @@ processors:
                     field: _ingest._value.exploit_last_seen_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_09e13863
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -804,6 +861,7 @@ processors:
                     field: _ingest._value.first_seen_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_2e6136e4
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -822,6 +880,7 @@ processors:
                     field: _ingest._value.first_seen_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_21056a68
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -835,6 +894,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_0a595b1b
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -854,6 +914,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_37f40faf
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -873,6 +934,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_6f14ec51
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -893,6 +955,7 @@ processors:
                     field: _ingest._value.last_seen_time_dt
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_0c8ded38
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -911,6 +974,7 @@ processors:
                     field: _ingest._value.last_seen_time
                     ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_4a5350a1
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -927,6 +991,7 @@ processors:
                 field: _ingest._value.whois.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_c34978d4
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -941,6 +1006,7 @@ processors:
                 field: _ingest._value.whois.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_2ad93e9e
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -950,6 +1016,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_3d9a8695
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -966,6 +1033,7 @@ processors:
                 field: _ingest._value.whois.last_seen_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_osint_67410348
       field: aws_securityhub.finding.osint
       if: ctx.aws_securityhub?.finding?.osint instanceof List
       processor:
@@ -985,7 +1053,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_resources.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_resources.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Resource object.
 # Resource Details object docs: https://schema.ocsf.io/1.5.0/objects/resource_details
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_68806d5e
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -16,6 +17,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_cc0109cc
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -32,6 +34,7 @@ processors:
                 field: _ingest._value.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_44a67db1
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -46,6 +49,7 @@ processors:
                 field: _ingest._value.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_9d9193ba
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -59,6 +63,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_784cab4a
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -72,6 +77,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_e63457a5
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -92,6 +98,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_00dd5bd6
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -105,6 +112,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_d2065b8e
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -125,6 +133,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_172456d4
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -141,6 +150,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_5c7acf12
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -157,6 +167,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_7f05a5f8
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -173,6 +184,7 @@ processors:
                 field: _ingest._value.data.awsEc2InstanceDetails.launchedAt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_0c9b0ed2
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -189,6 +201,7 @@ processors:
                 field: _ingest._value.data.awsLambdaFunctionDetails.lastModifiedAt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_a8acc058
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -205,6 +218,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_3a441974
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -221,6 +235,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_87c165a4
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -237,6 +252,7 @@ processors:
                 field: _ingest._value.modified_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_7f9cf711
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -251,6 +267,7 @@ processors:
                 field: _ingest._value.modified_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_9f5c7378
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -267,6 +284,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_956405e2
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -276,6 +294,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_f7a38a16
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -285,6 +304,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_8e77b731
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -301,6 +321,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_5ae67ef4
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -317,6 +338,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_resources_40714a1e
       field: aws_securityhub.finding.resources
       if: ctx.aws_securityhub?.finding?.resources instanceof List
       processor:
@@ -331,7 +353,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_vulnerabilities.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_vulnerabilities.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Vulnerability object.
 # Vulnerability object docs: https://schema.ocsf.io/1.5.0/objects/vulnerability
 processors:
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_9043b4b6
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -19,6 +20,7 @@ processors:
                 field: _ingest._value.advisory.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_65e02833
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -33,6 +35,7 @@ processors:
                 field: _ingest._value.advisory.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_b24b588b
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -42,6 +45,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_ad17ef76
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -57,6 +61,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_b0f0253e
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -73,6 +78,7 @@ processors:
                 field: _ingest._value.advisory.modified_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_1b9882a3
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -87,6 +93,7 @@ processors:
                 field: _ingest._value.advisory.modified_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_18eeef60
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -102,6 +109,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_a9159634
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -121,6 +129,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_7b81a114
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -140,6 +149,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_560df44f
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -159,6 +169,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_5d17cb7f
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -178,6 +189,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_dbe32687
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -197,6 +209,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_a9c53f61
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -210,6 +223,7 @@ processors:
               type: string
               ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_e4a0625c
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -226,6 +240,7 @@ processors:
                 field: _ingest._value.cve.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_96653541
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -240,6 +255,7 @@ processors:
                 field: _ingest._value.cve.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_9d6d2447
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -259,6 +275,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_b335a571
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -278,6 +295,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_54403621
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -294,6 +312,7 @@ processors:
                 field: _ingest._value.cve.epss.created_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_b1207a54
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -308,6 +327,7 @@ processors:
                 field: _ingest._value.cve.epss.created_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_255ecddf
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -323,6 +343,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_e7c89798
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -339,6 +360,7 @@ processors:
                 field: _ingest._value.cve.modified_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_2d239a1d
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -353,6 +375,7 @@ processors:
                 field: _ingest._value.cve.modified_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_aa0b4d5b
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -369,6 +392,7 @@ processors:
                 field: _ingest._value.exploit_last_seen_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_5b308426
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -383,6 +407,7 @@ processors:
                 field: _ingest._value.exploit_last_seen_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_28ad9579
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -399,6 +424,7 @@ processors:
                 field: _ingest._value.first_seen_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_dcb0af9a
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -413,6 +439,7 @@ processors:
                 field: _ingest._value.first_seen_time
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_77ac0b9e
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -422,6 +449,7 @@ processors:
           type: string
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_7ff17451
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -437,6 +465,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_6379dfc5
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -452,6 +481,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_537b1c5f
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -468,6 +498,7 @@ processors:
                 field: _ingest._value.last_seen_time_dt
                 ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_finding_vulnerabilities_98ba4576
       field: aws_securityhub.finding.vulnerabilities
       if: ctx.aws_securityhub?.finding?.vulnerabilities instanceof List
       processor:
@@ -487,7 +518,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_securityhub
 title: "AWS Security Hub"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Elastic-2.0"
 description: Collect logs from AWS Security Hub with Elastic Agent.


### PR DESCRIPTION
## Proposed commit message

```
[aws_securityhub] Add processor tags to ingest pipelines

Add tag fields to every processor in all aws_securityhub ingest
pipelines using elastic-package modify --modifiers pipeline-tag, and
update pipeline-level on_failure error messages to include
_ingest.pipeline per the SVR00009 linter rule. Both are requirements
that will be enforced when the package format_version is bumped to
3.6.x for Identity Federation support.

Also fix a pre-existing copy-paste bug surfaced by the tagging: the
pipeline_object_evidence pipeline processor in default.yml was tagged
pipeline_object_device, duplicating the device processor's tag.
```

## Background

Part of https://github.com/elastic/ingest-dev/issues/8812.

Enabling Identity Federation on `aws_securityhub` requires bumping `format_version` from 3.5.0 to 3.6.4 (`var_groups` needs 3.6.0, `provider_permissions` needs 3.6.4). That bump activates stricter pipeline validators (SVR00006 processor tags, SVR00009 on_failure message format) which surface 514 pre-existing violations across the package's ingest pipelines.

This PR pre-lands those mechanical fixes so the upcoming federation PR stays small and reviewable, following the precedent of #19824 for the `aws` package. There is no functional effect at format_version 3.5.0.

Verified: `elastic-package lint` passes both at 3.5.0 and with a local 3.6.4 bump applied; `elastic-package build` succeeds.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)