### PR TITLE
Crowdstrike: use inclusive >= cursor boundary for host data stream

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.5.1"
+  changes:
+    - description: Use inclusive >= cursor boundary in host CEL program to avoid permanently skipping same-timestamp records at page or error boundaries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20190
 - version: "4.5.0"
   changes:
     - description: Map CommandHistory events to ECS process fields.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use inclusive >= cursor boundary in host CEL program to avoid permanently skipping same-timestamp records at page or error boundaries.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/20190
+      link: https://github.com/elastic/integrations/pull/20524
 - version: "4.5.0"
   changes:
     - description: Map CommandHistory events to ECS process fields.

--- a/packages/crowdstrike/data_stream/host/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/host/_dev/test/policy/test-default.expected
@@ -84,6 +84,7 @@ inputs:
                             ),
                           },
                         },
+                        "offset": 0,
                         "want_more": false,
                         "next": {},
                       }
@@ -131,6 +132,7 @@ inputs:
                                 ),
                               },
                             },
+                            "offset": 0,
                             "want_more": false,
                             "next": {},
                           }

--- a/packages/crowdstrike/data_stream/host/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/host/_dev/test/policy/test-default.expected
@@ -45,7 +45,10 @@ inputs:
                           optional.of(
                             [
                               [
-                                ?filter.optMap(f, "modified_timestamp:>\"" + f + "\""),
+                                // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                                // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                                // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                                ?filter.optMap(f, "modified_timestamp:>=\"" + f + "\""),
                                 ?state.?query.optMap(q, "(" + q + ")"),
                               ].join("+"),
                             ]
@@ -154,7 +157,10 @@ inputs:
                         "sort": ["modified_timestamp|asc"],
                         "filter": [
                           [
-                            "modified_timestamp:>'" + start_time + "'",
+                            // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                            // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                            // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                            "modified_timestamp:>='" + start_time + "'",
                             ?state.?query.optMap(q, "(" + q + ")"),
                           ].join("+"),
                         ],

--- a/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
@@ -64,7 +64,10 @@ program: |-
                 optional.of(
                   [
                     [
-                      ?filter.optMap(f, "modified_timestamp:>\"" + f + "\""),
+                      // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                      // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                      // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                      ?filter.optMap(f, "modified_timestamp:>=\"" + f + "\""),
                       ?state.?query.optMap(q, "(" + q + ")"),
                     ].join("+"),
                   ]
@@ -173,7 +176,10 @@ program: |-
               "sort": ["modified_timestamp|asc"],
               "filter": [
                 [
-                  "modified_timestamp:>'" + start_time + "'",
+                  // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                  // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                  // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                  "modified_timestamp:>='" + start_time + "'",
                   ?state.?query.optMap(q, "(" + q + ")"),
                 ].join("+"),
               ],

--- a/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
@@ -103,6 +103,7 @@ program: |-
                   ),
                 },
               },
+              "offset": 0,
               "want_more": false,
               "next": {},
             }
@@ -150,6 +151,7 @@ program: |-
                       ),
                     },
                   },
+                  "offset": 0,
                   "want_more": false,
                   "next": {},
                 }

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "4.5.0"
+version: "4.5.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
## Proposed commit message

```
crowdstrike/data_stream/host: use inclusive >= cursor boundary in CEL program

Strict > on modified_timestamp permanently skips records that share a
boundary timestamp when a page or error boundary falls mid-group.
Switch to >= in both the GovCloud and commercial-CID branches so
same-timestamp records are always re-queried on the next poll.

Re-fetched boundary records are absorbed without creating duplicates:
the host ingest pipeline runs a fingerprint processor that includes
modified_timestamp, so events that were already ingested are dropped.

Follows up on https://github.com/elastic/integrations/pull/20190,
applying the same fix to the host data stream.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/20190

