### PR TITLE
Add group field to mysql packages

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.30.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20547
 - version: "1.30.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,9 +1,10 @@
 format_version: "3.4.0"
 name: mysql
 title: MySQL
-version: "1.30.1"
+version: "1.30.2"
 description: Collect error logs, slow logs, and performance metrics from MySQL via Elastic Agent.
 type: integration
+group: mysql
 categories:
   - datastore
   - observability

--- a/packages/mysql_enterprise/changelog.yml
+++ b/packages/mysql_enterprise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.17.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/mysql_enterprise/changelog.yml
+++ b/packages/mysql_enterprise/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20547
 - version: "1.17.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/mysql_enterprise/manifest.yml
+++ b/packages/mysql_enterprise/manifest.yml
@@ -1,9 +1,10 @@
 format_version: "3.0.0"
 name: mysql_enterprise
 title: "MySQL Enterprise (Audit Logs)"
-version: "1.17.1"
+version: "1.17.2"
 description: Collect MySQL Enterprise audit logs for security monitoring.
 type: integration
+group: mysql
 categories:
   - security
   # Added observability category as MySQL Enterprise integration collects audit logs which are essential for monitoring and observability

--- a/packages/mysql_input_otel/changelog.yml
+++ b/packages/mysql_input_otel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.3"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.2.2"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/mysql_input_otel/changelog.yml
+++ b/packages/mysql_input_otel/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20547
 - version: "0.2.2"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/mysql_input_otel/manifest.yml
+++ b/packages/mysql_input_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.6.0
 name: mysql_input_otel
 title: "MySQL (OpenTelemetry)"
-version: 0.2.2
+version: 0.2.3
 source:
   license: "Elastic-2.0"
 description: "Collect MySQL performance metrics and query samples via the OTel mysqlreceiver."
 type: input
+group: mysql
 categories:
   - datastore
   - observability

--- a/packages/mysql_otel/changelog.yml
+++ b/packages/mysql_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.6.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/mysql_otel/changelog.yml
+++ b/packages/mysql_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20547
 - version: "0.6.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/mysql_otel/manifest.yml
+++ b/packages/mysql_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.5
 name: mysql_otel
 title: MySQL OpenTelemetry Assets
-version: 0.6.0
+version: 0.6.1
 source:
   license: "Elastic-2.0"
 description: "MySQL Assets for OpenTelemetry Collector"
 type: content
+group: mysql
 categories:
   - datastore
   - observability


### PR DESCRIPTION
## Proposed commit message

Add `group: mysql` to the manifest of all mysql-related packages: `mysql`, `mysql_enterprise`, `mysql_input_otel`, `mysql_otel`.

**WHAT:** Adds a `group` field to each package's `manifest.yml`, immediately after the `type` field, with the value `mysql`. Each package receives a patch version bump and a corresponding changelog entry.

**WHY:** The Kibana UI uses the `group` field to display related packages as a unified technology tile, allowing users to discover and install the full mysql observability stack from a single entry point.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Verify `group: mysql` appears in all 4 package manifests.
- [ ] Verify the Kibana UI renders the mysql technology tile correctly grouping all packages.

## How to test this PR locally

Start a local registry (v1.40.0) pointing at this branch using `elastic-package` v0.126.0 and query each package:

```
elastic-package stack up
```

Requires `elastic-package` v0.126.0, which starts the registry at v1.40.0.

```
GET https://localhost:8080/search?package=mysql
GET https://localhost:8080/search?package=mysql_enterprise
GET https://localhost:8080/search?package=mysql_input_otel
GET https://localhost:8080/search?package=mysql_otel
```

Each response should contain `"group": "mysql"`. Example:

```
GET https://localhost:8080/search?package=mysql
```

```json
{
  "name": "mysql",
  "version": "1.30.2",
  "type": "integration",
  "group": "mysql"
}
```

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/8085

## Screenshots

<!-- Add Kibana UI screenshot of the mysql technology tile once available. -->