### PR TITLE
chore: update dependabot configuration to include cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "daily"
     labels:
       - automation
+    cooldown:
+      default-days: 3
+      exclude:
+        - github.com/elastic/package-registry
+        - github.com/elastic/elastic-package
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Added a default cooldown of 3 days for dependency updates, excluding specific repositories for GitHub Actions. This change aims to optimize the update frequency and reduce potential disruptions.

