### PR TITLE
[cisco_ftd] Fix grok for 111008/111009 to capture usernames with spaces.

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix grok pattern for messages 111008 and 111009 to capture usernames containing spaces.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20563
 - version: "3.13.8"
   changes:
     - description: Convert FileSize to long instead of integer so large file sizes above the 32-bit integer limit no longer fail parsing for event.code.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.9"
+  changes:
+    - description: Fix grok pattern for messages 111008 and 111009 to capture usernames containing spaces.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.13.8"
   changes:
     - description: Convert FileSize to long instead of integer so large file sizes above the 32-bit integer limit no longer fail parsing for event.code.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -56,3 +56,4 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Password malformed : server = 192.0.2.20 : user = engineer@elastic.co : user IP = 198.51.100.30
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Unspecified : server = 192.0.2.20 : user = **** : user IP = 198.51.100.30
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Password has expired : server = 192.0.2.20 : user = engineer@elastic.co : user IP = 198.51.100.30
+<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111008: User 'example-service account' executed the 'show running-config zero-trust' command.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -4302,6 +4302,68 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-07-07T14:12:01.000Z",
+            "cisco": {
+                "ftd": {
+                    "command_line_arguments": "'show running-config zero-trust' command."
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "111008",
+                "kind": "event",
+                "original": "<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111008: User 'example-service account' executed the 'show running-config zero-trust' command.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 22
+                    },
+                    "priority": 181,
+                    "severity": {
+                        "code": 5
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "user": [
+                    "example-service account"
+                ]
+            },
+            "server": {
+                "user": {
+                    "name": "example-service account"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -408,8 +408,8 @@ processors:
       description: "111008, 111009"
       field: "message"
       patterns:
-        - "^%{NOTSPACE} '%{NOTSPACE:server.user.name}' executed %{NOTSPACE} %{GREEDYDATA:_temp_.cisco.command_line_arguments}"
-        - "^%{NOTSPACE} '%{NOTSPACE:server.user.name}' executed the '%{DATA}' command"
+        - "^%{NOTSPACE} '%{DATA:server.user.name}' executed %{NOTSPACE} %{GREEDYDATA:_temp_.cisco.command_line_arguments}"
+        - "^%{NOTSPACE} '%{DATA:server.user.name}' executed the '%{DATA}' command"
   - grok:
       tag: grok_message_5ccd264e
       if: "ctx._temp_.cisco.message_id == '111010'"

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.13.8"
+version: "3.13.9"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

The grok patterns for Cisco FTD message codes 111008 and 111009 used `%{NOTSPACE}` to capture the username field (`server.user.name`), which excludes whitespace and therefore fails to parse usernames containing spaces (e.g., service accounts like `example-service account`). The fix replaces `%{NOTSPACE}` with `%{DATA}` in both patterns, allowing the username to contain spaces while still being correctly bounded by the surrounding single quotes. A new pipeline test fixture was added to validate the space-containing username case, and the package version was bumped to 3.13.9.

## Proposed commit message

```
[cisco_ftd] Fix grok for 111008/111009 to capture usernames with spaces.
```

## Root cause

The `grok_message_e6caac62` processor uses `%{NOTSPACE:server.user.name}` (regex `\S+`) to capture the username from 111008/111009 messages, which stops at the first whitespace character. Cisco FTD allows service accounts and domain accounts with embedded spaces in their names, causing the pattern to fail mid-match and the processor to throw a parse error.

## Approach

In the `grok_message_e6caac62` processor (which handles message IDs 111008 and 111009), replace `%{NOTSPACE:server.user.name}` with `%{DATA:server.user.name}` in both grok patterns. The username is already delimited on both sides by literal single-quote characters, so `DATA` (which matches any character including spaces) is safely bounded and will correctly capture multi-word usernames such as service accounts and domain accounts. Add a pipeline test fixture for the sanitized event to validate the corrected patterns. Bump package version from 3.13.4 to 3.13.5 with a bugfix changelog entry.

## Implementation

1. Step 1: Edit `packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml` — in the `grok_message_e6caac62` processor (line ~410), change pattern 1 from `^%{NOTSPACE} '%{NOTSPACE:server.user.name}' executed %{NOTSPACE} %{GREEDYDATA:_temp_.cisco.command_line_arguments}` to `^%{NOTSPACE} '%{DATA:server.user.name}' executed %{NOTSPACE} %{GREEDYDATA:_temp_.cisco.command_line_arguments}`
2. Step 2: Edit `packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml` — in the same `grok_message_e6caac62` processor (line ~411), change pattern 2 from `^%{NOTSPACE} '%{NOTSPACE:server.user.name}' executed the '%{DATA}' command` to `^%{NOTSPACE} '%{DATA:server.user.name}' executed the '%{DATA}' command`
3. Step 3: Append the sanitized test event to `packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log`: `<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111008: User 'example-service account' executed the 'show running-config zero-trust' command.`
4. Step 4: Update `packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json` — add the expected output entry for the new event with `server.user.name: "example-service account"`, `event.code: "111008"`, `_temp_.cisco.command_line_arguments: "show running-config zero-trust"`, and `related.user` containing `"example-service account"` (the existing `append_related_user_6a92751c` processor at line ~3104 already handles this append for `server.user.name`)
5. Step 5: Update `packages/cisco_ftd/changelog.yml` — prepend a new entry for version `3.13.5` with `type: bugfix` and description: `Fix grok pattern for messages 111008 and 111009 to capture usernames containing spaces.`
6. Step 6: Update `packages/cisco_ftd/manifest.yml` — bump `version` from `3.13.4` to `3.13.5`
7. Step 7: Run `elastic-package test pipeline --data-streams log` from `packages/cisco_ftd/` to validate all test fixtures pass

## Pipeline changes

- grok_message_e6caac62, pattern 1: replace `%{NOTSPACE:server.user.name}` with `%{DATA:server.user.name}` — username is bounded by surrounding single-quote delimiters so DATA cannot over-capture
- grok_message_e6caac62, pattern 2: replace `%{NOTSPACE:server.user.name}` with `%{DATA:server.user.name}` — same bounding rationale applies

## Field / mapping changes

—

## Sanitized error message

`[pipeline error]`

## Sanitized log (`event_sanitized` excerpt)

```json
<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111008: User 'example-service account' executed the 'show running-config zero-trust' command.
```

## Reviewer concerns

- The test fixture file (`test-ftd-fix.log`) is missing a trailing newline (`\ No newline at end of file`); minor style issue that some CI linters flag.
- The first grok pattern uses `%{GREEDYDATA}` for `command_line_arguments` after `%{DATA}` for the username — both rely on the single-quote delimiters being well-formed in the log message. If a username itself contained a literal single quote, `DATA` (non-greedy `.*?`) would stop at the first `'` and potentially misparse; this edge case is unlikely in practice but worth noting.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, test-fixture, ingest
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_ftd.log [PIPELINE_FIX]: [pipeline error]
- **Pipeline case**: `394498904ab18c7a`
