### PR TITLE
amazon_security_lake: add routing test and MinIO support

### DIFF
--- a/packages/amazon_security_lake/changelog.yml
+++ b/packages/amazon_security_lake/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Add support for non-AWS S3-compatible providers via new `non_aws_bucket_name`, `endpoint`, and `path_style` configuration options.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20532
 - version: "2.8.3"
   changes:
     - description: Use ECS definitions for email.attachments and threat.enrichments.

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/scripts/routed_data_streams.txt
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/scripts/routed_data_streams.txt
@@ -1,0 +1,89 @@
+# Verify that events from the event data stream are routed to OCSF-category-specific
+# data streams via routing rules.
+#
+# The test data in MinIO provides one event per OCSF category_uid value (1–6),
+# derived from the pipeline test fixtures:
+#   - category_uid 1  → amazon_security_lake.system_activity (rerouted)
+#   - category_uid 2  → amazon_security_lake.findings (rerouted)
+#   - category_uid 3  → amazon_security_lake.iam (rerouted)
+#   - category_uid 4  → amazon_security_lake.network_activity (rerouted)
+#   - category_uid 5  → amazon_security_lake.discovery (rerouted)
+#   - category_uid 6  → amazon_security_lake.application_activity (rerouted)
+#
+# The aws-s3 input decodes files as Parquet. The test data is a minimal
+# Parquet file (6 rows, one per OCSF category_uid) stored base64-encoded
+# in testdata/events.parquet.b64 and decoded at MinIO startup.
+
+[!external_stack] skip 'Skipping external stack test.'
+
+# Connect to the running stack.
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+
+# Install an agent.
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+
+# Start MinIO with the test data pre-loaded.
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} asl-minio
+
+# Add the package resources.
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+
+# Add the data stream policy reading from MinIO.
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml EVENT_DS
+
+# Each OCSF category should route to its own data stream.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.system_activity-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.findings-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.iam-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.network_activity-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.discovery-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.application_activity-*
+
+# Clean up.
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${EVENT_DS}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down asl-minio
+
+-- test_config.yaml --
+input: aws-s3
+data_stream:
+  vars:
+    collect_s3_logs: true
+    non_aws_bucket_name: test-bucket
+    endpoint: http://svc-asl-minio:9000
+    path_style: true
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    region: us-east-1
+    interval: 10s
+    preserve_original_event: false
+
+-- asl-minio/docker-compose.yml --
+services:
+  asl-minio:
+    image: minio/minio:RELEASE.2024-06-13T22-53-53Z
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        minio server /data &
+        MINIO_PID=$$!
+        until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done
+        mc alias set local http://localhost:9000 minioadmin minioadmin
+        mc mb local/test-bucket
+        base64 -d /testdata/events.parquet.b64 > /tmp/events.parquet
+        mc cp /tmp/events.parquet local/test-bucket/amazon-security-lake/events.parquet
+        wait $$MINIO_PID
+    healthcheck:
+      test: ["CMD-SHELL", "mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 && mc stat local/test-bucket/amazon-security-lake/events.parquet >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - ./testdata:/testdata:ro
+
+-- asl-minio/testdata/events.parquet.b64 --
+UEFSMRUEFWAVSEwVDBUAEgAAMAQBAAkBAAIJBwQAAw0IAAQNCDwFAAAAAAAAAAYAAAAAAAAAFQAVFhUaLBUMFRAVBhUGHBgIBgAAAAAAAAAYCAEAAAAAAAAAFgAoCAYAAAAAAAAAGAgBAAAAAAAAABERAAAACygCAAAADAEDA4jGAhUEGSw1ABgGc2NoZW1hFQIAFQQlAhgMY2F0ZWdvcnlfdWlkABYMGRwZHCYAHBUEGTUABhAZGAxjYXRlZ29yeV91aWQVAhYMFpACFvwBJmwmCBwYCAYAAAAAAAAAGAgBAAAAAAAAABYAKAgGAAAAAAAAABgIAQAAAAAAAAAREQAZLBUEFQAVAgAVABUQFQIAPCkGGSYADAAAABaQAhYMJggW/AEAGRwYDEFSUk9XOnNjaGVtYRjAAS8vLy8vNGdBQUFBUUFBQUFBQUFLQUF3QUJnQUZBQWdBQ2dBQUFBQUJCQUFNQUFBQUNBQUlBQUFBQkFBSUFBQUFCQUFBQUFFQUFBQVVBQUFBRUFBVUFBZ0FCZ0FIQUF3QUFBQVFBQkFBQUFBQUFBRUNFQUFBQUNnQUFBQUVBQUFBQUFBQUFBd0FBQUJqWVhSbFoyOXllVjkxYVdRQUFBQUFDQUFNQUFnQUJ3QUlBQUFBQUFBQUFVQUFBQUFBQUFBQQAYIHBhcnF1ZXQtY3BwLWFycm93IHZlcnNpb24gMjUuMC4wGRwcAAAAoAEAAFBBUjE=

--- a/packages/amazon_security_lake/data_stream/event/_dev/test/scripts/routed_data_streams.txt
+++ b/packages/amazon_security_lake/data_stream/event/_dev/test/scripts/routed_data_streams.txt
@@ -31,13 +31,16 @@ add_package -profile ${CONFIG_PROFILES}/${PROFILE}
 # Add the data stream policy reading from MinIO.
 add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml EVENT_DS
 
-# Each OCSF category should route to its own data stream.
-get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.system_activity-*
-get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.findings-*
-get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.iam-*
-get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.network_activity-*
-get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.discovery-*
-get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 30s -timeout 5m logs-amazon_security_lake.application_activity-*
+# Wait for all routed docs to arrive, then confirm the total holds.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 6 -confirm 5s -timeout 5m logs-amazon_security_lake.system_activity-*,logs-amazon_security_lake.findings-*,logs-amazon_security_lake.iam-*,logs-amazon_security_lake.network_activity-*,logs-amazon_security_lake.discovery-*,logs-amazon_security_lake.application_activity-*
+
+# Each destination got its one document (docs already indexed, these return immediately).
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 0 -timeout 30s logs-amazon_security_lake.system_activity-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 0 -timeout 30s logs-amazon_security_lake.findings-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 0 -timeout 30s logs-amazon_security_lake.iam-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 0 -timeout 30s logs-amazon_security_lake.network_activity-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 0 -timeout 30s logs-amazon_security_lake.discovery-*
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 0 -timeout 30s logs-amazon_security_lake.application_activity-*
 
 # Clean up.
 remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${EVENT_DS}

--- a/packages/amazon_security_lake/data_stream/event/agent/stream/aws-s3.yml.hbs
+++ b/packages/amazon_security_lake/data_stream/event/agent/stream/aws-s3.yml.hbs
@@ -4,6 +4,11 @@
 bucket_arn: {{bucket_arn}}
 {{else if access_point_arn}}
 access_point_arn: {{access_point_arn}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{#if region}}
+region: {{region}}
 {{/if}}
 {{#if interval}}
 bucket_list_interval: {{interval}}
@@ -36,10 +41,6 @@ api_timeout: {{api_timeout}}
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
-{{#if file_selectors}}
-file_selectors:
-{{file_selectors}}
-{{/if}}
 
 {{/if}}
 
@@ -71,6 +72,16 @@ external_id: {{external_id}}
 {{/if}}
 {{#if default_region}}
 default_region: {{default_region}}
+{{/if}}
+{{#if endpoint}}
+endpoint: {{endpoint}}
+{{/if}}
+{{#if path_style}}
+path_style: {{path_style}}
+{{/if}}
+{{#if file_selectors}}
+file_selectors:
+{{file_selectors}}
 {{/if}}
 decoding.codec.parquet.enabled: true
 {{#if decoding_batch_size}}

--- a/packages/amazon_security_lake/data_stream/event/manifest.yml
+++ b/packages/amazon_security_lake/data_stream/event/manifest.yml
@@ -145,7 +145,7 @@ streams:
         description: Deprecated in agent version 8.16.0, this parameter is ignored if present, use number_of_workers instead. The maximum number of SQS messages that can be inflight at any time.
       - name: file_selectors
         type: yaml
-        title: "[SQS] File Selectors"
+        title: "File Selectors"
         multi: false
         required: false
         show_user: false
@@ -153,7 +153,7 @@ streams:
         default: "# Example: if you want to consume events that contain 'CloudTrail' in the S3 object key and apply parquet decoding to the events.\n# - regex: '/CloudTrail/'\n#   decoding.codec.parquet.enabled: true\n#   decoding.codec.parquet.batch_size: 100\n#   decoding.codec.parquet.process_parallel: true    \n"
       - name: region
         type: text
-        title: "[SQS] Region"
+        title: "Region"
         multi: false
         required: false
         show_user: true

--- a/packages/amazon_security_lake/data_stream/event/manifest.yml
+++ b/packages/amazon_security_lake/data_stream/event/manifest.yml
@@ -69,6 +69,13 @@ streams:
         required: false
         show_user: true
         description: ARN of the AWS S3 Access Point that will be polled for list operation. Mandatory if the "Collect logs via S3 Bucket" switch is on. It is a required parameter for collecting logs via the AWS S3 Bucket unless you set a Bucket ARN.
+      - name: non_aws_bucket_name
+        type: text
+        title: "[S3] Non-AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: false
+        description: Name of the S3-compatible bucket for 3rd-party providers. Required when not using `bucket_arn` or `access_point_arn`.
       - name: bucket_list_prefix
         type: text
         title: "[S3] Bucket Prefix"
@@ -252,6 +259,20 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: endpoint
+        type: text
+        title: Endpoint
+        multi: false
+        required: false
+        show_user: false
+        description: URL of the endpoint for 3rd-party S3-compatible services such as MinIO. Not required when using AWS S3.
+      - name: path_style
+        type: bool
+        title: Path Style
+        multi: false
+        required: false
+        show_user: false
+        description: Sets the bucket name as a path rather than a subdomain. Required for MinIO and similar non-AWS S3 providers.
       - name: ssl
         type: yaml
         title: SSL Configuration

--- a/packages/amazon_security_lake/manifest.yml
+++ b/packages/amazon_security_lake/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: amazon_security_lake
 title: Amazon Security Lake
-version: "2.8.3"
+version: "2.9.0"
 description: Collect logs from Amazon Security Lake with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
amazon_security_lake: add routing test and MinIO support

Adds a routing test that verifies each OCSF category_uid value (1–6)
routes to the correct target data stream after the ingest pipeline
converts category_uid from integer to string.

The test uses MinIO as an S3-compatible server. To support MinIO (and
other non-AWS S3 providers), the manifest and aws-s3 template are
extended with three optional variables: non_aws_bucket_name, endpoint,
and path_style. Region is also made available in S3 polling mode
(previously it was only used in SQS mode).

The test data is a minimal pre-generated Parquet file (6 rows, one per
OCSF category_uid) stored base64-encoded in testdata/events.parquet.b64
and decoded into MinIO at startup. This exercises the parquet codec
without any changes to the package manifest.

The docker-compose healthcheck verifies the test object exists in MinIO
(via mc stat) before returning, ensuring the agent always finds data on
its first poll. All stream-level variables are placed under
data_stream.vars: in test_config.yaml, matching how Fleet applies them
to the data stream policy.

Test events are drawn from the existing pipeline test fixtures that are
already validated against the ingest pipeline.

Each record is taken verbatim from the first line of the corresponding
category-specific pipeline test fixture:

  data_stream/event/_dev/test/pipeline/test-system-activity.log
  data_stream/event/_dev/test/pipeline/test-findings.log
  data_stream/event/_dev/test/pipeline/test-iam.log
  data_stream/event/_dev/test/pipeline/test-network-activity.log
  data_stream/event/_dev/test/pipeline/test-discovery.log
  data_stream/event/_dev/test/pipeline/test-application-activity.log
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #20458

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
