### PR TITLE
[aws] Enable Identity Federation for the CloudWatch policy template

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "7.4.0"
+  changes:
+    - description: Enable Identity Federation for the AWS CloudWatch policy template (cloudwatch_logs and cloudwatch_metrics data streams). Adds `external_id` support to the `aws-cloudwatch` and `aws/metrics` input templates, enabling role assumption with an External ID when using the Identity Federation credential group.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20440
 - version: "7.3.0"
   changes:
     - description: Enable Identity Federation (Cloud Connectors) for the Amazon Inspector data stream by migrating its HTTPJSON template from hand-rolled SigV4 signing to the input's `auth.aws` configuration. This also fixes temporary credentials (session tokens) and adds Role ARN and shared-credential support, none of which the hand-rolled signing handled.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "7.3.0"
+  changes:
+    - description: Enable Identity Federation (Cloud Connectors) for the Amazon Inspector data stream by migrating its HTTPJSON template from hand-rolled SigV4 signing to the input's `auth.aws` configuration. This also fixes temporary credentials (session tokens) and adds Role ARN and shared-credential support, none of which the hand-rolled signing handled.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Identity Federation (Cloud Connectors) for the Amazon Inspector data stream by migrating its HTTPJSON template from hand-rolled SigV4 signing to the input's `auth.aws` configuration. This also fixes temporary credentials (session tokens) and adds Role ARN and shared-credential support, none of which the hand-rolled signing handled.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20439
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Identity Federation for the AWS CloudWatch policy template (cloudwatch_logs and cloudwatch_metrics data streams). Adds `external_id` support to the `aws-cloudwatch` and `aws/metrics` input templates, enabling role assumption with an External ID when using the Identity Federation credential group.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/20440
+      link: https://github.com/elastic/integrations/pull/20525
 - version: "7.3.0"
   changes:
     - description: Enable Identity Federation (Cloud Connectors) for the Amazon Inspector data stream by migrating its HTTPJSON template from hand-rolled SigV4 signing to the input's `auth.aws` configuration. This also fixes temporary credentials (session tokens) and adds Role ARN and shared-credential support, none of which the hand-rolled signing handled.

--- a/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -87,6 +87,9 @@ session_token: {{session_token}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if external_id}}
+external_id: {{external_id}}
+{{/if}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/cloudwatch_metrics/agent/stream/stream.yml.hbs
@@ -27,6 +27,9 @@ shared_credential_file: {{shared_credential_file}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if external_id}}
+external_id: {{external_id}}
+{{/if}}
 {{#if default_region}}
 default_region: {{default_region}}
 {{/if}}

--- a/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
@@ -17,9 +17,6 @@ request.ssl: {{ssl}}
 request.url: https://inspector2.{{aws_region}}.{{tld}}/findings/list
 request.transforms:
   - set:
-      target: header.X-Amz-Date
-      value: '[[formatDate (now) "20060102T150405Z"]]'
-  - set:
       target: body.maxResults
       value: 100
       value_type: int
@@ -41,21 +38,12 @@ request.transforms:
       value: '[{ "startInclusive": [[mul (div (toInt .cursor.last_update_datetime) 1000) 1000]], "endInclusive": 1956528000 }]'
       default: '[{ "startInclusive": [[mul (div (toInt (now (parseDuration "-{{initial_interval}}")).Unix) 1000) 1000]], "endInclusive": 1956528000 }]'
       value_type: json
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/inspector2/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "inspector2")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/inspector2/aws4_request") (hash "sha256" "POST\n" "/findings/list\n" "\n" "host:inspector2.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
-{{!-- https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html --}}
 response.pagination:
   - set:
       target: body.nextToken
       value: '[[if (eq (len .last_response.body.findings) 100)]][[.last_response.body.nextToken]][[end]]'
       fail_on_template_error: true
       do_not_log_failure: true
-  - delete:
-      target: header.Authorization
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/inspector2/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "inspector2")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/inspector2/aws4_request") (hash "sha256" "POST\n" "/findings/list\n" "\n" "host:inspector2.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
 {{!-- Store the poll time minus lag_time as the watermark. Because the window advances
       by wall-clock time (not by a value seen in the data), a finding whose updatedAt
       predates the poll but only becomes visible later would be missed; the lag_time
@@ -66,6 +54,37 @@ cursor:
     value: '[[if (ne (len .last_response.body.findings) 100)]][[(now (parseDuration "-{{lag_time}}")).Unix]][[end]]'
 response.split:
   target: body.findings
+auth.aws:
+{{#if access_key_id}}
+  access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+  secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+  session_token: {{session_token}}
+{{/if}}
+{{#if shared_credential_file}}
+  shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if credential_profile_name}}
+  credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if role_arn}}
+  role_arn: {{role_arn}}
+{{/if}}
+{{#if external_id}}
+  external_id: {{external_id}}
+{{/if}}
+{{#if assume_role_duration}}
+  assume_role.duration: {{assume_role_duration}}
+{{/if}}
+{{#if assume_role_expiry_window}}
+  assume_role.expiry_window: {{assume_role_expiry_window}}
+{{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.1.1
+version: 7.3.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -1055,8 +1055,6 @@ policy_templates:
       - type: httpjson
         title: Collect Amazon Inspector logs via API
         description: Collecting Amazon Inspector logs via API.
-        hide_in_var_group_options:
-          credential_type: [identity_federation]
     screenshots:
       - src: /img/inspector-findings-overview-dashboard.png
         title: Inspector Findings Overview dashboard

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.3.0
+version: 7.4.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -257,14 +257,10 @@ policy_templates:
         title: Collect logs from CloudWatch
         description: Collecting logs using aws-cloudwatch input
         input_group: logs
-        hide_in_var_group_options:
-          credential_type: [identity_federation]
       - type: aws/metrics
         title: Collect metrics from CloudWatch
         description: Collecting metrics using AWS CloudWatch
         input_group: metrics
-        hide_in_var_group_options:
-          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true


### PR DESCRIPTION
## Summary

- Removes `hide_in_var_group_options: credential_type: [identity_federation]` from the `aws-cloudwatch` and `aws/metrics` inputs in the `cloudwatch` policy template, making them visible in the Identity Federation credential group
- Adds `external_id: {{external_id}}` to `cloudwatch_logs/aws-cloudwatch.yml.hbs` and `cloudwatch_metrics/stream.yml.hbs`, enabling role assumption with an External ID
- Part of [ingest-dev#8802](https://github.com/elastic/ingest-dev/issues/8802) — enabling Identity Federation across agentless-eligible aws package streams

> **Note:** Cloud Connectors automatic token exchange (`use_cloud_connectors`) is not yet supported by the `aws-cloudwatch` and `aws/metrics` Beats input types. This PR enables the role-assumption path (user provides `role_arn` + `external_id`); the Cloud Connectors path will follow in a future Beats release.

**Paired cloudbeat PR:** elastic/cloudbeat#7622 (adds `logs:DescribeLogGroups`, `logs:FilterLogEvents`, `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData` to the federated IAM role)

**Depends on:** #20437 (Config), #20439 (Inspector) — carries federation infrastructure from those PRs; hold merge until both predecessors land

## E2E test plan

**What this run uniquely proves:** role assumption with `external_id` works for both `aws-cloudwatch` and `aws/metrics` input types when using the Identity Federation credential group.

1. Create the federated IAM role via the paired cloudbeat CFT (or the deployed `cloudformation-federated-identity-aws-9.4.0.yml`)
2. In Fleet, create a CloudWatch policy with credential type = Identity Federation; enter the role ARN and external ID from the CFT output
3. Enable the cloudwatch_logs data stream; confirm logs appear in `logs-aws.cloudwatch_logs-*`
4. Enable the cloudwatch_metrics data stream; confirm metrics appear in `metrics-aws.cloudwatch_metrics-*`
5. Verify no `DEGRADED` status in Fleet for either data stream
6. **Regression:** Create a second policy with Direct Access Keys; confirm it still collects data (gate removal must not break non-federation paths)