### PR TITLE
Add group field to nginx packages

### DIFF
--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "3.2.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20544
 - version: "3.2.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,9 +1,10 @@
 format_version: "3.0.2"
 name: nginx
 title: Nginx
-version: "3.2.1"
+version: "3.2.2"
 description: Collect access logs, error logs, and stub_status metrics from Nginx via Elastic Agent.
 type: integration
+group: nginx
 categories:
   - web
   - observability

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20544
 - version: "1.14.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.14.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,9 +1,10 @@
 format_version: 3.0.4
 name: nginx_ingress_controller
 title: "Nginx Ingress Controller (Kubernetes)"
-version: 1.14.1
+version: 1.14.2
 description: Collect access and error logs from nginx-ingress pods. Use this instead of the standard Nginx integration when running the Kubernetes ingress controller.
 type: integration
+group: nginx
 categories:
   - observability
   - containers

--- a/packages/nginx_ingress_controller_otel/changelog.yml
+++ b/packages/nginx_ingress_controller_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.1"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.4.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/nginx_ingress_controller_otel/changelog.yml
+++ b/packages/nginx_ingress_controller_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20544
 - version: "0.4.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/nginx_ingress_controller_otel/manifest.yml
+++ b/packages/nginx_ingress_controller_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: nginx_ingress_controller_otel
 title: Nginx Ingress Controller OpenTelemetry Logs
-version: 0.4.0
+version: 0.4.1
 source:
   license: "Elastic-2.0"
 description: Collect Nginx Ingress Controller logs using the OpenTelemetry collector.
 type: content
+group: nginx
 categories:
   - observability
   - containers

--- a/packages/nginx_input_otel/changelog.yml
+++ b/packages/nginx_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20544
 - version: "0.2.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/nginx_input_otel/changelog.yml
+++ b/packages/nginx_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.2.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/nginx_input_otel/manifest.yml
+++ b/packages/nginx_input_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: nginx_otel_input
 title: "Nginx (OpenTelemetry)"
-version: 0.2.1
+version: 0.2.2
 source:
   license: "Elastic-2.0"
 description: "Collect Nginx metrics via the OTel nginxreceiver."
 type: input
+group: nginx
 categories:
   - web
   - observability

--- a/packages/nginx_otel/changelog.yml
+++ b/packages/nginx_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20544
 - version: "0.6.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/nginx_otel/changelog.yml
+++ b/packages/nginx_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.6.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/nginx_otel/manifest.yml
+++ b/packages/nginx_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.5
 name: nginx_otel
 title: "NGINX OpenTelemetry Assets"
-version: 0.6.0
+version: 0.6.1
 source:
   license: "Elastic-2.0"
 description: "NGINX Assets from OpenTelemetry Collector"
 type: content
+group: nginx
 categories:
   - observability
   - web


### PR DESCRIPTION
## Proposed commit message

Add `group: nginx` to the manifest of all nginx-related packages: `nginx`, `nginx_ingress_controller`, `nginx_ingress_controller_otel`, `nginx_otel`, `nginx_input_otel`.

**WHAT:** Adds a `group` field to each package's `manifest.yml`, immediately after the `type` field, with the value `nginx`. Each package receives a patch version bump and a corresponding changelog entry.

**WHY:** The Kibana UI uses the `group` field to display related packages as a unified technology tile, allowing users to discover and install the full nginx observability stack from a single entry point.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Verify `group: nginx` appears in all 5 package manifests.
- [ ] Verify the Kibana UI renders the nginx technology tile correctly grouping all packages.

## How to test this PR locally

Start a local registry (v1.40.0) pointing at this branch using `elastic-package` v0.126.0 and query each package:

```
elastic-package stack up
```

Requires `elastic-package` v0.126.0, which starts the registry at v1.40.0.

```
GET https://localhost:8080/search?package=nginx
GET https://localhost:8080/search?package=nginx_ingress_controller
GET https://localhost:8080/search?package=nginx_ingress_controller_otel
GET https://localhost:8080/search?package=nginx_otel
GET https://localhost:8080/search?package=nginx_input_otel
```

Each response should contain `"group": "nginx"`. Example:

```
GET https://localhost:8080/search?package=nginx
```

```json
{
  "name": "nginx",
  "version": "3.2.2",
  "type": "integration",
  "group": "nginx"
}
```

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/8085

## Screenshots

<!-- Add Kibana UI screenshot of the nginx technology tile once available. -->