### PR TITLE
[Azure] Add AMQP-over-WebSockets support to Event Hub integrations

### DIFF
--- a/packages/azure_ai_foundry/_dev/build/docs/README.md
+++ b/packages/azure_ai_foundry/_dev/build/docs/README.md
@@ -36,11 +36,22 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
-#### AMQP-over-WebSockets and proxy support
+#### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 9.2.4 or later.
+
+#### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 9.2.4 or later.
 
 #### Native logging
 

--- a/packages/azure_ai_foundry/_dev/build/docs/README.md
+++ b/packages/azure_ai_foundry/_dev/build/docs/README.md
@@ -36,6 +36,12 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
+#### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 #### Native logging
 
 The Microsoft Foundry provides native logging and monitoring to track the telemetry of the service. The `Audit` and `RequestResponse` log categories come under the native logging. However, the default logging doesn't log the inputs and outputs of the service. This is useful to ensure that the services operates as expected.

--- a/packages/azure_ai_foundry/_dev/build/docs/README.md
+++ b/packages/azure_ai_foundry/_dev/build/docs/README.md
@@ -40,7 +40,7 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 9.2.4 or later.
 
 #### Native logging
 

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -6,6 +6,9 @@
     - description: Add the Event Hub processor version option and switch the default processor version to v2.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.12.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -3,6 +3,9 @@
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the Event Hub processor version option and switch the default processor version to v2.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.12.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.13.0"
+  changes:
+    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
+      type: enhancement
+      link: https://github.com/elastic/obs-integration-team/issues/973
 - version: "0.12.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -1,12 +1,6 @@
 - version: "0.13.0"
   changes:
-    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the Event Hub processor version option and switch the default processor version to v2.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+    - description: Add AMQP-over-WebSockets transport, proxy support, and Event Hub processor v2 configuration options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
 - version: "0.12.0"

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
-      link: https://github.com/elastic/obs-integration-team/issues/973
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.12.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -46,6 +46,19 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+migrate_checkpoint: {{migrate_checkpoint}}
+{{#if processor_update_interval}}
+processor_update_interval: {{processor_update_interval}}
+{{/if}}
+{{#if processor_start_position}}
+processor_start_position: {{processor_start_position}}
+{{/if}}
+{{#if partition_receive_timeout}}
+partition_receive_timeout: {{partition_receive_timeout}}
+{{/if}}
+{{#if partition_receive_count}}
+partition_receive_count: {{partition_receive_count}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if transport}}
+transport: {{transport}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -46,7 +46,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+{{#if migrate_checkpoint}}
 migrate_checkpoint: {{migrate_checkpoint}}
+{{/if}}
 {{#if processor_update_interval}}
 processor_update_interval: {{processor_update_interval}}
 {{/if}}

--- a/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_ai_foundry/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if processor_version}}
+processor_version: {{processor_version}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_ai_foundry/data_stream/logs/manifest.yml
+++ b/packages/azure_ai_foundry/data_stream/logs/manifest.yml
@@ -113,6 +113,21 @@ streams:
         description: >-
           (Optional when **Authentication Type** is **Client Secret**) Microsoft Entra ID authority endpoint. Defaults to https://login.microsoftonline.com (Azure Public Cloud).
           Change for other Azure environments: Azure Government (https://login.microsoftonline.us), Azure China (https://login.chinacloudapi.cn), or Azure Germany (https://login.microsoftonline.de).
+      - name: processor_version
+        type: select
+        title: Processor version
+        multi: false
+        required: false
+        show_user: false
+        default: v2
+        options:
+          - text: v1 (legacy)
+            value: v1
+          - text: v2
+            value: v2
+        description: >
+          The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
+          The v2 event hub processor is recommended for typical use cases. Defaults to v2.
       - name: transport
         type: select
         title: Event Hubs transport protocol

--- a/packages/azure_ai_foundry/data_stream/logs/manifest.yml
+++ b/packages/azure_ai_foundry/data_stream/logs/manifest.yml
@@ -128,6 +128,65 @@ streams:
         description: >
           The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
           The v2 event hub processor is recommended for typical use cases. Defaults to v2.
+      - name: processor_update_interval
+        type: text
+        title: Processor update interval
+        multi: false
+        required: false
+        show_user: false
+        default: 10s
+        description: >-
+          (Processor v2 only) How often the processor should attempt to claim partitions.
+
+          Default is `10` seconds.
+      - name: processor_start_position
+        type: select
+        title: Processor start position
+        multi: false
+        required: false
+        show_user: false
+        default: earliest
+        options:
+          - text: earliest
+            value: earliest
+          - text: latest
+            value: latest
+        description: >-
+          (Processor v2 only) Controls from what position in the event hub the processor should start processing messages for all partitions.
+
+          Possible values are `earliest` and `latest`.
+
+          `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+
+          `latest` starts processing messages from the latest event in the event hub and continues to process new events as they arrive.
+
+          Default is `earliest`.
+      - name: partition_receive_timeout
+        type: text
+        title: Partition receive timeout
+        multi: false
+        required: false
+        show_user: false
+        default: 5s
+        description: >-
+          (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
+
+          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+          Default is `5` seconds.
+      - name: partition_receive_count
+        type: text
+        title: Partition receive count
+        multi: false
+        required: false
+        show_user: false
+        default: 100
+        description: >-
+          (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
+
+          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+          Default is `100` messages.
       - name: transport
         type: select
         title: Event Hubs transport protocol
@@ -143,6 +202,19 @@ streams:
         description: >
           (Processor v2 only) The transport protocol used to connect to Event Hubs.
           Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
+      - name: migrate_checkpoint
+        type: bool
+        title: Migrate checkpoint information
+        multi: false
+        required: false
+        show_user: false
+        default: true
+        description: >-
+          (Processor v2 only) Flag to control if the processor should perform the checkpoint information migration from processor v1 to v2 at startup.
+
+          The checkpoint migration converts the checkpoint information from the v1 format to the v2 format, so the processor resumes from where v1 left off instead of reprocessing the event hub retention window.
+
+          Default is `true`.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/azure_ai_foundry/data_stream/logs/manifest.yml
+++ b/packages/azure_ai_foundry/data_stream/logs/manifest.yml
@@ -171,7 +171,7 @@ streams:
         description: >-
           (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
 
-          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+          The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
           Default is `5` seconds.
       - name: partition_receive_count
@@ -184,7 +184,7 @@ streams:
         description: >-
           (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
-          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+          The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
           Default is `100` messages.
       - name: transport

--- a/packages/azure_ai_foundry/data_stream/logs/manifest.yml
+++ b/packages/azure_ai_foundry/data_stream/logs/manifest.yml
@@ -113,6 +113,21 @@ streams:
         description: >-
           (Optional when **Authentication Type** is **Client Secret**) Microsoft Entra ID authority endpoint. Defaults to https://login.microsoftonline.com (Azure Public Cloud).
           Change for other Azure environments: Azure Government (https://login.microsoftonline.us), Azure China (https://login.chinacloudapi.cn), or Azure Germany (https://login.microsoftonline.de).
+      - name: transport
+        type: select
+        title: Event Hubs transport protocol
+        multi: false
+        required: true
+        show_user: false
+        default: amqp
+        options:
+          - text: AMQP
+            value: amqp
+          - text: AMQP-over-WebSockets
+            value: websocket
+        description: >
+          (Processor v2 only) The transport protocol used to connect to Event Hubs.
+          Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/azure_ai_foundry/docs/README.md
+++ b/packages/azure_ai_foundry/docs/README.md
@@ -36,11 +36,22 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
-#### AMQP-over-WebSockets and proxy support
+#### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 9.2.4 or later.
+
+#### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 9.2.4 or later.
 
 #### Native logging
 

--- a/packages/azure_ai_foundry/docs/README.md
+++ b/packages/azure_ai_foundry/docs/README.md
@@ -36,6 +36,12 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
+#### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 #### Native logging
 
 The Microsoft Foundry provides native logging and monitoring to track the telemetry of the service. The `Audit` and `RequestResponse` log categories come under the native logging. However, the default logging doesn't log the inputs and outputs of the service. This is useful to ensure that the services operates as expected.
@@ -501,6 +507,5 @@ The following alert rule templates are available:
 
 
 **[Microsoft Foundry] Provisioned Utilization above threshold**
-
 
 

--- a/packages/azure_ai_foundry/docs/README.md
+++ b/packages/azure_ai_foundry/docs/README.md
@@ -40,7 +40,7 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 9.2.4 or later.
 
 #### Native logging
 
@@ -507,5 +507,7 @@ The following alert rule templates are available:
 
 
 **[Microsoft Foundry] Provisioned Utilization above threshold**
+
+
 
 

--- a/packages/azure_ai_foundry/manifest.yml
+++ b/packages/azure_ai_foundry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: azure_ai_foundry
 title: "Microsoft Foundry"
-version: "0.12.0"
+version: "0.13.0"
 source:
   license: "Elastic-2.0"
 description: "Collects Microsoft Foundry logs and metrics"

--- a/packages/azure_app_service/_dev/build/docs/README.md
+++ b/packages/azure_app_service/_dev/build/docs/README.md
@@ -27,7 +27,7 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## App Service Logs
 

--- a/packages/azure_app_service/_dev/build/docs/README.md
+++ b/packages/azure_app_service/_dev/build/docs/README.md
@@ -23,11 +23,22 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
-### AMQP-over-WebSockets and proxy support
+### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
+### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## App Service Logs
 

--- a/packages/azure_app_service/_dev/build/docs/README.md
+++ b/packages/azure_app_service/_dev/build/docs/README.md
@@ -23,6 +23,12 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
+### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 ## App Service Logs
 
 Collects different types of logs from Azure App Service via Event Hub.

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
-      link: https://github.com/elastic/obs-integration-team/issues/973
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "1.1.0"
   changes:
     - description: Add client secret authentication support for Azure Event Hub with RBAC.

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -7,6 +7,9 @@
     - description: Add the Event Hub processor version option and switch the default processor version to v2.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "1.1.0"
   changes:
     - description: Add client secret authentication support for Azure Event Hub with RBAC.

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the Event Hub processor version option and switch the default processor version to v2.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "1.1.0"
   changes:
     - description: Add client secret authentication support for Azure Event Hub with RBAC.

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -1,13 +1,7 @@
 # newer versions go on top
 - version: "1.2.0"
   changes:
-    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the Event Hub processor version option and switch the default processor version to v2.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+    - description: Add AMQP-over-WebSockets transport, proxy support, and Event Hub processor v2 configuration options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
 - version: "1.1.0"

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
+      type: enhancement
+      link: https://github.com/elastic/obs-integration-team/issues/973
 - version: "1.1.0"
   changes:
     - description: Add client secret authentication support for Azure Event Hub with RBAC.

--- a/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
@@ -46,6 +46,19 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+migrate_checkpoint: {{migrate_checkpoint}}
+{{#if processor_update_interval}}
+processor_update_interval: {{processor_update_interval}}
+{{/if}}
+{{#if processor_start_position}}
+processor_start_position: {{processor_start_position}}
+{{/if}}
+{{#if partition_receive_timeout}}
+partition_receive_timeout: {{partition_receive_timeout}}
+{{/if}}
+{{#if partition_receive_count}}
+partition_receive_count: {{partition_receive_count}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if transport}}
+transport: {{transport}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
@@ -46,7 +46,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+{{#if migrate_checkpoint}}
 migrate_checkpoint: {{migrate_checkpoint}}
+{{/if}}
 {{#if processor_update_interval}}
 processor_update_interval: {{processor_update_interval}}
 {{/if}}

--- a/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_app_service/data_stream/app_service_logs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if processor_version}}
+processor_version: {{processor_version}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_app_service/docs/README.md
+++ b/packages/azure_app_service/docs/README.md
@@ -27,7 +27,7 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## App Service Logs
 

--- a/packages/azure_app_service/docs/README.md
+++ b/packages/azure_app_service/docs/README.md
@@ -23,11 +23,22 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
-### AMQP-over-WebSockets and proxy support
+### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
+### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## App Service Logs
 

--- a/packages/azure_app_service/docs/README.md
+++ b/packages/azure_app_service/docs/README.md
@@ -23,6 +23,12 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
+### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 ## App Service Logs
 
 Collects different types of logs from Azure App Service via Event Hub.

--- a/packages/azure_app_service/manifest.yml
+++ b/packages/azure_app_service/manifest.yml
@@ -131,6 +131,21 @@ vars:
     multi: false
     required: false
     show_user: false
+  - name: processor_version
+    type: select
+    title: Processor version
+    multi: false
+    required: false
+    show_user: false
+    default: v2
+    options:
+      - text: v1 (legacy)
+        value: v1
+      - text: v2
+        value: v2
+    description: >
+      The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
+      The v2 event hub processor is recommended for typical use cases. Defaults to v2.
   - name: transport
     type: select
     title: Event Hubs transport protocol

--- a/packages/azure_app_service/manifest.yml
+++ b/packages/azure_app_service/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: azure_app_service
 title: "Azure App Service"
-version: "1.1.0"
+version: "1.2.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Azure App Service with Elastic Agent."
@@ -131,6 +131,21 @@ vars:
     multi: false
     required: false
     show_user: false
+  - name: transport
+    type: select
+    title: Event Hubs transport protocol
+    multi: false
+    required: true
+    show_user: false
+    default: amqp
+    options:
+      - text: AMQP
+        value: amqp
+      - text: AMQP-over-WebSockets
+        value: websocket
+    description: >
+      (Processor v2 only) The transport protocol used to connect to Event Hubs.
+      Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
 icons:
   - src: /img/app-service-logo.svg
     title: App Service Logo

--- a/packages/azure_app_service/manifest.yml
+++ b/packages/azure_app_service/manifest.yml
@@ -146,6 +146,65 @@ vars:
     description: >
       The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
       The v2 event hub processor is recommended for typical use cases. Defaults to v2.
+  - name: processor_update_interval
+    type: text
+    title: Processor update interval
+    multi: false
+    required: false
+    show_user: false
+    default: 10s
+    description: >-
+      (Processor v2 only) How often the processor should attempt to claim partitions.
+
+      Default is `10` seconds.
+  - name: processor_start_position
+    type: select
+    title: Processor start position
+    multi: false
+    required: false
+    show_user: false
+    default: earliest
+    options:
+      - text: earliest
+        value: earliest
+      - text: latest
+        value: latest
+    description: >-
+      (Processor v2 only) Controls from what position in the event hub the processor should start processing messages for all partitions.
+
+      Possible values are `earliest` and `latest`.
+
+      `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+
+      `latest` starts processing messages from the latest event in the event hub and continues to process new events as they arrive.
+
+      Default is `earliest`.
+  - name: partition_receive_timeout
+    type: text
+    title: Partition receive timeout
+    multi: false
+    required: false
+    show_user: false
+    default: 5s
+    description: >-
+      (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
+
+      The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+      Default is `5` seconds.
+  - name: partition_receive_count
+    type: text
+    title: Partition receive count
+    multi: false
+    required: false
+    show_user: false
+    default: 100
+    description: >-
+      (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
+
+      The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+      Default is `100` messages.
   - name: transport
     type: select
     title: Event Hubs transport protocol
@@ -161,6 +220,19 @@ vars:
     description: >
       (Processor v2 only) The transport protocol used to connect to Event Hubs.
       Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
+  - name: migrate_checkpoint
+    type: bool
+    title: Migrate checkpoint information
+    multi: false
+    required: false
+    show_user: false
+    default: true
+    description: >-
+      (Processor v2 only) Flag to control if the processor should perform the checkpoint information migration from processor v1 to v2 at startup.
+
+      The checkpoint migration converts the checkpoint information from the v1 format to the v2 format, so the processor resumes from where v1 left off instead of reprocessing the event hub retention window.
+
+      Default is `true`.
 icons:
   - src: /img/app-service-logo.svg
     title: App Service Logo

--- a/packages/azure_app_service/manifest.yml
+++ b/packages/azure_app_service/manifest.yml
@@ -189,7 +189,7 @@ vars:
     description: >-
       (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
 
-      The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+      The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
       Default is `5` seconds.
   - name: partition_receive_count
@@ -202,7 +202,7 @@ vars:
     description: >-
       (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
-      The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+      The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
       Default is `100` messages.
   - name: transport

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -154,6 +154,26 @@ _string_
 _string_
 The Event Hub processor version that the integration should use. Possible values are `v1` (legacy) and `v2` (recommended). Defaults to `v2`.
 
+`processor_update_interval` :
+_string_
+(Processor v2 only) How often the processor should attempt to claim partitions. Defaults to `10s`.
+
+`processor_start_position` :
+_string_
+(Processor v2 only) Where the processor starts processing messages for all partitions. `earliest` (default) starts from the last checkpoint, or the beginning of the event hub if no checkpoint is available. `latest` starts from the latest event and continues with new events as they arrive.
+
+`partition_receive_timeout` :
+_string_
+(Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `5s`.
+
+`partition_receive_count` :
+_int_
+(Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `100`.
+
+`migrate_checkpoint` :
+_bool_
+(Processor v2 only) Controls whether the processor migrates checkpoint information from the v1 format to the v2 format at startup, so it resumes from where v1 left off instead of reprocessing the event hub retention window. Defaults to `true`.
+
 `transport` :
 _string_
 (Processor v2 only) The transport protocol to use when connecting to Event Hubs. `amqp` (default) uses ports `5671` and `5672`. `websocket` uses AMQP-over-WebSockets on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -100,7 +100,7 @@ Instead of a connection string, you can authenticate using a Microsoft Entra ID 
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 #### Configuration options
 
@@ -149,6 +149,10 @@ _string_
 `authority_host` :
 _string_
 (Optional, for client secret authentication.) Microsoft Entra ID authority endpoint. Defaults to `https://login.microsoftonline.com` (Azure Public Cloud). Use a different endpoint for other clouds (for example Azure Government, China, Germany).
+
+`processor_version` :
+_string_
+The Event Hub processor version that the integration should use. Possible values are `v1` (legacy) and `v2` (recommended). Defaults to `v2`.
 
 `transport` :
 _string_

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -96,11 +96,22 @@ Instead of a connection string, you can authenticate using a Microsoft Entra ID 
 4. **Configure the integration**  
    Set **Authentication type** to **Client Secret**. Provide **Tenant ID**, **Client ID**, **Client Secret**, and the fully qualified **Event Hub namespace** (for example `yournamespace.servicebus.windows.net`). Use the same Storage Account and container as for connection string authentication; the integration will use the client secret to access both Event Hubs and Storage.
 
-#### AMQP-over-WebSockets and proxy support
+#### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
+#### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 #### Configuration options
 

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -175,11 +175,11 @@ _string_
 
 `partition_receive_timeout` :
 _string_
-(Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `5s`.
+(Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first. Defaults to `5s`.
 
 `partition_receive_count` :
 _int_
-(Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `100`.
+(Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first. Defaults to `100`.
 
 `migrate_checkpoint` :
 _bool_

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -96,6 +96,12 @@ Instead of a connection string, you can authenticate using a Microsoft Entra ID 
 4. **Configure the integration**  
    Set **Authentication type** to **Client Secret**. Provide **Tenant ID**, **Client ID**, **Client Secret**, and the fully qualified **Event Hub namespace** (for example `yournamespace.servicebus.windows.net`). Use the same Storage Account and container as for connection string authentication; the integration will use the client secret to access both Event Hubs and Storage.
 
+#### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 #### Configuration options
 
 `auth_type` :
@@ -143,6 +149,10 @@ _string_
 `authority_host` :
 _string_
 (Optional, for client secret authentication.) Microsoft Entra ID authority endpoint. Defaults to `https://login.microsoftonline.com` (Azure Public Cloud). Use a different endpoint for other clouds (for example Azure Government, China, Germany).
+
+`transport` :
+_string_
+(Processor v2 only) The transport protocol to use when connecting to Event Hubs. `amqp` (default) uses ports `5671` and `5672`. `websocket` uses AMQP-over-WebSockets on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
 `storage_account_container` :
 _string_

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
-      link: https://github.com/elastic/obs-integration-team/issues/973
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.15.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,13 +1,7 @@
 # newer versions go on top
 - version: "0.16.0"
   changes:
-    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the Event Hub processor version option and switch the default processor version to v2.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+    - description: Add AMQP-over-WebSockets transport, proxy support, and Event Hub processor v2 configuration options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
 - version: "0.15.0"

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -7,6 +7,9 @@
     - description: Add the Event Hub processor version option and switch the default processor version to v2.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.15.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.16.0"
+  changes:
+    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
+      type: enhancement
+      link: https://github.com/elastic/obs-integration-team/issues/973
 - version: "0.15.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the Event Hub processor version option and switch the default processor version to v2.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.15.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
@@ -46,6 +46,19 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+migrate_checkpoint: {{migrate_checkpoint}}
+{{#if processor_update_interval}}
+processor_update_interval: {{processor_update_interval}}
+{{/if}}
+{{#if processor_start_position}}
+processor_start_position: {{processor_start_position}}
+{{/if}}
+{{#if partition_receive_timeout}}
+partition_receive_timeout: {{partition_receive_timeout}}
+{{/if}}
+{{#if partition_receive_count}}
+partition_receive_count: {{partition_receive_count}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if transport}}
+transport: {{transport}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
@@ -46,7 +46,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+{{#if migrate_checkpoint}}
 migrate_checkpoint: {{migrate_checkpoint}}
+{{/if}}
 {{#if processor_update_interval}}
 processor_update_interval: {{processor_update_interval}}
 {{/if}}

--- a/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_functions/data_stream/functionapplogs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if processor_version}}
+processor_version: {{processor_version}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_functions/data_stream/functionapplogs/manifest.yml
+++ b/packages/azure_functions/data_stream/functionapplogs/manifest.yml
@@ -114,6 +114,21 @@ streams:
         description: >-
           (Optional when **Authentication Type** is **Client Secret**) Microsoft Entra ID authority endpoint. Defaults to https://login.microsoftonline.com (Azure Public Cloud).
           Change for other Azure environments: Azure Government (https://login.microsoftonline.us), Azure China (https://login.chinacloudapi.cn), or Azure Germany (https://login.microsoftonline.de).
+      - name: transport
+        type: select
+        title: Event Hubs transport protocol
+        multi: false
+        required: true
+        show_user: false
+        default: amqp
+        options:
+          - text: AMQP
+            value: amqp
+          - text: AMQP-over-WebSockets
+            value: websocket
+        description: >
+          (Processor v2 only) The transport protocol used to connect to Event Hubs.
+          Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/azure_functions/data_stream/functionapplogs/manifest.yml
+++ b/packages/azure_functions/data_stream/functionapplogs/manifest.yml
@@ -129,6 +129,65 @@ streams:
         description: >
           The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
           The v2 event hub processor is recommended for typical use cases. Defaults to v2.
+      - name: processor_update_interval
+        type: text
+        title: Processor update interval
+        multi: false
+        required: false
+        show_user: false
+        default: 10s
+        description: >-
+          (Processor v2 only) How often the processor should attempt to claim partitions.
+
+          Default is `10` seconds.
+      - name: processor_start_position
+        type: select
+        title: Processor start position
+        multi: false
+        required: false
+        show_user: false
+        default: earliest
+        options:
+          - text: earliest
+            value: earliest
+          - text: latest
+            value: latest
+        description: >-
+          (Processor v2 only) Controls from what position in the event hub the processor should start processing messages for all partitions.
+
+          Possible values are `earliest` and `latest`.
+
+          `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+
+          `latest` starts processing messages from the latest event in the event hub and continues to process new events as they arrive.
+
+          Default is `earliest`.
+      - name: partition_receive_timeout
+        type: text
+        title: Partition receive timeout
+        multi: false
+        required: false
+        show_user: false
+        default: 5s
+        description: >-
+          (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
+
+          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+          Default is `5` seconds.
+      - name: partition_receive_count
+        type: text
+        title: Partition receive count
+        multi: false
+        required: false
+        show_user: false
+        default: 100
+        description: >-
+          (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
+
+          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+          Default is `100` messages.
       - name: transport
         type: select
         title: Event Hubs transport protocol
@@ -144,6 +203,19 @@ streams:
         description: >
           (Processor v2 only) The transport protocol used to connect to Event Hubs.
           Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
+      - name: migrate_checkpoint
+        type: bool
+        title: Migrate checkpoint information
+        multi: false
+        required: false
+        show_user: false
+        default: true
+        description: >-
+          (Processor v2 only) Flag to control if the processor should perform the checkpoint information migration from processor v1 to v2 at startup.
+
+          The checkpoint migration converts the checkpoint information from the v1 format to the v2 format, so the processor resumes from where v1 left off instead of reprocessing the event hub retention window.
+
+          Default is `true`.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/azure_functions/data_stream/functionapplogs/manifest.yml
+++ b/packages/azure_functions/data_stream/functionapplogs/manifest.yml
@@ -172,7 +172,7 @@ streams:
         description: >-
           (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
 
-          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+          The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
           Default is `5` seconds.
       - name: partition_receive_count
@@ -185,7 +185,7 @@ streams:
         description: >-
           (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
-          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+          The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
           Default is `100` messages.
       - name: transport

--- a/packages/azure_functions/data_stream/functionapplogs/manifest.yml
+++ b/packages/azure_functions/data_stream/functionapplogs/manifest.yml
@@ -114,6 +114,21 @@ streams:
         description: >-
           (Optional when **Authentication Type** is **Client Secret**) Microsoft Entra ID authority endpoint. Defaults to https://login.microsoftonline.com (Azure Public Cloud).
           Change for other Azure environments: Azure Government (https://login.microsoftonline.us), Azure China (https://login.chinacloudapi.cn), or Azure Germany (https://login.microsoftonline.de).
+      - name: processor_version
+        type: select
+        title: Processor version
+        multi: false
+        required: false
+        show_user: false
+        default: v2
+        options:
+          - text: v1 (legacy)
+            value: v1
+          - text: v2
+            value: v2
+        description: >
+          The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
+          The v2 event hub processor is recommended for typical use cases. Defaults to v2.
       - name: transport
         type: select
         title: Event Hubs transport protocol

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -154,6 +154,26 @@ _string_
 _string_
 The Event Hub processor version that the integration should use. Possible values are `v1` (legacy) and `v2` (recommended). Defaults to `v2`.
 
+`processor_update_interval` :
+_string_
+(Processor v2 only) How often the processor should attempt to claim partitions. Defaults to `10s`.
+
+`processor_start_position` :
+_string_
+(Processor v2 only) Where the processor starts processing messages for all partitions. `earliest` (default) starts from the last checkpoint, or the beginning of the event hub if no checkpoint is available. `latest` starts from the latest event and continues with new events as they arrive.
+
+`partition_receive_timeout` :
+_string_
+(Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `5s`.
+
+`partition_receive_count` :
+_int_
+(Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `100`.
+
+`migrate_checkpoint` :
+_bool_
+(Processor v2 only) Controls whether the processor migrates checkpoint information from the v1 format to the v2 format at startup, so it resumes from where v1 left off instead of reprocessing the event hub retention window. Defaults to `true`.
+
 `transport` :
 _string_
 (Processor v2 only) The transport protocol to use when connecting to Event Hubs. `amqp` (default) uses ports `5671` and `5672`. `websocket` uses AMQP-over-WebSockets on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -100,7 +100,7 @@ Instead of a connection string, you can authenticate using a Microsoft Entra ID 
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 #### Configuration options
 
@@ -149,6 +149,10 @@ _string_
 `authority_host` :
 _string_
 (Optional, for client secret authentication.) Microsoft Entra ID authority endpoint. Defaults to `https://login.microsoftonline.com` (Azure Public Cloud). Use a different endpoint for other clouds (for example Azure Government, China, Germany).
+
+`processor_version` :
+_string_
+The Event Hub processor version that the integration should use. Possible values are `v1` (legacy) and `v2` (recommended). Defaults to `v2`.
 
 `transport` :
 _string_

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -96,11 +96,22 @@ Instead of a connection string, you can authenticate using a Microsoft Entra ID 
 4. **Configure the integration**  
    Set **Authentication type** to **Client Secret**. Provide **Tenant ID**, **Client ID**, **Client Secret**, and the fully qualified **Event Hub namespace** (for example `yournamespace.servicebus.windows.net`). Use the same Storage Account and container as for connection string authentication; the integration will use the client secret to access both Event Hubs and Storage.
 
-#### AMQP-over-WebSockets and proxy support
+#### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
+#### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 #### Configuration options
 

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -175,11 +175,11 @@ _string_
 
 `partition_receive_timeout` :
 _string_
-(Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `5s`.
+(Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first. Defaults to `5s`.
 
 `partition_receive_count` :
 _int_
-(Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Defaults to `100`.
+(Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first. Defaults to `100`.
 
 `migrate_checkpoint` :
 _bool_

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -96,6 +96,12 @@ Instead of a connection string, you can authenticate using a Microsoft Entra ID 
 4. **Configure the integration**  
    Set **Authentication type** to **Client Secret**. Provide **Tenant ID**, **Client ID**, **Client Secret**, and the fully qualified **Event Hub namespace** (for example `yournamespace.servicebus.windows.net`). Use the same Storage Account and container as for connection string authentication; the integration will use the client secret to access both Event Hubs and Storage.
 
+#### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 #### Configuration options
 
 `auth_type` :
@@ -143,6 +149,10 @@ _string_
 `authority_host` :
 _string_
 (Optional, for client secret authentication.) Microsoft Entra ID authority endpoint. Defaults to `https://login.microsoftonline.com` (Azure Public Cloud). Use a different endpoint for other clouds (for example Azure Government, China, Germany).
+
+`transport` :
+_string_
+(Processor v2 only) The transport protocol to use when connecting to Event Hubs. `amqp` (default) uses ports `5671` and `5672`. `websocket` uses AMQP-over-WebSockets on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
 `storage_account_container` :
 _string_

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: azure_functions
 title: "Azure Functions"
-version: "0.15.0"
+version: "0.16.0"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"

--- a/packages/azure_logs/_dev/build/docs/README.md
+++ b/packages/azure_logs/_dev/build/docs/README.md
@@ -391,9 +391,14 @@ Optionally, you can restrict the traffic to the following domain names:
 
 #### Proxy support
 
-When using AMQP-over-WebSockets, both Event Hubs and Storage Account traffic use HTTPS on port `443`. Set the `HTTPS_PROXY` environment variable to route this traffic through a proxy.
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
 
-Proxy support requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**, processor v2, and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## Settings
 

--- a/packages/azure_logs/_dev/build/docs/README.md
+++ b/packages/azure_logs/_dev/build/docs/README.md
@@ -328,7 +328,9 @@ The Agent creates one SA container for the integration. The SA container name co
 
 ### Running the integration behind a firewall
 
-When you run the Elastic Agent behind a firewall, you must allow traffic on ports `5671` and `5672` for the event hub and port `443` for the Storage Account container to ensure proper communication with the necessary components.
+When the Elastic Agent runs in an environment with network restrictions, check that the required ports are open for the transport protocol used by the integration.
+
+The Elastic Agent requires access to Event Hubs and Storage Accounts.
 
 ```text
 ┌────────────────────────────────┐  ┌───────────────────┐  ┌───────────────────┐
@@ -356,18 +358,26 @@ When you run the Elastic Agent behind a firewall, you must allow traffic on port
 └─Azure──────────────────────────┘
 ```
 
-#### Event hub
+#### Event Hubs (AMQP)
 
-Port `5671` and `5672` are commonly used for secure communication with the event hub. These ports are used to receive events. The Elastic Agent can establish a secure connection with the event hub by allowing traffic on these ports. 
+By default, the integration uses AMQP to communicate with Event Hubs.
+
+AMQP uses ports `5671` and `5672`. The Elastic Agent initiates outbound TCP connections to these ports on the Azure Event Hubs service to receive events.
 
 For more information, check the following documents:
 
-* [What ports do I need to open on the firewall?](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall) from the [Event Hubs frequently asked questions](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall).
-* [AMQP outbound port requirements](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-protocol-guide#amqp-outbound-port-requirements)
+- [What ports do I need to open on the firewall?](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall) from the [Event Hubs frequently asked questions](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall).
+- [AMQP outbound port requirements](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-protocol-guide#amqp-outbound-port-requirements)
 
-#### Storage Account container
+#### Event Hubs (AMQP-over-WebSockets)
 
-Port `443` is used for secure communication with the Storage Account container. This port is commonly used for HTTPS traffic. By allowing traffic on port 443, the Elastic Agent can securely access and interact with the Storage Account container, essential for storing and retrieving checkpoint data for each event hub partition.
+If ports `5671` and `5672` are blocked, the integration can use AMQP-over-WebSockets. This protocol tunnels AMQP over port `443` (HTTPS), which is typically allowed through firewalls.
+
+To use it, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
+#### Storage Account
+
+The Elastic Agent initiates outbound TCP connections to port `443` (HTTPS) to store and retrieve checkpoint data from the Azure Storage Account service.
 
 #### DNS
 
@@ -378,6 +388,12 @@ Optionally, you can restrict the traffic to the following domain names:
 *.blob.core.windows.net
 *.cloudapp.net
 ```
+
+#### Proxy support
+
+When using AMQP-over-WebSockets, both Event Hubs and Storage Account traffic use HTTPS on port `443`. Set the `HTTPS_PROXY` environment variable to route this traffic through a proxy.
+
+Proxy support requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**, processor v2, and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## Settings
 
@@ -491,6 +507,15 @@ _string_
 (processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
+
+`transport` :
+_string_
+(processor v2 only) The transport protocol to use when connecting to Event Hubs. Possible values are:
+
+* `amqp` (default): Use AMQP on ports `5671` and `5672`.
+* `websocket`: Use AMQP-over-WebSockets on port `443`. Use this option when AMQP ports are blocked.
+
+When `websocket` is selected, traffic can be routed through a proxy by setting the `HTTPS_PROXY` environment variable.
 
 ## Handling Malformed JSON in Azure Logs
 

--- a/packages/azure_logs/agent/input/input.yml.hbs
+++ b/packages/azure_logs/agent/input/input.yml.hbs
@@ -68,6 +68,9 @@ partition_receive_timeout: {{partition_receive_timeout}}
 {{#if partition_receive_count}}
 partition_receive_count: {{partition_receive_count}}
 {{/if}}
+{{#if transport}}
+transport: {{transport}}
+{{/if}}
 
 tags:
 {{#if preserve_original_event}}

--- a/packages/azure_logs/changelog.yml
+++ b/packages/azure_logs/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
-      link: https://github.com/elastic/obs-integration-team/issues/973
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "0.6.0"
   changes:
     - description: Add client secret authentication support for Azure Event Hub with RBAC.

--- a/packages/azure_logs/changelog.yml
+++ b/packages/azure_logs/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.0"
+  changes:
+    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
+      type: enhancement
+      link: https://github.com/elastic/obs-integration-team/issues/973
 - version: "0.6.0"
   changes:
     - description: Add client secret authentication support for Azure Event Hub with RBAC.

--- a/packages/azure_logs/docs/README.md
+++ b/packages/azure_logs/docs/README.md
@@ -391,9 +391,14 @@ Optionally, you can restrict the traffic to the following domain names:
 
 #### Proxy support
 
-When using AMQP-over-WebSockets, both Event Hubs and Storage Account traffic use HTTPS on port `443`. Set the `HTTPS_PROXY` environment variable to route this traffic through a proxy.
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
 
-Proxy support requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**, processor v2, and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## Settings
 

--- a/packages/azure_logs/docs/README.md
+++ b/packages/azure_logs/docs/README.md
@@ -328,7 +328,9 @@ The Agent creates one SA container for the integration. The SA container name co
 
 ### Running the integration behind a firewall
 
-When you run the Elastic Agent behind a firewall, you must allow traffic on ports `5671` and `5672` for the event hub and port `443` for the Storage Account container to ensure proper communication with the necessary components.
+When the Elastic Agent runs in an environment with network restrictions, check that the required ports are open for the transport protocol used by the integration.
+
+The Elastic Agent requires access to Event Hubs and Storage Accounts.
 
 ```text
 ┌────────────────────────────────┐  ┌───────────────────┐  ┌───────────────────┐
@@ -356,18 +358,26 @@ When you run the Elastic Agent behind a firewall, you must allow traffic on port
 └─Azure──────────────────────────┘
 ```
 
-#### Event hub
+#### Event Hubs (AMQP)
 
-Port `5671` and `5672` are commonly used for secure communication with the event hub. These ports are used to receive events. The Elastic Agent can establish a secure connection with the event hub by allowing traffic on these ports. 
+By default, the integration uses AMQP to communicate with Event Hubs.
+
+AMQP uses ports `5671` and `5672`. The Elastic Agent initiates outbound TCP connections to these ports on the Azure Event Hubs service to receive events.
 
 For more information, check the following documents:
 
-* [What ports do I need to open on the firewall?](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall) from the [Event Hubs frequently asked questions](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall).
-* [AMQP outbound port requirements](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-protocol-guide#amqp-outbound-port-requirements)
+- [What ports do I need to open on the firewall?](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall) from the [Event Hubs frequently asked questions](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-ports-do-i-need-to-open-on-the-firewall).
+- [AMQP outbound port requirements](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-protocol-guide#amqp-outbound-port-requirements)
 
-#### Storage Account container
+#### Event Hubs (AMQP-over-WebSockets)
 
-Port `443` is used for secure communication with the Storage Account container. This port is commonly used for HTTPS traffic. By allowing traffic on port 443, the Elastic Agent can securely access and interact with the Storage Account container, essential for storing and retrieving checkpoint data for each event hub partition.
+If ports `5671` and `5672` are blocked, the integration can use AMQP-over-WebSockets. This protocol tunnels AMQP over port `443` (HTTPS), which is typically allowed through firewalls.
+
+To use it, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
+#### Storage Account
+
+The Elastic Agent initiates outbound TCP connections to port `443` (HTTPS) to store and retrieve checkpoint data from the Azure Storage Account service.
 
 #### DNS
 
@@ -378,6 +388,12 @@ Optionally, you can restrict the traffic to the following domain names:
 *.blob.core.windows.net
 *.cloudapp.net
 ```
+
+#### Proxy support
+
+When using AMQP-over-WebSockets, both Event Hubs and Storage Account traffic use HTTPS on port `443`. Set the `HTTPS_PROXY` environment variable to route this traffic through a proxy.
+
+Proxy support requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**, processor v2, and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
 
 ## Settings
 
@@ -491,6 +507,15 @@ _string_
 (processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
 The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.
+
+`transport` :
+_string_
+(processor v2 only) The transport protocol to use when connecting to Event Hubs. Possible values are:
+
+* `amqp` (default): Use AMQP on ports `5671` and `5672`.
+* `websocket`: Use AMQP-over-WebSockets on port `443`. Use this option when AMQP ports are blocked.
+
+When `websocket` is selected, traffic can be routed through a proxy by setting the `HTTPS_PROXY` environment variable.
 
 ## Handling Malformed JSON in Azure Logs
 

--- a/packages/azure_logs/manifest.yml
+++ b/packages/azure_logs/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: azure_logs
 title: "Custom Azure Logs"
-version: "0.6.0"
+version: "0.7.0"
 source:
   license: Elastic-2.0
 description: "Collect log events from Azure Event Hubs with Elastic Agent"
@@ -277,6 +277,21 @@ policy_templates:
           The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
 
           Default is `100` messages.
+      - name: transport
+        type: select
+        title: Event Hubs transport protocol
+        multi: false
+        required: true
+        show_user: false
+        default: amqp
+        options:
+          - text: AMQP
+            value: amqp
+          - text: AMQP-over-WebSockets
+            value: websocket
+        description: >
+          (Processor v2 only) The transport protocol used to connect to Event Hubs.
+          Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
       - name: migrate_checkpoint
         type: bool
         title: Migrate checkpoint information

--- a/packages/azure_openai/_dev/build/docs/README.md
+++ b/packages/azure_openai/_dev/build/docs/README.md
@@ -45,7 +45,7 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.2.4, or later.
 
 #### Default Logging
 

--- a/packages/azure_openai/_dev/build/docs/README.md
+++ b/packages/azure_openai/_dev/build/docs/README.md
@@ -41,11 +41,22 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
-#### AMQP-over-WebSockets and proxy support
+#### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.2.4, or later.
+
+#### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.2.4, or later.
 
 #### Default Logging
 

--- a/packages/azure_openai/_dev/build/docs/README.md
+++ b/packages/azure_openai/_dev/build/docs/README.md
@@ -41,6 +41,12 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
+#### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 #### Default Logging
 
 The Azure OpenAI provides native logging and monitoring to track the telemetry of the service. The Audit and RequestResponse log categories come under the native logging. However, the default logging doesn't log the inputs and outputs of the service. This is useful to ensure that the services operates as expected.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -7,6 +7,9 @@
     - description: Add the Event Hub processor version option and switch the default processor version to v2.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "1.14.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
-      link: https://github.com/elastic/obs-integration-team/issues/973
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "1.14.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
+      type: enhancement
+      link: https://github.com/elastic/obs-integration-team/issues/973
 - version: "1.14.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
+    - description: Add the Event Hub processor version option and switch the default processor version to v2.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20559
 - version: "1.14.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,13 +1,7 @@
 # newer versions go on top
 - version: "1.15.0"
   changes:
-    - description: Add support for AMQP-over-WebSockets transport protocol and proxy configuration.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the Event Hub processor version option and switch the default processor version to v2.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/20559
-    - description: Add the remaining Event Hub processor v2 options (processor update interval, processor start position, partition receive timeout, partition receive count, and checkpoint migration).
+    - description: Add AMQP-over-WebSockets transport, proxy support, and Event Hub processor v2 configuration options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20559
 - version: "1.14.0"

--- a/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -46,6 +46,19 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+migrate_checkpoint: {{migrate_checkpoint}}
+{{#if processor_update_interval}}
+processor_update_interval: {{processor_update_interval}}
+{{/if}}
+{{#if processor_start_position}}
+processor_start_position: {{processor_start_position}}
+{{/if}}
+{{#if partition_receive_timeout}}
+partition_receive_timeout: {{partition_receive_timeout}}
+{{/if}}
+{{#if partition_receive_count}}
+partition_receive_count: {{partition_receive_count}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if transport}}
+transport: {{transport}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -46,7 +46,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if processor_version}}
 processor_version: {{processor_version}}
 {{/if}}
+{{#if migrate_checkpoint}}
 migrate_checkpoint: {{migrate_checkpoint}}
+{{/if}}
 {{#if processor_update_interval}}
 processor_update_interval: {{processor_update_interval}}
 {{/if}}

--- a/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
+++ b/packages/azure_openai/data_stream/logs/agent/stream/azure-eventhub.yml.hbs
@@ -43,6 +43,9 @@ storage_account_key: {{storage_account_key}}
 {{#if resource_manager_endpoint}}
 resource_manager_endpoint: {{resource_manager_endpoint}}
 {{/if}}
+{{#if processor_version}}
+processor_version: {{processor_version}}
+{{/if}}
 {{#if transport}}
 transport: {{transport}}
 {{/if}}

--- a/packages/azure_openai/data_stream/logs/manifest.yml
+++ b/packages/azure_openai/data_stream/logs/manifest.yml
@@ -113,6 +113,21 @@ streams:
         description: >-
           (Optional when **Authentication Type** is **Client Secret**) Microsoft Entra ID authority endpoint. Defaults to https://login.microsoftonline.com (Azure Public Cloud).
           Change for other Azure environments: Azure Government (https://login.microsoftonline.us), Azure China (https://login.chinacloudapi.cn), or Azure Germany (https://login.microsoftonline.de).
+      - name: processor_version
+        type: select
+        title: Processor version
+        multi: false
+        required: false
+        show_user: false
+        default: v2
+        options:
+          - text: v1 (legacy)
+            value: v1
+          - text: v2
+            value: v2
+        description: >
+          The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
+          The v2 event hub processor is recommended for typical use cases. Defaults to v2.
       - name: transport
         type: select
         title: Event Hubs transport protocol

--- a/packages/azure_openai/data_stream/logs/manifest.yml
+++ b/packages/azure_openai/data_stream/logs/manifest.yml
@@ -128,6 +128,65 @@ streams:
         description: >
           The processor version that the integration should use. Possible values are v1 (legacy) and v2 (recommended).
           The v2 event hub processor is recommended for typical use cases. Defaults to v2.
+      - name: processor_update_interval
+        type: text
+        title: Processor update interval
+        multi: false
+        required: false
+        show_user: false
+        default: 10s
+        description: >-
+          (Processor v2 only) How often the processor should attempt to claim partitions.
+
+          Default is `10` seconds.
+      - name: processor_start_position
+        type: select
+        title: Processor start position
+        multi: false
+        required: false
+        show_user: false
+        default: earliest
+        options:
+          - text: earliest
+            value: earliest
+          - text: latest
+            value: latest
+        description: >-
+          (Processor v2 only) Controls from what position in the event hub the processor should start processing messages for all partitions.
+
+          Possible values are `earliest` and `latest`.
+
+          `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available.
+
+          `latest` starts processing messages from the latest event in the event hub and continues to process new events as they arrive.
+
+          Default is `earliest`.
+      - name: partition_receive_timeout
+        type: text
+        title: Partition receive timeout
+        multi: false
+        required: false
+        show_user: false
+        default: 5s
+        description: >-
+          (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
+
+          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+          Default is `5` seconds.
+      - name: partition_receive_count
+        type: text
+        title: Partition receive count
+        multi: false
+        required: false
+        show_user: false
+        default: 100
+        description: >-
+          (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
+
+          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+
+          Default is `100` messages.
       - name: transport
         type: select
         title: Event Hubs transport protocol
@@ -143,6 +202,19 @@ streams:
         description: >
           (Processor v2 only) The transport protocol used to connect to Event Hubs.
           Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
+      - name: migrate_checkpoint
+        type: bool
+        title: Migrate checkpoint information
+        multi: false
+        required: false
+        show_user: false
+        default: true
+        description: >-
+          (Processor v2 only) Flag to control if the processor should perform the checkpoint information migration from processor v1 to v2 at startup.
+
+          The checkpoint migration converts the checkpoint information from the v1 format to the v2 format, so the processor resumes from where v1 left off instead of reprocessing the event hub retention window.
+
+          Default is `true`.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/azure_openai/data_stream/logs/manifest.yml
+++ b/packages/azure_openai/data_stream/logs/manifest.yml
@@ -171,7 +171,7 @@ streams:
         description: >-
           (Processor v2 only) Maximum time to wait before processing the messages received from the event hub.
 
-          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+          The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
           Default is `5` seconds.
       - name: partition_receive_count
@@ -184,7 +184,7 @@ streams:
         description: >-
           (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them.
 
-          The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first.
+          The partition consumer waits up to a "receive count" or a "receive timeout," whichever comes first.
 
           Default is `100` messages.
       - name: transport

--- a/packages/azure_openai/data_stream/logs/manifest.yml
+++ b/packages/azure_openai/data_stream/logs/manifest.yml
@@ -113,6 +113,21 @@ streams:
         description: >-
           (Optional when **Authentication Type** is **Client Secret**) Microsoft Entra ID authority endpoint. Defaults to https://login.microsoftonline.com (Azure Public Cloud).
           Change for other Azure environments: Azure Government (https://login.microsoftonline.us), Azure China (https://login.chinacloudapi.cn), or Azure Germany (https://login.microsoftonline.de).
+      - name: transport
+        type: select
+        title: Event Hubs transport protocol
+        multi: false
+        required: true
+        show_user: false
+        default: amqp
+        options:
+          - text: AMQP
+            value: amqp
+          - text: AMQP-over-WebSockets
+            value: websocket
+        description: >
+          (Processor v2 only) The transport protocol used to connect to Event Hubs.
+          Supported values are AMQP and AMQP-over-WebSockets. Defaults to AMQP.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/azure_openai/docs/README.md
+++ b/packages/azure_openai/docs/README.md
@@ -41,11 +41,22 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
-#### AMQP-over-WebSockets and proxy support
+#### AMQP-over-WebSockets
 
-By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443`.
 
 This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.2.4, or later.
+
+#### Proxy support
+
+Proxy support is optional and requires **Event Hubs transport protocol** set to **AMQP-over-WebSockets**.
+
+To enable it:
+
+1. In the advanced options, set **Event Hubs transport protocol** to **AMQP-over-WebSockets**.
+2. Define the `HTTPS_PROXY` environment variable for the Elastic Agent process, for example `HTTPS_PROXY=http://proxy.example.com:8080`. Elastic Agent routes both Event Hubs and Storage Account traffic through the proxy.
+
+This requires processor v2 and Elastic Agent 8.19.10, 9.2.4, or later.
 
 #### Default Logging
 

--- a/packages/azure_openai/docs/README.md
+++ b/packages/azure_openai/docs/README.md
@@ -45,7 +45,7 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
 
-This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+This option requires the Event Hub processor v2 (**Processor version** set to `v2`, which is the default) and Elastic Agent 8.19.10, 9.2.4, or later.
 
 #### Default Logging
 
@@ -422,5 +422,7 @@ The following alert rule templates are available:
 
 
 **[Azure OpenAI] Quota Error Rates above threshold**
+
+
 
 

--- a/packages/azure_openai/docs/README.md
+++ b/packages/azure_openai/docs/README.md
@@ -41,6 +41,12 @@ Refer to the [Azure Logs](https://docs.elastic.co/integrations/azure) page for m
 
 **Authentication (Event Hub):** The Event Hub input supports two authentication methods: **connection string** (default) and **client secret** (Microsoft Entra ID). For setup steps, required RBAC roles (Azure Event Hubs Data Receiver, Storage Blob Data Contributor), and configuration options, see the [Azure Logs integration](https://docs.elastic.co/integrations/azure) or [Filebeat azure-eventhub input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-eventhub.html) documentation.
 
+#### AMQP-over-WebSockets and proxy support
+
+By default, the integration uses AMQP ports `5671` and `5672` to communicate with Event Hubs. If these ports are blocked, set **Event Hubs transport protocol** to **AMQP-over-WebSockets** in the advanced options. This tunnels AMQP over HTTPS on port `443` and enables proxy support through the `HTTPS_PROXY` environment variable.
+
+This option requires processor v2 and Elastic Agent 8.19.10, 9.1.10, 9.2.4, or later.
+
 #### Default Logging
 
 The Azure OpenAI provides native logging and monitoring to track the telemetry of the service. The Audit and RequestResponse log categories come under the native logging. However, the default logging doesn't log the inputs and outputs of the service. This is useful to ensure that the services operates as expected.
@@ -416,6 +422,5 @@ The following alert rule templates are available:
 
 
 **[Azure OpenAI] Quota Error Rates above threshold**
-
 
 

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: azure_openai
 title: "Azure OpenAI"
-version: "1.14.0"
+version: "1.15.0"
 source:
   license: "Elastic-2.0"
 description: "Collects Azure OpenAI Logs and Metrics"


### PR DESCRIPTION
Closes #20570

## Proposed commit message

Add AMQP-over-WebSockets transport support to the Azure Event Hub integrations (Azure OpenAI, Azure Functions, Microsoft Foundry, Azure App Service, and Custom Azure Logs).

`transport` defaults to `amqp`; `websocket` tunnels AMQP over HTTPS port `443`, enabling Event Hubs traffic through restrictive firewalls and `HTTPS_PROXY` proxies.

Because `transport` is a processor v2 option, this also exposes the processor v2 settings in the four packages that lacked them and flips their default processor version from v1 to v2 (matching `azure`, #16955). On upgrade, `migrate_checkpoint` (default `true`) migrates v1 checkpoints once, so consumption resumes where v1 left off.

This was requested for exactly these five integrations: Azure OpenAI, Azure Functions, Microsoft Foundry, Azure App Service, and Custom Azure Logs (which already used processor v2). Existing kibana constraints already require a stack supporting `transport` (8.19.10 / 9.1.10 / 9.2.4+, per package), so no constraint changes are needed.

## Changes

- Add and render a hidden `transport` selector (`amqp` default; `websocket` on port `443`) in each `azure-eventhub` input.
- Expose the processor v2 settings (`processor_version`, `migrate_checkpoint`, `processor_update_interval`, `processor_start_position`, `partition_receive_timeout`, `partition_receive_count`) and default to v2 for Azure OpenAI, Azure Functions, Microsoft Foundry, and Azure App Service; Custom Azure Logs already had them.
- Document firewall and AMQP-over-WebSockets requirements, plus proxy setup: how to enable optional proxy support via the `HTTPS_PROXY` environment variable and that it requires `websocket` transport.
- Bump package minors and add changelog entries.

## Impact on existing installations

The four packages above move from processor v1 to v2 on upgrade; the automatic v1→v2 checkpoint migration preserves the consumer position.

## Verification

- `elastic-package build` and `elastic-package check` for all five packages.
- `git diff --check`.
- Azure OpenAI reports the pre-existing skipped dashboard validation `SVR00002`; that dashboard is unchanged.

## Related issues

- Follows #16954
- Follows #16955