### PR TITLE
[aws] Enable Identity Federation for aws.securityhub data stream and standalone SecurityHub integration

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "7.2.0"
+  changes:
+    - description: Enable Identity Federation (Cloud Connectors) for the SecurityHub data streams (securityhub_findings, securityhub_findings_full_posture, securityhub_insights) by migrating their HTTPJSON templates from hand-rolled SigV4 signing to the input's auth.aws configuration. Fixes silent session-token breakage in the hand-rolled path.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20527
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: "7.2.0"
+- version: "7.5.0"
   changes:
     - description: Enable Identity Federation (Cloud Connectors) for the SecurityHub data streams (securityhub_findings, securityhub_findings_full_posture, securityhub_insights) by migrating their HTTPJSON templates from hand-rolled SigV4 signing to the input's auth.aws configuration. Fixes silent session-token breakage in the hand-rolled path.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/20527
+      link: https://github.com/elastic/integrations/pull/20529
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -18,6 +18,9 @@
         Fix `aws.cloudtrail.service_event_details` surviving `retain: flattened` and `retain: none`. It is now governed like the other payload fields.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20403
+    - description: Enable Identity Federation (Cloud Connectors) for the SecurityHub data streams (securityhub_findings, securityhub_findings_full_posture, securityhub_insights) by migrating their HTTPJSON templates from hand-rolled SigV4 signing to the input's auth.aws configuration. Fixes silent session-token breakage in the hand-rolled path.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20529
 - version: "7.3.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "7.5.0"
+- version: "7.3.0"
   changes:
     - description: Enable Identity Federation (Cloud Connectors) for the SecurityHub data streams (securityhub_findings, securityhub_findings_full_posture, securityhub_insights) by migrating their HTTPJSON templates from hand-rolled SigV4 signing to the input's auth.aws configuration. Fixes silent session-token breakage in the hand-rolled path.
       type: enhancement

--- a/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
+++ b/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
@@ -1,0 +1,67 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws
+      name: test-httpjson-agentless-cloud-connector-aws
+      streams:
+        - auth.aws:
+            role_arn: arn:aws:iam::123456789012:role/ElasticFederatedIdentity
+            use_cloud_connectors: true
+          config_version: 2
+          cursor:
+            last_execution_datetime:
+                value: '[[if (ne (len .last_response.body.Findings) 100)]][[.last_event.UpdatedAt]][[end]]'
+          data_stream:
+            dataset: aws.securityhub_findings
+          interval: 1h
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 2m
+          request.transforms:
+            - set:
+                target: body.MaxResults
+                value: 100
+                value_type: int
+            - set:
+                target: body.SortCriteria
+                value: '[{"Field":"UpdatedAt","SortOrder":"asc"}]'
+                value_type: json
+            - set:
+                default: '[{ "Start": "[[formatDate (now (parseDuration "-24h")) "2006-01-02T15"]]", "End": "2099-01-01T00" }]'
+                target: body.Filters.UpdatedAt
+                value: '[{ "Start": "[[formatDate (parseDate .cursor.last_execution_datetime "RFC3339") "2006-01-02T15"]]", "End": "2099-01-01T00" }]'
+                value_type: json
+          request.url: https://securityhub.us-east-1.amazonaws.com/findings
+          response.pagination:
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.NextToken
+                value: '[[if (eq (len .last_response.body.Findings) 100)]][[.last_response.body.NextToken]][[end]]'
+          response.split:
+            ignore_empty_value: true
+            target: body.Findings
+          tags:
+            - forwarded
+            - aws_securityhub_findings
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.securityhub_findings-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
+++ b/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
@@ -1,0 +1,12 @@
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticFederatedIdentity
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    interval: 1h
+    initial_interval: 24h
+    aws_region: us-east-1
+    tld: amazonaws.com
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-legacy-credentials.expected
+++ b/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-legacy-credentials.expected
@@ -1,0 +1,69 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws
+      name: test-httpjson-legacy-credentials-aws
+      streams:
+        - auth.aws:
+            access_key_id: ${SECRET_0}
+            secret_access_key: ${SECRET_1}
+          config_version: 2
+          cursor:
+            last_execution_datetime:
+                value: '[[if (ne (len .last_response.body.Findings) 100)]][[.last_event.UpdatedAt]][[end]]'
+          data_stream:
+            dataset: aws.securityhub_findings
+          interval: 1h
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 2m
+          request.transforms:
+            - set:
+                target: body.MaxResults
+                value: 100
+                value_type: int
+            - set:
+                target: body.SortCriteria
+                value: '[{"Field":"UpdatedAt","SortOrder":"asc"}]'
+                value_type: json
+            - set:
+                default: '[{ "Start": "[[formatDate (now (parseDuration "-24h")) "2006-01-02T15"]]", "End": "2099-01-01T00" }]'
+                target: body.Filters.UpdatedAt
+                value: '[{ "Start": "[[formatDate (parseDate .cursor.last_execution_datetime "RFC3339") "2006-01-02T15"]]", "End": "2099-01-01T00" }]'
+                value_type: json
+          request.url: https://securityhub.us-east-1.amazonaws.com/findings
+          response.pagination:
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.NextToken
+                value: '[[if (eq (len .last_response.body.Findings) 100)]][[.last_response.body.NextToken]][[end]]'
+          response.split:
+            ignore_empty_value: true
+            target: body.Findings
+          tags:
+            - forwarded
+            - aws_securityhub_findings
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.securityhub_findings-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}
+    - {}

--- a/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-legacy-credentials.yml
+++ b/packages/aws/data_stream/securityhub_findings/_dev/test/policy/test-httpjson-legacy-credentials.yml
@@ -1,0 +1,12 @@
+vars:
+  access_key_id: FAKE_AWS_ACCESS_KEY_ID_FOR_TESTS_ONLY
+  secret_access_key: FAKE_AWS_SECRET_ACCESS_KEY_FOR_TESTS_ONLY
+  default_region: us-east-1
+data_stream:
+  vars:
+    interval: 1h
+    initial_interval: 24h
+    aws_region: us-east-1
+    tld: amazonaws.com
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/securityhub_findings/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_findings/agent/stream/httpjson.yml.hbs
@@ -17,9 +17,6 @@ request.ssl: {{ssl}}
 request.url: https://securityhub.{{aws_region}}.{{tld}}/findings
 request.transforms:
   - set:
-      target: header.X-Amz-Date
-      value: '[[formatDate (now) "20060102T150405Z"]]'
-  - set:
       target: body.MaxResults
       value: 100
       value_type: int
@@ -36,21 +33,12 @@ request.transforms:
       value: '[{ "Start": "[[formatDate (parseDate .cursor.last_execution_datetime "RFC3339") "2006-01-02T15"]]", "End": "2099-01-01T00" }]'
       default: '[{ "Start": "[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15"]]", "End": "2099-01-01T00" }]'
       value_type: json
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/securityhub/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "securityhub")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/securityhub/aws4_request") (hash "sha256" "POST\n" "/findings\n" "\n" "host:securityhub.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
-{{!-- https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html --}}
 response.pagination:
   - set:
       target: body.NextToken
       value: '[[if (eq (len .last_response.body.Findings) 100)]][[.last_response.body.NextToken]][[end]]'
       fail_on_template_error: true
       do_not_log_failure: true
-  - delete:
-      target: header.Authorization
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/securityhub/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "securityhub")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/securityhub/aws4_request") (hash "sha256" "POST\n" "/findings\n" "\n" "host:securityhub.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
 cursor:
   last_execution_datetime:
     value: '[[if (ne (len .last_response.body.Findings) 100)]][[.last_event.UpdatedAt]][[end]]'
@@ -73,4 +61,35 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
+{{/if}}
+auth.aws:
+{{#if access_key_id}}
+  access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+  secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+  session_token: {{session_token}}
+{{/if}}
+{{#if shared_credential_file}}
+  shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if credential_profile_name}}
+  credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if role_arn}}
+  role_arn: {{role_arn}}
+{{/if}}
+{{#if external_id}}
+  external_id: {{external_id}}
+{{/if}}
+{{#if assume_role_duration}}
+  assume_role.duration: {{assume_role_duration}}
+{{/if}}
+{{#if assume_role_expiry_window}}
+  assume_role.expiry_window: {{assume_role_expiry_window}}
+{{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
 {{/if}}

--- a/packages/aws/data_stream/securityhub_findings/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_findings/agent/stream/httpjson.yml.hbs
@@ -81,9 +81,6 @@ auth.aws:
 {{#if role_arn}}
   role_arn: {{role_arn}}
 {{/if}}
-{{#if external_id}}
-  external_id: {{external_id}}
-{{/if}}
 {{#if assume_role_duration}}
   assume_role.duration: {{assume_role_duration}}
 {{/if}}

--- a/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
@@ -1,0 +1,63 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws
+      name: test-httpjson-agentless-cloud-connector-aws
+      streams:
+        - auth.aws:
+            role_arn: arn:aws:iam::123456789012:role/ElasticFederatedIdentity
+            use_cloud_connectors: true
+          config_version: 2
+          data_stream:
+            dataset: aws.securityhub_findings_full_posture
+          interval: 24h
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 2m
+          request.transforms:
+            - set:
+                target: body.MaxResults
+                value: 100
+                value_type: int
+            - set:
+                target: body.Filters.RecordState
+                value: '[{"Comparison":"NOT_EQUALS","Value":"ARCHIVED"}]'
+                value_type: json
+            - set:
+                target: body.Filters.WorkflowStatus
+                value: '[{"Comparison":"NOT_EQUALS","Value":"SUPPRESSED"}]'
+                value_type: json
+          request.url: https://securityhub.us-east-1.amazonaws.com/findings
+          response.pagination:
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.NextToken
+                value: '[[if (eq (len .last_response.body.Findings) 100)]][[.last_response.body.NextToken]][[end]]'
+          response.split:
+            ignore_empty_value: true
+            target: body.Findings
+          tags:
+            - forwarded
+            - aws_securityhub_findings_full_posture
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.securityhub_findings_full_posture-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
@@ -1,0 +1,10 @@
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticFederatedIdentity
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    aws_region: us-east-1
+    tld: amazonaws.com
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-legacy-credentials.expected
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-legacy-credentials.expected
@@ -1,0 +1,65 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws
+      name: test-httpjson-legacy-credentials-aws
+      streams:
+        - auth.aws:
+            access_key_id: ${SECRET_0}
+            secret_access_key: ${SECRET_1}
+          config_version: 2
+          data_stream:
+            dataset: aws.securityhub_findings_full_posture
+          interval: 24h
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 2m
+          request.transforms:
+            - set:
+                target: body.MaxResults
+                value: 100
+                value_type: int
+            - set:
+                target: body.Filters.RecordState
+                value: '[{"Comparison":"NOT_EQUALS","Value":"ARCHIVED"}]'
+                value_type: json
+            - set:
+                target: body.Filters.WorkflowStatus
+                value: '[{"Comparison":"NOT_EQUALS","Value":"SUPPRESSED"}]'
+                value_type: json
+          request.url: https://securityhub.us-east-1.amazonaws.com/findings
+          response.pagination:
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.NextToken
+                value: '[[if (eq (len .last_response.body.Findings) 100)]][[.last_response.body.NextToken]][[end]]'
+          response.split:
+            ignore_empty_value: true
+            target: body.Findings
+          tags:
+            - forwarded
+            - aws_securityhub_findings_full_posture
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.securityhub_findings_full_posture-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}
+    - {}

--- a/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-legacy-credentials.yml
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/_dev/test/policy/test-httpjson-legacy-credentials.yml
@@ -1,0 +1,10 @@
+vars:
+  access_key_id: FAKE_AWS_ACCESS_KEY_ID_FOR_TESTS_ONLY
+  secret_access_key: FAKE_AWS_SECRET_ACCESS_KEY_FOR_TESTS_ONLY
+  default_region: us-east-1
+data_stream:
+  vars:
+    aws_region: us-east-1
+    tld: amazonaws.com
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/securityhub_findings_full_posture/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/agent/stream/httpjson.yml.hbs
@@ -73,9 +73,6 @@ auth.aws:
 {{#if role_arn}}
   role_arn: {{role_arn}}
 {{/if}}
-{{#if external_id}}
-  external_id: {{external_id}}
-{{/if}}
 {{#if assume_role_duration}}
   assume_role.duration: {{assume_role_duration}}
 {{/if}}

--- a/packages/aws/data_stream/securityhub_findings_full_posture/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/agent/stream/httpjson.yml.hbs
@@ -17,35 +17,23 @@ request.ssl: {{ssl}}
 request.url: https://securityhub.{{aws_region}}.{{tld}}/findings
 request.transforms:
   - set:
-      target: header.X-Amz-Date
-      value: '[[formatDate (now) "20060102T150405Z"]]'
-  - set:
       target: body.MaxResults
       value: 100
       value_type: int
   - set:
-      target: body.Filters.RecordState 
+      target: body.Filters.RecordState
       value: '[{"Comparison":"NOT_EQUALS","Value":"ARCHIVED"}]'
       value_type: json
   - set:
-      target: body.Filters.WorkflowStatus 
+      target: body.Filters.WorkflowStatus
       value: '[{"Comparison":"NOT_EQUALS","Value":"SUPPRESSED"}]'
       value_type: json
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/securityhub/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "securityhub")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/securityhub/aws4_request") (hash "sha256" "POST\n" "/findings\n" "\n" "host:securityhub.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
-{{!-- https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html --}}
 response.pagination:
   - set:
       target: body.NextToken
       value: '[[if (eq (len .last_response.body.Findings) 100)]][[.last_response.body.NextToken]][[end]]'
       fail_on_template_error: true
       do_not_log_failure: true
-  - delete:
-      target: header.Authorization
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/securityhub/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "securityhub")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/securityhub/aws4_request") (hash "sha256" "POST\n" "/findings\n" "\n" "host:securityhub.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
 response.split:
   target: body.Findings
   ignore_empty_value: true
@@ -65,4 +53,35 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
+{{/if}}
+auth.aws:
+{{#if access_key_id}}
+  access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+  secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+  session_token: {{session_token}}
+{{/if}}
+{{#if shared_credential_file}}
+  shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if credential_profile_name}}
+  credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if role_arn}}
+  role_arn: {{role_arn}}
+{{/if}}
+{{#if external_id}}
+  external_id: {{external_id}}
+{{/if}}
+{{#if assume_role_duration}}
+  assume_role.duration: {{assume_role_duration}}
+{{/if}}
+{{#if assume_role_expiry_window}}
+  assume_role.expiry_window: {{assume_role_expiry_window}}
+{{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
 {{/if}}

--- a/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
+++ b/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
@@ -1,0 +1,68 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws
+      name: test-httpjson-agentless-cloud-connector-aws
+      streams:
+        - auth.aws:
+            role_arn: arn:aws:iam::123456789012:role/ElasticFederatedIdentity
+            use_cloud_connectors: true
+          config_version: 2
+          data_stream:
+            dataset: aws.securityhub_insights
+          interval: 1m
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 2m
+          request.transforms:
+            - set:
+                target: body.MaxResults
+                value: 100
+                value_type: int
+            - set:
+                target: body.InsightArns
+                value: "[\n  \"arn:aws:securityhub:::insight/securityhub/default/1\",\n  \"arn:aws:securityhub:::insight/securityhub/default/10\",\n  \"arn:aws:securityhub:::insight/securityhub/default/3\",\n  \"arn:aws:securityhub:::insight/securityhub/default/14\",\n  \"arn:aws:securityhub:::insight/securityhub/default/9\",\n  \"arn:aws:securityhub:::insight/securityhub/default/6\",\n  \"arn:aws:securityhub:::insight/securityhub/default/7\",\n  \"arn:aws:securityhub:::insight/securityhub/default/8\",\n  \"arn:aws:securityhub:::insight/securityhub/default/11\",\n  \"arn:aws:securityhub:::insight/securityhub/default/12\",\n  \"arn:aws:securityhub:::insight/securityhub/default/13\",\n  \"arn:aws:securityhub:::insight/securityhub/default/16\",\n  \"arn:aws:securityhub:::insight/securityhub/default/17\",\n  \"arn:aws:securityhub:::insight/securityhub/default/18\",\n  \"arn:aws:securityhub:::insight/securityhub/default/19\",\n  \"arn:aws:securityhub:::insight/securityhub/default/21\",\n  \"arn:aws:securityhub:::insight/securityhub/default/22\",\n  \"arn:aws:securityhub:::insight/securityhub/default/23\",\n  \"arn:aws:securityhub:::insight/securityhub/default/24\",\n  \"arn:aws:securityhub:::insight/securityhub/default/25\",\n  \"arn:aws:securityhub:::insight/securityhub/default/26\",\n  \"arn:aws:securityhub:::insight/securityhub/default/27\",\n  \"arn:aws:securityhub:::insight/securityhub/default/28\",\n  \"arn:aws:securityhub:::insight/securityhub/default/29\",\n  \"arn:aws:securityhub:::insight/securityhub/default/30\",\n  \"arn:aws:securityhub:::insight/securityhub/default/31\",\n  \"arn:aws:securityhub:::insight/securityhub/default/32\",\n  \"arn:aws:securityhub:::insight/securityhub/default/33\",\n  \"arn:aws:securityhub:::insight/securityhub/default/34\",\n  \"arn:aws:securityhub:::insight/securityhub/default/35\",\n  \"arn:aws:securityhub:::insight/securityhub/default/36\",\n  \"arn:aws:securityhub:::insight/securityhub/default/37\",\n  \"arn:aws:securityhub:::insight/securityhub/default/38\",\n  \"arn:aws:securityhub:::insight/securityhub/default/39\",\n  \"arn:aws:securityhub:::insight/securityhub/default/40\"\n]"
+                value_type: json
+          request.url: https://securityhub.us-east-1.amazonaws.com/insights/get
+          response.pagination:
+            - delete:
+                target: body.InsightArns
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.NextToken
+                value: '[[if (eq (.last_response.page) 0)]][["placeholder"]][[else]][[if index .last_response.body "NextToken"]][[.last_response.body.NextToken]][[end]][[end]]'
+            - delete:
+                target: body.NextToken
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: false
+                target: body.NextToken
+                value: '[[with (index .last_response.body "NextToken")]][[.]][[end]]'
+          response.split:
+            ignore_empty_value: true
+            target: body.Insights
+          tags:
+            - forwarded
+            - aws_securityhub_insights
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.securityhub_insights-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
+++ b/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
@@ -1,0 +1,11 @@
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticFederatedIdentity
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    interval: 1m
+    aws_region: us-east-1
+    tld: amazonaws.com
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-legacy-credentials.expected
+++ b/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-legacy-credentials.expected
@@ -1,0 +1,70 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws
+      name: test-httpjson-legacy-credentials-aws
+      streams:
+        - auth.aws:
+            access_key_id: ${SECRET_0}
+            secret_access_key: ${SECRET_1}
+          config_version: 2
+          data_stream:
+            dataset: aws.securityhub_insights
+          interval: 1m
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 2m
+          request.transforms:
+            - set:
+                target: body.MaxResults
+                value: 100
+                value_type: int
+            - set:
+                target: body.InsightArns
+                value: "[\n  \"arn:aws:securityhub:::insight/securityhub/default/1\",\n  \"arn:aws:securityhub:::insight/securityhub/default/10\",\n  \"arn:aws:securityhub:::insight/securityhub/default/3\",\n  \"arn:aws:securityhub:::insight/securityhub/default/14\",\n  \"arn:aws:securityhub:::insight/securityhub/default/9\",\n  \"arn:aws:securityhub:::insight/securityhub/default/6\",\n  \"arn:aws:securityhub:::insight/securityhub/default/7\",\n  \"arn:aws:securityhub:::insight/securityhub/default/8\",\n  \"arn:aws:securityhub:::insight/securityhub/default/11\",\n  \"arn:aws:securityhub:::insight/securityhub/default/12\",\n  \"arn:aws:securityhub:::insight/securityhub/default/13\",\n  \"arn:aws:securityhub:::insight/securityhub/default/16\",\n  \"arn:aws:securityhub:::insight/securityhub/default/17\",\n  \"arn:aws:securityhub:::insight/securityhub/default/18\",\n  \"arn:aws:securityhub:::insight/securityhub/default/19\",\n  \"arn:aws:securityhub:::insight/securityhub/default/21\",\n  \"arn:aws:securityhub:::insight/securityhub/default/22\",\n  \"arn:aws:securityhub:::insight/securityhub/default/23\",\n  \"arn:aws:securityhub:::insight/securityhub/default/24\",\n  \"arn:aws:securityhub:::insight/securityhub/default/25\",\n  \"arn:aws:securityhub:::insight/securityhub/default/26\",\n  \"arn:aws:securityhub:::insight/securityhub/default/27\",\n  \"arn:aws:securityhub:::insight/securityhub/default/28\",\n  \"arn:aws:securityhub:::insight/securityhub/default/29\",\n  \"arn:aws:securityhub:::insight/securityhub/default/30\",\n  \"arn:aws:securityhub:::insight/securityhub/default/31\",\n  \"arn:aws:securityhub:::insight/securityhub/default/32\",\n  \"arn:aws:securityhub:::insight/securityhub/default/33\",\n  \"arn:aws:securityhub:::insight/securityhub/default/34\",\n  \"arn:aws:securityhub:::insight/securityhub/default/35\",\n  \"arn:aws:securityhub:::insight/securityhub/default/36\",\n  \"arn:aws:securityhub:::insight/securityhub/default/37\",\n  \"arn:aws:securityhub:::insight/securityhub/default/38\",\n  \"arn:aws:securityhub:::insight/securityhub/default/39\",\n  \"arn:aws:securityhub:::insight/securityhub/default/40\"\n]"
+                value_type: json
+          request.url: https://securityhub.us-east-1.amazonaws.com/insights/get
+          response.pagination:
+            - delete:
+                target: body.InsightArns
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.NextToken
+                value: '[[if (eq (.last_response.page) 0)]][["placeholder"]][[else]][[if index .last_response.body "NextToken"]][[.last_response.body.NextToken]][[end]][[end]]'
+            - delete:
+                target: body.NextToken
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: false
+                target: body.NextToken
+                value: '[[with (index .last_response.body "NextToken")]][[.]][[end]]'
+          response.split:
+            ignore_empty_value: true
+            target: body.Insights
+          tags:
+            - forwarded
+            - aws_securityhub_insights
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.securityhub_insights-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}
+    - {}

--- a/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-legacy-credentials.yml
+++ b/packages/aws/data_stream/securityhub_insights/_dev/test/policy/test-httpjson-legacy-credentials.yml
@@ -1,0 +1,11 @@
+vars:
+  access_key_id: FAKE_AWS_ACCESS_KEY_ID_FOR_TESTS_ONLY
+  secret_access_key: FAKE_AWS_SECRET_ACCESS_KEY_FOR_TESTS_ONLY
+  default_region: us-east-1
+data_stream:
+  vars:
+    interval: 1m
+    aws_region: us-east-1
+    tld: amazonaws.com
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/securityhub_insights/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_insights/agent/stream/httpjson.yml.hbs
@@ -129,9 +129,6 @@ auth.aws:
 {{#if role_arn}}
   role_arn: {{role_arn}}
 {{/if}}
-{{#if external_id}}
-  external_id: {{external_id}}
-{{/if}}
 {{#if assume_role_duration}}
   assume_role.duration: {{assume_role_duration}}
 {{/if}}

--- a/packages/aws/data_stream/securityhub_insights/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_insights/agent/stream/httpjson.yml.hbs
@@ -17,9 +17,6 @@ request.ssl: {{ssl}}
 request.url: https://securityhub.{{aws_region}}.{{tld}}/insights/get
 request.transforms:
   - set:
-      target: header.X-Amz-Date
-      value: '[[(formatDate (now) "20060102T150405Z")]]'
-  - set:
       target: body.MaxResults
       value: 100
       value_type: int
@@ -69,10 +66,6 @@ request.transforms:
           "arn:aws:securityhub:::insight/securityhub/default/39",
           "arn:aws:securityhub:::insight/securityhub/default/40"
         ]
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/securityhub/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "securityhub")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/securityhub/aws4_request") (hash "sha256" "POST\n" "/insights/get\n" "\n" "host:securityhub.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
-{{!-- https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html --}}
 response.pagination:
   - delete:
       # Only request specific ARNs in the first request (for managed insights).
@@ -97,11 +90,6 @@ response.pagination:
       value: '[[with (index .last_response.body "NextToken")]][[.]][[end]]'
       fail_on_template_error: false
       do_not_log_failure: true
-  - delete:
-      target: header.Authorization
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/securityhub/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "securityhub")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/securityhub/aws4_request") (hash "sha256" "POST\n" "/insights/get\n" "\n" "host:securityhub.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
 response.split:
   target: body.Insights
   ignore_empty_value: true
@@ -121,4 +109,35 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
+{{/if}}
+auth.aws:
+{{#if access_key_id}}
+  access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+  secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+  session_token: {{session_token}}
+{{/if}}
+{{#if shared_credential_file}}
+  shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if credential_profile_name}}
+  credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if role_arn}}
+  role_arn: {{role_arn}}
+{{/if}}
+{{#if external_id}}
+  external_id: {{external_id}}
+{{/if}}
+{{#if assume_role_duration}}
+  assume_role.duration: {{assume_role_duration}}
+{{/if}}
+{{#if assume_role_expiry_window}}
+  assume_role.expiry_window: {{assume_role_expiry_window}}
+{{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
 {{/if}}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -965,8 +965,6 @@ policy_templates:
       - type: httpjson
         title: Collect AWS Security Hub CSPM logs via API
         description: Collecting AWS Security Hub CSPM logs via API.
-        hide_in_var_group_options:
-          credential_type: [identity_federation]
     screenshots:
       - src: /img/securityhub_cspm_findings_insights_dashboard.png
         title: Security Hub CSPM Findings and Insights dashboard screenshot

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.6.1
+format_version: 3.6.4
 name: aws
 title: AWS
 version: 7.4.0

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.5.0
+version: 7.3.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -965,6 +965,12 @@ policy_templates:
       - type: httpjson
         title: Collect AWS Security Hub CSPM logs via API
         description: Collecting AWS Security Hub CSPM logs via API.
+        provider_permissions:
+          - provider: aws
+            description: Security Hub read access for findings and insights collection.
+            permissions:
+              - name: securityhub:GetFindings
+              - name: securityhub:GetInsights
     screenshots:
       - src: /img/securityhub_cspm_findings_insights_dashboard.png
         title: Security Hub CSPM Findings and Insights dashboard screenshot

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.2.0
+version: 7.5.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.1.1
+version: 7.2.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -1017,8 +1017,6 @@ policy_templates:
       - type: httpjson
         title: Collect AWS Security Hub CSPM logs via API
         description: Collecting AWS Security Hub CSPM logs via API.
-        hide_in_var_group_options:
-          credential_type: [identity_federation]
     screenshots:
       - src: /img/securityhub_cspm_findings_insights_dashboard.png
         title: Security Hub CSPM Findings and Insights dashboard screenshot

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Enable Identity Federation (Cloud Connectors) authentication for agentless deployments.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20529
 - version: "1.3.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,7 +1,10 @@
 # newer versions go on top
-- version: "1.4.0"
+- version: "2.0.0"
   changes:
-    - description: Enable Identity Federation (Cloud Connectors) authentication for agentless deployments.
+    - description: Raise the minimum required Kibana version from 9.3.0 to 9.6.0 and add an Elastic Agent 9.6.0 floor, needed for Identity Federation (`use_cloud_connectors`) support. Deployments on older stacks cannot upgrade to 2.x; the 1.x line is reserved for backports serving older stacks.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/20529
+    - description: Enable Identity Federation (Cloud Connectors) authentication for agentless deployments. Adds var_groups credential selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, and Shared Credentials options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20529
 - version: "1.3.0"

--- a/packages/aws_securityhub/data_stream/finding/agent/stream/cel.yml.hbs
+++ b/packages/aws_securityhub/data_stream/finding/agent/stream/cel.yml.hbs
@@ -49,6 +49,9 @@ auth.aws:
 {{#if assume_role_expiry_window}}
   assume_role.expiry_window: {{assume_role_expiry_window}}
 {{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 
 state:
   batch_size: {{batch_size}}

--- a/packages/aws_securityhub/data_stream/finding/agent/stream/cel.yml.hbs
+++ b/packages/aws_securityhub/data_stream/finding/agent/stream/cel.yml.hbs
@@ -40,9 +40,6 @@ auth.aws:
 {{#if role_arn}}
   role_arn: {{role_arn}}
 {{/if}}
-{{#if external_id}}
-  external_id: {{external_id}}
-{{/if}}
 {{#if assume_role_duration}}
   assume_role.duration: {{assume_role_duration}}
 {{/if}}

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/default.yml
@@ -83,7 +83,7 @@ processors:
         - append:
             tag: append_error_message_d83dd772
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   - convert:
       field: aws_securityhub.finding.action_id
@@ -123,7 +123,7 @@ processors:
                     - append:
                         tag: append_error_message_3f03edf5
                         field: error.message
-                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_anomaly_analyses_25e26cf9
       field: aws_securityhub.finding.anomaly_analyses
@@ -152,7 +152,7 @@ processors:
                     - append:
                         tag: append_error_message_d225b162
                         field: error.message
-                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.api.response.code
       tag: convert_api_response_code_to_long_1e9cb266
@@ -166,7 +166,7 @@ processors:
         - append:
             tag: append_error_message_243ed815
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - json:
       tag: json_aws_securityhub_finding_api_request_data_c0e0d4ab
       field: aws_securityhub.finding.api.request.data
@@ -230,7 +230,7 @@ processors:
         - append:
             tag: append_error_message_053809e9
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.created_time
       tag: date_assignee_ldap_person_created_time_d05ded45
@@ -246,7 +246,7 @@ processors:
         - append:
             tag: append_error_message_7791e972
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.deleted_time_dt
       tag: date_assignee_ldap_person_deleted_time_dt_97270c4f
@@ -264,7 +264,7 @@ processors:
         - append:
             tag: append_error_message_bd84f2ff
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.deleted_time
       tag: date_assignee_ldap_person_deleted_time_454d073f
@@ -280,7 +280,7 @@ processors:
         - append:
             tag: append_error_message_a1b2f988
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.hire_time_dt
       tag: date_assignee_ldap_person_hire_time_dt_e43cf87f
@@ -298,7 +298,7 @@ processors:
         - append:
             tag: append_error_message_cc22b535
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.hire_time
       tag: date_assignee_ldap_person_hire_time_06b00e60
@@ -314,7 +314,7 @@ processors:
         - append:
             tag: append_error_message_b9a1728a
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.last_login_time_dt
       tag: date_assignee_ldap_person_last_login_time_dt_6d32ba60
@@ -332,7 +332,7 @@ processors:
         - append:
             tag: append_error_message_9add4915
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.last_login_time
       tag: date_assignee_ldap_person_last_login_time_ad9419d1
@@ -348,7 +348,7 @@ processors:
         - append:
             tag: append_error_message_31b0fdc2
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.leave_time_dt
       tag: date_assignee_ldap_person_leave_time_dt_763a6f94
@@ -366,7 +366,7 @@ processors:
         - append:
             tag: append_error_message_b9840317
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.leave_time
       tag: date_assignee_ldap_person_leave_time_7e1edc24
@@ -382,7 +382,7 @@ processors:
         - append:
             tag: append_error_message_80990fa0
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.modified_time_dt
       tag: date_assignee_ldap_person_modified_time_dt_a5519df9
@@ -400,7 +400,7 @@ processors:
         - append:
             tag: append_error_message_e070431d
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.assignee.ldap_person.modified_time
       tag: date_assignee_ldap_person_modified_time_0fe9cfaf
@@ -416,7 +416,7 @@ processors:
         - append:
             tag: append_error_message_2dfc1dae
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.assignee.risk_level_id
       tag: convert_assignee_risk_level_id_to_string_7299d73f
@@ -565,7 +565,7 @@ processors:
         - append:
             tag: append_error_message_39b6d28f
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.end_time_dt
       tag: date_end_time_dt_bb7e2cc9
@@ -583,7 +583,7 @@ processors:
         - append:
             tag: append_error_message_df5f1975
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.end_time
       tag: date_end_time_99cc5f9d
@@ -599,7 +599,7 @@ processors:
         - append:
             tag: append_error_message_b4535bb2
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_enrichments_0b1cfe1a
       field: aws_securityhub.finding.enrichments
@@ -675,7 +675,7 @@ processors:
         - append:
             tag: append_error_message_9e1142b5
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.firewall_rule.rate_limit
       tag: convert_finding_firewall_rule_rate_limit_to_long_7dc963ab
@@ -689,7 +689,7 @@ processors:
         - append:
             tag: append_error_message_007cfe57
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.impact_id
       tag: convert_finding_impact_id_to_string_a1ad0a7e
@@ -708,7 +708,7 @@ processors:
         - append:
             tag: append_error_message_32638be8
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.is_alert
       tag: convert_finding_is_alert_to_boolean_da81ec8e
@@ -722,7 +722,7 @@ processors:
         - append:
             tag: append_error_message_22c881ae
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.is_suspected_breach
       tag: convert_finding_is_suspected_breach_to_boolean_c23f4b60
@@ -736,7 +736,7 @@ processors:
         - append:
             tag: append_error_message_b9b04af0
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.malware_scan_info.end_time_dt
       tag: date_malware_scan_info_end_time_dt_983023e1
@@ -754,7 +754,7 @@ processors:
         - append:
             tag: append_error_message_a1b5e831
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.malware_scan_info.end_time
       tag: date_malware_scan_info_end_time_635e9015
@@ -770,7 +770,7 @@ processors:
         - append:
             tag: append_error_message_dd432fcc
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.malware_scan_info.num_files
       tag: convert_finding_malware_scan_info_num_files_to_long_191158d2
@@ -784,7 +784,7 @@ processors:
         - append:
             tag: append_error_message_3a9b6b8e
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.malware_scan_info.num_infected
       tag: convert_finding_malware_scan_info_num_infected_to_long_728e98c2
@@ -798,7 +798,7 @@ processors:
         - append:
             tag: append_error_message_91bcba63
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.malware_scan_info.num_volumes
       tag: convert_finding_malware_scan_info_num_volumes_to_long_430ec752
@@ -812,7 +812,7 @@ processors:
         - append:
             tag: append_error_message_3233d9f6
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.malware_scan_info.size
       tag: convert_finding_malware_scan_info_size_to_long_6822c865
@@ -826,7 +826,7 @@ processors:
         - append:
             tag: append_error_message_f784cb1f
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.malware_scan_info.start_time_dt
       tag: date_malware_scan_info_start_time_dt_71194c58
@@ -844,7 +844,7 @@ processors:
         - append:
             tag: append_error_message_f25a570f
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.malware_scan_info.start_time
       tag: date_malware_scan_info_start_time_265b4d8c
@@ -860,7 +860,7 @@ processors:
         - append:
             tag: append_error_message_6441eae6
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.malware_scan_info.type_id
       tag: convert_finding_malware_scan_info_type_id_to_string_3e8cb472
@@ -879,7 +879,7 @@ processors:
         - append:
             tag: append_error_message_74e86de9
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_observables_d0e278ae
       field: aws_securityhub.finding.observables
@@ -898,7 +898,7 @@ processors:
             - append:
                 tag: append_error_message_3d8903eb
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_observables_5c289cc1
       field: aws_securityhub.finding.observables
@@ -932,7 +932,7 @@ processors:
         - append:
             tag: append_error_message_e33f98ca
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.priority_id
       tag: convert_finding_priority_id_to_string_54006126
@@ -961,7 +961,7 @@ processors:
         - append:
             tag: append_error_message_d9fa892c
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_remediation_kb_article_list_8e3cb575
       field: aws_securityhub.finding.remediation.kb_article_list
@@ -1024,7 +1024,7 @@ processors:
             - append:
                 tag: append_error_message_67066f51
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_remediation_kb_article_list_c47b3677
       field: aws_securityhub.finding.remediation.kb_article_list
@@ -1043,7 +1043,7 @@ processors:
             - append:
                 tag: append_error_message_13d1c649
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.risk_level_id
       tag: convert_finding_risk_level_id_to_string_19696b1f
@@ -1062,7 +1062,7 @@ processors:
         - append:
             tag: append_error_message_ce4e04ab
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.severity_id
       tag: convert_finding_severity_id_to_string_d920b4ae
@@ -1085,7 +1085,7 @@ processors:
         - append:
             tag: append_error_message_df8e9357
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.start_time
       tag: date_start_time_fcc8f809
@@ -1101,7 +1101,7 @@ processors:
         - append:
             tag: append_error_message_f333c436
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.status_id
       tag: convert_finding_status_id_to_string_8281c40a
@@ -1144,7 +1144,7 @@ processors:
         - append:
             tag: append_error_message_8c6de387
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.time
       tag: date_finding_time_ff89aadb
@@ -1160,7 +1160,7 @@ processors:
         - append:
             tag: append_error_message_efb42808
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.timezone_offset
       tag: convert_finding_timezone_offset_to_long_99a59401
@@ -1174,7 +1174,7 @@ processors:
         - append:
             tag: append_error_message_3dfafd56
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.type_uid
       tag: convert_finding_type_uid_to_string_2fc1667c
@@ -1502,7 +1502,7 @@ processors:
         - append:
             tag: append_error_message_d0c2e3f7
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   # cloud.*
   - set:
@@ -1608,7 +1608,7 @@ processors:
         - append:
             tag: append_error_message_1dbb93e7
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   # result.*
   - set:
@@ -1699,7 +1699,7 @@ processors:
         - append:
             tag: append_error_message_63ad53c7
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       lang: painless
       description: Script to set event.severity and vulnerability.severity.
@@ -1729,7 +1729,7 @@ processors:
         - append:
             tag: append_error_message_f8e813ce
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   # related.*
   - append:
@@ -2047,7 +2047,7 @@ processors:
         - append:
             tag: append_error_message_11999c97
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_c8d21433
       field: aws_securityhub.finding.resources
@@ -2247,7 +2247,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_actor.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_actor.yml
@@ -15,7 +15,7 @@ processors:
         - append:
             tag: append_error_message_45f9519c
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.idp.state_id
       tag: convert_actor_idp_state_id_to_string_a2c0e83a
@@ -53,7 +53,7 @@ processors:
         - append:
             tag: append_error_message_558bfaf1
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.process.created_time
       tag: date_actor_process_created_time_b3142900
@@ -69,7 +69,7 @@ processors:
         - append:
             tag: append_error_message_f21e0c92
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.process.integrity_id
       tag: convert_actor_process_integrity_id_to_string_2a0db76f
@@ -88,7 +88,7 @@ processors:
         - append:
             tag: append_error_message_fe3084b2
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.process.pid
       tag: convert_actor_process_pid_to_long_9688ec1b
@@ -102,7 +102,7 @@ processors:
         - append:
             tag: append_error_message_f98f6b32
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.process.terminated_time_dt
       tag: date_actor_process_terminated_time_dt_3faf7e46
@@ -120,7 +120,7 @@ processors:
         - append:
             tag: append_error_message_dbb3c7ef
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.process.terminated_time
       tag: date_actor_process_terminated_time_4167e110
@@ -136,7 +136,7 @@ processors:
         - append:
             tag: append_error_message_b7c6425c
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.process.tid
       tag: convert_actor_process_tid_to_string_831f8e44
@@ -155,7 +155,7 @@ processors:
         - append:
             tag: append_error_message_54dd06dd
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.session.created_time_dt
       tag: date_actor_session_created_time_dt_7aeae993
@@ -173,7 +173,7 @@ processors:
         - append:
             tag: append_error_message_dbbab837
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.session.created_time
       tag: date_actor_session_created_time_dd156c46
@@ -189,7 +189,7 @@ processors:
         - append:
             tag: append_error_message_18b068d0
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.session.expiration_time_dt
       tag: date_actor_session_expiration_time_dt_99da3ddd
@@ -207,7 +207,7 @@ processors:
         - append:
             tag: append_error_message_76575d9b
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.actor.session.expiration_time
       tag: date_actor_session_expiration_time_a540f423
@@ -223,7 +223,7 @@ processors:
         - append:
             tag: append_error_message_94dcc170
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.session.is_mfa
       tag: convert_actor_session_is_mfa_to_boolean_fe9ab5ec
@@ -237,7 +237,7 @@ processors:
         - append:
             tag: append_error_message_f9578ac1
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.session.is_remote
       tag: convert_actor_session_is_remote_to_boolean_02c62c0c
@@ -251,7 +251,7 @@ processors:
         - append:
             tag: append_error_message_da207511
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.session.is_vpn
       tag: convert_actor_session_is_vpn_to_boolean_5ec849c2
@@ -265,7 +265,7 @@ processors:
         - append:
             tag: append_error_message_0fae2c43
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.user.has_mfa
       tag: convert_actor_user_has_mfa_to_boolean_a3b32006
@@ -279,7 +279,7 @@ processors:
         - append:
             tag: append_error_message_21c56c82
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.user.risk_level_id
       tag: convert_actor_user_risk_level_id_to_string_5ad735c9
@@ -298,7 +298,7 @@ processors:
         - append:
             tag: append_error_message_2781ed4f
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.actor.user.type_id
       tag: convert_actor_user_type_id_to_string_15e64181
@@ -311,7 +311,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_attack.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_attack.yml
@@ -99,7 +99,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_device.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_device.yml
@@ -29,7 +29,7 @@ processors:
         - append:
             tag: append_error_message_0bd0ede3
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.boot_time
       tag: date_device_boot_time_ebdf0a57
@@ -45,7 +45,7 @@ processors:
         - append:
             tag: append_error_message_74c0f2f6
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.container.size
       tag: convert_finding_device_container_size_to_long_0ce3f6a6
@@ -76,7 +76,7 @@ processors:
         - append:
             tag: append_error_message_aaf66be9
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.created_time
       tag: date_device_created_time_9d15828a
@@ -92,7 +92,7 @@ processors:
         - append:
             tag: append_error_message_01f89738
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.first_seen_time_dt
       tag: date_device_first_seen_time_dt_8b85660f
@@ -110,7 +110,7 @@ processors:
         - append:
             tag: append_error_message_207c682f
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.first_seen_time
       tag: date_device_first_seen_time_9ba54df1
@@ -126,7 +126,7 @@ processors:
         - append:
             tag: append_error_message_f9a2fe32
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.hw_info.cpu_architecture_id
       tag: convert_device_hw_info_cpu_architecture_id_to_string_37d07fdc
@@ -145,7 +145,7 @@ processors:
         - append:
             tag: append_error_message_b64f2d38
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.hw_info.cpu_cores
       tag: convert_device_hw_info_cpu_cores_to_long_8b127603
@@ -159,7 +159,7 @@ processors:
         - append:
             tag: append_error_message_e868eb80
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.hw_info.cpu_count
       tag: convert_device_hw_info_cpu_count_to_long_0c984ef3
@@ -173,7 +173,7 @@ processors:
         - append:
             tag: append_error_message_449f9961
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.hw_info.cpu_speed
       tag: convert_device_hw_info_cpu_speed_to_long_3fff0c20
@@ -187,7 +187,7 @@ processors:
         - append:
             tag: append_error_message_046b2d3d
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.hw_info.ram_size
       tag: convert_device_hw_info_ram_size_to_long_178eb107
@@ -201,7 +201,7 @@ processors:
         - append:
             tag: append_error_message_2828c4a7
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
       field: aws_securityhub.finding.device.ip
       tag: remove_empty_device_ip_22cf9224
@@ -219,7 +219,7 @@ processors:
         - append:
             tag: append_error_message_a4602cc3
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_backed_up
       tag: convert_device_is_backed_up_to_boolean_6869101a
@@ -233,7 +233,7 @@ processors:
         - append:
             tag: append_error_message_c4508f0b
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_compliant
       tag: convert_device_is_compliant_to_boolean_bafc9104
@@ -247,7 +247,7 @@ processors:
         - append:
             tag: append_error_message_fda22a74
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_managed
       tag: convert_device_is_managed_to_boolean_7ada5e44
@@ -261,7 +261,7 @@ processors:
         - append:
             tag: append_error_message_e4c4f10c
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_mobile_account_active
       tag: convert_device_is_mobile_account_active_to_boolean_b041c127
@@ -275,7 +275,7 @@ processors:
         - append:
             tag: append_error_message_ad2710bc
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_personal
       tag: convert_device_is_personal_to_boolean_5387f4b4
@@ -289,7 +289,7 @@ processors:
         - append:
             tag: append_error_message_9b63e2ef
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_shared
       tag: convert_device_is_shared_to_boolean_f88e9cff
@@ -303,7 +303,7 @@ processors:
         - append:
             tag: append_error_message_bde92a7c
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_supervised
       tag: convert_device_is_supervised_to_boolean_78aa2319
@@ -317,7 +317,7 @@ processors:
         - append:
             tag: append_error_message_95706a01
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.is_trusted
       tag: convert_device_is_trusted_to_boolean_63153bcf
@@ -331,7 +331,7 @@ processors:
         - append:
             tag: append_error_message_e32f7b76
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.last_seen_time_dt
       tag: date_device_last_seen_time_dt_72c86dfe
@@ -349,7 +349,7 @@ processors:
         - append:
             tag: append_error_message_976b03e1
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.last_seen_time
       tag: date_device_last_seen_time_fd1e1d94
@@ -365,7 +365,7 @@ processors:
         - append:
             tag: append_error_message_6e78e5d4
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.location.is_on_premises
       tag: convert_device_location_is_on_premises_to_boolean_9ad3209d
@@ -379,7 +379,7 @@ processors:
         - append:
             tag: append_error_message_86aaf8cb
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.location.lat
       tag: convert_device_location_lat_to_double_3068d7a0
@@ -393,7 +393,7 @@ processors:
         - append:
             tag: append_error_message_ae185245
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.location.long
       tag: convert_device_location_long_to_double_3adb7fc1
@@ -407,7 +407,7 @@ processors:
         - append:
             tag: append_error_message_db1f79ae
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: aws_securityhub.finding.device.location.value.lat
       copy_from: aws_securityhub.finding.device.location.lat
@@ -432,7 +432,7 @@ processors:
         - append:
             tag: append_error_message_05c4b6db
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
       field: aws_securityhub.finding.device.mac
       tag: uppercase_device_mac_0ddd5db4
@@ -446,7 +446,7 @@ processors:
         - append:
             tag: append_error_message_0b90d902
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.modified_time_dt
       tag: date_device_modified_time_dt_7ad7ae3e
@@ -464,7 +464,7 @@ processors:
         - append:
             tag: append_error_message_42df26d5
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.device.modified_time
       tag: date_device_modified_time_3e02b033
@@ -480,7 +480,7 @@ processors:
         - append:
             tag: append_error_message_98dade48
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.namespace_pid
       tag: convert_device_namespace_pid_to_long_ad4264c9
@@ -494,7 +494,7 @@ processors:
         - append:
             tag: append_error_message_461b9c87
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_device_network_interfaces_2e8ed360
       field: aws_securityhub.finding.device.network_interfaces
@@ -513,7 +513,7 @@ processors:
             - append:
                 tag: append_error_message_fc0fcaaa
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_device_network_interfaces_e094a9c0
       field: aws_securityhub.finding.device.network_interfaces
@@ -533,7 +533,7 @@ processors:
             - append:
                 tag: append_error_message_da3fa10d
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_device_network_interfaces_812a41ff
       field: aws_securityhub.finding.device.network_interfaces
@@ -551,7 +551,7 @@ processors:
             - append:
                 tag: append_error_message_dc2baaf6
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_device_network_interfaces_1a678ac9
       field: aws_securityhub.finding.device.network_interfaces
@@ -580,7 +580,7 @@ processors:
             - append:
                 tag: append_error_message_d73f2edd
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.os.cpu_bits
       tag: convert_device_os_cpu_bits_to_long_b2a3247a
@@ -594,7 +594,7 @@ processors:
         - append:
             tag: append_error_message_e47ed148
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.os.sp_ver
       tag: convert_device_os_sp_ver_to_string_a0d961c1
@@ -618,7 +618,7 @@ processors:
         - append:
             tag: append_error_message_31528448
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.owner.risk_level_id
       tag: convert_device_owner_risk_level_id_to_string_cd40032f
@@ -637,7 +637,7 @@ processors:
         - append:
             tag: append_error_message_40148eee
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.risk_level_id
       tag: convert_device_risk_level_id_to_string_5117e227
@@ -656,7 +656,7 @@ processors:
         - append:
             tag: append_error_message_81ae0ad8
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.device.type_id
       tag: convert_device_type_id_to_string_bab4e9d4
@@ -669,7 +669,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_evidence.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_evidence.yml
@@ -20,7 +20,7 @@ processors:
             - append:
                 tag: append_error_message_51a6877b
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_cf2ef4e8
       field: aws_securityhub.finding.evidences
@@ -123,7 +123,7 @@ processors:
             - append:
                 tag: append_error_message_e1751d6e
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_f1c1794b
       field: aws_securityhub.finding.evidences
@@ -142,7 +142,7 @@ processors:
             - append:
                 tag: append_error_message_9e9da0c3
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_a9f98587
       field: aws_securityhub.finding.evidences
@@ -164,7 +164,7 @@ processors:
             - append:
                 tag: append_error_message_8e2d66bc
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_6f66441c
       field: aws_securityhub.finding.evidences
@@ -184,7 +184,7 @@ processors:
             - append:
                 tag: append_error_message_d2b4be67
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_c9b3ad26
       field: aws_securityhub.finding.evidences
@@ -213,7 +213,7 @@ processors:
             - append:
                 tag: append_error_message_50de189c
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_2919e631
       field: aws_securityhub.finding.evidences
@@ -235,7 +235,7 @@ processors:
             - append:
                 tag: append_error_message_b6c6b733
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_d3cdca14
       field: aws_securityhub.finding.evidences
@@ -255,7 +255,7 @@ processors:
             - append:
                 tag: append_error_message_77c76c2e
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_731de3d9
       field: aws_securityhub.finding.evidences
@@ -277,7 +277,7 @@ processors:
             - append:
                 tag: append_error_message_912e24cd
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_ba45f2ac
       field: aws_securityhub.finding.evidences
@@ -297,7 +297,7 @@ processors:
             - append:
                 tag: append_error_message_d4857886
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_25877c82
       field: aws_securityhub.finding.evidences
@@ -316,7 +316,7 @@ processors:
             - append:
                 tag: append_error_message_904041b5
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_a055f60e
       field: aws_securityhub.finding.evidences
@@ -335,7 +335,7 @@ processors:
             - append:
                 tag: append_error_message_49dac70a
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_87841044
       field: aws_securityhub.finding.evidences
@@ -354,7 +354,7 @@ processors:
             - append:
                 tag: append_error_message_40e09c19
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_a654f27b
       field: aws_securityhub.finding.evidences
@@ -373,7 +373,7 @@ processors:
             - append:
                 tag: append_error_message_d67a143a
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_23d9a90c
       field: aws_securityhub.finding.evidences
@@ -402,7 +402,7 @@ processors:
             - append:
                 tag: append_error_message_96d5dda3
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_40de1dd4
       field: aws_securityhub.finding.evidences
@@ -431,7 +431,7 @@ processors:
             - append:
                 tag: append_error_message_8089c1f6
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_ca572291
       field: aws_securityhub.finding.evidences
@@ -470,7 +470,7 @@ processors:
             - append:
                 tag: append_error_message_4567d81a
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_037633a9
       field: aws_securityhub.finding.evidences
@@ -499,7 +499,7 @@ processors:
             - append:
                 tag: append_error_message_e353fe8d
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_8e97c021
       field: aws_securityhub.finding.evidences
@@ -518,7 +518,7 @@ processors:
             - append:
                 tag: append_error_message_f9deee40
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_6c783354
       field: aws_securityhub.finding.evidences
@@ -537,7 +537,7 @@ processors:
             - append:
                 tag: append_error_message_53776224
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_01b7c9f6
       field: aws_securityhub.finding.evidences
@@ -557,7 +557,7 @@ processors:
             - append:
                 tag: append_error_message_a5730789
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_cad9318d
       field: aws_securityhub.finding.evidences
@@ -575,7 +575,7 @@ processors:
             - append:
                 tag: append_error_message_c47cefb5
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_745067ae
       field: aws_securityhub.finding.evidences
@@ -594,7 +594,7 @@ processors:
             - append:
                 tag: append_error_message_83fbb6de
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_a7da4b28
       field: aws_securityhub.finding.evidences
@@ -613,7 +613,7 @@ processors:
             - append:
                 tag: append_error_message_d610ca56
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_1ab9f419
       field: aws_securityhub.finding.evidences
@@ -716,7 +716,7 @@ processors:
             - append:
                 tag: append_error_message_2b92ee7e
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_2b219a35
       field: aws_securityhub.finding.evidences
@@ -735,7 +735,7 @@ processors:
             - append:
                 tag: append_error_message_9c346ce3
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_304eba36
       field: aws_securityhub.finding.evidences
@@ -757,7 +757,7 @@ processors:
             - append:
                 tag: append_error_message_93b85626
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_61eb0d7f
       field: aws_securityhub.finding.evidences
@@ -777,7 +777,7 @@ processors:
             - append:
                 tag: append_error_message_47a662fe
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_evidences_3f397f69
       field: aws_securityhub.finding.evidences
@@ -825,7 +825,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_finding.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_finding.yml
@@ -24,7 +24,7 @@ processors:
         - append:
             tag: append_error_message_fa7fa741
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.finding_info.created_time
       tag: date_finding_info_created_time_ced608de
@@ -40,7 +40,7 @@ processors:
         - append:
             tag: append_error_message_5ae2c6d0
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.finding_info.first_seen_time_dt
       tag: date_finding_info_first_seen_time_dt_cc388283
@@ -58,7 +58,7 @@ processors:
         - append:
             tag: append_error_message_ac3be137
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.finding_info.first_seen_time
       tag: date_finding_info_first_seen_time_069afe7d
@@ -74,7 +74,7 @@ processors:
         - append:
             tag: append_error_message_f513d53a
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.finding_info.kill_chain.phase_id
       tag: convert_finding_info_kill_chain_phase_id_to_string_2fd9d2ab
@@ -97,7 +97,7 @@ processors:
         - append:
             tag: append_error_message_f07ec589
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.finding_info.last_seen_time
       tag: date_finding_info_last_seen_time_353bc432
@@ -113,7 +113,7 @@ processors:
         - append:
             tag: append_error_message_58c9271c
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.finding_info.modified_time_dt
       tag: date_finding_info_modified_time_dt_2a9d17c9
@@ -131,7 +131,7 @@ processors:
         - append:
             tag: append_error_message_700d4d55
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.finding_info.modified_time
       tag: date_finding_info_modified_time_0b482126
@@ -147,7 +147,7 @@ processors:
         - append:
             tag: append_error_message_ebd95230
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_finding_info_related_analytics_b9d78805
       field: aws_securityhub.finding.finding_info.related_analytics
@@ -178,7 +178,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_malware.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_malware.yml
@@ -83,7 +83,7 @@ processors:
                     - append:
                         tag: append_error_message_15f7f2d9
                         field: error.message
-                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_malware_5b850172
       field: aws_securityhub.finding.malware
@@ -111,7 +111,7 @@ processors:
                     - append:
                         tag: append_error_message_fde465b9
                         field: error.message
-                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                        value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_malware_a48cb9e3
       field: aws_securityhub.finding.malware
@@ -483,7 +483,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_metadata.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_metadata.yml
@@ -40,7 +40,7 @@ processors:
             - append:
                 tag: append_error_message_189828a1
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_metadata_data_classifications_f3ecb729
       field: aws_securityhub.finding.metadata.data_classifications
@@ -69,7 +69,7 @@ processors:
             - append:
                 tag: append_error_message_cb6021f0
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.metadata.logged_time_dt
       tag: date_metadata_logged_time_dt_0fece172
@@ -87,7 +87,7 @@ processors:
         - append:
             tag: append_error_message_b4e4c4c3
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.metadata.logged_time
       tag: date_metadata_logged_time_a3070fa8
@@ -103,7 +103,7 @@ processors:
         - append:
             tag: append_error_message_5e3157f6
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_metadata_loggers_f4e7e83f
       field: aws_securityhub.finding.metadata.loggers
@@ -189,7 +189,7 @@ processors:
         - append:
             tag: append_error_message_ea5d8909
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.metadata.modified_time
       tag: date_metadata_modified_time_9ec1cb36
@@ -205,7 +205,7 @@ processors:
         - append:
             tag: append_error_message_7483ff98
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.metadata.processed_time_dt
       tag: date_metadata_processed_time_dt_f83bf714
@@ -223,7 +223,7 @@ processors:
         - append:
             tag: append_error_message_9001c3a3
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: aws_securityhub.finding.metadata.processed_time
       tag: date_metadata_processed_time_01fe61de
@@ -239,7 +239,7 @@ processors:
         - append:
             tag: append_error_message_86a1cff2
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: aws_securityhub.finding.metadata.sequence
       tag: convert_finding_metadata_sequence_to_long_4414d3bb
@@ -253,7 +253,7 @@ processors:
         - append:
             tag: append_error_message_5b8e2cd4
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_metadata_transformation_info_list_4553a877
       field: aws_securityhub.finding.metadata.transformation_info_list
@@ -295,7 +295,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_osint.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_osint.yml
@@ -24,7 +24,7 @@ processors:
                 - append:
                     tag: append_error_message_59d15d55
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_e376f74a
       field: aws_securityhub.finding.osint
@@ -72,7 +72,7 @@ processors:
             - append:
                 tag: append_error_message_e10e9406
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_6c1fa157
       field: aws_securityhub.finding.osint
@@ -134,7 +134,7 @@ processors:
             - append:
                 tag: append_error_message_4d6da5cf
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_40b854a8
       field: aws_securityhub.finding.osint
@@ -162,7 +162,7 @@ processors:
             - append:
                 tag: append_error_message_afe1f1bd
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_57ecfa74
       field: aws_securityhub.finding.osint
@@ -200,7 +200,7 @@ processors:
             - append:
                 tag: append_error_message_5d55a4fe
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_7c48ab48
       field: aws_securityhub.finding.osint
@@ -218,7 +218,7 @@ processors:
             - append:
                 tag: append_error_message_0c4ee4e1
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_049cdcab
       field: aws_securityhub.finding.osint
@@ -242,7 +242,7 @@ processors:
                 - append:
                     tag: append_error_message_25567178
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_6f7557c2
       field: aws_securityhub.finding.osint
@@ -328,7 +328,7 @@ processors:
             - append:
                 tag: append_error_message_9822e7f2
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_e0a3cc46
       field: aws_securityhub.finding.osint
@@ -400,7 +400,7 @@ processors:
             - append:
                 tag: append_error_message_7ab0ab17
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_a4c84df6
       field: aws_securityhub.finding.osint
@@ -418,7 +418,7 @@ processors:
             - append:
                 tag: append_error_message_fadae676
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_4cba3235
       field: aws_securityhub.finding.osint
@@ -436,7 +436,7 @@ processors:
             - append:
                 tag: append_error_message_d9b547a8
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_0bd2b3e1
       field: aws_securityhub.finding.osint
@@ -498,7 +498,7 @@ processors:
             - append:
                 tag: append_error_message_070bc9f5
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_713620a8
       field: aws_securityhub.finding.osint
@@ -531,7 +531,7 @@ processors:
             - append:
                 tag: append_error_message_27eabdfd
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_4979dfdd
       field: aws_securityhub.finding.osint
@@ -549,7 +549,7 @@ processors:
             - append:
                 tag: append_error_message_33b9a4ea
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_68824284
       field: aws_securityhub.finding.osint
@@ -567,7 +567,7 @@ processors:
             - append:
                 tag: append_error_message_dc49b37b
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_80fcecb6
       field: aws_securityhub.finding.osint
@@ -605,7 +605,7 @@ processors:
                 - append:
                     tag: append_error_message_63a5d178
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_e0768186
       field: aws_securityhub.finding.osint
@@ -687,7 +687,7 @@ processors:
             - append:
                 tag: append_error_message_e8237c03
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_e3553a96
       field: aws_securityhub.finding.osint
@@ -715,7 +715,7 @@ processors:
             - append:
                 tag: append_error_message_65c50f2b
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_c1ee6418
       field: aws_securityhub.finding.osint
@@ -989,7 +989,7 @@ processors:
                 - append:
                     tag: append_error_message_0f42210d
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_37f40faf
       field: aws_securityhub.finding.osint
@@ -1012,7 +1012,7 @@ processors:
                 - append:
                     tag: append_error_message_1f09d265
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_osint_6f14ec51
       field: aws_securityhub.finding.osint
@@ -1142,7 +1142,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_resources.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_resources.yml
@@ -104,7 +104,7 @@ processors:
                 - append:
                     tag: append_error_message_31a68fb7
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_00dd5bd6
       field: aws_securityhub.finding.resources
@@ -143,7 +143,7 @@ processors:
                 - append:
                     tag: append_error_message_310b81c6
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_172456d4
       field: aws_securityhub.finding.resources
@@ -162,7 +162,7 @@ processors:
             - append:
                 tag: append_error_message_b5b64bdd
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_5c7acf12
       field: aws_securityhub.finding.resources
@@ -181,7 +181,7 @@ processors:
             - append:
                 tag: append_error_message_2ec1591c
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_7f05a5f8
       field: aws_securityhub.finding.resources
@@ -236,7 +236,7 @@ processors:
             - append:
                 tag: append_error_message_be0a0f87
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_3a441974
       field: aws_securityhub.finding.resources
@@ -255,7 +255,7 @@ processors:
             - append:
                 tag: append_error_message_42a48f4f
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_87c165a4
       field: aws_securityhub.finding.resources
@@ -308,7 +308,7 @@ processors:
             - append:
                 tag: append_error_message_be48647d
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_956405e2
       field: aws_securityhub.finding.resources
@@ -347,7 +347,7 @@ processors:
             - append:
                 tag: append_error_message_286b226e
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_5ae67ef4
       field: aws_securityhub.finding.resources
@@ -366,7 +366,7 @@ processors:
             - append:
                 tag: append_error_message_2a871e03
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_resources_40714a1e
       field: aws_securityhub.finding.resources
@@ -384,7 +384,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_vulnerabilities.yml
+++ b/packages/aws_securityhub/data_stream/finding/elasticsearch/ingest_pipeline/pipeline_object_vulnerabilities.yml
@@ -63,7 +63,7 @@ processors:
             - append:
                 tag: append_error_message_55b5b1e6
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_b0f0253e
       field: aws_securityhub.finding.vulnerabilities
@@ -115,7 +115,7 @@ processors:
             - append:
                 tag: append_error_message_a0346c25
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_a9159634
       field: aws_securityhub.finding.vulnerabilities
@@ -138,7 +138,7 @@ processors:
                 - append:
                     tag: append_error_message_ba30ba98
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_7b81a114
       field: aws_securityhub.finding.vulnerabilities
@@ -161,7 +161,7 @@ processors:
                 - append:
                     tag: append_error_message_34483c8e
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_560df44f
       field: aws_securityhub.finding.vulnerabilities
@@ -184,7 +184,7 @@ processors:
                 - append:
                     tag: append_error_message_009f2054
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_5d17cb7f
       field: aws_securityhub.finding.vulnerabilities
@@ -207,7 +207,7 @@ processors:
                 - append:
                     tag: append_error_message_19a01064
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_dbe32687
       field: aws_securityhub.finding.vulnerabilities
@@ -230,7 +230,7 @@ processors:
                 - append:
                     tag: append_error_message_c31b2f2c
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_a9c53f61
       field: aws_securityhub.finding.vulnerabilities
@@ -302,7 +302,7 @@ processors:
                 - append:
                     tag: append_error_message_66d32b53
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_b335a571
       field: aws_securityhub.finding.vulnerabilities
@@ -325,7 +325,7 @@ processors:
                 - append:
                     tag: append_error_message_e0d0b1bb
                     field: error.message
-                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                    value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_54403621
       field: aws_securityhub.finding.vulnerabilities
@@ -377,7 +377,7 @@ processors:
             - append:
                 tag: append_error_message_ec4387f2
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_e7c89798
       field: aws_securityhub.finding.vulnerabilities
@@ -507,7 +507,7 @@ processors:
             - append:
                 tag: append_error_message_7a4ed021
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_6379dfc5
       field: aws_securityhub.finding.vulnerabilities
@@ -525,7 +525,7 @@ processors:
             - append:
                 tag: append_error_message_70e568da
                 field: error.message
-                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+                value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       tag: foreach_aws_securityhub_finding_vulnerabilities_537b1c5f
       field: aws_securityhub.finding.vulnerabilities
@@ -567,7 +567,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind_72b1902f

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.5.0
+format_version: 3.6.4
 name: aws_securityhub
 title: "AWS Security Hub"
-version: 1.3.0
+version: 1.4.0
 source:
   license: "Elastic-2.0"
 description: Collect logs from AWS Security Hub with Elastic Agent.
@@ -13,9 +13,12 @@ categories:
   - vulnerability_workflow
 conditions:
   kibana:
-    version: "^9.3.0"
+    version: "^9.4.0"
   elastic:
     subscription: "basic"
+  # auth.aws support with cloud connectors in the CEL input requires Elastic Agent 9.4.0+.
+  agent:
+    version: "^9.4.0"
 icons:
   - src: /img/logo_securityhub.svg
     title: AWS Security Hub logo
@@ -26,6 +29,36 @@ screenshots:
     title: AWS Security Hub Findings Overview Dashboard
     size: 600x600
     type: image/png
+var_groups:
+  - name: credential_type
+    required: true
+    title: Setup Access
+    selector_title: Preferred method
+    options:
+      - name: identity_federation
+        title: Identity Federation
+        vars: [role_arn, external_id, supports_identity_federation]
+        hide_in_deployment_modes: [default]
+        provider: aws
+      - name: direct_access_key
+        title: Direct Access Keys
+        vars: [access_key_id, secret_access_key]
+      - name: temporary_access_key
+        title: Temporary Access Keys
+        vars: [access_key_id, secret_access_key, session_token]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role
+        title: Assume Role
+        vars: [role_arn]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role_external_id
+        title: Assume Role with External ID
+        vars: [role_arn, external_id]
+        hide_in_deployment_modes: [agentless]
+      - name: shared_credentials
+        title: Shared Credentials
+        vars: [shared_credential_file, credential_profile_name]
+        hide_in_deployment_modes: [agentless]
 policy_templates:
   - name: aws_securityhub
     title: AWS Security Hub logs
@@ -43,6 +76,13 @@ policy_templates:
       - type: cel
         title: Collect AWS Security Hub logs via API
         description: Collecting AWS Security Hub logs via API.
+        provider_permissions:
+          - provider: aws
+            description: Read access to Security Hub findings via the GetFindingsV2 API.
+            permissions:
+              # GetFindings and GetFindingsV2 both use securityhub:GetFindings in
+              # the Action element of an IAM policy statement (AWS API reference).
+              - name: securityhub:GetFindings
         vars:
           - name: access_key_id
             type: password
@@ -112,6 +152,12 @@ policy_templates:
             required: false
             show_user: false
             description: Specifies the credentials retrieved by the IAM assume-role to trigger refreshing prior to the credentials actually expiring. It is optional and can be used when `Role ARN` is configured.
+          - name: supports_identity_federation
+            type: bool
+            title: Supports Identity Federation
+            multi: false
+            required: false
+            show_user: false
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.4
 name: aws_securityhub
 title: "AWS Security Hub"
-version: 1.4.0
+version: 2.0.0
 source:
   license: "Elastic-2.0"
 description: Collect logs from AWS Security Hub with Elastic Agent.

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -13,12 +13,12 @@ categories:
   - vulnerability_workflow
 conditions:
   kibana:
-    version: "^9.4.0"
+    version: "^9.6.0"
   elastic:
     subscription: "basic"
-  # auth.aws support with cloud connectors in the CEL input requires Elastic Agent 9.4.0+.
+  # auth.aws.use_cloud_connectors (Identity Federation) requires Elastic Agent 9.6.0+.
   agent:
-    version: "^9.4.0"
+    version: "^9.6.0"
 icons:
   - src: /img/logo_securityhub.svg
     title: AWS Security Hub logo

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -29,6 +29,74 @@ screenshots:
     title: AWS Security Hub Findings Overview Dashboard
     size: 600x600
     type: image/png
+vars:
+  - name: shared_credential_file
+    type: text
+    title: Shared Credential File
+    multi: false
+    required: false
+    show_user: false
+    description: Directory of the shared credentials file. This parameter is required if we are not providing value for the parameters - `Secret Access Key` and `Access Key ID`.
+  - name: credential_profile_name
+    type: text
+    title: Credential Profile Name
+    multi: false
+    required: false
+    show_user: false
+    description: Profile name in shared credentials file.
+  - name: access_key_id
+    type: password
+    title: Access Key ID
+    secret: true
+    multi: false
+    required: false
+    show_user: false
+    description: First part of access key. This parameter along with the `Secret Access Key` parameter is required if we are not providing `Shared Credential File`.
+  - name: secret_access_key
+    type: password
+    title: Secret Access Key
+    secret: true
+    multi: false
+    required: false
+    show_user: false
+    description: Second part of access key. This parameter along with the `Access Key ID` parameter is required if we are not providing `Shared Credential File`.
+  - name: session_token
+    type: password
+    title: Session Token
+    secret: true
+    multi: false
+    required: false
+    show_user: false
+    description: Required when using temporary security credentials.
+  - name: role_arn
+    type: text
+    title: Role ARN
+    multi: false
+    required: false
+    show_user: false
+    description: AWS IAM Role to assume.
+  - name: supports_identity_federation
+    type: bool
+    title: Supports Identity Federation
+    multi: false
+    required: false
+    show_user: false
+  - name: assume_role_duration
+    type: duration
+    title: Assume Role Duration
+    multi: false
+    required: false
+    show_user: false
+    max_duration: 12h
+    min_duration: 15m
+    description: Specifies the duration of the credentials retrieved by the IAM assume-role. It is optional and can be used when `Role ARN` is configured.
+  - name: assume_role_expiry_window
+    type: duration
+    title: Assume Role Expiry Window
+    multi: false
+    required: false
+    show_user: false
+    description: Specifies the credentials retrieved by the IAM assume-role to trigger refreshing prior to the credentials actually expiring. It is optional and can be used when `Role ARN` is configured.
 var_groups:
   - name: credential_type
     required: true
@@ -81,73 +149,6 @@ policy_templates:
               # the Action element of an IAM policy statement (AWS API reference).
               - name: securityhub:GetFindings
         vars:
-          - name: access_key_id
-            type: password
-            title: Access Key ID
-            multi: false
-            required: false
-            show_user: true
-            description: First part of access key. This parameter along with the `Secret Access Key` parameter is required if we are not providing `Shared Credential File`.
-            secret: true
-          - name: secret_access_key
-            type: password
-            title: Secret Access Key
-            multi: false
-            required: false
-            show_user: true
-            description: Second part of access key. This parameter along with the `Access Key ID` parameter is required if we are not providing `Shared Credential File`.
-            secret: true
-          - name: session_token
-            type: password
-            title: Session Token
-            multi: false
-            required: false
-            show_user: true
-            description: Required when using temporary security credentials.
-            secret: true
-          - name: shared_credential_file
-            type: text
-            title: Shared Credential File
-            multi: false
-            required: false
-            show_user: false
-            description: Directory of the shared credentials file. This parameter is required if we are not providing value for the parameters - `Secret Access Key` and `Access Key ID`.
-          - name: credential_profile_name
-            type: text
-            title: Credential Profile Name
-            multi: false
-            required: false
-            show_user: false
-            description: Profile name in shared credentials file.
-          - name: role_arn
-            type: text
-            title: Role ARN
-            multi: false
-            required: false
-            show_user: false
-            description: AWS IAM Role to assume.
-          - name: assume_role_duration
-            type: duration
-            title: Assume Role Duration
-            multi: false
-            required: false
-            show_user: false
-            max_duration: 12h
-            min_duration: 15m
-            description: Specifies the duration of the credentials retrieved by the IAM assume-role. It is optional and can be used when `Role ARN` is configured.
-          - name: assume_role_expiry_window
-            type: duration
-            title: Assume Role Expiry Window
-            multi: false
-            required: false
-            show_user: false
-            description: Specifies the credentials retrieved by the IAM assume-role to trigger refreshing prior to the credentials actually expiring. It is optional and can be used when `Role ARN` is configured.
-          - name: supports_identity_federation
-            type: bool
-            title: Supports Identity Federation
-            multi: false
-            required: false
-            show_user: false
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -40,6 +40,7 @@ var_groups:
         vars: [role_arn, external_id, supports_identity_federation]
         hide_in_deployment_modes: [default]
         provider: aws
+        iac_template_url: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-federated-identity-aws-9.4.0.yml&param_ElasticResourceId=RESOURCE_ID
       - name: direct_access_key
         title: Direct Access Keys
         vars: [access_key_id, secret_access_key]

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -37,10 +37,10 @@ var_groups:
     options:
       - name: identity_federation
         title: Identity Federation
-        vars: [role_arn, external_id, supports_identity_federation]
+        vars: [role_arn, supports_identity_federation]
         hide_in_deployment_modes: [default]
         provider: aws
-        iac_template_url: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-federated-identity-aws-9.4.0.yml&param_ElasticResourceId=RESOURCE_ID
+        iac_template_url: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-federated-identity-aws-9.6.0.yml
       - name: direct_access_key
         title: Direct Access Keys
         vars: [access_key_id, secret_access_key]
@@ -51,10 +51,6 @@ var_groups:
       - name: assume_role
         title: Assume Role
         vars: [role_arn]
-        hide_in_deployment_modes: [agentless]
-      - name: assume_role_external_id
-        title: Assume Role with External ID
-        vars: [role_arn, external_id]
         hide_in_deployment_modes: [agentless]
       - name: shared_credentials
         title: Shared Credentials
@@ -130,13 +126,6 @@ policy_templates:
             required: false
             show_user: false
             description: AWS IAM Role to assume.
-          - name: external_id
-            type: text
-            title: External ID
-            multi: false
-            required: false
-            show_user: false
-            description: External ID to use when assuming a role in another account, see [the AWS documentation for use of external IDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
           - name: assume_role_duration
             type: duration
             title: Assume Role Duration


### PR DESCRIPTION
## Proposed commit message

Enable Identity Federation (Cloud Connectors) for the SecurityHub data streams in the `aws` package and the standalone `aws_securityhub` package.

**`aws` package (`securityhub_findings`, `securityhub_findings_full_posture`, `securityhub_insights`)**

Migrates the three SecurityHub HTTPJSON stream templates from hand-rolled SigV4 signing (X-Amz-Date/Authorization set transforms, including pagination re-sign) to the input's `auth.aws` configuration with `use_cloud_connectors` driven by `supports_identity_federation`. Removes the `identity_federation` gate from the securityhub policy template. Fixes silent session-token breakage — the hand-rolled path never set `X-Amz-Security-Token`.

**`aws_securityhub` standalone package**

Adds `var_groups` with the full credential selector (Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, Shared Credentials), bumps `format_version` to 3.6.4 and `kibana`/`agent` floors to `^9.6.0`, removes `external_id` per ingest-dev#9116, and fixes pipeline hygiene violations surfaced by the format_version bump.

Part of elastic/ingest-dev#8812. Supersedes #20436.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs. *(E2E validation pending — see test plan below)*
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition)
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) *(no dashboards added or changed)*

## Author's Checklist

- [x] E2E: all three `aws` SecurityHub streams validated via Identity Federation (`HEALTHY`, no `AccessDeniedException`)
- [x] E2E: `aws_securityhub` CEL stream validated via Identity Federation
- [x] elastic/cloudbeat#8030 merged and CFT published to S3 before this ships (adds `securityhub:GetFindings` + `securityhub:GetInsights` to the federated role)

## How to test this PR locally

```bash
# aws package
cd packages/aws
elastic-package check
elastic-package test policy

# aws_securityhub package
cd packages/aws_securityhub
elastic-package check
elastic-package test policy
```

For the federated path E2E:
1. Deploy elastic/cloudbeat#8030's CFT (adds `securityhub:GetFindings` + `securityhub:GetInsights` to the federated role)
2. In Fleet, create an agentless AWS integration using the **Identity Federation** credential type
3. Enable the SecurityHub CSPM policy template (`aws` package) and validate `securityhub_findings`, `securityhub_findings_full_posture`, and `securityhub_insights` all show `HEALTHY`
4. Enable the `aws_securityhub` integration and validate the CEL stream shows `HEALTHY`

## Related issues

- Relates elastic/ingest-dev#8812
- Relates elastic/ingest-dev#9116 (external_id removal)
- Companion CFT PR: elastic/cloudbeat#8030
- Supersedes #20436
- Relates #20527 (rest of the `aws` package federation)
- elastic/integrations#20895 (1.x backport branch)