### PR TITLE
o365: fix document_parsing_exception on o365.audit.Message

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix document_parsing_exception on o365.audit.Message for AIInteractionCreatedNotification events by moving object-typed values to o365.audit.MessageObject.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20476
 - version: "3.10.6"
   changes:
     - description: >- 

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.7"
+  changes:
+    - description: Fix document_parsing_exception on o365.audit.Message for AIInteractionCreatedNotification events by moving object-typed values to o365.audit.MessageObject.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.10.6"
   changes:
     - description: >- 

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-ai-interaction-events.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-ai-interaction-events.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "event": {
+        "original": "{\"CreationTime\":\"2026-01-15T10:23:44\",\"Id\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\",\"Operation\":\"AIInteractionCreatedNotification\",\"OrganizationId\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"RecordType\":\"25\",\"UserId\":\"user@example.com\",\"UserKey\":\"user@example.com\",\"UserType\":\"0\",\"Version\":\"1\",\"Workload\":\"MicrosoftTeams\",\"Message\":{\"ThreadId\":\"19:abc123def456ghi789jkl012mno345pqr678@thread.v2\",\"SizeInBytes\":186,\"Id\":\"1785411409439\"}}"
+      },
+      "o365audit": {
+        "CreationTime": "2026-01-15T10:23:44",
+        "Id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "Operation": "AIInteractionCreatedNotification",
+        "OrganizationId": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+        "RecordType": "25",
+        "UserId": "user@example.com",
+        "UserKey": "user@example.com",
+        "UserType": "0",
+        "Version": "1",
+        "Workload": "MicrosoftTeams",
+        "Message": {
+          "ThreadId": "19:abc123def456ghi789jkl012mno345pqr678@thread.v2",
+          "SizeInBytes": 186,
+          "Id": "1785411409439"
+        }
+      }
+    },
+    {
+      "event": {
+        "original": "{\"CreationTime\":\"2026-01-15T10:24:00\",\"Id\":\"b2c3d4e5-f6a7-8901-bcde-f12345678901\",\"Operation\":\"FileAccessed\",\"OrganizationId\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"RecordType\":\"6\",\"UserId\":\"user@example.com\",\"UserKey\":\"user@example.com\",\"UserType\":\"0\",\"Version\":\"1\",\"Workload\":\"SharePoint\",\"Message\":\"Notification message for file access\"}"
+      },
+      "o365audit": {
+        "CreationTime": "2026-01-15T10:24:00",
+        "Id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+        "Operation": "FileAccessed",
+        "OrganizationId": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+        "RecordType": "6",
+        "UserId": "user@example.com",
+        "UserKey": "user@example.com",
+        "UserType": "0",
+        "Version": "1",
+        "Workload": "SharePoint",
+        "Message": "Notification message for file access"
+      }
+    }
+  ]
+}

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-ai-interaction-events.json-expected.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-ai-interaction-events.json-expected.json
@@ -1,0 +1,128 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-01-15T10:23:44.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "AIInteractionCreatedNotification",
+                "category": [
+                    "web"
+                ],
+                "code": "MicrosoftTeams",
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "kind": "event",
+                "original": "{\"CreationTime\":\"2026-01-15T10:23:44\",\"Id\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\",\"Operation\":\"AIInteractionCreatedNotification\",\"OrganizationId\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"RecordType\":\"25\",\"UserId\":\"user@example.com\",\"UserKey\":\"user@example.com\",\"UserType\":\"0\",\"Version\":\"1\",\"Workload\":\"MicrosoftTeams\",\"Message\":{\"ThreadId\":\"19:abc123def456ghi789jkl012mno345pqr678@thread.v2\",\"SizeInBytes\":186,\"Id\":\"1785411409439\"}}",
+                "outcome": "success",
+                "provider": "MicrosoftTeams",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "name": "mytenant.onmicrosoft.com"
+            },
+            "o365": {
+                "audit": {
+                    "CreationTime": "2026-01-15T10:23:44",
+                    "MessageObject": {
+                        "Id": "1785411409439",
+                        "SizeInBytes": 186,
+                        "ThreadId": "19:abc123def456ghi789jkl012mno345pqr678@thread.v2"
+                    },
+                    "RecordType": "25",
+                    "UserId": "user@example.com",
+                    "UserKey": "user@example.com",
+                    "UserType": "0",
+                    "Version": "1"
+                }
+            },
+            "organization": {
+                "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "name": "mytenant.onmicrosoft.com"
+            },
+            "related": {
+                "hosts": [
+                    "mytenant.onmicrosoft.com",
+                    "example.com"
+                ],
+                "user": [
+                    "user",
+                    "user@example.com"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "domain": "example.com",
+                "email": "user@example.com",
+                "id": "user@example.com",
+                "name": "user"
+            }
+        },
+        {
+            "@timestamp": "2026-01-15T10:24:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "FileAccessed",
+                "category": [
+                    "web",
+                    "file"
+                ],
+                "code": "SharePointFileOperation",
+                "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "kind": "event",
+                "original": "{\"CreationTime\":\"2026-01-15T10:24:00\",\"Id\":\"b2c3d4e5-f6a7-8901-bcde-f12345678901\",\"Operation\":\"FileAccessed\",\"OrganizationId\":\"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\",\"RecordType\":\"6\",\"UserId\":\"user@example.com\",\"UserKey\":\"user@example.com\",\"UserType\":\"0\",\"Version\":\"1\",\"Workload\":\"SharePoint\",\"Message\":\"Notification message for file access\"}",
+                "outcome": "success",
+                "provider": "SharePoint",
+                "type": [
+                    "info",
+                    "access"
+                ]
+            },
+            "host": {
+                "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "name": "mytenant.onmicrosoft.com"
+            },
+            "o365": {
+                "audit": {
+                    "CreationTime": "2026-01-15T10:24:00",
+                    "Message": "Notification message for file access",
+                    "RecordType": "6",
+                    "UserId": "user@example.com",
+                    "UserKey": "user@example.com",
+                    "UserType": "0",
+                    "Version": "1"
+                }
+            },
+            "organization": {
+                "id": "b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd",
+                "name": "mytenant.onmicrosoft.com"
+            },
+            "related": {
+                "hosts": [
+                    "mytenant.onmicrosoft.com",
+                    "example.com"
+                ],
+                "user": [
+                    "user",
+                    "user@example.com"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "domain": "example.com",
+                "email": "user@example.com",
+                "id": "user@example.com",
+                "name": "user"
+            }
+        }
+    ]
+}

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -86,6 +86,14 @@ processors:
       if: ctx.o365audit?.Sender instanceof Map
       ignore_missing: true
 
+  - rename:
+      tag: rename_message_object_to_message_object_field
+      description: Move structured Message values to MessageObject to keep Message consistently a keyword.
+      field: o365audit.Message
+      target_field: o365audit.MessageObject
+      if: ctx.o365audit?.Message instanceof Map
+      ignore_missing: true
+
   - fingerprint:
       tag: fingerprint_443be558
       fields:

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -435,8 +435,12 @@
       type: keyword
     - name: Members
       type: flattened
+    - name: Message
+      type: keyword
     - name: MessageDate
       type: keyword
+    - name: MessageObject
+      type: flattened
     - name: MessageTime
       type: keyword
     - name: ModifiedProperties.Role_DisplayName.NewValue

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -504,7 +504,9 @@ An example event for `audit` looks as following:
 | o365.audit.MailboxOwnerSid |  | keyword |
 | o365.audit.MailboxOwnerUPN |  | keyword |
 | o365.audit.Members |  | flattened |
+| o365.audit.Message |  | keyword |
 | o365.audit.MessageDate |  | keyword |
+| o365.audit.MessageObject |  | flattened |
 | o365.audit.MessageTime |  | keyword |
 | o365.audit.ModifiedProperties |  | object |
 | o365.audit.ModifiedProperties.\*.\* |  | object |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.10.6"
+version: "3.10.7"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
o365: fix document_parsing_exception on o365.audit.Message

Microsoft's AIInteractionCreatedNotification event sends the Message
field as a JSON object rather than a plain string. Because the field
was not explicitly mapped, Elasticsearch inferred its type from the
first document after a rollover; when that type resolved to keyword,
any subsequent object-valued Message caused a document_parsing_exception
and the event was routed to the failure store.

Add a rename processor that moves Message to MessageObject when its
value is a Map, following the same pattern used for the Sender /
SenderEntity split in v3.10.4. Explicitly map Message as keyword and
MessageObject as flattened to prevent mapping explosion.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
