### PR TITLE
Add group field to docker packages

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20550
 - version: "2.15.2"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.3"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "2.15.2"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,8 +1,9 @@
 name: docker
 title: Docker
-version: 2.15.2
+version: 2.15.3
 description: Collect container logs and metrics from Docker (or Podman) via Elastic Agent.
 type: integration
+group: docker
 icons:
   - src: /img/logo_docker.svg
     title: logo docker

--- a/packages/docker_input_otel/changelog.yml
+++ b/packages/docker_input_otel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.1.2"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/docker_input_otel/changelog.yml
+++ b/packages/docker_input_otel/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20550
 - version: "0.1.1"
   changes:
     - description: Update package title and description to improve clarity of use.

--- a/packages/docker_input_otel/manifest.yml
+++ b/packages/docker_input_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: docker_input_otel
 title: "Docker (OpenTelemetry)"
-version: 0.1.1
+version: 0.1.2
 source:
   license: "Elastic-2.0"
 description: "Collect Docker container metrics via the OTel dockerstatsreceiver."
 type: input
+group: docker
 categories:
   - containers
   - monitoring

--- a/packages/docker_otel/changelog.yml
+++ b/packages/docker_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Add group field to package manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/docker_otel/changelog.yml
+++ b/packages/docker_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add group field to package manifest.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20550
 - version: "0.3.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/docker_otel/manifest.yml
+++ b/packages/docker_otel/manifest.yml
@@ -1,11 +1,12 @@
 format_version: 3.5.0
 name: docker_otel
 title: "Docker OpenTelemetry Assets"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Utilise the pre-built dashboard for OTel-native metrics of Docker hosts and their running containers"
 type: content
+group: docker
 categories:
   - containers
   - monitoring


### PR DESCRIPTION
## Proposed commit message

Add `group: docker` to the manifest of all docker-related packages: `docker`, `docker_input_otel`, `docker_otel`.

**WHAT:** Adds a `group` field to each package's `manifest.yml`, immediately after the `type` field, with the value `docker`. Each package receives a patch version bump and a corresponding changelog entry.

**WHY:** The Kibana UI uses the `group` field to display related packages as a unified technology tile, allowing users to discover and install the full docker observability stack from a single entry point.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Verify `group: docker` appears in all 3 package manifests.
- [ ] Verify the Kibana UI renders the docker technology tile correctly grouping all packages.

## How to test this PR locally

Start a local registry (v1.40.0) pointing at this branch using `elastic-package` v0.126.0 and query each package:

```
elastic-package stack up
```

Requires `elastic-package` v0.126.0, which starts the registry at v1.40.0.

```
GET https://localhost:8080/search?package=docker
GET https://localhost:8080/search?package=docker_input_otel
GET https://localhost:8080/search?package=docker_otel
```

Each response should contain `"group": "docker"`. Example:

```
GET https://localhost:8080/search?package=docker
```

```json
{
  "name": "docker",
  "version": "2.15.3",
  "type": "integration",
  "group": "docker"
}
```

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/8085

## Screenshots

<!-- Add Kibana UI screenshot of the docker technology tile once available. -->