### PR TITLE
[cisco_ftd] Fix 113005 REASON pattern to include locked out and other r…

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "3.13.9"
   changes:
-    - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and other valid rejection reasons.
+    - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and Users account has expired rejection reasons.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20552
 - version: "3.13.8"

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.9"
+  changes:
+    - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and other valid rejection reasons.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.13.8"
   changes:
     - description: Convert FileSize to long instead of integer so large file sizes above the 32-bit integer limit no longer fail parsing for event.code.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and other valid rejection reasons.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20552
 - version: "3.13.8"
   changes:
     - description: Convert FileSize to long instead of integer so large file sizes above the 32-bit integer limit no longer fail parsing for event.code.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -56,3 +56,4 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Password malformed : server = 192.0.2.20 : user = engineer@elastic.co : user IP = 198.51.100.30
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Unspecified : server = 192.0.2.20 : user = **** : user IP = 198.51.100.30
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Password has expired : server = 192.0.2.20 : user = engineer@elastic.co : user IP = 198.51.100.30
+<182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -57,3 +57,4 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Unspecified : server = 192.0.2.20 : user = **** : user IP = 198.51.100.30
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Password has expired : server = 192.0.2.20 : user = engineer@elastic.co : user IP = 198.51.100.30
 <182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30
+<182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -4394,6 +4394,98 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-07-07T11:22:54.000Z",
+            "destination": {
+                "address": "203.0.113.20",
+                "as": {
+                    "number": 64502,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Madrid",
+                    "continent_name": "Europe",
+                    "country_iso_code": "ES",
+                    "country_name": "Spain",
+                    "location": {
+                        "lat": 40.41639,
+                        "lon": -3.7025
+                    },
+                    "region_iso_code": "ES-M",
+                    "region_name": "Madrid"
+                },
+                "ip": "203.0.113.20"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "code": "113005",
+                "original": "<182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30",
+                "outcome": "failure",
+                "reason": "Users account has expired",
+                "severity": 6,
+                "timezone": "UTC"
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 22
+                    },
+                    "priority": 182,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "ip": [
+                    "192.0.2.30",
+                    "203.0.113.20"
+                ]
+            },
+            "source": {
+                "address": "192.0.2.30",
+                "as": {
+                    "number": 64500,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Las Vegas",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 36.17497,
+                        "lon": -115.13722
+                    },
+                    "region_iso_code": "US-NV",
+                    "region_name": "Nevada"
+                },
+                "ip": "192.0.2.30"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -4302,6 +4302,98 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-07-07T11:22:54.000Z",
+            "destination": {
+                "address": "203.0.113.20",
+                "as": {
+                    "number": 64502,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Madrid",
+                    "continent_name": "Europe",
+                    "country_iso_code": "ES",
+                    "country_name": "Spain",
+                    "location": {
+                        "lat": 40.41639,
+                        "lon": -3.7025
+                    },
+                    "region_iso_code": "ES-M",
+                    "region_name": "Madrid"
+                },
+                "ip": "203.0.113.20"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "code": "113005",
+                "original": "<182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30",
+                "outcome": "failure",
+                "reason": "Account has been locked out",
+                "severity": 6,
+                "timezone": "UTC"
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 22
+                    },
+                    "priority": 182,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "ip": [
+                    "192.0.2.30",
+                    "203.0.113.20"
+                ]
+            },
+            "source": {
+                "address": "192.0.2.30",
+                "as": {
+                    "number": 64500,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Las Vegas",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 36.17497,
+                        "lon": -115.13722
+                    },
+                    "region_iso_code": "US-NV",
+                    "region_name": "Nevada"
+                },
+                "ip": "192.0.2.30"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -434,7 +434,7 @@ processors:
       patterns:
         - "AAA user (authentication|authorization) Rejected(%{SPACE})?: reason = %{REASON:event.reason}(%{SPACE})?: server = %{IP:destination.address}(%{SPACE})?: user = ?(%{CISCO_USER:source.user.name}|\\*+)(%{SPACE})?: user IP = %{IP:source.address}"
       pattern_definitions:
-        REASON: (AAA failure|Account has been disabled|Account has been locked out|Invalid password|Password has expired|Password is expiring|Password malformed|Unspecified)
+        REASON: (AAA failure|Account has been disabled|Account has been locked out|Invalid password|Password has expired|Password is expiring|Password malformed|Unspecified|Users account has expired)
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - grok:
       tag: grok_message_9e29df82

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -434,7 +434,7 @@ processors:
       patterns:
         - "AAA user (authentication|authorization) Rejected(%{SPACE})?: reason = %{REASON:event.reason}(%{SPACE})?: server = %{IP:destination.address}(%{SPACE})?: user = ?(%{CISCO_USER:source.user.name}|\\*+)(%{SPACE})?: user IP = %{IP:source.address}"
       pattern_definitions:
-        REASON: (AAA failure|Account has been disabled|Invalid password|Password has expired|Password is expiring|Password malformed|Unspecified)
+        REASON: (AAA failure|Account has been disabled|Account has been locked out|Invalid password|Password has expired|Password is expiring|Password malformed|Unspecified)
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
   - grok:
       tag: grok_message_9e29df82

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.13.8"
+version: "3.13.9"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

The fix adds 'Account has been locked out' to the REASON grok pattern for Cisco FTD message 113005. The existing pattern only matched a fixed set of rejection reasons, causing a MISSING_CASE error when the AAA server returned this particular locked-out message. Adding the new reason string to the alternation group allows the grok processor to successfully parse these events.

## Proposed commit message

```
[cisco_ftd] Fix 113005 REASON pattern to include locked out and other r…
```

## Root cause

The REASON pattern_definition in the grok_message_800e7540 processor only lists two rejection reasons (AAA failure|Account has been disabled), but Cisco FTD legitimately emits 'Account has been locked out' and several other valid reason strings for message 113005; the pattern was never extended to cover the full documented set.

## Approach

Extend the REASON pattern_definition in the grok_message_800e7540 processor (message ID 113005) from its current two-value alternation to the full set of documented Cisco FTD rejection reasons, mirroring the complete list already present in the cisco_asa integration. Add a pipeline test fixture entry for the 'Account has been locked out' reason using the sanitized event. Bump the package version with a bugfix changelog entry.

## Implementation

1. Step 1: In packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml, locate the grok processor at tag grok_message_800e7540 (around line 429). Update the REASON pattern_definition from `(AAA failure|Account has been disabled)` to `(AAA failure|Account has been disabled|Account has been locked out|Invalid password|Password has expired|Password is expiring|Password malformed|Unspecified)` — matching the full set used in the cisco_asa integration.
2. Step 2: In packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log, append the sanitized test event: `<182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30`
3. Step 3: In packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json, append the corresponding expected output document for the new test event, including event.action=logon-failed, event.outcome=failure, event.code=113005, destination.address=203.0.113.20, source.address=192.0.2.30, and related.ip entries for both IPs.
4. Step 4: In packages/cisco_ftd/changelog.yml, prepend a new version entry (3.13.5) with type: bugfix and description: 'Fix grok REASON pattern for 113005 to include Account has been locked out and other valid rejection reasons.'
5. Step 5: In packages/cisco_ftd/manifest.yml, update the version field to 3.13.5.
6. Step 6: Run `elastic-package test pipeline` against the cisco_ftd package to confirm all existing and new test fixtures pass.

## Pipeline changes

- Modify grok_message_800e7540 processor: expand REASON pattern_definition from `(AAA failure|Account has been disabled)` to `(AAA failure|Account has been disabled|Account has been locked out|Invalid password|Password has expired|Password is expiring|Password malformed|Unspecified)`

## Field / mapping changes

—

## Sanitized error message

`Processor 'grok' with tag 'grok_message_800e7540' in pipeline 'logs-cisco_ftd.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30
```

## Reviewer concerns

- The REASON pattern remains a fixed enumeration; any future undocumented rejection reason from Cisco ASA/FTD will cause the same MISSING_CASE failure again. A fallback catch-all pattern (e.g. `[^:]+`) might be more resilient, but that is a separate enhancement decision.
- The new test fixture line is missing a trailing newline (`\ No newline at end of file`), which is cosmetically untidy but functionally harmless for pipeline tests.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, test-fixture
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_ftd.log [MISSING_CASE]: Processor 'grok' with tag 'grok_message_800e7540' in pipeline 'logs-cisc…
- **Pipeline case**: `046694414ff152f6`
