### PR TITLE
Add group field to kafka packages

### DIFF
--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20548
 - version: "1.27.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.27.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,9 +1,10 @@
 format_version: "3.0.2"
 name: kafka
 title: Kafka
-version: "1.27.1"
+version: "1.27.2"
 description: Monitor Kafka broker health - logs and metrics via Jolokia JMX and Elastic Agent.
 type: integration
+group: kafka
 categories:
   - stream_processing
   - observability

--- a/packages/kafka_connect/changelog.yml
+++ b/packages/kafka_connect/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.1.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka_connect/changelog.yml
+++ b/packages/kafka_connect/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20548
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka_connect/manifest.yml
+++ b/packages/kafka_connect/manifest.yml
@@ -1,8 +1,9 @@
 name: kafka_connect
 title: Kafka Connect
-version: "0.1.1"
+version: "0.1.2"
 description: Collect metrics from Kafka Connect instances via Jolokia JMX.
 type: integration
+group: kafka
 icons:
   - src: /img/kafka-connect.svg
     title: Kafka Connect

--- a/packages/kafka_input_otel/changelog.yml
+++ b/packages/kafka_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka_input_otel/changelog.yml
+++ b/packages/kafka_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20548
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka_input_otel/manifest.yml
+++ b/packages/kafka_input_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.6.0
 name: kafka_input_otel
 title: "Kafka Consumer (OpenTelemetry)"
-version: 0.1.1
+version: 0.1.2
 source:
   license: "Elastic-2.0"
 description: "Consume logs, metrics, and traces from Kafka topics via the OTel Collector. Use this to ingest OTLP-format telemetry routed through Kafka."
 type: input
+group: kafka
 categories:
   - message_queue
   - observability

--- a/packages/kafka_log/changelog.yml
+++ b/packages/kafka_log/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.1.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "2.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka_log/changelog.yml
+++ b/packages/kafka_log/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20548
 - version: "2.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/kafka_log/manifest.yml
+++ b/packages/kafka_log/manifest.yml
@@ -3,7 +3,8 @@ name: kafka_log
 title: Kafka Log Consumer
 description: Consume log data from Kafka topics via Elastic Agent. Use this to route existing Kafka log streams into Elasticsearch.
 type: input
-version: "2.1.1"
+group: kafka
+version: "2.1.2"
 conditions:
   kibana:
     version: "^8.13.0 || ^9.0.0"

--- a/packages/kafka_otel/changelog.yml
+++ b/packages/kafka_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/kafka_otel/changelog.yml
+++ b/packages/kafka_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20548
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/kafka_otel/manifest.yml
+++ b/packages/kafka_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: kafka_otel
 title: "Kafka OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Kafka Assets for OpenTelemetry Collector"
 type: content
+group: kafka
 categories:
   - observability
   - message_queue


### PR DESCRIPTION
## Proposed commit message

Add `group: kafka` to the manifest of all kafka-related packages: `kafka`, `kafka_connect`, `kafka_input_otel`, `kafka_log`, `kafka_otel`.

**WHAT:** Adds a `group` field to each package's `manifest.yml`, immediately after the `type` field, with the value `kafka`. Each package receives a patch version bump and a corresponding changelog entry.

**WHY:** The Kibana UI uses the `group` field to display related packages as a unified technology tile, allowing users to discover and install the full kafka observability stack from a single entry point.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Verify `group: kafka` appears in all 5 package manifests.
- [ ] Verify the Kibana UI renders the kafka technology tile correctly grouping all packages.

## How to test this PR locally

Start a local registry (v1.40.0) pointing at this branch using `elastic-package` v0.126.0 and query each package:

```
elastic-package stack up
```

Requires `elastic-package` v0.126.0, which starts the registry at v1.40.0.

```
GET https://localhost:8080/search?package=kafka
GET https://localhost:8080/search?package=kafka_connect
GET https://localhost:8080/search?package=kafka_input_otel
GET https://localhost:8080/search?package=kafka_log
GET https://localhost:8080/search?package=kafka_otel
```

Each response should contain `"group": "kafka"`. Example:

```
GET https://localhost:8080/search?package=kafka
```

```json
{
  "name": "kafka",
  "version": "1.27.2",
  "type": "integration",
  "group": "kafka"
}
```

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/8085

## Screenshots

<!-- Add Kibana UI screenshot of the kafka technology tile once available. -->