### PR TITLE
[Coordination & infra OTel] Regenerate OTel dashboards with adHocDataViews

### DIFF
--- a/packages/airflow_otel/changelog.yml
+++ b/packages/airflow_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/airflow_otel/changelog.yml
+++ b/packages/airflow_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20483
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/airflow_otel/kibana/dashboard/airflow_otel-dag-processing.json
+++ b/packages/airflow_otel/kibana/dashboard/airflow_otel-dag-processing.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962",
+                                    "name": "indexpattern-datasource-layer-c35ac9fc-4d64-4d11-3ed6-deb21b81542f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962": {
+                                    "id": "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -277,13 +298,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4c3796df-fe91-9f3e-0466-05d1f90fa912"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4c3796df-fe91-9f3e-0466-05d1f90fa912",
+                                    "name": "indexpattern-datasource-layer-8ff7cc59-00a2-3f94-0d4c-127ca97230d6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4c3796df-fe91-9f3e-0466-05d1f90fa912": {
+                                    "id": "4c3796df-fe91-9f3e-0466-05d1f90fa912",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -381,13 +423,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "df115e05-1752-62d5-18cc-d103b64dc91a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "df115e05-1752-62d5-18cc-d103b64dc91a",
+                                    "name": "indexpattern-datasource-layer-317c778a-576f-a708-e5ae-6370cbb29601"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "df115e05-1752-62d5-18cc-d103b64dc91a": {
+                                    "id": "df115e05-1752-62d5-18cc-d103b64dc91a",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -485,13 +548,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "22078d7f-832f-9e6a-7559-bf21564ebdb8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "22078d7f-832f-9e6a-7559-bf21564ebdb8",
+                                    "name": "indexpattern-datasource-layer-6d9c3cd3-0a28-00d9-41d4-e05fa0874ac7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "22078d7f-832f-9e6a-7559-bf21564ebdb8": {
+                                    "id": "22078d7f-832f-9e6a-7559-bf21564ebdb8",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -637,13 +721,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "95624c85-5c8f-d393-9a32-bcf5f76b6d33"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "95624c85-5c8f-d393-9a32-bcf5f76b6d33",
+                                    "name": "indexpattern-datasource-layer-ab351eac-a3e3-7253-c24f-2f6d9f0b3f99"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "95624c85-5c8f-d393-9a32-bcf5f76b6d33": {
+                                    "id": "95624c85-5c8f-d393-9a32-bcf5f76b6d33",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -797,13 +902,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "98b31208-bd0c-771f-6012-3bc04e0bfe0a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "98b31208-bd0c-771f-6012-3bc04e0bfe0a",
+                                    "name": "indexpattern-datasource-layer-de767845-9ee1-7ed0-b9d8-f4acfc816b61"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "98b31208-bd0c-771f-6012-3bc04e0bfe0a": {
+                                    "id": "98b31208-bd0c-771f-6012-3bc04e0bfe0a",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/airflow_otel/kibana/dashboard/airflow_otel-overview.json
+++ b/packages/airflow_otel/kibana/dashboard/airflow_otel-overview.json
@@ -177,13 +177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "256645ea-2164-a2c0-f5b8-305f94814e5b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "256645ea-2164-a2c0-f5b8-305f94814e5b",
+                                    "name": "indexpattern-datasource-layer-a1a8be02-c3a9-7761-96cf-577c1b582cda"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "256645ea-2164-a2c0-f5b8-305f94814e5b": {
+                                    "id": "256645ea-2164-a2c0-f5b8-305f94814e5b",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -281,13 +302,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b984a453-0787-8c42-f322-553d23fa80a3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b984a453-0787-8c42-f322-553d23fa80a3",
+                                    "name": "indexpattern-datasource-layer-7e305878-3442-90f0-1c59-e9e56163c7e1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b984a453-0787-8c42-f322-553d23fa80a3": {
+                                    "id": "b984a453-0787-8c42-f322-553d23fa80a3",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -385,13 +427,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bf9503fd-76bf-efae-2c86-a79833dea810"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bf9503fd-76bf-efae-2c86-a79833dea810",
+                                    "name": "indexpattern-datasource-layer-08b787cf-3ac3-0f1f-dff0-efb14b9b3d4a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bf9503fd-76bf-efae-2c86-a79833dea810": {
+                                    "id": "bf9503fd-76bf-efae-2c86-a79833dea810",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -487,13 +550,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7d1ef773-6496-0d74-11bb-0a9aa20e7448"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7d1ef773-6496-0d74-11bb-0a9aa20e7448",
+                                    "name": "indexpattern-datasource-layer-ce4422c2-e535-3a9d-0cd8-0c66f49fe0db"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7d1ef773-6496-0d74-11bb-0a9aa20e7448": {
+                                    "id": "7d1ef773-6496-0d74-11bb-0a9aa20e7448",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -589,13 +673,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962",
+                                    "name": "indexpattern-datasource-layer-c35ac9fc-4d64-4d11-3ed6-deb21b81542f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962": {
+                                    "id": "09e1b6aa-8e6e-d4f3-b816-7c4d1c8dc962",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -691,13 +796,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "664af6dd-7a7a-704e-1e29-d2290f8d5d0a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "664af6dd-7a7a-704e-1e29-d2290f8d5d0a",
+                                    "name": "indexpattern-datasource-layer-6f2190fa-dd77-122b-cf2f-1ac9b2ce3ceb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "664af6dd-7a7a-704e-1e29-d2290f8d5d0a": {
+                                    "id": "664af6dd-7a7a-704e-1e29-d2290f8d5d0a",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -843,13 +969,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ff1e155e-8eb0-49a3-5e08-6733d97b31ca"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ff1e155e-8eb0-49a3-5e08-6733d97b31ca",
+                                    "name": "indexpattern-datasource-layer-bde03bfd-7017-a3b8-0065-cef2493a4741"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ff1e155e-8eb0-49a3-5e08-6733d97b31ca": {
+                                    "id": "ff1e155e-8eb0-49a3-5e08-6733d97b31ca",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1030,13 +1177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "de54f21d-ea4d-756c-2d33-510f87dc885d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "de54f21d-ea4d-756c-2d33-510f87dc885d",
+                                    "name": "indexpattern-datasource-layer-260c5c6e-72df-b5d0-3885-1e7a27ed07a9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "de54f21d-ea4d-756c-2d33-510f87dc885d": {
+                                    "id": "de54f21d-ea4d-756c-2d33-510f87dc885d",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1213,13 +1381,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b0cce665-2ec4-07ad-7223-313d03af6b96"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b0cce665-2ec4-07ad-7223-313d03af6b96",
+                                    "name": "indexpattern-datasource-layer-4d2921bc-b09b-3b7f-c2ee-50591b1e91ef"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b0cce665-2ec4-07ad-7223-313d03af6b96": {
+                                    "id": "b0cce665-2ec4-07ad-7223-313d03af6b96",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1373,13 +1562,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "655a5170-4252-091b-2ef3-b1ef510b5338"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "655a5170-4252-091b-2ef3-b1ef510b5338",
+                                    "name": "indexpattern-datasource-layer-c48258ff-7814-d2cf-4a6a-780941e1f9a2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "655a5170-4252-091b-2ef3-b1ef510b5338": {
+                                    "id": "655a5170-4252-091b-2ef3-b1ef510b5338",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/airflow_otel/kibana/dashboard/airflow_otel-scheduler-capacity.json
+++ b/packages/airflow_otel/kibana/dashboard/airflow_otel-scheduler-capacity.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d6bf565c-2d85-ca8e-1de2-9d7f797df045"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d6bf565c-2d85-ca8e-1de2-9d7f797df045",
+                                    "name": "indexpattern-datasource-layer-2b3aef75-59b1-2b75-4610-6ba311658d44"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d6bf565c-2d85-ca8e-1de2-9d7f797df045": {
+                                    "id": "d6bf565c-2d85-ca8e-1de2-9d7f797df045",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -277,13 +298,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7d1ef773-6496-0d74-11bb-0a9aa20e7448"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7d1ef773-6496-0d74-11bb-0a9aa20e7448",
+                                    "name": "indexpattern-datasource-layer-ce4422c2-e535-3a9d-0cd8-0c66f49fe0db"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7d1ef773-6496-0d74-11bb-0a9aa20e7448": {
+                                    "id": "7d1ef773-6496-0d74-11bb-0a9aa20e7448",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -379,13 +421,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "664af6dd-7a7a-704e-1e29-d2290f8d5d0a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "664af6dd-7a7a-704e-1e29-d2290f8d5d0a",
+                                    "name": "indexpattern-datasource-layer-6f2190fa-dd77-122b-cf2f-1ac9b2ce3ceb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "664af6dd-7a7a-704e-1e29-d2290f8d5d0a": {
+                                    "id": "664af6dd-7a7a-704e-1e29-d2290f8d5d0a",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -531,13 +594,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fe6a13ac-d033-f516-9874-a37c609df054"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fe6a13ac-d033-f516-9874-a37c609df054",
+                                    "name": "indexpattern-datasource-layer-ebe42106-0700-ef82-bde8-4d818ec0f1dd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fe6a13ac-d033-f516-9874-a37c609df054": {
+                                    "id": "fe6a13ac-d033-f516-9874-a37c609df054",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -683,13 +767,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1735626d-d1cc-4a32-9591-ed6652a60cdc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1735626d-d1cc-4a32-9591-ed6652a60cdc",
+                                    "name": "indexpattern-datasource-layer-2178f801-9eb8-faff-906c-223aaa5062d2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1735626d-d1cc-4a32-9591-ed6652a60cdc": {
+                                    "id": "1735626d-d1cc-4a32-9591-ed6652a60cdc",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -866,13 +971,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5200b2bb-a358-94a3-9b94-ae9dc577f293"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5200b2bb-a358-94a3-9b94-ae9dc577f293",
+                                    "name": "indexpattern-datasource-layer-11415483-05eb-55b7-19b2-a08dcfa570b0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5200b2bb-a358-94a3-9b94-ae9dc577f293": {
+                                    "id": "5200b2bb-a358-94a3-9b94-ae9dc577f293",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1018,13 +1144,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6a0a13ca-d502-ef81-e9c4-26d55dc42212"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6a0a13ca-d502-ef81-e9c4-26d55dc42212",
+                                    "name": "indexpattern-datasource-layer-07b5897f-acc5-d77d-dd3a-a1b7a5c966a4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6a0a13ca-d502-ef81-e9c4-26d55dc42212": {
+                                    "id": "6a0a13ca-d502-ef81-e9c4-26d55dc42212",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/airflow_otel/kibana/dashboard/airflow_otel-tasks.json
+++ b/packages/airflow_otel/kibana/dashboard/airflow_otel-tasks.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6e58d1b9-3c5d-cce3-6859-3af3ee14b58e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6e58d1b9-3c5d-cce3-6859-3af3ee14b58e",
+                                    "name": "indexpattern-datasource-layer-6a109492-c504-9bd7-ca49-b9cfc9a612ef"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6e58d1b9-3c5d-cce3-6859-3af3ee14b58e": {
+                                    "id": "6e58d1b9-3c5d-cce3-6859-3af3ee14b58e",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -277,13 +298,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8a8f1f0b-4880-653a-2a65-1120a4ad4538"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8a8f1f0b-4880-653a-2a65-1120a4ad4538",
+                                    "name": "indexpattern-datasource-layer-cdb0fda6-a28c-a48e-29dd-402d0ebab567"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8a8f1f0b-4880-653a-2a65-1120a4ad4538": {
+                                    "id": "8a8f1f0b-4880-653a-2a65-1120a4ad4538",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -381,13 +423,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "dde67cd2-b9a4-c93a-8777-12b6207f9051"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "dde67cd2-b9a4-c93a-8777-12b6207f9051",
+                                    "name": "indexpattern-datasource-layer-7a59dffd-9c43-cdfe-9114-b9f786f3239e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "dde67cd2-b9a4-c93a-8777-12b6207f9051": {
+                                    "id": "dde67cd2-b9a4-c93a-8777-12b6207f9051",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -485,13 +548,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7a86be7c-a59b-ed96-56c3-075378ca2c9d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7a86be7c-a59b-ed96-56c3-075378ca2c9d",
+                                    "name": "indexpattern-datasource-layer-38ba0faf-c9cd-2f26-03dc-cb4c24f2547a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7a86be7c-a59b-ed96-56c3-075378ca2c9d": {
+                                    "id": "7a86be7c-a59b-ed96-56c3-075378ca2c9d",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -672,13 +756,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "de54f21d-ea4d-756c-2d33-510f87dc885d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "de54f21d-ea4d-756c-2d33-510f87dc885d",
+                                    "name": "indexpattern-datasource-layer-260c5c6e-72df-b5d0-3885-1e7a27ed07a9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "de54f21d-ea4d-756c-2d33-510f87dc885d": {
+                                    "id": "de54f21d-ea4d-756c-2d33-510f87dc885d",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -838,13 +943,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1ee453cf-7ebe-0342-07a4-f631d47e2c81"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1ee453cf-7ebe-0342-07a4-f631d47e2c81",
+                                    "name": "indexpattern-datasource-layer-849cc897-986d-f617-c9e3-613dcf929761"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1ee453cf-7ebe-0342-07a4-f631d47e2c81": {
+                                    "id": "1ee453cf-7ebe-0342-07a4-f631d47e2c81",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1030,13 +1156,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "498c6bef-f25e-3e8d-96f0-8f09a49a591d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "498c6bef-f25e-3e8d-96f0-8f09a49a591d",
+                                    "name": "indexpattern-datasource-layer-22e4a9ad-48cc-e9c2-fd78-ab81afa3633b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "498c6bef-f25e-3e8d-96f0-8f09a49a591d": {
+                                    "id": "498c6bef-f25e-3e8d-96f0-8f09a49a591d",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1152,13 +1299,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1d5f1dba-6df8-46e4-71ba-ea12c38f516e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1d5f1dba-6df8-46e4-71ba-ea12c38f516e",
+                                    "name": "indexpattern-datasource-layer-6d061b5e-bc9e-de52-2bd0-d0fa870a34d9"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1d5f1dba-6df8-46e4-71ba-ea12c38f516e": {
+                                    "id": "1d5f1dba-6df8-46e4-71ba-ea12c38f516e",
+                                    "type": "esql",
+                                    "name": "metrics-airflow.otel-default*",
+                                    "title": "metrics-airflow.otel-default*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/airflow_otel/manifest.yml
+++ b/packages/airflow_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: airflow_otel
 title: Airflow OpenTelemetry
-version: 0.3.0
+version: 0.3.1
 description: Airflow OpenTelemetry Integration.
 type: content
 source:

--- a/packages/etcd_otel/changelog.yml
+++ b/packages/etcd_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/etcd_otel/changelog.yml
+++ b/packages/etcd_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20483
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/etcd_otel/kibana/dashboard/etcd_otel-grpc.json
+++ b/packages/etcd_otel/kibana/dashboard/etcd_otel-grpc.json
@@ -174,13 +174,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9cec7447-69df-63bf-1cd1-9866db97997c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9cec7447-69df-63bf-1cd1-9866db97997c",
+                                    "name": "indexpattern-datasource-layer-920a5d73-4199-92b7-94de-e26010dc2bd7"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9cec7447-69df-63bf-1cd1-9866db97997c": {
+                                    "id": "9cec7447-69df-63bf-1cd1-9866db97997c",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -276,13 +297,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a540c122-06eb-969d-8938-153c9f94bbcb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a540c122-06eb-969d-8938-153c9f94bbcb",
+                                    "name": "indexpattern-datasource-layer-d75ec847-d9b8-263a-d7b6-1970d811102c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a540c122-06eb-969d-8938-153c9f94bbcb": {
+                                    "id": "a540c122-06eb-969d-8938-153c9f94bbcb",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -378,13 +420,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "def5ba42-7469-daff-01ad-38e60d943a4f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "def5ba42-7469-daff-01ad-38e60d943a4f",
+                                    "name": "indexpattern-datasource-layer-ada376dc-a550-c357-0df9-a7f9f1f69c44"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "def5ba42-7469-daff-01ad-38e60d943a4f": {
+                                    "id": "def5ba42-7469-daff-01ad-38e60d943a4f",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -480,13 +543,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "24737ee9-0fec-aa26-a3ce-a968ca2093fc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "24737ee9-0fec-aa26-a3ce-a968ca2093fc",
+                                    "name": "indexpattern-datasource-layer-795b8a95-9f50-6b8f-7389-25eea0313859"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "24737ee9-0fec-aa26-a3ce-a968ca2093fc": {
+                                    "id": "24737ee9-0fec-aa26-a3ce-a968ca2093fc",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -645,13 +729,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "21da8aa6-afeb-08e3-057b-be3aa114c99e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "21da8aa6-afeb-08e3-057b-be3aa114c99e",
+                                    "name": "indexpattern-datasource-layer-92baca14-60fc-a709-5b83-43d966b93d4c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "21da8aa6-afeb-08e3-057b-be3aa114c99e": {
+                                    "id": "21da8aa6-afeb-08e3-057b-be3aa114c99e",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -841,13 +946,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1a9ae2c7-71a7-7ada-3513-4a21f001bf84"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1a9ae2c7-71a7-7ada-3513-4a21f001bf84",
+                                    "name": "indexpattern-datasource-layer-9fe09402-cdd9-e118-251f-ee4b234db15d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1a9ae2c7-71a7-7ada-3513-4a21f001bf84": {
+                                    "id": "1a9ae2c7-71a7-7ada-3513-4a21f001bf84",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -970,13 +1096,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f3587c6f-2455-14f6-4c9a-4f8cbb689493"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f3587c6f-2455-14f6-4c9a-4f8cbb689493",
+                                    "name": "indexpattern-datasource-layer-a50ea02c-1b3c-995a-d12f-1a53a2026845"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f3587c6f-2455-14f6-4c9a-4f8cbb689493": {
+                                    "id": "f3587c6f-2455-14f6-4c9a-4f8cbb689493",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1099,13 +1246,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "46e6325a-c69e-2d0d-6d02-2d7492ef6811"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "46e6325a-c69e-2d0d-6d02-2d7492ef6811",
+                                    "name": "indexpattern-datasource-layer-d1dec229-b906-753f-5854-b295f21e5768"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "46e6325a-c69e-2d0d-6d02-2d7492ef6811": {
+                                    "id": "46e6325a-c69e-2d0d-6d02-2d7492ef6811",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1264,13 +1432,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5832aea9-9c81-72a5-c6ad-09c1a139a143"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5832aea9-9c81-72a5-c6ad-09c1a139a143",
+                                    "name": "indexpattern-datasource-layer-6146dad8-e87a-369f-bf68-202e9bf67471"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5832aea9-9c81-72a5-c6ad-09c1a139a143": {
+                                    "id": "5832aea9-9c81-72a5-c6ad-09c1a139a143",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1407,13 +1596,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "395861af-4cf6-b0f5-b04f-6d0bfedfdf73"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "395861af-4cf6-b0f5-b04f-6d0bfedfdf73",
+                                    "name": "indexpattern-datasource-layer-a4987e1c-af86-35aa-6062-61a5242422f1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "395861af-4cf6-b0f5-b04f-6d0bfedfdf73": {
+                                    "id": "395861af-4cf6-b0f5-b04f-6d0bfedfdf73",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/etcd_otel/kibana/dashboard/etcd_otel-overview.json
+++ b/packages/etcd_otel/kibana/dashboard/etcd_otel-overview.json
@@ -174,13 +174,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "71817519-44bc-bf0b-83fb-e62e4d4c45e2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "71817519-44bc-bf0b-83fb-e62e4d4c45e2",
+                                    "name": "indexpattern-datasource-layer-900ba4b1-8bcb-3a8a-5362-2a7b5be7165b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "71817519-44bc-bf0b-83fb-e62e4d4c45e2": {
+                                    "id": "71817519-44bc-bf0b-83fb-e62e4d4c45e2",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -276,13 +297,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d",
+                                    "name": "indexpattern-datasource-layer-99755dcd-7b19-f21c-dc3b-298f0247afcc"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d": {
+                                    "id": "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -378,13 +420,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9",
+                                    "name": "indexpattern-datasource-layer-fabcb0f4-424a-6645-5664-4492414e1e96"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9": {
+                                    "id": "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -480,13 +543,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "822d4ed8-3e53-ef12-dd6a-4d07a785e757"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "822d4ed8-3e53-ef12-dd6a-4d07a785e757",
+                                    "name": "indexpattern-datasource-layer-d3b18ab7-0eba-7ed4-704e-7f7ea03dbb47"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "822d4ed8-3e53-ef12-dd6a-4d07a785e757": {
+                                    "id": "822d4ed8-3e53-ef12-dd6a-4d07a785e757",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -582,13 +666,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3d2aae00-08e9-1ba1-7671-1259b3fa07df"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3d2aae00-08e9-1ba1-7671-1259b3fa07df",
+                                    "name": "indexpattern-datasource-layer-5b023f33-70b7-6012-dd6d-978e71a56c2b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3d2aae00-08e9-1ba1-7671-1259b3fa07df": {
+                                    "id": "3d2aae00-08e9-1ba1-7671-1259b3fa07df",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -684,13 +789,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "daa1447d-3af7-7374-4a47-883ba0166546"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "daa1447d-3af7-7374-4a47-883ba0166546",
+                                    "name": "indexpattern-datasource-layer-68a13484-ba0f-4a4d-2b56-e467ca7e5b93"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "daa1447d-3af7-7374-4a47-883ba0166546": {
+                                    "id": "daa1447d-3af7-7374-4a47-883ba0166546",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -895,13 +1021,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3a2320fa-e353-8405-c0e3-4dc63bfdd547"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3a2320fa-e353-8405-c0e3-4dc63bfdd547",
+                                    "name": "indexpattern-datasource-layer-a7e7f54f-b29f-8bd5-898f-675566772c22"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3a2320fa-e353-8405-c0e3-4dc63bfdd547": {
+                                    "id": "3a2320fa-e353-8405-c0e3-4dc63bfdd547",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1060,13 +1207,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "60c30e63-cbbe-bc10-cc77-7b9fad0e0066"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "60c30e63-cbbe-bc10-cc77-7b9fad0e0066",
+                                    "name": "indexpattern-datasource-layer-fcdcc44f-6e48-830b-305e-96254fd40712"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "60c30e63-cbbe-bc10-cc77-7b9fad0e0066": {
+                                    "id": "60c30e63-cbbe-bc10-cc77-7b9fad0e0066",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1217,13 +1385,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "88f7af47-12fc-759e-d7cb-026415ec8e15"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "88f7af47-12fc-759e-d7cb-026415ec8e15",
+                                    "name": "indexpattern-datasource-layer-7aa9abb6-3678-d7a5-d55a-ff90f3d88897"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "88f7af47-12fc-759e-d7cb-026415ec8e15": {
+                                    "id": "88f7af47-12fc-759e-d7cb-026415ec8e15",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1387,13 +1576,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6dc1fc6d-9511-e268-c08a-c9d3a31f8705"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6dc1fc6d-9511-e268-c08a-c9d3a31f8705",
+                                    "name": "indexpattern-datasource-layer-8f1875af-fd73-b738-bd7c-f231840c643e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6dc1fc6d-9511-e268-c08a-c9d3a31f8705": {
+                                    "id": "6dc1fc6d-9511-e268-c08a-c9d3a31f8705",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1550,13 +1760,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8b049359-b2f0-1373-faad-ae1516b2186c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8b049359-b2f0-1373-faad-ae1516b2186c",
+                                    "name": "indexpattern-datasource-layer-4b8771b9-168f-d2dd-f2c5-f409fb47714e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8b049359-b2f0-1373-faad-ae1516b2186c": {
+                                    "id": "8b049359-b2f0-1373-faad-ae1516b2186c",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1715,13 +1946,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "005ef269-6945-72b1-d83b-2f5c55138e27"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "005ef269-6945-72b1-d83b-2f5c55138e27",
+                                    "name": "indexpattern-datasource-layer-de94310d-5e50-1d27-c588-baddd8996b79"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "005ef269-6945-72b1-d83b-2f5c55138e27": {
+                                    "id": "005ef269-6945-72b1-d83b-2f5c55138e27",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1880,13 +2132,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d4449316-9b6b-a9c2-ae36-374f411d8dcb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d4449316-9b6b-a9c2-ae36-374f411d8dcb",
+                                    "name": "indexpattern-datasource-layer-4622702e-b8cd-6937-8234-417b5260c4fd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d4449316-9b6b-a9c2-ae36-374f411d8dcb": {
+                                    "id": "d4449316-9b6b-a9c2-ae36-374f411d8dcb",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2086,13 +2359,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "42b69f8c-c741-8322-9567-e2ce00dee057"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "42b69f8c-c741-8322-9567-e2ce00dee057",
+                                    "name": "indexpattern-datasource-layer-8eb5bd40-73a0-0e6a-0738-7ef1177c5039"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "42b69f8c-c741-8322-9567-e2ce00dee057": {
+                                    "id": "42b69f8c-c741-8322-9567-e2ce00dee057",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2251,13 +2545,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0c71dbc1-f37c-2074-f0ff-f12891c816fe"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0c71dbc1-f37c-2074-f0ff-f12891c816fe",
+                                    "name": "indexpattern-datasource-layer-5ca34f65-5df6-fe1d-afca-0b9df87529f4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0c71dbc1-f37c-2074-f0ff-f12891c816fe": {
+                                    "id": "0c71dbc1-f37c-2074-f0ff-f12891c816fe",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2416,13 +2731,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "208da1f8-7403-ec46-6aad-25f80d593e49"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "208da1f8-7403-ec46-6aad-25f80d593e49",
+                                    "name": "indexpattern-datasource-layer-f972fc0e-59ed-1c6c-f023-875729ba805c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "208da1f8-7403-ec46-6aad-25f80d593e49": {
+                                    "id": "208da1f8-7403-ec46-6aad-25f80d593e49",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2581,13 +2917,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5832aea9-9c81-72a5-c6ad-09c1a139a143"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5832aea9-9c81-72a5-c6ad-09c1a139a143",
+                                    "name": "indexpattern-datasource-layer-6146dad8-e87a-369f-bf68-202e9bf67471"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5832aea9-9c81-72a5-c6ad-09c1a139a143": {
+                                    "id": "5832aea9-9c81-72a5-c6ad-09c1a139a143",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/etcd_otel/kibana/dashboard/etcd_otel-raft-consensus.json
+++ b/packages/etcd_otel/kibana/dashboard/etcd_otel-raft-consensus.json
@@ -174,13 +174,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "71817519-44bc-bf0b-83fb-e62e4d4c45e2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "71817519-44bc-bf0b-83fb-e62e4d4c45e2",
+                                    "name": "indexpattern-datasource-layer-900ba4b1-8bcb-3a8a-5362-2a7b5be7165b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "71817519-44bc-bf0b-83fb-e62e4d4c45e2": {
+                                    "id": "71817519-44bc-bf0b-83fb-e62e4d4c45e2",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -276,13 +297,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ff4dc192-a76d-b00f-ba3f-f8829dda20d9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ff4dc192-a76d-b00f-ba3f-f8829dda20d9",
+                                    "name": "indexpattern-datasource-layer-bf50c7ca-70a2-2418-1d57-e9b813b1a7c1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ff4dc192-a76d-b00f-ba3f-f8829dda20d9": {
+                                    "id": "ff4dc192-a76d-b00f-ba3f-f8829dda20d9",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -378,13 +420,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d",
+                                    "name": "indexpattern-datasource-layer-99755dcd-7b19-f21c-dc3b-298f0247afcc"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d": {
+                                    "id": "43a77a4a-ca8c-c43c-cf4e-1610bbb8f08d",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -480,13 +543,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9",
+                                    "name": "indexpattern-datasource-layer-fabcb0f4-424a-6645-5664-4492414e1e96"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9": {
+                                    "id": "7d4a1da7-bd95-bd7c-f7c1-3a8a1f9589c9",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -582,13 +666,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "daa1447d-3af7-7374-4a47-883ba0166546"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "daa1447d-3af7-7374-4a47-883ba0166546",
+                                    "name": "indexpattern-datasource-layer-68a13484-ba0f-4a4d-2b56-e467ca7e5b93"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "daa1447d-3af7-7374-4a47-883ba0166546": {
+                                    "id": "daa1447d-3af7-7374-4a47-883ba0166546",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -684,13 +789,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3d2aae00-08e9-1ba1-7671-1259b3fa07df"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3d2aae00-08e9-1ba1-7671-1259b3fa07df",
+                                    "name": "indexpattern-datasource-layer-5b023f33-70b7-6012-dd6d-978e71a56c2b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3d2aae00-08e9-1ba1-7671-1259b3fa07df": {
+                                    "id": "3d2aae00-08e9-1ba1-7671-1259b3fa07df",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -849,13 +975,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e6553877-cd8f-c0bd-8230-4d9ed40daf28"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e6553877-cd8f-c0bd-8230-4d9ed40daf28",
+                                    "name": "indexpattern-datasource-layer-1a77d92b-a26a-89ee-683d-6e2abdf22d8c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e6553877-cd8f-c0bd-8230-4d9ed40daf28": {
+                                    "id": "e6553877-cd8f-c0bd-8230-4d9ed40daf28",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1014,13 +1161,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "60c30e63-cbbe-bc10-cc77-7b9fad0e0066"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "60c30e63-cbbe-bc10-cc77-7b9fad0e0066",
+                                    "name": "indexpattern-datasource-layer-fcdcc44f-6e48-830b-305e-96254fd40712"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "60c30e63-cbbe-bc10-cc77-7b9fad0e0066": {
+                                    "id": "60c30e63-cbbe-bc10-cc77-7b9fad0e0066",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1184,13 +1352,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "005ea91b-6258-73ea-ac37-dc50dbdb7679"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "005ea91b-6258-73ea-ac37-dc50dbdb7679",
+                                    "name": "indexpattern-datasource-layer-39865ecf-1dcf-1d64-587d-987b45a4cc08"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "005ea91b-6258-73ea-ac37-dc50dbdb7679": {
+                                    "id": "005ea91b-6258-73ea-ac37-dc50dbdb7679",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1354,13 +1543,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7a3e31b9-db26-09bc-e559-75711d4e81f0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7a3e31b9-db26-09bc-e559-75711d4e81f0",
+                                    "name": "indexpattern-datasource-layer-47184cb2-f411-fcdc-a644-217e97a91cb1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7a3e31b9-db26-09bc-e559-75711d4e81f0": {
+                                    "id": "7a3e31b9-db26-09bc-e559-75711d4e81f0",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1524,13 +1734,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f1b154c4-0ccf-e6d7-ea1a-0bd45a50b20f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f1b154c4-0ccf-e6d7-ea1a-0bd45a50b20f",
+                                    "name": "indexpattern-datasource-layer-5e12e03a-aae8-71c2-82c2-26f9244a4864"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f1b154c4-0ccf-e6d7-ea1a-0bd45a50b20f": {
+                                    "id": "f1b154c4-0ccf-e6d7-ea1a-0bd45a50b20f",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1694,13 +1925,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9d8226b6-9860-6e3f-01e4-db9b97a44d98"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9d8226b6-9860-6e3f-01e4-db9b97a44d98",
+                                    "name": "indexpattern-datasource-layer-c200d13b-b404-93fc-6acb-ffa8035ecebf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9d8226b6-9860-6e3f-01e4-db9b97a44d98": {
+                                    "id": "9d8226b6-9860-6e3f-01e4-db9b97a44d98",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1851,13 +2103,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a43d3d8f-a744-ad7b-635e-e5f8ae54e796"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a43d3d8f-a744-ad7b-635e-e5f8ae54e796",
+                                    "name": "indexpattern-datasource-layer-acff3e7c-e871-ffe7-e6ca-41aaf32745aa"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a43d3d8f-a744-ad7b-635e-e5f8ae54e796": {
+                                    "id": "a43d3d8f-a744-ad7b-635e-e5f8ae54e796",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/etcd_otel/kibana/dashboard/etcd_otel-storage.json
+++ b/packages/etcd_otel/kibana/dashboard/etcd_otel-storage.json
@@ -174,13 +174,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a5cf9799-c6eb-dc64-98c8-3d624a8e2c5a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a5cf9799-c6eb-dc64-98c8-3d624a8e2c5a",
+                                    "name": "indexpattern-datasource-layer-6f0bb0b2-4821-da0f-e97f-80b5e24e3d72"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a5cf9799-c6eb-dc64-98c8-3d624a8e2c5a": {
+                                    "id": "a5cf9799-c6eb-dc64-98c8-3d624a8e2c5a",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -276,13 +297,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e2d15635-305c-cc44-dffc-e6092e24c25f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e2d15635-305c-cc44-dffc-e6092e24c25f",
+                                    "name": "indexpattern-datasource-layer-556ae501-fff7-abee-2edd-36cef3b9a494"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e2d15635-305c-cc44-dffc-e6092e24c25f": {
+                                    "id": "e2d15635-305c-cc44-dffc-e6092e24c25f",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -380,13 +422,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "40e3903b-5806-b3da-5ee3-4ff296e1cf06"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "40e3903b-5806-b3da-5ee3-4ff296e1cf06",
+                                    "name": "indexpattern-datasource-layer-d84f6325-2811-4b51-7c5a-72e3770b63ae"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "40e3903b-5806-b3da-5ee3-4ff296e1cf06": {
+                                    "id": "40e3903b-5806-b3da-5ee3-4ff296e1cf06",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -482,13 +545,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "474fb343-3fd6-72fa-85a2-7ff877989710"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "474fb343-3fd6-72fa-85a2-7ff877989710",
+                                    "name": "indexpattern-datasource-layer-60771cf8-b393-5368-0e59-8aa19d8d0555"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "474fb343-3fd6-72fa-85a2-7ff877989710": {
+                                    "id": "474fb343-3fd6-72fa-85a2-7ff877989710",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -604,13 +688,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8b049359-b2f0-1373-faad-ae1516b2186c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8b049359-b2f0-1373-faad-ae1516b2186c",
+                                    "name": "indexpattern-datasource-layer-4b8771b9-168f-d2dd-f2c5-f409fb47714e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8b049359-b2f0-1373-faad-ae1516b2186c": {
+                                    "id": "8b049359-b2f0-1373-faad-ae1516b2186c",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -769,13 +874,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "005ef269-6945-72b1-d83b-2f5c55138e27"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "005ef269-6945-72b1-d83b-2f5c55138e27",
+                                    "name": "indexpattern-datasource-layer-de94310d-5e50-1d27-c588-baddd8996b79"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "005ef269-6945-72b1-d83b-2f5c55138e27": {
+                                    "id": "005ef269-6945-72b1-d83b-2f5c55138e27",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -934,13 +1060,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4d0db593-b567-aa3f-3f0a-a806dbd40eb0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4d0db593-b567-aa3f-3f0a-a806dbd40eb0",
+                                    "name": "indexpattern-datasource-layer-6835e01b-2f38-6a6c-29a1-23717c65c229"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4d0db593-b567-aa3f-3f0a-a806dbd40eb0": {
+                                    "id": "4d0db593-b567-aa3f-3f0a-a806dbd40eb0",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1099,13 +1246,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d4449316-9b6b-a9c2-ae36-374f411d8dcb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d4449316-9b6b-a9c2-ae36-374f411d8dcb",
+                                    "name": "indexpattern-datasource-layer-4622702e-b8cd-6937-8234-417b5260c4fd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d4449316-9b6b-a9c2-ae36-374f411d8dcb": {
+                                    "id": "d4449316-9b6b-a9c2-ae36-374f411d8dcb",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1264,13 +1432,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "048d67ab-60d6-d594-d302-e09b413f4c3c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "048d67ab-60d6-d594-d302-e09b413f4c3c",
+                                    "name": "indexpattern-datasource-layer-34f3a260-80a2-df36-5940-a958e6e543dd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "048d67ab-60d6-d594-d302-e09b413f4c3c": {
+                                    "id": "048d67ab-60d6-d594-d302-e09b413f4c3c",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1429,13 +1618,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "eb4926e5-159e-625f-b078-9ec402f6f44f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "eb4926e5-159e-625f-b078-9ec402f6f44f",
+                                    "name": "indexpattern-datasource-layer-30453d21-9559-913c-bbe4-f428cb142364"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "eb4926e5-159e-625f-b078-9ec402f6f44f": {
+                                    "id": "eb4926e5-159e-625f-b078-9ec402f6f44f",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1594,13 +1804,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9587d3ed-4598-d541-0ec4-8b57d89c4b03"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9587d3ed-4598-d541-0ec4-8b57d89c4b03",
+                                    "name": "indexpattern-datasource-layer-50d396a1-70e8-bb9f-5542-bb23076e04ec"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9587d3ed-4598-d541-0ec4-8b57d89c4b03": {
+                                    "id": "9587d3ed-4598-d541-0ec4-8b57d89c4b03",
+                                    "type": "esql",
+                                    "name": "metrics-etcd.otel-*",
+                                    "title": "metrics-etcd.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/etcd_otel/manifest.yml
+++ b/packages/etcd_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: etcd_otel
 title: "etcd OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "etcd Assets from OpenTelemetry Collector"

--- a/packages/nvidia_gpu_otel/changelog.yml
+++ b/packages/nvidia_gpu_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/nvidia_gpu_otel/changelog.yml
+++ b/packages/nvidia_gpu_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20483
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/nvidia_gpu_otel/kibana/dashboard/nvidia_gpu_otel-overview.json
+++ b/packages/nvidia_gpu_otel/kibana/dashboard/nvidia_gpu_otel-overview.json
@@ -127,13 +127,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "66629569-00c6-4ec3-7157-42fc9a450290"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "66629569-00c6-4ec3-7157-42fc9a450290",
+                                    "name": "indexpattern-datasource-layer-2a090b01-e388-3615-d59a-8baaa1c844d4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "66629569-00c6-4ec3-7157-42fc9a450290": {
+                                    "id": "66629569-00c6-4ec3-7157-42fc9a450290",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -231,13 +252,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "38331094-71e4-fd01-f315-ce0743163f40"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "38331094-71e4-fd01-f315-ce0743163f40",
+                                    "name": "indexpattern-datasource-layer-55bda98c-bdf9-e142-d74e-f8b0b527753f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "38331094-71e4-fd01-f315-ce0743163f40": {
+                                    "id": "38331094-71e4-fd01-f315-ce0743163f40",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -335,13 +377,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7fcdd48f-e95f-1048-3d9b-be7b619488b3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7fcdd48f-e95f-1048-3d9b-be7b619488b3",
+                                    "name": "indexpattern-datasource-layer-c36fdfea-afa7-5f6e-0346-8481a05670ec"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7fcdd48f-e95f-1048-3d9b-be7b619488b3": {
+                                    "id": "7fcdd48f-e95f-1048-3d9b-be7b619488b3",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -439,13 +502,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "33f291a8-8bf8-1b3a-b973-e5c712a2755d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "33f291a8-8bf8-1b3a-b973-e5c712a2755d",
+                                    "name": "indexpattern-datasource-layer-bad532fe-e557-7e60-a0b3-aaef28aed68c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "33f291a8-8bf8-1b3a-b973-e5c712a2755d": {
+                                    "id": "33f291a8-8bf8-1b3a-b973-e5c712a2755d",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -543,13 +627,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "357d6cc0-daa9-e461-635c-d38a02e73704"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "357d6cc0-daa9-e461-635c-d38a02e73704",
+                                    "name": "indexpattern-datasource-layer-cc06473e-a81d-aea5-8217-9ba1f3af9e1f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "357d6cc0-daa9-e461-635c-d38a02e73704": {
+                                    "id": "357d6cc0-daa9-e461-635c-d38a02e73704",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -645,13 +750,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0b1d2df8-a600-59cc-8c66-eaaaee39b506"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0b1d2df8-a600-59cc-8c66-eaaaee39b506",
+                                    "name": "indexpattern-datasource-layer-9db46139-1294-5741-cba6-4f03ad930852"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0b1d2df8-a600-59cc-8c66-eaaaee39b506": {
+                                    "id": "0b1d2df8-a600-59cc-8c66-eaaaee39b506",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -749,13 +875,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "23ea2115-485c-0a52-cef5-8707d34a720a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "23ea2115-485c-0a52-cef5-8707d34a720a",
+                                    "name": "indexpattern-datasource-layer-b625b511-0b97-18a9-6ea2-edd835808922"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "23ea2115-485c-0a52-cef5-8707d34a720a": {
+                                    "id": "23ea2115-485c-0a52-cef5-8707d34a720a",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -853,13 +1000,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e32793d4-74a9-4ac7-f384-0f2b2caebe6f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e32793d4-74a9-4ac7-f384-0f2b2caebe6f",
+                                    "name": "indexpattern-datasource-layer-11c1470b-f351-d4f4-96ee-b87f260c813e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e32793d4-74a9-4ac7-f384-0f2b2caebe6f": {
+                                    "id": "e32793d4-74a9-4ac7-f384-0f2b2caebe6f",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1060,13 +1228,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d0279020-3d4f-4e2c-c996-9017727133c8"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d0279020-3d4f-4e2c-c996-9017727133c8",
+                                    "name": "indexpattern-datasource-layer-5b82defd-79e9-9cc0-1b15-ab34e8e83a56"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d0279020-3d4f-4e2c-c996-9017727133c8": {
+                                    "id": "d0279020-3d4f-4e2c-c996-9017727133c8",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1226,13 +1415,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2820c695-1bce-610e-6bee-7cb81c488e91"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2820c695-1bce-610e-6bee-7cb81c488e91",
+                                    "name": "indexpattern-datasource-layer-beb2e9df-17af-8c13-8ed3-fa3fe12ff8d2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2820c695-1bce-610e-6bee-7cb81c488e91": {
+                                    "id": "2820c695-1bce-610e-6bee-7cb81c488e91",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1433,13 +1643,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d5ae23f7-665f-77b7-9856-edb7423b441c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d5ae23f7-665f-77b7-9856-edb7423b441c",
+                                    "name": "indexpattern-datasource-layer-1d3bb3d6-14da-6942-5f33-ee1dd404ee8a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d5ae23f7-665f-77b7-9856-edb7423b441c": {
+                                    "id": "d5ae23f7-665f-77b7-9856-edb7423b441c",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1599,13 +1830,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ba11f7f3-c201-8e8a-f598-dce7d4aabab0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ba11f7f3-c201-8e8a-f598-dce7d4aabab0",
+                                    "name": "indexpattern-datasource-layer-159ff331-fd5f-90fc-abf1-331b7c5e900d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ba11f7f3-c201-8e8a-f598-dce7d4aabab0": {
+                                    "id": "ba11f7f3-c201-8e8a-f598-dce7d4aabab0",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1765,13 +2017,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4064392d-7603-603b-7510-a3c531056aad"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4064392d-7603-603b-7510-a3c531056aad",
+                                    "name": "indexpattern-datasource-layer-427500ee-209f-ceb2-128c-3c52205cdb89"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4064392d-7603-603b-7510-a3c531056aad": {
+                                    "id": "4064392d-7603-603b-7510-a3c531056aad",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1931,13 +2204,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "104360d4-f427-1a63-bb51-736239ad7ed9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "104360d4-f427-1a63-bb51-736239ad7ed9",
+                                    "name": "indexpattern-datasource-layer-b9c03a7b-2b09-4d49-ad82-21564fda8104"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "104360d4-f427-1a63-bb51-736239ad7ed9": {
+                                    "id": "104360d4-f427-1a63-bb51-736239ad7ed9",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2138,13 +2432,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "24c54b99-0f7d-315f-24e9-458df8ff3fdd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "24c54b99-0f7d-315f-24e9-458df8ff3fdd",
+                                    "name": "indexpattern-datasource-layer-197bf54e-b18b-072b-eda9-530cee1d796e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "24c54b99-0f7d-315f-24e9-458df8ff3fdd": {
+                                    "id": "24c54b99-0f7d-315f-24e9-458df8ff3fdd",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2304,13 +2619,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1ae13b5c-a758-a71b-4568-a83fc165d2a6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1ae13b5c-a758-a71b-4568-a83fc165d2a6",
+                                    "name": "indexpattern-datasource-layer-3aadc345-e8f5-107c-f617-13213147e45d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1ae13b5c-a758-a71b-4568-a83fc165d2a6": {
+                                    "id": "1ae13b5c-a758-a71b-4568-a83fc165d2a6",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2511,13 +2847,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "79934166-64fa-7f8c-8bdc-5767644cbeae"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "79934166-64fa-7f8c-8bdc-5767644cbeae",
+                                    "name": "indexpattern-datasource-layer-b8ed8b0b-691f-364a-7b11-20fe3f07c2b0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "79934166-64fa-7f8c-8bdc-5767644cbeae": {
+                                    "id": "79934166-64fa-7f8c-8bdc-5767644cbeae",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2677,13 +3034,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0c1c5223-261e-e2ce-b492-3274938f060a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0c1c5223-261e-e2ce-b492-3274938f060a",
+                                    "name": "indexpattern-datasource-layer-139bb07a-f703-770e-0cf6-08a2023632b8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0c1c5223-261e-e2ce-b492-3274938f060a": {
+                                    "id": "0c1c5223-261e-e2ce-b492-3274938f060a",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2969,13 +3347,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "814623df-cda7-8cfb-0e16-54e11d45c80c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "814623df-cda7-8cfb-0e16-54e11d45c80c",
+                                    "name": "indexpattern-datasource-layer-c58476d1-0425-c0fd-aa7f-d26c19473d57"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "814623df-cda7-8cfb-0e16-54e11d45c80c": {
+                                    "id": "814623df-cda7-8cfb-0e16-54e11d45c80c",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -3311,13 +3710,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ac33b5aa-0231-033a-10cf-3cca70ec746c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ac33b5aa-0231-033a-10cf-3cca70ec746c",
+                                    "name": "indexpattern-datasource-layer-1ee8f27c-a3bc-2240-d95d-dd6014bbc3a0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ac33b5aa-0231-033a-10cf-3cca70ec746c": {
+                                    "id": "ac33b5aa-0231-033a-10cf-3cca70ec746c",
+                                    "type": "esql",
+                                    "name": "metrics-nvidia_gpu.otel-default",
+                                    "title": "metrics-nvidia_gpu.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/nvidia_gpu_otel/manifest.yml
+++ b/packages/nvidia_gpu_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: nvidia_gpu_otel
 title: "NVIDIA GPU OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "NVIDIA GPU Assets for OpenTelemetry Collector"

--- a/packages/vsphere_otel/changelog.yml
+++ b/packages/vsphere_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/vsphere_otel/changelog.yml
+++ b/packages/vsphere_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20483
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/vsphere_otel/kibana/dashboard/vsphere_otel-hosts.json
+++ b/packages/vsphere_otel/kibana/dashboard/vsphere_otel-hosts.json
@@ -177,13 +177,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3f3a8449-e830-8812-d0c7-714751088400"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3f3a8449-e830-8812-d0c7-714751088400",
+                                    "name": "indexpattern-datasource-layer-94b4c745-aa9f-c964-f492-09916c429bdf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3f3a8449-e830-8812-d0c7-714751088400": {
+                                    "id": "3f3a8449-e830-8812-d0c7-714751088400",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -281,13 +302,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c4e5db8e-635d-a2a3-0779-1a48d29bc4dc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c4e5db8e-635d-a2a3-0779-1a48d29bc4dc",
+                                    "name": "indexpattern-datasource-layer-f05fbc7f-a53f-0103-6053-5de329dad1f1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c4e5db8e-635d-a2a3-0779-1a48d29bc4dc": {
+                                    "id": "c4e5db8e-635d-a2a3-0779-1a48d29bc4dc",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -385,13 +427,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1d951445-eeb2-aa38-867e-387b06b23d29"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1d951445-eeb2-aa38-867e-387b06b23d29",
+                                    "name": "indexpattern-datasource-layer-34c53462-105b-f7cf-c77a-58efb4911e01"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1d951445-eeb2-aa38-867e-387b06b23d29": {
+                                    "id": "1d951445-eeb2-aa38-867e-387b06b23d29",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -487,13 +550,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "65324880-1b5c-3f79-1280-a0d4fac13815"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "65324880-1b5c-3f79-1280-a0d4fac13815",
+                                    "name": "indexpattern-datasource-layer-9177fa0f-8040-bfd0-5c88-c62c13e322ad"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "65324880-1b5c-3f79-1280-a0d4fac13815": {
+                                    "id": "65324880-1b5c-3f79-1280-a0d4fac13815",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -593,13 +677,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "75539760-bf47-8eb4-5954-7a53ca83142e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "75539760-bf47-8eb4-5954-7a53ca83142e",
+                                    "name": "indexpattern-datasource-layer-d25108df-8249-85e4-7cf9-c4420c3a4794"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "75539760-bf47-8eb4-5954-7a53ca83142e": {
+                                    "id": "75539760-bf47-8eb4-5954-7a53ca83142e",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -699,13 +804,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8f54fab7-52cf-e583-b3ec-14cc01d74f44"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8f54fab7-52cf-e583-b3ec-14cc01d74f44",
+                                    "name": "indexpattern-datasource-layer-12f9e067-3dc6-c130-60bc-3819bcf85ebc"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8f54fab7-52cf-e583-b3ec-14cc01d74f44": {
+                                    "id": "8f54fab7-52cf-e583-b3ec-14cc01d74f44",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -805,13 +931,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6e09c952-4140-36b7-865a-71f3e8f38e8d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6e09c952-4140-36b7-865a-71f3e8f38e8d",
+                                    "name": "indexpattern-datasource-layer-6dbf7bdc-0c26-ca9f-b775-b7b7eb2e6695"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6e09c952-4140-36b7-865a-71f3e8f38e8d": {
+                                    "id": "6e09c952-4140-36b7-865a-71f3e8f38e8d",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -909,13 +1056,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e3e3a46c-1282-0a3e-421c-445620b6f51c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e3e3a46c-1282-0a3e-421c-445620b6f51c",
+                                    "name": "indexpattern-datasource-layer-85be65ef-8dcc-d8d0-21a2-473f0b1bc217"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e3e3a46c-1282-0a3e-421c-445620b6f51c": {
+                                    "id": "e3e3a46c-1282-0a3e-421c-445620b6f51c",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1061,13 +1229,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "486c197e-b490-7fc6-0cc1-2dd01b16db31"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "486c197e-b490-7fc6-0cc1-2dd01b16db31",
+                                    "name": "indexpattern-datasource-layer-76d821bd-d81d-c2ab-3363-c8c09d22878d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "486c197e-b490-7fc6-0cc1-2dd01b16db31": {
+                                    "id": "486c197e-b490-7fc6-0cc1-2dd01b16db31",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1229,13 +1418,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7803d66f-73a1-07a8-d8f6-30308963adc7"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7803d66f-73a1-07a8-d8f6-30308963adc7",
+                                    "name": "indexpattern-datasource-layer-06d86ca7-e099-b5df-2d2d-4d64d3d21588"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7803d66f-73a1-07a8-d8f6-30308963adc7": {
+                                    "id": "7803d66f-73a1-07a8-d8f6-30308963adc7",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1397,13 +1607,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1819c9e6-d915-a51d-97ae-d6f50da802bb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1819c9e6-d915-a51d-97ae-d6f50da802bb",
+                                    "name": "indexpattern-datasource-layer-b46bd3ab-bfce-48c2-1e5d-863bba23e78a"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1819c9e6-d915-a51d-97ae-d6f50da802bb": {
+                                    "id": "1819c9e6-d915-a51d-97ae-d6f50da802bb",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1565,13 +1796,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "4dba4837-cc0a-f4d6-f9ac-16919ba4066b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "4dba4837-cc0a-f4d6-f9ac-16919ba4066b",
+                                    "name": "indexpattern-datasource-layer-f5652a07-0f38-f124-16c0-974b4b6e499e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "4dba4837-cc0a-f4d6-f9ac-16919ba4066b": {
+                                    "id": "4dba4837-cc0a-f4d6-f9ac-16919ba4066b",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1733,13 +1985,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e76b6165-2591-c443-87ad-a94fea769ab1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e76b6165-2591-c443-87ad-a94fea769ab1",
+                                    "name": "indexpattern-datasource-layer-7b10da0b-5498-372b-6c72-a1151a7bd8c2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e76b6165-2591-c443-87ad-a94fea769ab1": {
+                                    "id": "e76b6165-2591-c443-87ad-a94fea769ab1",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1901,13 +2174,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "914f4a76-e15f-3643-642c-883eb0ddc3fc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "914f4a76-e15f-3643-642c-883eb0ddc3fc",
+                                    "name": "indexpattern-datasource-layer-cba2d394-66d2-2436-6612-30d79adc2ca5"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "914f4a76-e15f-3643-642c-883eb0ddc3fc": {
+                                    "id": "914f4a76-e15f-3643-642c-883eb0ddc3fc",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2096,13 +2390,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d486d08c-29be-210b-70d2-b79bfe6dbaed"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d486d08c-29be-210b-70d2-b79bfe6dbaed",
+                                    "name": "indexpattern-datasource-layer-2b5543eb-0b2e-d415-c241-a555339da1af"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d486d08c-29be-210b-70d2-b79bfe6dbaed": {
+                                    "id": "d486d08c-29be-210b-70d2-b79bfe6dbaed",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2291,13 +2606,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8cf9dc15-36e1-c3f3-23aa-f0197d1a7600"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8cf9dc15-36e1-c3f3-23aa-f0197d1a7600",
+                                    "name": "indexpattern-datasource-layer-1cf39f37-4c60-e1c5-87a4-b715ea9facf8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8cf9dc15-36e1-c3f3-23aa-f0197d1a7600": {
+                                    "id": "8cf9dc15-36e1-c3f3-23aa-f0197d1a7600",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2484,13 +2820,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3d413205-545d-356b-27a7-48a910ad9599"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3d413205-545d-356b-27a7-48a910ad9599",
+                                    "name": "indexpattern-datasource-layer-b13aa8c8-a7ee-a32a-bc2b-558146eb4991"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3d413205-545d-356b-27a7-48a910ad9599": {
+                                    "id": "3d413205-545d-356b-27a7-48a910ad9599",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2677,13 +3034,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1c9395a3-ed00-b3d9-d38c-75b1c2a091cd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1c9395a3-ed00-b3d9-d38c-75b1c2a091cd",
+                                    "name": "indexpattern-datasource-layer-9c5a545c-82f2-6a17-91ae-f6fe8a76dccd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1c9395a3-ed00-b3d9-d38c-75b1c2a091cd": {
+                                    "id": "1c9395a3-ed00-b3d9-d38c-75b1c2a091cd",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2827,13 +3205,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "61e4c3b4-78b9-81a7-a496-a35f9f1255c1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "61e4c3b4-78b9-81a7-a496-a35f9f1255c1",
+                                    "name": "indexpattern-datasource-layer-40a83b37-cccf-419e-04f1-5c5384c31d5c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "61e4c3b4-78b9-81a7-a496-a35f9f1255c1": {
+                                    "id": "61e4c3b4-78b9-81a7-a496-a35f9f1255c1",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/vsphere_otel/kibana/dashboard/vsphere_otel-overview.json
+++ b/packages/vsphere_otel/kibana/dashboard/vsphere_otel-overview.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "aa3e29c9-62a7-7116-5710-82a91cab5253"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "aa3e29c9-62a7-7116-5710-82a91cab5253",
+                                    "name": "indexpattern-datasource-layer-c03a37ad-e388-ab57-f9c9-1786ce971b02"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "aa3e29c9-62a7-7116-5710-82a91cab5253": {
+                                    "id": "aa3e29c9-62a7-7116-5710-82a91cab5253",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -277,13 +298,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "20ca6392-eb56-05e1-49ec-ec22d0205be0"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "20ca6392-eb56-05e1-49ec-ec22d0205be0",
+                                    "name": "indexpattern-datasource-layer-341c6121-e82b-3326-564b-405a9a55b747"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "20ca6392-eb56-05e1-49ec-ec22d0205be0": {
+                                    "id": "20ca6392-eb56-05e1-49ec-ec22d0205be0",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -379,13 +421,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bba0fce4-580c-52ad-a21b-f55d71ae578c"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bba0fce4-580c-52ad-a21b-f55d71ae578c",
+                                    "name": "indexpattern-datasource-layer-81479dea-8943-8b7f-f426-24291a8b918c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bba0fce4-580c-52ad-a21b-f55d71ae578c": {
+                                    "id": "bba0fce4-580c-52ad-a21b-f55d71ae578c",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -481,13 +544,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "057245da-af37-09d4-1894-b9d26f52a7f5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "057245da-af37-09d4-1894-b9d26f52a7f5",
+                                    "name": "indexpattern-datasource-layer-9e768dd1-a518-b2ce-1ffb-3212943e60a4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "057245da-af37-09d4-1894-b9d26f52a7f5": {
+                                    "id": "057245da-af37-09d4-1894-b9d26f52a7f5",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -585,13 +669,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e0e0cc6c-57fe-4f46-0857-d636cbc89a37"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e0e0cc6c-57fe-4f46-0857-d636cbc89a37",
+                                    "name": "indexpattern-datasource-layer-0a5e0a56-9106-5268-d619-48c0bd48faa8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e0e0cc6c-57fe-4f46-0857-d636cbc89a37": {
+                                    "id": "e0e0cc6c-57fe-4f46-0857-d636cbc89a37",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -689,13 +794,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "961d97f4-7b10-8fd3-a309-9fe2b902c6d5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "961d97f4-7b10-8fd3-a309-9fe2b902c6d5",
+                                    "name": "indexpattern-datasource-layer-f2c275cc-1a03-f270-917a-90df1d9324d2"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "961d97f4-7b10-8fd3-a309-9fe2b902c6d5": {
+                                    "id": "961d97f4-7b10-8fd3-a309-9fe2b902c6d5",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -793,13 +919,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0dd241fc-bf0c-95f6-009c-bdd00f0b71ce"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0dd241fc-bf0c-95f6-009c-bdd00f0b71ce",
+                                    "name": "indexpattern-datasource-layer-ed980ebb-f8ba-2285-bba7-2fe3bfb23beb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0dd241fc-bf0c-95f6-009c-bdd00f0b71ce": {
+                                    "id": "0dd241fc-bf0c-95f6-009c-bdd00f0b71ce",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -895,13 +1042,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ee58019e-6294-9124-0ce5-0813ddf165eb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ee58019e-6294-9124-0ce5-0813ddf165eb",
+                                    "name": "indexpattern-datasource-layer-cd1bf115-a355-203b-5c19-050265bd6cc8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ee58019e-6294-9124-0ce5-0813ddf165eb": {
+                                    "id": "ee58019e-6294-9124-0ce5-0813ddf165eb",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1065,13 +1233,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d7953b8d-1cc5-1b72-fe0e-fe08e124e2db"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d7953b8d-1cc5-1b72-fe0e-fe08e124e2db",
+                                    "name": "indexpattern-datasource-layer-82bc0707-adae-e7c3-77a0-205ebc85c1fd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d7953b8d-1cc5-1b72-fe0e-fe08e124e2db": {
+                                    "id": "d7953b8d-1cc5-1b72-fe0e-fe08e124e2db",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1282,13 +1471,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2488757d-3a6a-b6fa-edf0-299695508d6f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2488757d-3a6a-b6fa-edf0-299695508d6f",
+                                    "name": "indexpattern-datasource-layer-38156f80-83c7-6a7b-d925-a65ee87e3f4b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2488757d-3a6a-b6fa-edf0-299695508d6f": {
+                                    "id": "2488757d-3a6a-b6fa-edf0-299695508d6f",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1499,13 +1709,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b430ac45-ffd2-c492-8854-291008c984b3"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b430ac45-ffd2-c492-8854-291008c984b3",
+                                    "name": "indexpattern-datasource-layer-29bdb8d1-45f5-f395-12d8-bd5cc078a874"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b430ac45-ffd2-c492-8854-291008c984b3": {
+                                    "id": "b430ac45-ffd2-c492-8854-291008c984b3",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1716,13 +1947,34 @@
                                                     "inMetricDimension": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5681b05a-7dee-9749-243c-ed449fc45b2f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5681b05a-7dee-9749-243c-ed449fc45b2f",
+                                    "name": "indexpattern-datasource-layer-8b065e12-9917-3665-56ec-e8b72ae8cd3c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5681b05a-7dee-9749-243c-ed449fc45b2f": {
+                                    "id": "5681b05a-7dee-9749-243c-ed449fc45b2f",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1884,13 +2136,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "e9eed196-2930-4256-244f-8ba0e5f44dfb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "e9eed196-2930-4256-244f-8ba0e5f44dfb",
+                                    "name": "indexpattern-datasource-layer-7076dffe-59b4-2095-87b2-fb13a286dd6c"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "e9eed196-2930-4256-244f-8ba0e5f44dfb": {
+                                    "id": "e9eed196-2930-4256-244f-8ba0e5f44dfb",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2052,13 +2325,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "21f50818-0bca-d2b1-d41f-a41800fd5d71"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "21f50818-0bca-d2b1-d41f-a41800fd5d71",
+                                    "name": "indexpattern-datasource-layer-0661c213-0119-4b0e-7719-c6bad7acafe6"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "21f50818-0bca-d2b1-d41f-a41800fd5d71": {
+                                    "id": "21f50818-0bca-d2b1-d41f-a41800fd5d71",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2221,13 +2515,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8598f572-c259-093c-0efb-2dbad3567955"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8598f572-c259-093c-0efb-2dbad3567955",
+                                    "name": "indexpattern-datasource-layer-65d1dddf-59e8-5bfc-168b-5202ad937214"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8598f572-c259-093c-0efb-2dbad3567955": {
+                                    "id": "8598f572-c259-093c-0efb-2dbad3567955",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2406,13 +2721,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1b8de5a0-5c3e-531e-15b8-311f45917169"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1b8de5a0-5c3e-531e-15b8-311f45917169",
+                                    "name": "indexpattern-datasource-layer-4b39badd-2176-f4b2-ee74-5a627fade2ec"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1b8de5a0-5c3e-531e-15b8-311f45917169": {
+                                    "id": "1b8de5a0-5c3e-531e-15b8-311f45917169",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2601,13 +2937,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b11c1fb7-1bb4-9557-4f96-2f1565b83299"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b11c1fb7-1bb4-9557-4f96-2f1565b83299",
+                                    "name": "indexpattern-datasource-layer-a0b8a94d-b344-ca22-f617-6c9482ec390e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b11c1fb7-1bb4-9557-4f96-2f1565b83299": {
+                                    "id": "b11c1fb7-1bb4-9557-4f96-2f1565b83299",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/vsphere_otel/kibana/dashboard/vsphere_otel-storage.json
+++ b/packages/vsphere_otel/kibana/dashboard/vsphere_otel-storage.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6d491df0-1b6b-7c46-1eed-7870ab8d3535"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6d491df0-1b6b-7c46-1eed-7870ab8d3535",
+                                    "name": "indexpattern-datasource-layer-81722af4-b26e-910e-ba39-dcc8614d92ca"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6d491df0-1b6b-7c46-1eed-7870ab8d3535": {
+                                    "id": "6d491df0-1b6b-7c46-1eed-7870ab8d3535",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5fe8b065-70e3-18b8-9864-a7a7a7f51c56"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5fe8b065-70e3-18b8-9864-a7a7a7f51c56",
+                                    "name": "indexpattern-datasource-layer-e63b8361-7a6a-2abb-ddcc-80c281e6f8ef"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5fe8b065-70e3-18b8-9864-a7a7a7f51c56": {
+                                    "id": "5fe8b065-70e3-18b8-9864-a7a7a7f51c56",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -383,13 +425,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "c77a59d9-bfa4-d7a7-29cd-8536aea0c66d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "c77a59d9-bfa4-d7a7-29cd-8536aea0c66d",
+                                    "name": "indexpattern-datasource-layer-39d3dcdc-07cb-fec5-0c16-258bd0b1d931"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "c77a59d9-bfa4-d7a7-29cd-8536aea0c66d": {
+                                    "id": "c77a59d9-bfa4-d7a7-29cd-8536aea0c66d",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -487,13 +550,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "cf9108ff-561e-832b-bb96-a03a9e42cebc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "cf9108ff-561e-832b-bb96-a03a9e42cebc",
+                                    "name": "indexpattern-datasource-layer-9310243f-bd8b-b39e-4187-ce75a81b41ef"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "cf9108ff-561e-832b-bb96-a03a9e42cebc": {
+                                    "id": "cf9108ff-561e-832b-bb96-a03a9e42cebc",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -589,13 +673,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d9d269c1-a3eb-e6af-631c-b5669828fcdd"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d9d269c1-a3eb-e6af-631c-b5669828fcdd",
+                                    "name": "indexpattern-datasource-layer-dd50ad2a-2a79-1ce6-7019-8b9a0293accd"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d9d269c1-a3eb-e6af-631c-b5669828fcdd": {
+                                    "id": "d9d269c1-a3eb-e6af-631c-b5669828fcdd",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -691,13 +796,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "72269591-7531-05ef-e19f-41b797b42216"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "72269591-7531-05ef-e19f-41b797b42216",
+                                    "name": "indexpattern-datasource-layer-6f5f9f04-8865-207b-29bd-6de113ca2057"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "72269591-7531-05ef-e19f-41b797b42216": {
+                                    "id": "72269591-7531-05ef-e19f-41b797b42216",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -798,13 +924,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1a17ca55-f74d-5f6d-cc6d-b1e75b3c635b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1a17ca55-f74d-5f6d-cc6d-b1e75b3c635b",
+                                    "name": "indexpattern-datasource-layer-a3a19251-f35d-294c-47a4-d5acbe2bf936"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1a17ca55-f74d-5f6d-cc6d-b1e75b3c635b": {
+                                    "id": "1a17ca55-f74d-5f6d-cc6d-b1e75b3c635b",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -944,13 +1091,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1d3ae50a-597c-2ea3-627f-8a7a35fa7ee2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1d3ae50a-597c-2ea3-627f-8a7a35fa7ee2",
+                                    "name": "indexpattern-datasource-layer-9ed5baef-1c34-c14e-b32b-819c23842cf4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1d3ae50a-597c-2ea3-627f-8a7a35fa7ee2": {
+                                    "id": "1d3ae50a-597c-2ea3-627f-8a7a35fa7ee2",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1129,13 +1297,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6501a0bd-d320-39ab-f1d9-219e1c50b90e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6501a0bd-d320-39ab-f1d9-219e1c50b90e",
+                                    "name": "indexpattern-datasource-layer-c69de62d-db72-00db-9fe2-dbcf4c8c5df0"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6501a0bd-d320-39ab-f1d9-219e1c50b90e": {
+                                    "id": "6501a0bd-d320-39ab-f1d9-219e1c50b90e",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1301,13 +1490,34 @@
                                                     "customLabel": true
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "61877857-028e-08ab-2430-04a3cd4c1861"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "61877857-028e-08ab-2430-04a3cd4c1861",
+                                    "name": "indexpattern-datasource-layer-dd2d719b-8062-067b-3e62-63060e4896cf"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "61877857-028e-08ab-2430-04a3cd4c1861": {
+                                    "id": "61877857-028e-08ab-2430-04a3cd4c1861",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1469,13 +1679,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1af9e495-1e76-59cd-4aa2-5cbc1c1649d1"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1af9e495-1e76-59cd-4aa2-5cbc1c1649d1",
+                                    "name": "indexpattern-datasource-layer-c59e6125-216c-67f3-ec71-48f38276842f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1af9e495-1e76-59cd-4aa2-5cbc1c1649d1": {
+                                    "id": "1af9e495-1e76-59cd-4aa2-5cbc1c1649d1",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1664,13 +1895,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8b5c4fe4-33c3-c19c-6414-7604256b51a6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8b5c4fe4-33c3-c19c-6414-7604256b51a6",
+                                    "name": "indexpattern-datasource-layer-ebbd5885-2022-9c80-e1e0-1f247197f293"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8b5c4fe4-33c3-c19c-6414-7604256b51a6": {
+                                    "id": "8b5c4fe4-33c3-c19c-6414-7604256b51a6",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1771,13 +2023,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "7ade5281-24cb-4480-d49f-b92d0d74de86"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "7ade5281-24cb-4480-d49f-b92d0d74de86",
+                                    "name": "indexpattern-datasource-layer-f037f27a-8210-8bcd-e4dc-c855a2c05eec"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "7ade5281-24cb-4480-d49f-b92d0d74de86": {
+                                    "id": "7ade5281-24cb-4480-d49f-b92d0d74de86",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/vsphere_otel/kibana/dashboard/vsphere_otel-vms.json
+++ b/packages/vsphere_otel/kibana/dashboard/vsphere_otel-vms.json
@@ -175,13 +175,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "1eff27c4-28d0-8c14-d4fc-f8826c7e90be"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "1eff27c4-28d0-8c14-d4fc-f8826c7e90be",
+                                    "name": "indexpattern-datasource-layer-db2d7a18-c846-c879-9c0c-f89ea0b04692"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "1eff27c4-28d0-8c14-d4fc-f8826c7e90be": {
+                                    "id": "1eff27c4-28d0-8c14-d4fc-f8826c7e90be",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -279,13 +300,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "2d13a3fd-1cc7-ea30-3c41-e1bf91c99a4f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "2d13a3fd-1cc7-ea30-3c41-e1bf91c99a4f",
+                                    "name": "indexpattern-datasource-layer-0a3be9f8-8f5e-9b38-c123-243d10a2287e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "2d13a3fd-1cc7-ea30-3c41-e1bf91c99a4f": {
+                                    "id": "2d13a3fd-1cc7-ea30-3c41-e1bf91c99a4f",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -381,13 +423,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "85cbf905-c197-5774-3d6e-39fc10f1996b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "85cbf905-c197-5774-3d6e-39fc10f1996b",
+                                    "name": "indexpattern-datasource-layer-26081627-2e5e-dd72-91d5-1f38122e6894"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "85cbf905-c197-5774-3d6e-39fc10f1996b": {
+                                    "id": "85cbf905-c197-5774-3d6e-39fc10f1996b",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -483,13 +546,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "162aeea0-52d3-8010-4aa0-e09bd2048e6e"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "162aeea0-52d3-8010-4aa0-e09bd2048e6e",
+                                    "name": "indexpattern-datasource-layer-695d798e-c73a-0415-b9b7-256d7dd9afbb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "162aeea0-52d3-8010-4aa0-e09bd2048e6e": {
+                                    "id": "162aeea0-52d3-8010-4aa0-e09bd2048e6e",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -587,13 +671,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "bb0846c8-21ad-aa2d-b2ef-0d75dc8de2b4"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "bb0846c8-21ad-aa2d-b2ef-0d75dc8de2b4",
+                                    "name": "indexpattern-datasource-layer-337ccbea-a3da-da49-34fe-718cfadcf903"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "bb0846c8-21ad-aa2d-b2ef-0d75dc8de2b4": {
+                                    "id": "bb0846c8-21ad-aa2d-b2ef-0d75dc8de2b4",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -691,13 +796,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ade1f023-fdb6-e502-6002-a09dc62709c2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ade1f023-fdb6-e502-6002-a09dc62709c2",
+                                    "name": "indexpattern-datasource-layer-a63335dc-7276-62da-15c0-9cfe5038b0a8"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ade1f023-fdb6-e502-6002-a09dc62709c2": {
+                                    "id": "ade1f023-fdb6-e502-6002-a09dc62709c2",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -795,13 +921,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "fd091e03-8e40-4d44-851c-dd063d1239fa"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "fd091e03-8e40-4d44-851c-dd063d1239fa",
+                                    "name": "indexpattern-datasource-layer-8a145683-b97a-deaa-a414-26b5ddf73c2f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "fd091e03-8e40-4d44-851c-dd063d1239fa": {
+                                    "id": "fd091e03-8e40-4d44-851c-dd063d1239fa",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -899,13 +1046,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0008eca1-764b-2184-547b-78d1f074a941"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0008eca1-764b-2184-547b-78d1f074a941",
+                                    "name": "indexpattern-datasource-layer-1f10e619-8613-dee6-8973-00f9649979ac"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0008eca1-764b-2184-547b-78d1f074a941": {
+                                    "id": "0008eca1-764b-2184-547b-78d1f074a941",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1135,13 +1303,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "36e288c9-e574-bc49-bec3-45eed90ea454"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "36e288c9-e574-bc49-bec3-45eed90ea454",
+                                    "name": "indexpattern-datasource-layer-7e0895e2-8701-ffee-5d41-efb905e44764"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "36e288c9-e574-bc49-bec3-45eed90ea454": {
+                                    "id": "36e288c9-e574-bc49-bec3-45eed90ea454",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1303,13 +1492,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8de7ed46-968d-547f-55ba-94801c15b5cc"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8de7ed46-968d-547f-55ba-94801c15b5cc",
+                                    "name": "indexpattern-datasource-layer-08d3d0a0-368b-894d-8e09-279adda90787"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8de7ed46-968d-547f-55ba-94801c15b5cc": {
+                                    "id": "8de7ed46-968d-547f-55ba-94801c15b5cc",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1471,13 +1681,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "af0399b6-fea2-40d3-623a-47c85a3702d9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "af0399b6-fea2-40d3-623a-47c85a3702d9",
+                                    "name": "indexpattern-datasource-layer-01bf2db8-bc9f-ca32-5b17-8ebe84a3da12"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "af0399b6-fea2-40d3-623a-47c85a3702d9": {
+                                    "id": "af0399b6-fea2-40d3-623a-47c85a3702d9",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1639,13 +1870,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "463f9100-ce4b-79ab-da2d-eafbeb7e8372"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "463f9100-ce4b-79ab-da2d-eafbeb7e8372",
+                                    "name": "indexpattern-datasource-layer-433e11ed-d272-a292-0ee9-ae956aa0dfef"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "463f9100-ce4b-79ab-da2d-eafbeb7e8372": {
+                                    "id": "463f9100-ce4b-79ab-da2d-eafbeb7e8372",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1807,13 +2059,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9592a216-ed7a-652a-6b5f-4dda55761f44"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9592a216-ed7a-652a-6b5f-4dda55761f44",
+                                    "name": "indexpattern-datasource-layer-887ac08b-5287-bc71-b9ae-0375ba325706"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9592a216-ed7a-652a-6b5f-4dda55761f44": {
+                                    "id": "9592a216-ed7a-652a-6b5f-4dda55761f44",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2002,13 +2275,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8b5c4fe4-33c3-c19c-6414-7604256b51a6"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8b5c4fe4-33c3-c19c-6414-7604256b51a6",
+                                    "name": "indexpattern-datasource-layer-ebbd5885-2022-9c80-e1e0-1f247197f293"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8b5c4fe4-33c3-c19c-6414-7604256b51a6": {
+                                    "id": "8b5c4fe4-33c3-c19c-6414-7604256b51a6",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2197,13 +2491,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "5e77d0ae-d7a3-a7c3-f804-477ca88cc3d2"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "5e77d0ae-d7a3-a7c3-f804-477ca88cc3d2",
+                                    "name": "indexpattern-datasource-layer-db7b5861-d6d9-1129-85b1-e2e058848d30"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "5e77d0ae-d7a3-a7c3-f804-477ca88cc3d2": {
+                                    "id": "5e77d0ae-d7a3-a7c3-f804-477ca88cc3d2",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2390,13 +2705,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "f97fa2d1-cf78-9e9f-1a3a-ed83cccd1abe"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "f97fa2d1-cf78-9e9f-1a3a-ed83cccd1abe",
+                                    "name": "indexpattern-datasource-layer-52522ec1-7945-b757-af22-035afec38190"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "f97fa2d1-cf78-9e9f-1a3a-ed83cccd1abe": {
+                                    "id": "f97fa2d1-cf78-9e9f-1a3a-ed83cccd1abe",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2581,13 +2917,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ff524e70-7575-d5fa-c6ae-9a0159b1d512"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ff524e70-7575-d5fa-c6ae-9a0159b1d512",
+                                    "name": "indexpattern-datasource-layer-8cefd58d-c254-edab-b198-7a52fdd94dc1"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ff524e70-7575-d5fa-c6ae-9a0159b1d512": {
+                                    "id": "ff524e70-7575-d5fa-c6ae-9a0159b1d512",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2731,13 +3088,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "3631bb5d-ce42-7d36-d408-9009ae28f479"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "3631bb5d-ce42-7d36-d408-9009ae28f479",
+                                    "name": "indexpattern-datasource-layer-a182560c-45f0-29df-8d0c-4bed52c323dc"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "3631bb5d-ce42-7d36-d408-9009ae28f479": {
+                                    "id": "3631bb5d-ce42-7d36-d408-9009ae28f479",
+                                    "type": "esql",
+                                    "name": "metrics-vcenterreceiver.otel-*",
+                                    "title": "metrics-vcenterreceiver.otel-*",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/vsphere_otel/manifest.yml
+++ b/packages/vsphere_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: vsphere_otel
 title: "VMware vSphere OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "VMware vSphere Assets for OpenTelemetry Collector"

--- a/packages/zookeeper_otel/changelog.yml
+++ b/packages/zookeeper_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/zookeeper_otel/changelog.yml
+++ b/packages/zookeeper_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/20483
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/zookeeper_otel/kibana/dashboard/zookeeper_otel-overview.json
+++ b/packages/zookeeper_otel/kibana/dashboard/zookeeper_otel-overview.json
@@ -154,13 +154,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "b12c1f2a-cdb2-4657-2321-841c2c47d52d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "b12c1f2a-cdb2-4657-2321-841c2c47d52d",
+                                    "name": "indexpattern-datasource-layer-1c0a1f84-43f4-5bda-fcfb-4815eccb8b45"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "b12c1f2a-cdb2-4657-2321-841c2c47d52d": {
+                                    "id": "b12c1f2a-cdb2-4657-2321-841c2c47d52d",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -258,13 +279,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "9643d6e8-870e-ff30-636c-4ece567ab96d"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "9643d6e8-870e-ff30-636c-4ece567ab96d",
+                                    "name": "indexpattern-datasource-layer-7614fbee-4ae9-0847-79d1-a30c462e7196"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "9643d6e8-870e-ff30-636c-4ece567ab96d": {
+                                    "id": "9643d6e8-870e-ff30-636c-4ece567ab96d",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -360,13 +402,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d0a9efac-0618-8c41-286f-ce91d84f0144"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d0a9efac-0618-8c41-286f-ce91d84f0144",
+                                    "name": "indexpattern-datasource-layer-5acae242-fff6-22f4-4b05-de91233db488"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d0a9efac-0618-8c41-286f-ce91d84f0144": {
+                                    "id": "d0a9efac-0618-8c41-286f-ce91d84f0144",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -462,13 +525,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "26b5d3d3-0a97-9fca-4fbb-7c020afd19bb"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "26b5d3d3-0a97-9fca-4fbb-7c020afd19bb",
+                                    "name": "indexpattern-datasource-layer-782cbb52-c20f-d974-a420-d8510bc7381b"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "26b5d3d3-0a97-9fca-4fbb-7c020afd19bb": {
+                                    "id": "26b5d3d3-0a97-9fca-4fbb-7c020afd19bb",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -564,13 +648,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "98069c88-fb3e-181b-2cdd-7b3154b45e5f"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "98069c88-fb3e-181b-2cdd-7b3154b45e5f",
+                                    "name": "indexpattern-datasource-layer-ef3fbc38-da19-a531-9479-f807d17a9360"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "98069c88-fb3e-181b-2cdd-7b3154b45e5f": {
+                                    "id": "98069c88-fb3e-181b-2cdd-7b3154b45e5f",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -666,13 +771,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "8a88fd53-7753-7b41-cfcb-6ca4e438f5ac"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "8a88fd53-7753-7b41-cfcb-6ca4e438f5ac",
+                                    "name": "indexpattern-datasource-layer-b5c460be-f94d-8efd-2c06-b9f20c385aa4"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "8a88fd53-7753-7b41-cfcb-6ca4e438f5ac": {
+                                    "id": "8a88fd53-7753-7b41-cfcb-6ca4e438f5ac",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -768,13 +894,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ffff66ca-f450-5426-d9ef-e3950dd02501"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ffff66ca-f450-5426-d9ef-e3950dd02501",
+                                    "name": "indexpattern-datasource-layer-281b8f77-7a10-8547-87a9-d90811654d97"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ffff66ca-f450-5426-d9ef-e3950dd02501": {
+                                    "id": "ffff66ca-f450-5426-d9ef-e3950dd02501",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -870,13 +1017,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "088794cc-cd9e-9d5c-4539-f6e2228ab550"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "088794cc-cd9e-9d5c-4539-f6e2228ab550",
+                                    "name": "indexpattern-datasource-layer-08174bbb-9c28-1d5f-c63a-683570c19e5e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "088794cc-cd9e-9d5c-4539-f6e2228ab550": {
+                                    "id": "088794cc-cd9e-9d5c-4539-f6e2228ab550",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1079,13 +1247,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "6aa490a4-0694-e70f-2d10-27e0feb2af21"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "6aa490a4-0694-e70f-2d10-27e0feb2af21",
+                                    "name": "indexpattern-datasource-layer-38fb3120-85fe-f370-7b15-742c3d0bab64"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "6aa490a4-0694-e70f-2d10-27e0feb2af21": {
+                                    "id": "6aa490a4-0694-e70f-2d10-27e0feb2af21",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1247,13 +1436,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "dfb2a241-b318-f30a-e01a-bed964d2d411"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "dfb2a241-b318-f30a-e01a-bed964d2d411",
+                                    "name": "indexpattern-datasource-layer-5284b091-97cc-32e8-8b35-10f05f428687"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "dfb2a241-b318-f30a-e01a-bed964d2d411": {
+                                    "id": "dfb2a241-b318-f30a-e01a-bed964d2d411",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1454,13 +1664,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "0f4ed47e-269d-3502-53b9-291fee4c4eb5"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "0f4ed47e-269d-3502-53b9-291fee4c4eb5",
+                                    "name": "indexpattern-datasource-layer-98ff9cd6-3e60-b301-8d11-c30990b0229f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "0f4ed47e-269d-3502-53b9-291fee4c4eb5": {
+                                    "id": "0f4ed47e-269d-3502-53b9-291fee4c4eb5",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1606,13 +1837,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "558b2a50-909b-143d-5b05-c41ba1d04b9b"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "558b2a50-909b-143d-5b05-c41ba1d04b9b",
+                                    "name": "indexpattern-datasource-layer-119937ad-1784-c966-0deb-f00842552f4f"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "558b2a50-909b-143d-5b05-c41ba1d04b9b": {
+                                    "id": "558b2a50-909b-143d-5b05-c41ba1d04b9b",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1799,13 +2051,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "654d6d0d-e12f-851e-937f-f5dbbc49152a"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "654d6d0d-e12f-851e-937f-f5dbbc49152a",
+                                    "name": "indexpattern-datasource-layer-e817c464-e185-63c5-2a9d-5b7d51d1df31"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "654d6d0d-e12f-851e-937f-f5dbbc49152a": {
+                                    "id": "654d6d0d-e12f-851e-937f-f5dbbc49152a",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -1951,13 +2224,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "a1c05ba0-62b6-a25f-d5e8-337751b5bf01"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "a1c05ba0-62b6-a25f-d5e8-337751b5bf01",
+                                    "name": "indexpattern-datasource-layer-5bcd8e0a-7426-9784-9018-e83401672be3"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "a1c05ba0-62b6-a25f-d5e8-337751b5bf01": {
+                                    "id": "a1c05ba0-62b6-a25f-d5e8-337751b5bf01",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2144,13 +2438,34 @@
                                                     "customLabel": false
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "86f27667-f7b7-7b07-f1d7-38cd7af13b90"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "86f27667-f7b7-7b07-f1d7-38cd7af13b90",
+                                    "name": "indexpattern-datasource-layer-f8d9d210-bdda-de2a-b2b3-784579545abb"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "86f27667-f7b7-7b07-f1d7-38cd7af13b90": {
+                                    "id": "86f27667-f7b7-7b07-f1d7-38cd7af13b90",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2296,13 +2611,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "43384fa9-9e94-2209-ca17-fb907274a8a9"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "43384fa9-9e94-2209-ca17-fb907274a8a9",
+                                    "name": "indexpattern-datasource-layer-2b3cc151-a66b-2e42-a557-23b91e188c49"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "43384fa9-9e94-2209-ca17-fb907274a8a9": {
+                                    "id": "43384fa9-9e94-2209-ca17-fb907274a8a9",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2448,13 +2784,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "d226bff6-912b-cae4-ea6e-f6ecc7b61309"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "d226bff6-912b-cae4-ea6e-f6ecc7b61309",
+                                    "name": "indexpattern-datasource-layer-c8ee06ee-0390-8de6-bd43-d20b7972a20d"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "d226bff6-912b-cae4-ea6e-f6ecc7b61309": {
+                                    "id": "d226bff6-912b-cae4-ea6e-f6ecc7b61309",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,
@@ -2600,13 +2957,34 @@
                                                     }
                                                 }
                                             ],
-                                            "timeField": "@timestamp"
+                                            "timeField": "@timestamp",
+                                            "index": "ee925192-7cf6-e8b5-1879-a26443473361"
                                         }
                                     }
                                 }
                             },
-                            "internalReferences": [],
-                            "adHocDataViews": {}
+                            "internalReferences": [
+                                {
+                                    "type": "index-pattern",
+                                    "id": "ee925192-7cf6-e8b5-1879-a26443473361",
+                                    "name": "indexpattern-datasource-layer-cac6c9b9-847a-836c-f6fd-9b17aa7efd0e"
+                                }
+                            ],
+                            "adHocDataViews": {
+                                "ee925192-7cf6-e8b5-1879-a26443473361": {
+                                    "id": "ee925192-7cf6-e8b5-1879-a26443473361",
+                                    "type": "esql",
+                                    "name": "metrics-generic.otel-default",
+                                    "title": "metrics-generic.otel-default",
+                                    "timeFieldName": "@timestamp",
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": []
+                                }
+                            }
                         }
                     },
                     "syncTooltips": false,

--- a/packages/zookeeper_otel/manifest.yml
+++ b/packages/zookeeper_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: zookeeper_otel
 title: "Zookeeper OTel Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Zookeeper OTel Assets"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

**WHAT**

Recompiles the committed Kibana dashboard JSON for five OTel content packages — `etcd_otel`,
`zookeeper_otel`, `airflow_otel`, `nvidia_gpu_otel`, `vsphere_otel` — from their existing, unchanged
`_dev/shared/kibana/*.yaml` sources. Across 14 dashboards and 187 ES|QL Lens layers, every layer now
carries the three pieces of state a Lens ES|QL panel needs to resolve its own data view:

- `state.datasourceStates.textBased.layers.<layerId>.index` — the ad-hoc data view id
- `state.adHocDataViews.<id>` — `title` equal to the layer's ES|QL `FROM`/`TS` index pattern,
  `timeFieldName: "@timestamp"`
- `state.internalReferences` — the matching `index-pattern` reference

Counts after regeneration (1:1 on every layer, no orphans, no duplicates):

| package | dashboards | ES\|QL layers | `layer.index` | `adHocDataViews` | `internalReferences` |
|---|---|---|---|---|---|
| `etcd_otel` | 4 | 51 | 51 | 51 | 51 |
| `zookeeper_otel` | 1 | 18 | 18 | 18 | 18 |
| `airflow_otel` | 4 | 31 | 31 | 31 | 31 |
| `nvidia_gpu_otel` | 1 | 20 | 20 | 20 | 20 |
| `vsphere_otel` | 4 | 67 | 67 | 67 | 67 |
| **total** | **14** | **187** | **187** | **187** | **187** |

Nothing else changes. A field-by-field diff against the committed 0.3.0 JSON shows the additions
above (plus the `indexPatternRefs` bookkeeping the compiler writes alongside them) and no other
edits: ES|QL queries, visualization types and dimensions, panel titles, layout, dashboard-level
filters, controls and drill-down links are byte-identical. `manifest.yml` goes 0.3.0 -> 0.3.1 with a
`bugfix` changelog entry per package.

**WHY**

On Kibana 9.3+ a Lens ES|QL panel whose layer has no `index`/`adHocDataViews` cannot resolve a data
view, so the "Explore in Discover" panel action is never registered and the panel loses its
drill-down. The failure is silent — the action is simply absent rather than erroring — so it is easy
to miss in review. Populating the three fields restores the drill-down without touching any query or
visualization.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm the JSON diff is limited to `layer.index`, `adHocDataViews`, `internalReferences` and
      `indexPatternRefs` — no query, visualization, filter, control, title or layout changes.
- [ ] Confirm each `adHocDataViews[<id>].title` matches its layer's ES|QL source index pattern and
      that `timeFieldName` is `@timestamp`.
- [ ] **Compiler pin:** these JSON files are intentionally ahead of what the CI-pinned compiler
      (`kb-dashboard-cli==0.4.1`, `.github/workflows/validate-yaml-dashboards.requirements.txt`)
      produces — 0.4.1 emits 0 `adHocDataViews`. The "Validate Dashboard Compilation" workflow is a
      no-op here because no YAML changed, but the compiler fix must be released and the pin bumped
      before the next PR touches these YAML sources, or the fix will be recompiled away.
- [ ] **Pre-existing, out of scope:** 28 of 187 panels (27 in `etcd_otel`, 1 in `zookeeper_otel`) now
      open Discover but the handed-off query is rejected by Elasticsearch:
      `[:] operator cannot operate on [data_stream.dataset] ... in non-STANDARD mode [time_series]`.
      Kibana appends the dashboard-level KQL filter as ``| WHERE `data_stream.dataset` : "..."`` and
      ES|QL rejects the `:` match operator against `time_series` indices for these rate/counter
      queries. The same 159-pass/28-fail split occurs when the simulation is run against the
      committed 0.3.0 JSON, so it is independent of this change — it was previously unreachable
      because the action did not exist. All four `vsphere_otel` dashboards have no dashboard-level
      filter and see 0 failures.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### Executed while preparing this PR (Kibana/Elasticsearch 9.5, local `elastic-package` stack)

Package validation — all five pass:

```
$ cd packages/<package> && elastic-package check -v
Package built: .../build/packages/etcd_otel-0.3.1.zip           Done   (exit 0)
Package built: .../build/packages/zookeeper_otel-0.3.1.zip      Done   (exit 0)
Package built: .../build/packages/airflow_otel-0.3.1.zip        Done   (exit 0)
Package built: .../build/packages/nvidia_gpu_otel-0.3.1.zip     Done   (exit 0)
Package built: .../build/packages/vsphere_otel-0.3.1.zip        Done   (exit 0)
```

`vsphere_otel` additionally reports 4 pre-existing `SVR00002` findings ("expected filter in
dashboard") as skipped errors; they are identical on the committed 0.3.0 files and do not fail the
check.

Structural verification of all 187 layers (ids agree across `layer.index`, `adHocDataViews` and
`internalReferences`; data-view title equals the ES|QL source; `timeFieldName == "@timestamp"`; no
duplicate refs; no orphan data views): 187/187 pass, 0 failures.

Live validation on 9.5 with synthetic OTel metrics ingested into TSDB indices for all five datasets:

- All 374 panel query instances execute against Elasticsearch and return rows.
- "Explore in Discover" is present on 187/187 ES|QL panels across all 14 dashboards, with 0 panel
  render errors. Non-ES|QL panels (markdown, links) correctly do not offer it.
- A side-by-side dashboard rebuilt from the committed 0.3.0 JSON shows the action absent on all 17
  ES|QL panels of `etcd_otel-overview`, and present on the same 17 panels after regeneration.
- Click-throughs on at least one panel per package (`TS`, `FROM` and `FORK` queries) open Discover
  with the query text, index pattern, columns and time range preserved, and results matching the
  panel. No `Cannot read properties of undefined (reading 'id')` in the console.
- Opening panels in Lens resolves the ad-hoc data view, its fields and its time field. Dashboard
  controls populate, and dashboard-to-dashboard links preserve the time range.
- A UI save round-trip (duplicate + save) preserves `layer.index`, `adHocDataViews` and
  `internalReferences` on all 13 panels of the saved copy, and the action still works.
- `GET /api/dashboards/<id>` returns HTTP 200 for all 14 dashboards with no schema failure, and the
  panel counts, panel types and ES|QL query sets are identical before and after.

Note for 9.5 reviewers: "Explore in Discover" is a panel **hover** button
(`embeddablePanelAction-ACTION_OPEN_IN_DISCOVER`), not an entry in the panel `⋯` menu.

### For the reviewer

```bash
# 1. Start a 9.3+ stack
elastic-package stack up -d -v --version 9.5.0

# 2. Build and install one of the packages
cd packages/etcd_otel && elastic-package check -v && elastic-package install -v

# 3. Open any of its dashboards in Kibana, hover an ES|QL panel, and click
#    "Explore in Discover" -> Discover opens with the panel's ES|QL query, index
#    pattern, columns and time range. Repeat on a 0.3.0 install to see the action missing.
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/obs-integration-team#1148
- Relates elastic/obs-integration-team#1014

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

N/A — no UI or dashboard content changes; the panels render exactly as before. The change only
restores the "Explore in Discover" panel action, which is described under "How to test this PR
locally".
