### PR TITLE
backport_branch: remove stale files before syncing directories from main

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -145,6 +145,7 @@ updateBackportBranchContents() {
 
   git checkout "$BACKPORT_BRANCH_NAME"
   echo "--- Copying $BUILDKITE_FOLDER_PATH from $SOURCE_BRANCH..."
+  echo "Deleting first ${BUILDKITE_FOLDER_PATH} folder"
   git rm -r --cached "${BUILDKITE_FOLDER_PATH}" 2>/dev/null || true
   git checkout $SOURCE_BRANCH -- $BUILDKITE_FOLDER_PATH
   git add $BUILDKITE_FOLDER_PATH
@@ -166,6 +167,7 @@ updateBackportBranchContents() {
 
   if git ls-tree -d --name-only main:${DEV_FOLDER} > /dev/null 2>&1 ; then
     echo "--- Copying $DEV_FOLDER from $SOURCE_BRANCH..."
+    echo "Deleting first ${DEV_FOLDER} folder"
     git rm -r --cached "${DEV_FOLDER}" 2>/dev/null || true
     git checkout "$SOURCE_BRANCH" -- "${DEV_FOLDER}"
     git add "${DEV_FOLDER}"
@@ -185,6 +187,7 @@ updateBackportBranchContents() {
     # > error: GH013: Repository rule violations found for ...
     # > refusing to allow a GitHub App to create or update workflow `.github/workflows/bump-elastic-stack-version.yml` without `workflows` permission
     echo "--- Copying .github/workflows from $SOURCE_BRANCH..."
+    echo "Deleting first .github/workflows folder"
     git rm -r --cached ".github/workflows" 2>/dev/null || true
     git checkout "$SOURCE_BRANCH" -- ".github/workflows"
     git add .github/workflows

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -145,7 +145,6 @@ updateBackportBranchContents() {
 
   git checkout "$BACKPORT_BRANCH_NAME"
   echo "--- Copying $BUILDKITE_FOLDER_PATH from $SOURCE_BRANCH..."
-  echo "Deleting first ${BUILDKITE_FOLDER_PATH} folder"
   git rm -r --cached "${BUILDKITE_FOLDER_PATH}" 2>/dev/null || true
   git checkout $SOURCE_BRANCH -- $BUILDKITE_FOLDER_PATH
   git add $BUILDKITE_FOLDER_PATH
@@ -167,7 +166,6 @@ updateBackportBranchContents() {
 
   if git ls-tree -d --name-only main:${DEV_FOLDER} > /dev/null 2>&1 ; then
     echo "--- Copying $DEV_FOLDER from $SOURCE_BRANCH..."
-    echo "Deleting first ${DEV_FOLDER} folder"
     git rm -r --cached "${DEV_FOLDER}" 2>/dev/null || true
     git checkout "$SOURCE_BRANCH" -- "${DEV_FOLDER}"
     git add "${DEV_FOLDER}"
@@ -187,7 +185,6 @@ updateBackportBranchContents() {
     # > error: GH013: Repository rule violations found for ...
     # > refusing to allow a GitHub App to create or update workflow `.github/workflows/bump-elastic-stack-version.yml` without `workflows` permission
     echo "--- Copying .github/workflows from $SOURCE_BRANCH..."
-    echo "Deleting first .github/workflows folder"
     git rm -r --cached ".github/workflows" 2>/dev/null || true
     git checkout "$SOURCE_BRANCH" -- ".github/workflows"
     git add .github/workflows

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -145,6 +145,7 @@ updateBackportBranchContents() {
 
   git checkout "$BACKPORT_BRANCH_NAME"
   echo "--- Copying $BUILDKITE_FOLDER_PATH from $SOURCE_BRANCH..."
+  git rm -r --cached "${BUILDKITE_FOLDER_PATH}" 2>/dev/null || true
   git checkout $SOURCE_BRANCH -- $BUILDKITE_FOLDER_PATH
   git add $BUILDKITE_FOLDER_PATH
 
@@ -165,6 +166,7 @@ updateBackportBranchContents() {
 
   if git ls-tree -d --name-only main:${DEV_FOLDER} > /dev/null 2>&1 ; then
     echo "--- Copying $DEV_FOLDER from $SOURCE_BRANCH..."
+    git rm -r --cached "${DEV_FOLDER}" 2>/dev/null || true
     git checkout "$SOURCE_BRANCH" -- "${DEV_FOLDER}"
     git add "${DEV_FOLDER}"
 
@@ -183,6 +185,7 @@ updateBackportBranchContents() {
     # > error: GH013: Repository rule violations found for ...
     # > refusing to allow a GitHub App to create or update workflow `.github/workflows/bump-elastic-stack-version.yml` without `workflows` permission
     echo "--- Copying .github/workflows from $SOURCE_BRANCH..."
+    git rm -r --cached ".github/workflows" 2>/dev/null || true
     git checkout "$SOURCE_BRANCH" -- ".github/workflows"
     git add .github/workflows
 


### PR DESCRIPTION

## Proposed commit message

```
backport_branch: remove stale files before syncing directories from main

`git checkout <branch> -- <dir>` only adds or updates files that exist
in the source branch. It does NOT remove files from the current branch
that have been deleted from the source branch since the backport branch
was created.

This means that if a file under `.buildkite`, `dev`, or
`.github/workflows` was deleted from \`main\` after a backport branch was
forked, that stale file would remain in the backport branch even after
the sync step ran.

Fix: call `git rm -r --cached <dir>` before each `git checkout` to
clear the index entries for that directory first. This ensures the
backport branch ends up as an exact mirror of `main` for those
directories, including any deletions.

Note: the `.ci` directory was already handled correctly with an explicit
removal step and is unchanged.
```

## Author's Checklist

- [x] Trigger the `backport_branch` Buildkite pipeline with a dry run to confirm no stale files remain after the sync step. https://buildkite.com/elastic/integrations-backport/builds/319

## Related issues

- Relates https://github.com/elastic/integrations/issues/19262

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).