### PR TITLE
kolide: fix system-test mock pagination origins with stream .request.host

### DIFF
--- a/packages/kolide/data_stream/audit/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/audit/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '2.3'
 services:
   kolide-audit:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-audit
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090

--- a/packages/kolide/data_stream/audit/_dev/deploy/docker/files/config-audit.yml
+++ b/packages/kolide/data_stream/audit/_dev/deploy/docker/files/config-audit.yml
@@ -51,7 +51,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/audit_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
+              "next": "http://{{ .request.host }}/audit_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
               "current_cursor": "",
               "next_cursor": "CURSORPAGE2",
               "count": 1
@@ -85,7 +85,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/audit_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
+              "next": "http://{{ .request.host }}/audit_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
               "current_cursor": "CURSORPAGE2",
               "next_cursor": "CURSORPAGE3",
               "count": 1

--- a/packages/kolide/data_stream/auth/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/auth/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '2.3'
 services:
   kolide-auth:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-auth
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090

--- a/packages/kolide/data_stream/auth/_dev/deploy/docker/files/config-auth.yml
+++ b/packages/kolide/data_stream/auth/_dev/deploy/docker/files/config-auth.yml
@@ -69,7 +69,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/auth_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
+              "next": "http://{{ .request.host }}/auth_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
               "current_cursor": "",
               "next_cursor": "CURSORPAGE2",
               "count": 1
@@ -119,7 +119,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/auth_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
+              "next": "http://{{ .request.host }}/auth_logs?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
               "current_cursor": "CURSORPAGE2",
               "next_cursor": "CURSORPAGE3",
               "count": 1

--- a/packages/kolide/data_stream/deprovisioned_person/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/deprovisioned_person/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '2.3'
 services:
   kolide-deprovisioned-person:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-deprovisioned-person
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090

--- a/packages/kolide/data_stream/deprovisioned_person/_dev/deploy/docker/files/config-deprovisioned-person.yml
+++ b/packages/kolide/data_stream/deprovisioned_person/_dev/deploy/docker/files/config-deprovisioned-person.yml
@@ -67,7 +67,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/deprovisioned_people?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
+              "next": "http://{{ .request.host }}/deprovisioned_people?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
               "current_cursor": "",
               "next_cursor": "CURSORPAGE2",
               "count": 1

--- a/packages/kolide/data_stream/device/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/device/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '2.3'
 services:
   kolide-device:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-device
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090

--- a/packages/kolide/data_stream/device/_dev/deploy/docker/files/config-device.yml
+++ b/packages/kolide/data_stream/device/_dev/deploy/docker/files/config-device.yml
@@ -40,7 +40,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/devices?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
+              "next": "http://{{ .request.host }}/devices?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
               "current_cursor": "CURSORPAGE2",
               "next_cursor": "CURSORPAGE3",
               "count": 1
@@ -134,7 +134,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/devices?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
+              "next": "http://{{ .request.host }}/devices?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
               "current_cursor": "",
               "next_cursor": "CURSORPAGE2",
               "count": 1

--- a/packages/kolide/data_stream/issues/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/issues/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '2.3'
 services:
   kolide-issues:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-issues
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090

--- a/packages/kolide/data_stream/issues/_dev/deploy/docker/files/config-issues.yml
+++ b/packages/kolide/data_stream/issues/_dev/deploy/docker/files/config-issues.yml
@@ -67,7 +67,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/issues?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
+              "next": "http://{{ .request.host }}/issues?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
               "current_cursor": "",
               "next_cursor": "CURSORPAGE2",
               "count": 1
@@ -108,7 +108,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/issues?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
+              "next": "http://{{ .request.host }}/issues?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE3",
               "current_cursor": "CURSORPAGE2",
               "next_cursor": "CURSORPAGE3",
               "count": 1
@@ -149,7 +149,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/issues?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE4",
+              "next": "http://{{ .request.host }}/issues?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE4",
               "current_cursor": "CURSORPAGE3",
               "next_cursor": "CURSORPAGE4",
               "count": 1

--- a/packages/kolide/data_stream/people/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/people/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '2.3'
 services:
   kolide-people:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-people
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090

--- a/packages/kolide/data_stream/people/_dev/deploy/docker/files/config-people.yml
+++ b/packages/kolide/data_stream/people/_dev/deploy/docker/files/config-people.yml
@@ -67,7 +67,7 @@ rules:
               }
             ],
             "pagination": {
-              "next": "http://{{ hostname }}:{{ env "PORT" }}/people?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
+              "next": "http://{{ .request.host }}/people?per_page={{ .request.vars.per_page }}&cursor=CURSORPAGE2",
               "current_cursor": "",
               "next_cursor": "CURSORPAGE2",
               "count": 1

--- a/packages/kolide/data_stream/request/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kolide/data_stream/request/_dev/deploy/docker/docker-compose.yml
@@ -1,27 +1,23 @@
 version: '2.3'
 services:
   kolide-request:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-request
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090
       - --config=/files/config-request.yml
   kolide-request-empty-registration:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: kolide-request-empty-registration
     ports:
       - 8090
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: '8090'
     command:
       - http-server
       - --addr=:8090


### PR DESCRIPTION
## Proposed commit message

Replace stream `{{ hostname }}:PORT` absolute URLs in Kolide system-test mocks with `{{ .request.host }}`, bump mock images to `stream:v0.23.0`, and remove unused `PORT` compose env vars (listen address is set via `--addr`).

httpjson/CEL reject pagination when the mock emits a container-ID origin instead of the `svc-*` alias the agent uses. elastic/stream#206 and elastic/stream#207 expose the inbound request Host so mocks stay same-origin.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Confirm `docker.elastic.co/observability/stream:v0.23.0` is published before merge
- [ ] Run Kolide system tests that exercise cursor/`next` pagination mocks

## How to test this PR locally

```bash
elastic-package stack up -d --version 9.5.0-SNAPSHOT
cd packages/kolide
elastic-package test system
```

## Related issues

- Relates https://github.com/elastic/stream/issues/206
- Relates https://github.com/elastic/stream/pull/207
- Relates #20074
- Relates #20495

## Screenshots

N/A — system-test mock and compose changes only.
