### PR TITLE
Add group field to prometheus packages

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20546
 - version: "1.24.3"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.4"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.24.3"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,9 +1,10 @@
 format_version: "3.3.0"
 name: prometheus
 title: Prometheus
-version: 1.24.3
+version: 1.24.4
 description: Scrape Prometheus-format metrics from exporters, query the Prometheus API, or receive remote_write data via Elastic Agent.
 type: integration
+group: prometheus
 categories:
   - observability
   - monitoring

--- a/packages/prometheus_input/changelog.yml
+++ b/packages/prometheus_input/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20546
 - version: "1.0.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus_input/changelog.yml
+++ b/packages/prometheus_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.0.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus_input/manifest.yml
+++ b/packages/prometheus_input/manifest.yml
@@ -1,9 +1,10 @@
 format_version: "3.0.2"
 name: prometheus_input
 title: "Prometheus (Kubernetes)"
-version: "1.0.1"
+version: "1.0.2"
 description: "Scrape Prometheus-format metrics via Elastic Agent with Kubernetes leader election support."
 type: input
+group: prometheus
 categories:
   - monitoring
   - containers

--- a/packages/prometheus_input_otel/changelog.yml
+++ b/packages/prometheus_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus_input_otel/changelog.yml
+++ b/packages/prometheus_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20546
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus_input_otel/manifest.yml
+++ b/packages/prometheus_input_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: prometheus_input_otel
 title: "Prometheus Scrape via OTel (Guided)"
-version: 0.1.1
+version: 0.1.2
 source:
   license: "Elastic-2.0"
 description: "Scrape Prometheus-format metrics via the OTel Collector with guided HTTPS/TLS/auth configuration."
 type: input
+group: prometheus
 categories:
   - monitoring
   - observability

--- a/packages/prometheus_input_otel_raw/changelog.yml
+++ b/packages/prometheus_input_otel_raw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus_input_otel_raw/changelog.yml
+++ b/packages/prometheus_input_otel_raw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20546
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/prometheus_input_otel_raw/manifest.yml
+++ b/packages/prometheus_input_otel_raw/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: prometheus_input_otel_raw
 title: "Prometheus Scrape via OTel (Custom Config)"
-version: 0.1.1
+version: 0.1.2
 source:
   license: "Elastic-2.0"
 description: "Scrape Prometheus-format metrics via the OTel Collector using your own prometheus.yml scrape_configs."
 type: input
+group: prometheus
 categories:
   - monitoring
   - observability


### PR DESCRIPTION
## Proposed commit message

Add `group: prometheus` to the manifest of all prometheus-related packages: `prometheus`, `prometheus_input`, `prometheus_input_otel`, `prometheus_input_otel_raw`.

**WHAT:** Adds a `group` field to each package's `manifest.yml`, immediately after the `type` field, with the value `prometheus`. Each package receives a patch version bump and a corresponding changelog entry.

**WHY:** The Kibana UI uses the `group` field to display related packages as a unified technology tile, allowing users to discover and install the full prometheus observability stack from a single entry point.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Verify `group: prometheus` appears in all 4 package manifests.
- [ ] Verify the Kibana UI renders the prometheus technology tile correctly grouping all packages.

## How to test this PR locally

Start a local registry (v1.40.0) pointing at this branch using `elastic-package` v0.126.0 and query each package:

```
elastic-package stack up
```

Requires `elastic-package` v0.126.0, which starts the registry at v1.40.0.

```
GET https://localhost:8080/search?package=prometheus
GET https://localhost:8080/search?package=prometheus_input
GET https://localhost:8080/search?package=prometheus_input_otel
GET https://localhost:8080/search?package=prometheus_input_otel_raw
```

Each response should contain `"group": "prometheus"`. Example:

```
GET https://localhost:8080/search?package=prometheus
```

```json
{
  "name": "prometheus",
  "version": "1.24.4",
  "type": "integration",
  "group": "prometheus"
}
```

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/8085

## Screenshots

<!-- Add Kibana UI screenshot of the prometheus technology tile once available. -->