### PR TITLE
[ti_flashpoint] set `X-FP-*` headers for HTTP requests

### DIFF
--- a/packages/ti_flashpoint/changelog.yml
+++ b/packages/ti_flashpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Add X-FP-IntegrationPlatform, X-FP-IntegrationVersion and X-FP-IntegrationPlatformVersion client identification headers to all API requests.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/ti_flashpoint/changelog.yml
+++ b/packages/ti_flashpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add X-FP-IntegrationPlatform, X-FP-IntegrationVersion and X-FP-IntegrationPlatformVersion client identification headers to all API requests.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20566
 - version: "0.3.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/ti_flashpoint/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/ti_flashpoint/data_stream/alert/agent/stream/cel.yml.hbs
@@ -22,6 +22,8 @@ state:
   initial_interval: {{initial_interval}}
   page_size: {{page_size}}
   api_token: {{api_token}}
+  integration_version: !!str {{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
+  integration_platform_version: !!str {{#if _meta.agent.version}}{{_meta.agent.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_token
@@ -40,6 +42,9 @@ program: |
       "Header": {
         "Accept": ["application/json"],
         "Authorization": ["Bearer " + state.api_token],
+        "X-FP-IntegrationPlatform": ["Elastic"],
+        "X-FP-IntegrationVersion": [state.integration_version],
+        "X-FP-IntegrationPlatformVersion": [state.integration_platform_version],
       }
     }).do_request().as(resp, resp.StatusCode == 200 ?
       resp.Body.decode_json().as(body,

--- a/packages/ti_flashpoint/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_flashpoint/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -22,6 +22,8 @@ state:
   initial_interval: {{initial_interval}}
   page_size: {{page_size}}
   api_token: {{api_token}}
+  integration_version: !!str {{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
+  integration_platform_version: !!str {{#if _meta.agent.version}}{{_meta.agent.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_token
@@ -40,6 +42,9 @@ program: |
       "Header": {
         "Accept": ["application/json"],
         "Authorization": ["Bearer " + state.api_token],
+        "X-FP-IntegrationPlatform": ["Elastic"],
+        "X-FP-IntegrationVersion": [state.integration_version],
+        "X-FP-IntegrationPlatformVersion": [state.integration_platform_version],
       }
     }).do_request().as(resp, resp.StatusCode == 200 ?
       resp.Body.decode_json().as(body,

--- a/packages/ti_flashpoint/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/ti_flashpoint/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -22,6 +22,8 @@ state:
   initial_interval: {{initial_interval}}
   page_size: {{page_size}}
   api_token: {{api_token}}
+  integration_version: !!str {{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
+  integration_platform_version: !!str {{#if _meta.agent.version}}{{_meta.agent.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_token
@@ -39,6 +41,9 @@ program: |
       "Header": {
         "Accept": ["application/json"],
         "Authorization": ["Bearer " + state.api_token],
+        "X-FP-IntegrationPlatform": ["Elastic"],
+        "X-FP-IntegrationVersion": [state.integration_version],
+        "X-FP-IntegrationPlatformVersion": [state.integration_platform_version],
       }
     }).do_request().as(resp, resp.StatusCode == 200 ?
       resp.Body.decode_json().as(body,

--- a/packages/ti_flashpoint/manifest.yml
+++ b/packages/ti_flashpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_flashpoint
 title: Flashpoint
-version: 0.3.2
+version: 0.4.0
 description: Collect logs from Flashpoint with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message
```
The Flashpoint API requests now carry the vendor-requested identification
headers: X-FP-IntegrationPlatform is set to "Elastic",
X-FP-IntegrationVersion to the package version and
X-FP-IntegrationPlatformVersion to the Elastic Agent version. Both
versions are taken from the policy template metadata when available
(this is the case for stacks at or above 9.3), otherwise they are set to
"unknown".

The headers are added to the alert, indicator and vulnerability data
streams.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
