### PR TITLE
[backport] Keep backport branch's own .go-version during branch creation

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -184,17 +184,21 @@ updateBackportBranchContents() {
     git checkout "$SOURCE_BRANCH" -- "tools.go"
     git add tools.go
 
-    # Switch to the backport branch's Go version so go mod tidy keeps go.mod as-is.
-    eval "$(gvm "$(cat .go-version)")"
-
     # Run go mod tidy to update just the dependencies related to magefile and dev scripts
     echo "--- Running go mod tidy to update dependencies related to magefile and dev scripts..."
+    # Switch to the backport branch's Go version so go mod tidy keeps go.mod as-is.
+    eval "$(gvm "$(cat .go-version)")"
+    echo "Setting go version from backport branch"
+    go version
+
     go mod tidy
 
     git add go.mod go.sum
 
     # Restore the Go version from the source branch for the rest of the script execution.
+    echo "Restoring go version from ${SOURCE_BRANCH} branch"
     eval "$(gvm "$(git show "${SOURCE_BRANCH}:.go-version")")"
+    go version
   fi
 
   if [ "${REMOVE_OTHER_PACKAGES}" == "true" ]; then

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -194,8 +194,6 @@ updateBackportBranchContents() {
     go mod tidy
 
     git add go.mod go.sum
-    echo "Run tests with $(go version)"
-    mage check
 
     # Restore the Go version from the source branch for the rest of the script execution.
     echo "Restoring go version from ${SOURCE_BRANCH} branch"

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -172,13 +172,6 @@ updateBackportBranchContents() {
     git checkout "$SOURCE_BRANCH" -- "magefile.go"
     git add magefile.go
 
-    # As this script runs in the context of the main branch (mainly go mod tidy), we need to copy
-    # the .go-version file from the main branch to the backport branch. This avoids failures
-    # installing dependencies in the backport Pull Request.
-    echo "--- Copying .go-version from $SOURCE_BRANCH..."
-    git checkout "$SOURCE_BRANCH" -- ".go-version"
-    git add .go-version
-
     # Restore workflows from the main branch since modifying them requires extra permissions.
     # > error: GH013: Repository rule violations found for ...
     # > refusing to allow a GitHub App to create or update workflow `.github/workflows/bump-elastic-stack-version.yml` without `workflows` permission
@@ -191,11 +184,17 @@ updateBackportBranchContents() {
     git checkout "$SOURCE_BRANCH" -- "tools.go"
     git add tools.go
 
+    # Switch to the backport branch's Go version so go mod tidy keeps go.mod as-is.
+    eval "$(gvm "$(cat .go-version)")"
+
     # Run go mod tidy to update just the dependencies related to magefile and dev scripts
     echo "--- Running go mod tidy to update dependencies related to magefile and dev scripts..."
     go mod tidy
 
     git add go.mod go.sum
+
+    # Restore the Go version from the source branch for the rest of the script execution.
+    eval "$(gvm "$(git show "${SOURCE_BRANCH}:.go-version")")"
   fi
 
   if [ "${REMOVE_OTHER_PACKAGES}" == "true" ]; then

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -194,6 +194,8 @@ updateBackportBranchContents() {
     go mod tidy
 
     git add go.mod go.sum
+    echo "Run tests with $(go version)"
+    mage check
 
     # Restore the Go version from the source branch for the rest of the script execution.
     echo "Restoring go version from ${SOURCE_BRANCH} branch"


### PR DESCRIPTION
## Proposed commit message

**WHAT:**
The `backport_branch.sh` script previously forced-copied `.go-version` from the source branch (main) into the backport branch before running `go mod tidy`. This silently overwrote the backport branch's Go version, meaning all backport branches ended up with main's Go version — even when they were intentionally pinned to an older one.

The fix removes that forced copy and instead activates the backport branch's own `.go-version` via `gvm` before running `go mod tidy`, so that `go.mod` is tidied against the correct toolchain. After `go mod tidy` completes, the source branch Go version is restored for the rest of the script.

**WHY:**
Backport branches targeting older release lines may need to pin an older Go version. Overwriting `.go-version` from main breaks that invariant and can cause `go mod tidy` to produce a `go.mod` that is incompatible with the toolchain the backport branch is actually meant to use.

Example of errors:
```
 $ mage check
...
exec: go "run" "gotest.tools/gotestsum" "--format" "testname" "--junitfile" "tests-report.xml" "./dev/..."
# golang.org/x/tools/internal/tokeninternal
/go/pkg/mod/golang.org/x/tools@v0.22.0/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)
Error: running "go run gotest.tools/gotestsum --format testname --junitfile tests-report.xml ./dev/..." failed with exit code 1
```

```
 $ mage check
dev/backports/owners/owners.go:13:2: package maps is not in GOROOT (/home/mariorodriguez/.gvm/versions/go1.19.1.linux.amd64/src/maps)
dev/citools/packages.go:13:2: package slices is not in GOROOT (/home/mariorodriguez/.gvm/versions/go1.19.1.linux.amd64/src/slices)
Error: error compiling magefiles
```

## Author's Checklist

- [ ] Verify that `gvm` is available in all Buildkite agent environments where this script runs.
- [ ] Confirm the restored source-branch Go version is correctly picked up after `go mod tidy`.

Buildkite build testing this: https://buildkite.com/elastic/integrations-backport/builds/318

## How to test this PR locally

1. Trigger the backport branch creation script against a backport branch that has a different `.go-version` than `main`.
2. Confirm `.go-version` on the resulting branch still reflects the backport branch's original version.
3. Confirm `go.mod` is updated correctly by `go mod tidy` without changing the `go` directive to a newer version.

## Related issues

- Follows up #20432
- Relates #13994
- Relates #19262

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).