### PR TITLE
[cisco_aironet] Fix date parsing for year-present, no-ms timestamps.

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.2"
+  changes:
+    - description: Fix date parsing for IOS-XE WLC Format 3 timestamps that include a year but lack millisecond precision.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.1"
   changes:
     - description: Add grok pattern for LOG-6-Q_IND Radius override messages

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix date parsing for IOS-XE WLC Format 3 timestamps that include a year but lack millisecond precision.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20553
 - version: "1.21.1"
   changes:
     - description: Add grok pattern for LOG-6-Q_IND Radius override messages

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
@@ -39,3 +39,4 @@
 <158>7779986: WLC001: 7842329: Oct 3 16:14:07.740 SGT: %APMGR_AWIPS_SYSLOG-6-APMGR_AWIPS_MESSAGE: Chassis 1 R0/0: wncd: AWIPS alarm:(TEST-AP-01) a1b2.c3d4.e5f6 Radio MAC a1b2.c3d4.e5f7 detected Airdrop Session (10021)
 <157>7781346: WLC001: 7843692: Oct 3 16:15:44.319 SGT: %SESSION_MGR-5-FAIL: Chassis 1 R0/6: wncd: Authorization failed or unapplied for client (de:fb:48:7c:4f:f7) on Interface capwap_12345678 AuditSessionID ABC123DEF456789012345678. Failure reason: Authc fail. Authc failure reason: Cred Fail.
 <46>host-1.example.local: *SISF BT Process: Jun 28 01:14:15.327: %LOG-6-Q_IND: [PA]apf_ms_radius_override.c:213 Radius overrides disabled, ignoring source 4
+<190>3393587: host-1.example.local: 3394483: Jun 27 2026 05:32:54 EDT: %SEC-6-IPACCESSLOGP: list vlan100-20240101000000 permitted tcp 198.51.100.10(49814) -> 203.0.113.20(443), 1 packet

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -1600,6 +1600,37 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-27T05:32:54.000+08:00",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "IPACCESSLOGP",
+                "original": "<190>3393587: host-1.example.local: 3394483: Jun 27 2026 05:32:54 EDT: %SEC-6-IPACCESSLOGP: list vlan100-20240101000000 permitted tcp 198.51.100.10(49814) -> 203.0.113.20(443), 1 packet",
+                "provider": "SEC",
+                "severity": 6
+            },
+            "host": {
+                "name": "host-1.example.local"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "message": "list vlan100-20240101000000 permitted tcp 198.51.100.10(49814) -> 203.0.113.20(443), 1 packet",
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -123,6 +123,7 @@ processors:
       tag: "raw_date_processor"
       formats:
         - "MMM d yyyy HH:mm:ss.SSS"
+        - "MMM d yyyy HH:mm:ss"
         - "MMM d HH:mm:ss.SSS"
         - "MMM d HH:mm:ss"
       timezone: '{{{_conf.tz_offset}}}'

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.21.1"
+version: "1.21.2"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Adds the `MMM d yyyy HH:mm:ss` date format to the `raw_date_processor` in the cisco_aironet ingest pipeline. IOS-XE WLC devices can emit syslog timestamps that include a four-digit year but omit millisecond precision (e.g., `Jun 27 2026 05:32:54 EDT`). The pipeline already handled the year-with-milliseconds variant (`MMM d yyyy HH:mm:ss.SSS`) but had no fallback for the no-milliseconds case, causing the date processor to raise a MISSING_CASE failure. Adding the new format directly below the existing year-aware pattern closes the gap.

## Proposed commit message

```
[cisco_aironet] Fix date parsing for year-present, no-ms timestamps.
```

## Root cause

The 'raw_date_processor' date processor in default.yml only declares formats with milliseconds ('MMM d yyyy HH:mm:ss.SSS', 'MMM d HH:mm:ss.SSS') or without year and without milliseconds ('MMM d HH:mm:ss'), so a valid IOS-XE WLC Format 3 timestamp that carries a year but lacks milliseconds (e.g. 'Jun 27 2026 05:32:54') matches none of the declared formats and causes the processor to fail.

## Approach

Add the missing format strings 'MMM d yyyy HH:mm:ss' and 'MMM d HH:mm:ss' to the 'raw_date_processor' date processor in default.yml. These handle the year-present/millisecond-absent variant (e.g. 'Jun 27 2026 05:32:54') and the year-absent/millisecond-absent variant respectively, placed after their millisecond-bearing counterparts so the more-specific pattern wins. Also add a test fixture line for the sanitized event and a corresponding expected output entry.

## Implementation

1. Step 1: In packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml, add 'MMM d yyyy HH:mm:ss' immediately after the existing 'MMM d yyyy HH:mm:ss.SSS' entry in the 'raw_date_processor' date processor's formats list (line ~125).
2. Step 2: In the same date processor, add 'MMM d HH:mm:ss' after the existing 'MMM d HH:mm:ss.SSS' entry to cover the no-year/no-millisecond variant (already present per line 127 inspection — verify; if missing, add it).
3. Step 3: Append the sanitized test event '<190>3393587: host-1.example.local: 3394483: Jun 27 2026 05:32:54 EDT: %SEC-6-IPACCESSLOGP: list vlan100-20240101000000 permitted tcp 198.51.100.10(49814) -> 203.0.113.20(443), 1 packet' to packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log.
4. Step 4: Add the corresponding expected output object to packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json, verifying @timestamp is parsed correctly (2026-06-27T09:32:54.000Z for EDT=UTC-4) and event fields are populated.
5. Step 5: Run 'elastic-package test pipeline' against the cisco_aironet package to confirm the new fixture passes and no existing fixtures regress.
6. Step 6: Bump the version in packages/cisco_aironet/changelog.yml with a 'bugfix' entry and a patch version bump (1.21.1 → 1.21.2, or next available patch).

## Pipeline changes

- In the 'raw_date_processor' date processor, add format 'MMM d yyyy HH:mm:ss' after 'MMM d yyyy HH:mm:ss.SSS' to handle year-present, millisecond-absent timestamps.
- In the 'raw_date_processor' date processor, verify 'MMM d HH:mm:ss' is present (after 'MMM d HH:mm:ss.SSS') to handle year-absent, millisecond-absent timestamps; add if missing.

## Field / mapping changes

—

## Sanitized error message

`Processor 'date' with tag 'raw_date_processor' in pipeline 'logs-cisco_aironet.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<190>3393587: host-1.example.local: 3394483: Jun 27 2026 05:32:54 EDT: %SEC-6-IPACCESSLOGP: list vlan100-20240101000000 permitted tcp 198.51.100.10(49814) -> 203.0.113.20(443), 1 packet
```

## Reviewer concerns

- The expected `@timestamp` in the new fixture is `2026-06-27T05:32:54.000+08:00` even though the raw log contains `EDT` (UTC-4). This is consistent with the pipeline's design — timezone resolution uses `_conf.tz_offset` rather than the timezone token captured by grok — but reviewers should confirm the test's `tz_offset` config is set to `+08:00` and that this behaviour matches production expectations.
- The new format is inserted between the year+ms and the no-year+ms patterns; ordering is correct (most-specific first) and will not accidentally shadow existing formats.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, test-fixture, ingest
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_aironet.log [MISSING_CASE]: Processor 'date' with tag 'raw_date_processor' in pipeline 'logs-cisco_a…
- **Pipeline case**: `12f5e5087f3b5d34`
