### PR TITLE
[cisco_asa] Add missing rejection reasons to 113005 grok pattern.

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.11"
+  changes:
+    - description: Add 'User was not found' as a valid rejection reason for ASA 113005 messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.45.10"
   changes:
     - description: Add grok pattern to parse_737016 to handle IPAA pool-freeing events with Session ID but without pool name.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add 'User was not found' as a valid rejection reason for ASA 113005 messages.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20567
 - version: "2.45.10"
   changes:
     - description: Add grok pattern to parse_737016 to handle IPAA pool-freeing events with Session ID but without pool name.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -192,4 +192,5 @@ May  5 18:40:50 dev-01: %ASA-6-305011: Built dynamic TCP translation from fw111:
 May  5 18:40:50 dev_01: %ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/61400 to out111:external-pool/61400
 <190>May 15 2026 12:54:07: %ASA-6-113015: AAA user authentication Rejected : reason = User was not found : local database : user = ;;alice-johnson(test user) : user IP = 203.0.113.20
 <166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20
+Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : reason = User was not found : server = 0.0.0.0 : user = alice.johnson : user IP = 198.51.100.20
 <140>Jun 27 00:53:12 host-1.example.local : %ASA-6-737016: IPAA: Session=0x0e5fc000, Freeing local pool address 198.51.100.10

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -13539,6 +13539,90 @@
             ]
         },
         {
+            "@timestamp": "2026-06-26T18:04:40.000Z",
+            "cisco": {
+                "asa": {
+                    "rejection_reason": "User was not found"
+                }
+            },
+            "destination": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113005",
+                "kind": "event",
+                "original": "Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : reason = User was not found : server = 0.0.0.0 : user = alice.johnson : user IP = 198.51.100.20",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "ip": [
+                    "198.51.100.20",
+                    "0.0.0.0"
+                ],
+                "user": [
+                    "alice.johnson"
+                ]
+            },
+            "source": {
+                "address": "198.51.100.20",
+                "as": {
+                    "number": 64501,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Amsterdam",
+                    "continent_name": "Europe",
+                    "country_iso_code": "NL",
+                    "country_name": "Netherlands",
+                    "location": {
+                        "lat": 52.37404,
+                        "lon": 4.88969
+                    },
+                    "region_iso_code": "NL-NH",
+                    "region_name": "North Holland"
+                },
+                "ip": "198.51.100.20",
+                "user": {
+                    "name": "alice.johnson"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2026-06-27T00:53:12.000Z",
             "cisco": {
                 "asa": {

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -429,7 +429,7 @@ processors:
       - "AAA user %{AUTH} Rejected(%{SPACE})?: reason = %{REASON:_temp_.cisco.rejection_reason}(%{SPACE})?: server = %{IPORHOST:destination.address}(%{SPACE})?: user = ?(%{CISCO_USER:source.user.name}|)(%{SPACE})?: user IP = %{IPORNONE}"
       pattern_definitions:
         AUTH: (authentication|authorization)
-        REASON: (AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified|Account has been locked out|Users account has expired)
+        REASON: (AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified|Account has been locked out|Users account has expired|User was not found)
         USERNAME: "[a-zA-Z0-9._'-]+"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
         IPORNONE: (%{IP:source.address}|None)

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.10"
+version: "2.45.11"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Added 'User was not found' as a valid rejection reason in the grok pattern for Cisco ASA message code 113005. The REASON pattern definition in the ingest pipeline's parse_113005 processor previously did not include this value, causing the grok processor to fail and emit a MISSING_CASE error when ASA devices sent authorization rejection events with this reason string. The fix extends the alternation group in the REASON custom pattern definition to include this case.

## Proposed commit message

```
[cisco_asa] Add missing rejection reasons to 113005 grok pattern.
```

## Root cause

The REASON pattern alternation in the parse_113005 grok processor omits 'User was not found' and 'Users account has expired', which are valid vendor-emitted rejection reason strings documented in the integration's own field-schema-analysis. The sibling parse_113015 processor already supports 'User was not found', creating an inconsistency. Any 113005 event with these reason values falls through to grok's on_failure handler.

## Approach

Add 'User was not found' and 'Users account has expired' to the REASON pattern alternation in the parse_113005 grok processor (line 431 of default.yml). The sibling processor parse_113015 already includes 'User was not found' in its REASON definition; parse_113005 must be brought to parity. Add a new test fixture line for the sanitized authorization-variant event and update the expected JSON output accordingly.

## Implementation

1. Step 1: Edit packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml — in the parse_113005 processor (line 431), extend the REASON alternation from '(AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified|Account has been locked out)' to also include '|Users account has expired|User was not found'.
2. Step 2: Add a new test input line to packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log for the sanitized authorization-variant event: 'Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : reason = User was not found : server = 0.0.0.0 : user = alice.johnson : user IP = 198.51.100.20'.
3. Step 3: Add the corresponding expected output block to packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json, modelling it after existing 113005 blocks, with cisco.asa.rejection_reason = 'User was not found', event.outcome = 'failure', event.code = '113005', source.user.name = 'alice.johnson', and destination.address = '0.0.0.0'.
4. Step 4: Prepend a new patch version entry to packages/cisco_asa/changelog.yml: version 2.45.3, type bugfix, description: "Add 'User was not found' and 'Users account has expired' as valid rejection reasons for ASA 113005 messages."
5. Step 5: Update the version field in packages/cisco_asa/manifest.yml from '2.45.2' to '2.45.3'.
6. Step 6: Run 'elastic-package test pipeline -v' scoped to the cisco_asa package to confirm the new fixture passes and no existing fixtures regress.

## Pipeline changes

- Modify parse_113005 grok processor pattern_definitions.REASON (default.yml line 431): add '|Users account has expired|User was not found' to the alternation so the full set matches parse_113015's REASON definition.

## Field / mapping changes

—

## Sanitized error message

`Processor 'grok' with tag 'parse_113005' in pipeline 'logs-cisco_asa.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : reason = User was not found : server = 0.0.0.0 : user = alice.johnson : user IP = 198.51.100.20
```

## Reviewer concerns

• The test fixture uses 198.51.100.20 as the source IP, which resolves to GeoIP/ASN enrichment data in the expected JSON; reviewers should confirm the expected output matches their local GeoIP database version or that the fixture was generated against the canonical test stack.
• The changelog link references pull/1 as a placeholder — this should be updated to the actual PR number before merge.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, test-fixture, ingest
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_asa.log [MISSING_CASE]: Processor 'grok' with tag 'parse_113005' in pipeline 'logs-cisco_asa.log…
- **Pipeline case**: `9e914042aeb5f5a3`
