### PR TITLE
salesforce: use stream .request.host in system-test mock instance_url

### DIFF
--- a/packages/salesforce/_dev/deploy/docker/docker-compose.yml
+++ b/packages/salesforce/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '3.8'
 services:
   salesforce:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.23.0
     hostname: salesforce
     ports:
       - 8010:8010
     volumes:
       - ./files:/files:ro
-    environment:
-      PORT: 8010
     command:
       - http-server
       - --addr=:8010

--- a/packages/salesforce/_dev/deploy/docker/files/config.yml
+++ b/packages/salesforce/_dev/deploy/docker/files/config.yml
@@ -5,7 +5,7 @@ rules:
       - status_code: 200
         headers:
           content-type: ["application/json"]
-        body: '{"access_token":"access_token","instance_url":"http://{{ hostname }}:{{ env "PORT" }}","id":"https://login.salesforce.com/id/temp_id/temp_token","token_type":"Bearer","issued_at":"1633689089545","signature":"signature"}'
+        body: '{"access_token":"access_token","instance_url":"http://{{ .request.host }}","id":"https://login.salesforce.com/id/temp_id/temp_token","token_type":"Bearer","issued_at":"1633689089545","signature":"signature"}'
   # Login ELF
   - path: /services/data/v56.0/query/
     methods: ["GET"]


### PR DESCRIPTION
## Proposed commit message

Adopt stream `{{ .request.host }}` for the Salesforce system-test OAuth mock `instance_url`, bump the mock image to `stream:v0.23.0`, and remove the unused `PORT` compose env var (the server already listens via `--addr=:8010`).

This is a consistency/cleanup change: the mock should return the same origin the agent requested, using the new stream template field from elastic/stream#206 / elastic/stream#207, instead of reconstructing the URL from `{{ hostname }}` and `PORT`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Confirm `docker.elastic.co/observability/stream:v0.23.0` is published before merge
- [ ] Run Salesforce system tests that use the mock `instance_url`

## How to test this PR locally

```bash
elastic-package stack up -d --version 9.5.0-SNAPSHOT
cd packages/salesforce
elastic-package test system
```

## Related issues

- Relates https://github.com/elastic/stream/issues/206
- Relates https://github.com/elastic/stream/pull/207

## Screenshots

N/A — system-test mock and compose changes only.