### PR TITLE
ssi: add processor tags and preserve_original_event on failure (4/4)

### DIFF
--- a/packages/airlock_digital/changelog.yml
+++ b/packages/airlock_digital/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/airlock_digital/changelog.yml
+++ b/packages/airlock_digital/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.5.2"
+- version: "0.6.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/airlock_digital/changelog.yml
+++ b/packages/airlock_digital/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -3,22 +3,22 @@ description: Pipeline for processing server activity logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
@@ -29,171 +29,171 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.type
-      tag: append_info_into_event_type
+      tag: append_info_into_event_type_5eab37e6
       value: info
   - append:
       field: event.category
-      tag: append_host_into_event_category
+      tag: append_host_into_event_category_5098f71a
       value: host
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_c26a03dc
       value: Airlock Digital
   - rename:
       field: json.agentid
-      tag: rename_agentid
+      tag: rename_agentid_9051482d
       target_field: airlock_digital.agent.agentid
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_agent_agentid
+      tag: set_host_id_from_agent_agentid_aeede6f5
       copy_from: airlock_digital.agent.agentid
       ignore_empty_value: true
   - rename:
       field: json.clientversion
-      tag: rename_clientversion
+      tag: rename_clientversion_37268905
       target_field: airlock_digital.agent.clientversion
       ignore_missing: true
   - rename:
       field: json.domain
-      tag: rename_domain
+      tag: rename_domain_49bb856f
       target_field: airlock_digital.agent.domain
       ignore_missing: true
   - set:
       field: host.domain
-      tag: set_host_domain_from_agent_domain
+      tag: set_host_domain_from_agent_domain_44accd24
       copy_from: airlock_digital.agent.domain
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_agent_domain_into_related_hosts
+      tag: append_agent_domain_into_related_hosts_96d6242b
       value: '{{{airlock_digital.agent.domain}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.agent?.domain != null
   - convert:
       field: json.freespace
-      tag: convert_freespace_to_long
+      tag: convert_freespace_to_long_224d6972
       target_field: airlock_digital.agent.freespace
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ed15c765
+            tag: append_error_message_4b487d1f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.groupid
-      tag: rename_groupid
+      tag: rename_groupid_694d1f58
       target_field: airlock_digital.agent.groupid
       ignore_missing: true
   - set:
       field: rule.id
-      tag: set_rule_id_from_agent_groupid
+      tag: set_rule_id_from_agent_groupid_acba03a6
       copy_from: airlock_digital.agent.groupid
       ignore_empty_value: true
   - rename:
       field: json.hostname
-      tag: rename_hostname
+      tag: rename_hostname_bdd49e3c
       target_field: airlock_digital.agent.hostname
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_agent_hostname
+      tag: set_host_hostname_from_agent_hostname_b71819b6
       copy_from: airlock_digital.agent.hostname
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_agent_hostname_into_related_hosts
+      tag: append_agent_hostname_into_related_hosts_062481c5
       value: '{{{airlock_digital.agent.hostname}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.agent?.hostname != null
   - convert:
       field: json.ip
-      tag: convert_ip_to_ip
+      tag: convert_ip_to_ip_38823b29
       target_field: airlock_digital.agent.ip
       type: ip
       ignore_missing: true
       if: ctx.json?.ip != ''
       on_failure:
         - append:
-            tag: append_error_message_b1bdbb98
+            tag: append_error_message_cf0b4657
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: host.ip
-      tag: append_airlock_digital_agent_ip_into_host_ip
+      tag: append_airlock_digital_agent_ip_into_host_ip_016487d7
       value: '{{{airlock_digital.agent.ip}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.agent?.ip != null
   - append:
       field: related.ip
-      tag: append_agent_ip_into_related_ip
+      tag: append_agent_ip_into_related_ip_2c010cf9
       value: '{{{airlock_digital.agent.ip}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.agent?.ip != null
   - date:
       field: json.lastcheckin
-      tag: date_lastcheckin
+      tag: date_lastcheckin_265aeac0
       target_field: airlock_digital.agent.lastcheckin
       formats:
         - ISO8601
       if: ctx.json?.lastcheckin != null && ctx.json.lastcheckin != ''
       on_failure:
         - append:
-            tag: append_error_message_1155faed
+            tag: append_error_message_68a0af4d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.localip
-      tag: convert_localip_to_ip
+      tag: convert_localip_to_ip_4bcabbce
       target_field: airlock_digital.agent.localip
       type: ip
       ignore_missing: true
       if: ctx.json?.localip != ''
       on_failure:
         - append:
-            tag: append_error_message_d86b373c
+            tag: append_error_message_d95a82e5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: related.ip
-      tag: append_agent_localip_into_related_ip
+      tag: append_agent_localip_into_related_ip_e4d4bf1f
       value: '{{{airlock_digital.agent.localip}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.agent?.localip != null
   - rename:
       field: json.os
-      tag: rename_os
+      tag: rename_os_7a7e8437
       target_field: airlock_digital.agent.os
       ignore_missing: true
   - set:
       field: host.os.full
-      tag: set_host_os_full_from_agent_os
+      tag: set_host_os_full_from_agent_os_42c1ec6b
       copy_from: airlock_digital.agent.os
       ignore_empty_value: true
   - dissect:
       field: host.os.full
-      tag: dissect_host_os_name
+      tag: dissect_host_os_name_08b5967b
       pattern: '%{host.os.name} %{}'
       ignore_failure: false
       if: ctx.host?.os?.full != null
   - script:
       description: Dynamically set host.os.type values.
-      tag: script_map_host_os_type
+      tag: script_map_host_os_type_a7bac811
       lang: painless
       if: ctx.host?.os?.full != null
       params:
@@ -214,384 +214,384 @@ processors:
         }
   - rename:
       field: json.policy_details.agentstopcode
-      tag: rename_policy_details_agentstopcode
+      tag: rename_policy_details_agentstopcode_c19439e8
       target_field: airlock_digital.agent.poilcy_details.agentstopcode
       ignore_missing: true
   - rename:
       field: json.policy_details.applications
-      tag: rename_policy_details_applications
+      tag: rename_policy_details_applications_2c1dccee
       target_field: airlock_digital.agent.poilcy_details.applications
       ignore_missing: true
   - convert:
       field: json.policy_details.auditmode
-      tag: convert_policy_details_auditmode_to_string
+      tag: convert_policy_details_auditmode_to_string_89b9276c
       target_field: airlock_digital.agent.poilcy_details.auditmode
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.autoupdate
-      tag: convert_policy_details_autoupdate_to_string
+      tag: convert_policy_details_autoupdate_to_string_3da0cb8c
       target_field: airlock_digital.agent.poilcy_details.autoupdate
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.baselines
-      tag: rename_policy_details_baselines
+      tag: rename_policy_details_baselines_a4b1ffcf
       target_field: airlock_digital.agent.poilcy_details.baselines
       ignore_missing: true
   - convert:
       field: json.policy_details.batch
-      tag: convert_policy_details_batch_to_string
+      tag: convert_policy_details_batch_to_string_5db477c3
       target_field: airlock_digital.agent.poilcy_details.batch
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.blocklists
-      tag: rename_policy_details_blocklists
+      tag: rename_policy_details_blocklists_5352d8b1
       target_field: airlock_digital.agent.poilcy_details.blocklists
       ignore_missing: true
   - convert:
       field: json.policy_details.check_ea
-      tag: convert_policy_details_check_ea_to_string
+      tag: convert_policy_details_check_ea_to_string_062b0722
       target_field: airlock_digital.agent.poilcy_details.check_ea
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.command
-      tag: convert_policy_details_command_to_string
+      tag: convert_policy_details_command_to_string_612dfaf8
       target_field: airlock_digital.agent.poilcy_details.command
       type: string
       ignore_missing: true
   - foreach:
       field: json.policy_details.commlist
-      tag: foreach_policy_details_commlist_ip
+      tag: foreach_policy_details_commlist_ip_25b9f0d0
       if: ctx.json?.policy_details?.commlist instanceof List
       processor:
         convert:
           field: _ingest._value.ip
-          tag: convert_policy_details_commlist_ip_to_ip
+          tag: convert_policy_details_commlist_ip_to_ip_69f3a84c
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_ip
+                tag: remove_ingest_value_ip_cee6d222
                 field: _ingest._value.ip
                 ignore_missing: true
             - append:
-                tag: append_error_message
+                tag: append_error_message_1bde96f4
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.policy_details.commlist
-      tag: foreach_policy_details_commlist_ip_761aaae4
+      tag: foreach_policy_details_commlist_ip_8e2094ab
       if: ctx.json?.policy_details?.commlist instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_policy_details_commlist_ip_into_related_ip
+          tag: append_policy_details_commlist_ip_into_related_ip_9e55e4d3
           value: '{{{_ingest._value.ip}}}'
           allow_duplicates: false
   - rename:
       field: json.policy_details.commlist
-      tag: rename_policy_details_commlist
+      tag: rename_policy_details_commlist_efe51e25
       target_field: airlock_digital.agent.poilcy_details.commlist
       ignore_missing: true
   - rename:
       field: json.policy_details.commlistid
-      tag: rename_policy_details_commlistid
+      tag: rename_policy_details_commlistid_bf6ca77a
       target_field: airlock_digital.agent.poilcy_details.commlistid
       ignore_missing: true
   - convert:
       field: json.policy_details.compiledhtml
-      tag: convert_policy_details_compiledhtml_to_string
+      tag: convert_policy_details_compiledhtml_to_string_41ff94b8
       target_field: airlock_digital.agent.poilcy_details.compiledhtml
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.dylib
-      tag: convert_policy_details_dylib_to_string
+      tag: convert_policy_details_dylib_to_string_b3f56b44
       target_field: airlock_digital.agent.poilcy_details.dylib
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.enable_notifications
-      tag: convert_policy_details_enable_notifications_to_string
+      tag: convert_policy_details_enable_notifications_to_string_48768739
       target_field: airlock_digital.agent.poilcy_details.enable_notifications
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.extensions_enabled
-      tag: convert_policy_details_extensions_enabled_to_string
+      tag: convert_policy_details_extensions_enabled_to_string_6e62b95c
       target_field: airlock_digital.agent.poilcy_details.extensions_enabled
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.generalisation
-      tag: convert_policy_details_generalisation_to_string
+      tag: convert_policy_details_generalisation_to_string_b3235d15
       target_field: airlock_digital.agent.poilcy_details.generalisation
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.gprocesses
-      tag: rename_policy_details_gprocesses
+      tag: rename_policy_details_gprocesses_76e4eaed
       target_field: airlock_digital.agent.poilcy_details.gprocesses
       ignore_missing: true
   - remove:
       field: json.policy_details.groupid
-      tag: rename_policy_details_groupid
+      tag: rename_policy_details_groupid_eac3e052
       ignore_missing: true
   - convert:
       field: json.policy_details.hashdb_ver
-      tag: convert_policy_details_hashdb_ver_to_string
+      tag: convert_policy_details_hashdb_ver_to_string_2cab841c
       target_field: airlock_digital.agent.poilcy_details.hashdb_ver
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.htmlapplication
-      tag: convert_policy_details_htmlapplication_to_string
+      tag: convert_policy_details_htmlapplication_to_string_b9a50a06
       target_field: airlock_digital.agent.poilcy_details.htmlapplication
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.javaapplication
-      tag: convert_policy_details_javaapplication_to_string
+      tag: convert_policy_details_javaapplication_to_string_d30ffa5a
       target_field: airlock_digital.agent.poilcy_details.javaapplication
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.javascript
-      tag: convert_policy_details_javascript_to_string
+      tag: convert_policy_details_javascript_to_string_f2e0910d
       target_field: airlock_digital.agent.poilcy_details.javascript
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.modreload
-      tag: convert_policy_details_modreload_to_string
+      tag: convert_policy_details_modreload_to_string_c4f5abe3
       target_field: airlock_digital.agent.poilcy_details.modreload
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.name
-      tag: rename_policy_details_name
+      tag: rename_policy_details_name_98601b62
       target_field: airlock_digital.agent.poilcy_details.name
       ignore_missing: true
   - set:
       field: rule.name
-      tag: set_rule_name_from_agent_poilcy_details_name
+      tag: set_rule_name_from_agent_poilcy_details_name_30558c05
       copy_from: airlock_digital.agent.poilcy_details.name
       ignore_empty_value: true
   - rename:
       field: json.policy_details.notification_message
-      tag: rename_policy_details_notification_message
+      tag: rename_policy_details_notification_message_b2fadebb
       target_field: airlock_digital.agent.poilcy_details.notification_message
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_agent_poilcy_details_notification_message
+      tag: set_message_from_agent_poilcy_details_notification_message_a8d5dcca
       copy_from: airlock_digital.agent.poilcy_details.notification_message
       ignore_empty_value: true
   - rename:
       field: json.policy_details.parent
-      tag: rename_policy_details_parent
+      tag: rename_policy_details_parent_5b418bb4
       target_field: airlock_digital.agent.poilcy_details.parent
       ignore_missing: true
   - foreach:
       field: json.policy_details.paths
-      tag: foreach_policy_details_paths_name
+      tag: foreach_policy_details_paths_name_1b3c0e16
       if: ctx.json?.policy_details?.paths instanceof List
       processor:
         append:
           field: file.path
-          tag: append_policy_details_paths_name_into_file_path
+          tag: append_policy_details_paths_name_into_file_path_2100ef6f
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - rename:
       field: json.policy_details.paths
-      tag: rename_policy_details_paths
+      tag: rename_policy_details_paths_9dedcb00
       target_field: airlock_digital.agent.poilcy_details.paths
       ignore_missing: true
   - rename:
       field: json.policy_details.policyver
-      tag: rename_policy_details_policyver
+      tag: rename_policy_details_policyver_40b919d5
       target_field: airlock_digital.agent.poilcy_details.policyver
       ignore_missing: true
   - convert:
       field: json.policy_details.poll_time
-      tag: convert_policy_details_poll_time_to_string
+      tag: convert_policy_details_poll_time_to_string_ae9da601
       target_field: airlock_digital.agent.poilcy_details.poll_time
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.powershell
-      tag: convert_policy_details_powershell_to_string
+      tag: convert_policy_details_powershell_to_string_95262bf8
       target_field: airlock_digital.agent.poilcy_details.powershell
       type: string
       ignore_missing: true
   - foreach:
       field: json.policy_details.pprocesses
-      tag: foreach_policy_details_pprocesses_name
+      tag: foreach_policy_details_pprocesses_name_81a379e0
       if: ctx.json?.policy_details?.pprocesses instanceof List
       processor:
         append:
           field: process.parent.name
-          tag: append_policy_details_pprocesses_name_into_process_parent_name
+          tag: append_policy_details_pprocesses_name_into_process_parent_name_86c85b44
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - rename:
       field: json.policy_details.pprocesses
-      tag: rename_policy_details_pprocesses
+      tag: rename_policy_details_pprocesses_1c3d6435
       target_field: airlock_digital.agent.poilcy_details.pprocesses
       ignore_missing: true
   - convert:
       field: json.policy_details.proxyauth
-      tag: convert_policy_details_proxyauth_to_string
+      tag: convert_policy_details_proxyauth_to_string_8820a1cc
       target_field: airlock_digital.agent.poilcy_details.proxyauth
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.proxyenabled
-      tag: convert_policy_details_proxyenabled_to_string
+      tag: convert_policy_details_proxyenabled_to_string_032d26ba
       target_field: airlock_digital.agent.poilcy_details.proxyenabled
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.proxypass
-      tag: rename_policy_details_proxypass
+      tag: rename_policy_details_proxypass_71082e93
       target_field: airlock_digital.agent.poilcy_details.proxypass
       ignore_missing: true
   - convert:
       field: json.policy_details.proxyport
       if: ctx.json?.policy_details?.proxyport != null && ctx.json.policy_details.proxyport != ''
-      tag: convert_policy_details_proxyport_to_long
+      tag: convert_policy_details_proxyport_to_long_bf44a572
       target_field: airlock_digital.agent.poilcy_details.proxyport
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_80c7c540
+            tag: append_error_message_9c2d0893
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.policy_details.proxyserver
-      tag: rename_policy_details_proxyserver
+      tag: rename_policy_details_proxyserver_704db6f3
       target_field: airlock_digital.agent.poilcy_details.proxyserver
       ignore_missing: true
   - rename:
       field: json.policy_details.proxyuser
-      tag: rename_policy_details_proxyuser
+      tag: rename_policy_details_proxyuser_5f96c331
       target_field: airlock_digital.agent.poilcy_details.proxyuser
       ignore_missing: true
   - convert:
       field: json.policy_details.pslockdown
-      tag: convert_policy_details_pslockdown_to_string
+      tag: convert_policy_details_pslockdown_to_string_eceac362
       target_field: airlock_digital.agent.poilcy_details.pslockdown
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.publishers
-      tag: rename_policy_details_publishers
+      tag: rename_policy_details_publishers_dce10e53
       target_field: airlock_digital.agent.poilcy_details.publishers
       ignore_missing: true
   - convert:
       field: json.policy_details.python
-      tag: convert_policy_details_python_to_string
+      tag: convert_policy_details_python_to_string_82b6aa6d
       target_field: airlock_digital.agent.poilcy_details.python
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.reflection
-      tag: convert_policy_details_reflection_to_string
+      tag: convert_policy_details_reflection_to_string_d534c156
       target_field: airlock_digital.agent.poilcy_details.reflection
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.script_custom
-      tag: convert_policy_details_script_custom_to_string
+      tag: convert_policy_details_script_custom_to_string_c73bc0f6
       target_field: airlock_digital.agent.poilcy_details.script_custom
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.script_enabled
-      tag: convert_policy_details_script_enabled_to_string
+      tag: convert_policy_details_script_enabled_to_string_8a4f72d5
       target_field: airlock_digital.agent.poilcy_details.script_enabled
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.selfservice
-      tag: convert_policy_details_selfservice_to_string
+      tag: convert_policy_details_selfservice_to_string_c87c2977
       target_field: airlock_digital.agent.poilcy_details.selfservice
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.selfupgrade
-      tag: convert_policy_details_selfupgrade_to_string
+      tag: convert_policy_details_selfupgrade_to_string_820fdc71
       target_field: airlock_digital.agent.poilcy_details.selfupgrade
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.shellscript
-      tag: convert_policy_details_shellscript_to_string
+      tag: convert_policy_details_shellscript_to_string_f860865b
       target_field: airlock_digital.agent.poilcy_details.shellscript
       type: string
       ignore_missing: true
   - rename:
       field: json.policy_details.targetvers
-      tag: rename_policy_details_targetvers
+      tag: rename_policy_details_targetvers_303a58f7
       target_field: airlock_digital.agent.poilcy_details.targetvers
       ignore_missing: true
   - convert:
       field: json.policy_details.trusted_config
-      tag: convert_policy_details_trusted_config_to_boolean
+      tag: convert_policy_details_trusted_config_to_boolean_07ce1563
       target_field: airlock_digital.agent.poilcy_details.trusted_config
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_97fa019b
+            tag: append_error_message_3b889f74
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.policy_details.trusted_upload
-      tag: convert_policy_details_trusted_upload_to_string
+      tag: convert_policy_details_trusted_upload_to_string_c825c6df
       target_field: airlock_digital.agent.poilcy_details.trusted_upload
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.vbscript
-      tag: convert_policy_details_vbscript_to_string
+      tag: convert_policy_details_vbscript_to_string_ad8aa0f2
       target_field: airlock_digital.agent.poilcy_details.vbscript
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.windowsinstaller
-      tag: convert_policy_details_windowsinstaller_to_string
+      tag: convert_policy_details_windowsinstaller_to_string_f6a25cbd
       target_field: airlock_digital.agent.poilcy_details.windowsinstaller
       type: string
       ignore_missing: true
   - convert:
       field: json.policy_details.windowsscriptcomponent
-      tag: convert_policy_details_windowsscriptcomponent_to_string
+      tag: convert_policy_details_windowsscriptcomponent_to_string_68c82b66
       target_field: airlock_digital.agent.poilcy_details.windowsscriptcomponent
       type: string
       ignore_missing: true
   - rename:
       field: json.policyversion
-      tag: rename_policyversion
+      tag: rename_policyversion_a0dd3c4b
       target_field: airlock_digital.agent.policyversion
       ignore_missing: true
   - set:
       field: rule.version
-      tag: set_rule_version_from_agent_policyversion
+      tag: set_rule_version_from_agent_policyversion_4677a1ff
       copy_from: airlock_digital.agent.policyversion
       ignore_empty_value: true
   - convert:
       field: json.status
-      tag: convert_status_to_keyword
+      tag: convert_status_to_keyword_417b83d6
       target_field: airlock_digital.agent.status
       type: string
       ignore_missing: true
   - script:
-      tag: script_1fd0624f
+      tag: script_6ac9c74d
       description: Map status to corresponding agent status.
       lang: painless
       params:
@@ -605,38 +605,38 @@ processors:
         ctx.airlock_digital.agent.status_value = params[(ctx.json.status).toString()];
   - rename:
       field: json.username
-      tag: rename_username
+      tag: rename_username_3902add1
       target_field: airlock_digital.agent.username
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_agent_username
+      tag: set_user_name_from_agent_username_b23d361e
       copy_from: airlock_digital.agent.username
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_agent_username_into_related_user
+      tag: append_agent_username_into_related_user_7a7a0552
       value: '{{{airlock_digital.agent.username}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.agent?.username != null
   - foreach:
       field: airlock_digital.agent.poilcy_details.paths
-      tag: foreach_airlock_digital_agent_poilcy_details_paths
+      tag: foreach_airlock_digital_agent_poilcy_details_paths_5ae5d0fe
       if: ctx.airlock_digital?.agent?.poilcy_details?.paths instanceof List
       processor:
         remove:
           field: _ingest._value.name
-          tag: remove_custom_duplicate_fields_from_airlock_digital_agent_poilcy_details_paths
+          tag: remove_custom_duplicate_fields_from_airlock_digital_agent_poilcy_details_paths_b410af55
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - foreach:
       field: airlock_digital.agent.poilcy_details.pprocesses
-      tag: foreach_airlock_digital_agent_poilcy_details_pprocesses
+      tag: foreach_airlock_digital_agent_poilcy_details_pprocesses_8ea87ee2
       if: ctx.airlock_digital?.agent?.poilcy_details?.pprocesses instanceof List
       processor:
         remove:
           field: _ingest._value.name
-          tag: remove_custom_duplicate_fields_from_airlock_digital_agent_poilcy_details_pprocesses
+          tag: remove_custom_duplicate_fields_from_airlock_digital_agent_poilcy_details_pprocesses_64b89e9d
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
@@ -651,15 +651,15 @@ processors:
         - airlock_digital.agent.poilcy_details.notification_message
         - airlock_digital.agent.policyversion
         - airlock_digital.agent.username
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_441cfab9
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -686,18 +686,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_3a6ad1cf
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -705,10 +705,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -274,14 +274,16 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_ip
                 field: _ingest._value.ip
                 ignore_missing: true
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.policy_details.commlist
-      tag: foreach_json_policy_details_commlist_761aaae4
+      tag: foreach_policy_details_commlist_ip_761aaae4
       if: ctx.json?.policy_details?.commlist instanceof List
       processor:
         append:
@@ -695,6 +697,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_3a6ad1cf
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -705,6 +708,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -338,7 +338,7 @@ processors:
       ignore_missing: true
   - remove:
       field: json.policy_details.groupid
-      tag: rename_policy_details_groupid_eac3e052
+      tag: remove_policy_details_groupid_eac3e052
       ignore_missing: true
   - convert:
       field: json.policy_details.hashdb_ver
@@ -591,7 +591,7 @@ processors:
       type: string
       ignore_missing: true
   - script:
-      tag: script_6ac9c74d
+      tag: script_map_status_to_corresponding_agent_status_6ac9c74d
       description: Map status to corresponding agent status.
       lang: painless
       params:

--- a/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -92,6 +92,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ed15c765
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -129,6 +130,7 @@ processors:
       if: ctx.json?.ip != ''
       on_failure:
         - append:
+            tag: append_error_message_b1bdbb98
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -152,6 +154,7 @@ processors:
       if: ctx.json?.lastcheckin != null && ctx.json.lastcheckin != ''
       on_failure:
         - append:
+            tag: append_error_message_1155faed
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -163,6 +166,7 @@ processors:
       if: ctx.json?.localip != ''
       on_failure:
         - append:
+            tag: append_error_message_d86b373c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -277,7 +281,7 @@ processors:
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.policy_details.commlist
-      tag: foreach_policy_details_commlist_ip
+      tag: foreach_json_policy_details_commlist_761aaae4
       if: ctx.json?.policy_details?.commlist instanceof List
       processor:
         append:
@@ -462,6 +466,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_80c7c540
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -540,6 +545,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_97fa019b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -583,6 +589,7 @@ processors:
       type: string
       ignore_missing: true
   - script:
+      tag: script_1fd0624f
       description: Map status to corresponding agent status.
       lang: painless
       params:
@@ -681,6 +688,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
@@ -273,7 +273,7 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: script_dfd09bea
+      tag: script_map_type_to_corresponding_execution_type_dfd09bea
       description: Map type to corresponding execution type.
       lang: painless
       params:

--- a/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
@@ -3,22 +3,22 @@ description: Pipeline for processing execution histories logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
@@ -29,92 +29,92 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata, as they can collide with ECS fields.
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: event.type
-      tag: append_info_into_event_type
+      tag: append_info_into_event_type_5eab37e6
       value: info
   - append:
       field: event.category
-      tag: append_host_into_event_category
+      tag: append_host_into_event_category_5098f71a
       value: host
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - rename:
       field: json.checkpoint
-      tag: rename_checkpoint
+      tag: rename_checkpoint_7420eccf
       target_field: airlock_digital.execution_histories.checkpoint
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_execution_histories_checkpoint
+      tag: set_event_id_from_execution_histories_checkpoint_9618b014
       copy_from: airlock_digital.execution_histories.checkpoint
       ignore_empty_value: true
   - rename:
       field: json.commandline
-      tag: rename_commandline
+      tag: rename_commandline_7a0c06b6
       target_field: airlock_digital.execution_histories.commandline
       ignore_missing: true
   - set:
       field: process.command_line
-      tag: set_process_command_line_from_execution_histories_commandline
+      tag: set_process_command_line_from_execution_histories_commandline_18d1aa0d
       copy_from: airlock_digital.execution_histories.commandline
       ignore_empty_value: true
   - date:
       field: json.datetime
-      tag: date_datetime
+      tag: date_datetime_1c151f24
       target_field: airlock_digital.execution_histories.datetime
       formats:
         - ISO8601
       if: ctx.json?.datetime != null && ctx.json.datetime != ''
       on_failure:
         - append:
-            tag: append_error_message_bf22f8e7
+            tag: append_error_message_aa577e32
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_execution_histories_datetime
+      tag: set_@timestamp_from_execution_histories_datetime_bf66cac9
       copy_from: airlock_digital.execution_histories.datetime
       ignore_empty_value: true
   - rename:
       field: json.filename
-      tag: rename_filename
+      tag: rename_filename_c82f1adc
       target_field: airlock_digital.execution_histories.filename
       ignore_missing: true
   - set:
       field: file.path
-      tag: set_file_path_from_execution_histories_filename
+      tag: set_file_path_from_execution_histories_filename_161fabdc
       copy_from: airlock_digital.execution_histories.filename
       ignore_empty_value: true
   - gsub:
-      tag: gsub_file_path_517235af
+      tag: gsub_file_path_25477c37
       field: file.path
       pattern: '\\'
       replacement: '/'
       ignore_failure: true
   - split:
-      tag: split_file_path_to_file_name_19cfdeb5
+      tag: split_file_path_to_file_name_414c6a55
       field: file.path
       separator: '/'
       target_field: file.name
       if: ctx.file?.path != null
       ignore_failure: true
   - script:
-      tag: script_file_name
+      tag: script_file_name_a689a8f4
       description: Set file.name to the last element of file.path.
       lang: painless
       source: |
@@ -122,158 +122,158 @@ processors:
       if: ctx.file?.name instanceof List && ctx.file.name.length > 0
   - rename:
       field: json.hostname
-      tag: rename_hostname
+      tag: rename_hostname_97eaad5e
       target_field: airlock_digital.execution_histories.hostname
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_name_from_execution_histories_hostname
+      tag: set_host_name_from_execution_histories_hostname_47294fe5
       copy_from: airlock_digital.execution_histories.hostname
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_execution_histories_hostname_into_related_host
+      tag: append_execution_histories_hostname_into_related_host_308fd2b5
       value: '{{{airlock_digital.execution_histories.hostname}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.hostname != null
   - rename:
       field: json.md5
-      tag: rename_md5
+      tag: rename_md5_88c510b5
       target_field: airlock_digital.execution_histories.md5
       ignore_missing: true
   - set:
       field: process.hash.md5
-      tag: set_process_hash_md5_from_execution_histories_md5
+      tag: set_process_hash_md5_from_execution_histories_md5_ccf6f429
       copy_from: airlock_digital.execution_histories.md5
       ignore_empty_value: true
   - append:
       field: related.hash
-      tag: append_execution_histories_md5_into_related_hash
+      tag: append_execution_histories_md5_into_related_hash_fe141408
       value: '{{{airlock_digital.execution_histories.md5}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.md5 != null
   - rename:
       field: json.netdomain
-      tag: rename_netdomain
+      tag: rename_netdomain_b0965b2b
       target_field: airlock_digital.execution_histories.netdomain
       ignore_missing: true
   - rename:
       field: json.policyname
-      tag: rename_policyname
+      tag: rename_policyname_41d1c0ba
       target_field: airlock_digital.execution_histories.policyname
       ignore_missing: true
   - set:
       field: rule.name
-      tag: set_rule_name_from_execution_histories_policyname
+      tag: set_rule_name_from_execution_histories_policyname_9c83f0a2
       copy_from: airlock_digital.execution_histories.policyname
       ignore_empty_value: true
   - rename:
       field: json.policyver
-      tag: rename_policyver
+      tag: rename_policyver_7f9928e9
       target_field: airlock_digital.execution_histories.policyver
       ignore_missing: true
   - set:
       field: rule.version
-      tag: set_rule_version_from_execution_histories_policyver
+      tag: set_rule_version_from_execution_histories_policyver_bdab5d1b
       copy_from: airlock_digital.execution_histories.policyver
       ignore_empty_value: true
   - rename:
       field: json.ppolicy
-      tag: rename_ppolicy
+      tag: rename_ppolicy_319e7087
       target_field: airlock_digital.execution_histories.ppolicy
       ignore_missing: true
   - set:
       field: rule.ruleset
-      tag: set_rule_ruleset_from_execution_histories_ppolicy
+      tag: set_rule_ruleset_from_execution_histories_ppolicy_68c9d545
       copy_from: airlock_digital.execution_histories.ppolicy
       ignore_empty_value: true
   - rename:
       field: json.pprocess
-      tag: rename_pprocess
+      tag: rename_pprocess_958ea2b6
       target_field: airlock_digital.execution_histories.pprocess
       ignore_missing: true
   - set:
       field: process.parent.name
-      tag: set_process_parent_name_from_execution_histories_pprocess
+      tag: set_process_parent_name_from_execution_histories_pprocess_3852a4fe
       copy_from: airlock_digital.execution_histories.pprocess
       ignore_empty_value: true
   - rename:
       field: json.publisher
-      tag: rename_publisher
+      tag: rename_publisher_64fcbac9
       target_field: airlock_digital.execution_histories.publisher
       ignore_missing: true
   - rename:
       field: json.sha128
-      tag: rename_sha128
+      tag: rename_sha128_29f8dafc
       target_field: airlock_digital.execution_histories.sha128
       ignore_missing: true
   - append:
       field: related.hash
-      tag: append_execution_histories_sha128_into_related_hash
+      tag: append_execution_histories_sha128_into_related_hash_0362ea16
       value: '{{{airlock_digital.execution_histories.sha128}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.sha128 != null
   - rename:
       field: json.sha256
-      tag: rename_sha256
+      tag: rename_sha256_94762ff7
       target_field: airlock_digital.execution_histories.sha256
       ignore_missing: true
   - set:
       field: process.hash.sha256
-      tag: set_process_hash_sha256_from_execution_histories_sha256
+      tag: set_process_hash_sha256_from_execution_histories_sha256_a2741c71
       copy_from: airlock_digital.execution_histories.sha256
       ignore_empty_value: true
   - append:
       field: related.hash
-      tag: append_execution_histories_sha256_into_related_hash
+      tag: append_execution_histories_sha256_into_related_hash_0e05c48e
       value: '{{{airlock_digital.execution_histories.sha256}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.sha256 != null
   - rename:
       field: json.sha384
-      tag: rename_sha384
+      tag: rename_sha384_c9e59812
       target_field: airlock_digital.execution_histories.sha384
       ignore_missing: true
   - set:
       field: process.hash.sha384
-      tag: set_process_hash_sha384_from_execution_histories_sha384
+      tag: set_process_hash_sha384_from_execution_histories_sha384_3a10a4de
       copy_from: airlock_digital.execution_histories.sha384
       ignore_empty_value: true
   - append:
       field: related.hash
-      tag: append_execution_histories_sha384_into_related_hash
+      tag: append_execution_histories_sha384_into_related_hash_a2c255a4
       value: '{{{airlock_digital.execution_histories.sha384}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.sha384 != null
   - rename:
       field: json.sha512
-      tag: rename_sha512
+      tag: rename_sha512_506cc39e
       target_field: airlock_digital.execution_histories.sha512
       ignore_missing: true
   - set:
       field: process.hash.sha512
-      tag: set_process_hash_sha512_from_execution_histories_sha512
+      tag: set_process_hash_sha512_from_execution_histories_sha512_0be3d2d2
       copy_from: airlock_digital.execution_histories.sha512
       ignore_empty_value: true
   - append:
       field: related.hash
-      tag: append_execution_histories_sha512_into_related_hash
+      tag: append_execution_histories_sha512_into_related_hash_05808766
       value: '{{{airlock_digital.execution_histories.sha512}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.sha512 != null
   - convert:
       field: json.type
-      tag: convert_type_to_long
+      tag: convert_type_to_long_fd969e74
       target_field: airlock_digital.execution_histories.type
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d064192d
+            tag: append_error_message_f73820a7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: script_5a14c280
+      tag: script_dfd09bea
       description: Map type to corresponding execution type.
       lang: painless
       params:
@@ -301,17 +301,17 @@ processors:
         ctx.airlock_digital.execution_histories.type_value = params[(ctx.json.type).toString()];
   - rename:
       field: json.username
-      tag: rename_username
+      tag: rename_username_ec01dc4c
       target_field: airlock_digital.execution_histories.username
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_execution_histories_username
+      tag: set_user_name_from_execution_histories_username_ec7de462
       copy_from: airlock_digital.execution_histories.username
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_execution_histories_username_into_related_user
+      tag: append_execution_histories_username_into_related_user_4c4d2013
       value: '{{{airlock_digital.execution_histories.username}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.execution_histories?.username != null
@@ -331,15 +331,15 @@ processors:
         - airlock_digital.execution_histories.sha384
         - airlock_digital.execution_histories.sha512
         - airlock_digital.execution_histories.username
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_098b464c
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -366,18 +366,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -385,10 +385,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -81,6 +82,7 @@ processors:
       if: ctx.json?.datetime != null && ctx.json.datetime != ''
       on_failure:
         - append:
+            tag: append_error_message_bf22f8e7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -99,11 +101,13 @@ processors:
       copy_from: airlock_digital.execution_histories.filename
       ignore_empty_value: true
   - gsub:
+      tag: gsub_file_path_517235af
       field: file.path
       pattern: '\\'
       replacement: '/'
       ignore_failure: true
   - split:
+      tag: split_file_path_to_file_name_19cfdeb5
       field: file.path
       separator: '/'
       target_field: file.name
@@ -265,9 +269,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d064192d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
+      tag: script_5a14c280
       description: Map type to corresponding execution type.
       lang: painless
       params:
@@ -364,6 +370,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/execution_histories/elasticsearch/ingest_pipeline/default.yml
@@ -377,6 +377,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -387,6 +388,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/server_activities/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/server_activities/elasticsearch/ingest_pipeline/default.yml
@@ -68,6 +68,7 @@ processors:
       if: ctx.json?.datetime != null && ctx.json.datetime != ''
       on_failure:
         - append:
+            tag: append_error_message_63229d47
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -107,6 +108,7 @@ processors:
       if: ctx.event?.action != ''
       on_failure:
         - append:
+            tag: append_error_message_ce1e3af4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - join:
@@ -116,6 +118,7 @@ processors:
       if: ctx.event?.action != ''
       on_failure:
         - append:
+            tag: append_error_message_abbd6eec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -179,6 +182,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/server_activities/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/server_activities/elasticsearch/ingest_pipeline/default.yml
@@ -3,22 +3,22 @@ description: Pipeline for processing server activities logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
@@ -29,111 +29,111 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.type
-      tag: append_info_into_event_type
+      tag: append_info_into_event_type_5eab37e6
       value: info
   - append:
       field: event.category
-      tag: append_host_into_event_category
+      tag: append_host_into_event_category_5098f71a
       value: host
   - rename:
       field: json.checkpoint
-      tag: rename_checkpoint
+      tag: rename_checkpoint_57ea5063
       target_field: airlock_digital.server_activities.checkpoint
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_server_activities_checkpoint
+      tag: set_event_id_from_server_activities_checkpoint_5ccc427a
       copy_from: airlock_digital.server_activities.checkpoint
       ignore_empty_value: true
   - date:
       field: json.datetime
-      tag: date_datetime
+      tag: date_datetime_ef5a0a7c
       target_field: airlock_digital.server_activities.datetime
       formats:
         - ISO8601
       if: ctx.json?.datetime != null && ctx.json.datetime != ''
       on_failure:
         - append:
-            tag: append_error_message_63229d47
+            tag: append_error_message_d6ac50ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_server_activities_datetime
+      tag: set_@timestamp_from_server_activities_datetime_0dd2dc44
       copy_from: airlock_digital.server_activities.datetime
       ignore_empty_value: true
   - rename:
       field: json.description
-      tag: rename_description
+      tag: rename_description_081a9254
       target_field: airlock_digital.server_activities.description
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_server_activities_description
+      tag: set_message_from_server_activities_description_13bec3fb
       copy_from: airlock_digital.server_activities.description
       ignore_empty_value: true
   - rename:
       field: json.task
-      tag: rename_task
+      tag: rename_task_122619d3
       target_field: airlock_digital.server_activities.task
       ignore_missing: true
   - set:
       field: event.action
-      tag: set_event_action_from_server_activities_task
+      tag: set_event_action_from_server_activities_task_063258c2
       copy_from: airlock_digital.server_activities.task
       ignore_empty_value: true
   - lowercase:
       field: event.action
-      tag: lowercase_event_action
+      tag: lowercase_event_action_945f0fcf
       ignore_missing: true
   - split:
       field: event.action
-      tag: split_event_action
+      tag: split_event_action_ee0a3f8a
       separator: \s+
       ignore_missing: true
       if: ctx.event?.action != ''
       on_failure:
         - append:
-            tag: append_error_message_ce1e3af4
+            tag: append_error_message_40560a09
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - join:
       field: event.action
-      tag: join_event_action
+      tag: join_event_action_c8e6fa50
       separator: '-'
       if: ctx.event?.action != ''
       on_failure:
         - append:
-            tag: append_error_message_abbd6eec
+            tag: append_error_message_e5e219ba
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.user
-      tag: rename_user
+      tag: rename_user_3676fc99
       target_field: airlock_digital.server_activities.user
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_server_activities_user
+      tag: set_user_name_from_server_activities_user_95fdc118
       copy_from: airlock_digital.server_activities.user
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_server_activities_user_into_related_user
+      tag: append_server_activities_user_into_related_user_c14da2e9
       value: '{{{airlock_digital.server_activities.user}}}'
       allow_duplicates: false
       if: ctx.airlock_digital?.server_activities?.user != null
@@ -143,15 +143,15 @@ processors:
         - airlock_digital.server_activities.datetime
         - airlock_digital.server_activities.description
         - airlock_digital.server_activities.user
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_5b3934ca
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -178,18 +178,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -197,10 +197,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/data_stream/server_activities/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/airlock_digital/data_stream/server_activities/elasticsearch/ingest_pipeline/default.yml
@@ -189,6 +189,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -199,6 +200,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/airlock_digital/manifest.yml
+++ b/packages/airlock_digital/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: airlock_digital
 title: Airlock Digital
-version: 0.5.1
+version: 0.5.2
 description: Collect logs from Airlock Digital with Elastic Agent.
 type: integration
 categories:

--- a/packages/airlock_digital/manifest.yml
+++ b/packages/airlock_digital/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: airlock_digital
 title: Airlock Digital
-version: 0.5.2
+version: 0.6.0
 description: Collect logs from Airlock Digital with Elastic Agent.
 type: integration
 categories:

--- a/packages/armis/changelog.yml
+++ b/packages/armis/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.6.2"
+- version: "0.7.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/armis/changelog.yml
+++ b/packages/armis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.6.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/armis/changelog.yml
+++ b/packages/armis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.6.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/armis/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -3,15 +3,15 @@ description: Pipeline for processing alert logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
-      tag: drop_retry_events
+      tag: drop_retry_events_1f05010a
   - remove:
       field:
         - organization
@@ -19,132 +19,132 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
       fields:
         - json.time
         - json.alertId
-      tag: fingerprint_alert
+      tag: fingerprint_alert_d7a9e6f7
       target_field: _id
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_event_kind_to_alert
+      tag: set_event_kind_to_alert_ab1166ce
       value: alert
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_1e721121
       value: Armis
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_4f1031b1
       value: Asset Management and Security
   - rename:
       field: json.activityUUIDs
-      tag: rename_activityUUIDs
+      tag: rename_activityUUIDs_bc8cbe85
       target_field: armis.alert.activity_uuids
       ignore_missing: true
   - convert:
       field: json.affectedDevicesCount
-      tag: convert_affectedDevicesCount_to_long
+      tag: convert_affectedDevicesCount_to_long_2bf40759
       target_field: armis.alert.affected_devices_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6bf4e364
+            tag: append_error_message_eb9ad3ce
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.alertId
-      tag: convert_alertId_to_string
+      tag: convert_alertId_to_string_af908a61
       target_field: armis.alert.alert_id
       type: string
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_alert_alert_id
+      tag: set_event_id_from_alert_alert_id_f3a3be33
       copy_from: armis.alert.alert_id
       ignore_empty_value: true
   - rename:
       field: json.classification
-      tag: rename_classification
+      tag: rename_classification_82be00c7
       target_field: armis.alert.classification
       ignore_missing: true
   - rename:
       field: json.connectionIds
-      tag: rename_connectionIds
+      tag: rename_connectionIds_78169558
       target_field: armis.alert.connection_ids
       ignore_missing: true
   - rename:
       field: json.description
-      tag: rename_description
+      tag: rename_description_1830810d
       target_field: armis.alert.description
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_alert_description
+      tag: set_message_from_alert_description_1a0e396b
       copy_from: armis.alert.description
       ignore_empty_value: true
   - rename:
       field: json.destinationEndpoints
-      tag: rename_destinationEndpoints
+      tag: rename_destinationEndpoints_0593a116
       target_field: armis.alert.destination_endpoints
       ignore_missing: true
   - convert:
       field: json.deviceIds
-      tag: convert_deviceIds_to_string
+      tag: convert_deviceIds_to_string_bf1f6fce
       target_field: armis.alert.device_ids
       type: string
       ignore_missing: true
   - foreach:
       field: armis.alert.device_ids
-      tag: foreach_deviceIds
+      tag: foreach_deviceIds_2c57ad89
       if: ctx.armis?.alert?.device_ids instanceof List
       processor:
         append:
           field: host.id
-          tag: append_deviceIds_into_host_id
+          tag: append_deviceIds_into_host_id_f392fb5f
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: armis.alert.device_ids
-      tag: foreach_deviceIds_4938258b
+      tag: foreach_deviceIds_4dad0bd9
       if: ctx.armis?.alert?.device_ids instanceof List
       processor:
         append:
           field: related.hosts
-          tag: append_deviceIds_into_related_hosts
+          tag: append_deviceIds_into_related_hosts_d4e7db0d
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - date:
       field: json.lastAlertUpdateTime
-      tag: date_lastAlertUpdateTime
+      tag: date_lastAlertUpdateTime_1ca28d43
       target_field: armis.alert.last_alert_update_time
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -153,60 +153,60 @@ processors:
       if: ctx.json?.lastAlertUpdateTime != null && ctx.json.lastAlertUpdateTime != ''
       on_failure:
         - append:
-            tag: append_error_message_962c6444
+            tag: append_error_message_76d6ade2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.mitreAttackLabels
-      tag: rename_mitreAttackLabels
+      tag: rename_mitreAttackLabels_9f54e46e
       target_field: armis.alert.mitre_attack_labels
       ignore_missing: true
   - append:
       field: threat.technique.name
-      tag: append_mitre_attack_labels_into_threat_technique_name
+      tag: append_mitre_attack_labels_into_threat_technique_name_59fdd6bf
       value: '{{{armis.alert.mitre_attack_labels}}}'
       allow_duplicates: false
       if: ctx.armis?.alert?.mitre_attack_labels != null
   - convert:
       field: json.policyId
-      tag: convert_policyId_to_string
+      tag: convert_policyId_to_string_2290a807
       target_field: armis.alert.policy_id
       type: string
       ignore_missing: true
   - set:
       field: rule.id
-      tag: set_rule_id_from_alert_policy_id
+      tag: set_rule_id_from_alert_policy_id_99a49515
       copy_from: armis.alert.policy_id
       ignore_empty_value: true
   - rename:
       field: json.policyLabels
-      tag: rename_policyLabels
+      tag: rename_policyLabels_512c7420
       target_field: armis.alert.policy_labels
       ignore_missing: true
   - rename:
       field: json.policyTitle
-      tag: rename_policyTitle
+      tag: rename_policyTitle_f0e31c36
       target_field: armis.alert.policy_title
       ignore_missing: true
   - set:
       field: rule.name
-      tag: set_rule_name_from_alert_policy_title
+      tag: set_rule_name_from_alert_policy_title_fb6b6b7a
       copy_from: armis.alert.policy_title
       ignore_empty_value: true
   - set:
       field: armis.alert.friendly_name
-      tag: set_armis_alert_friendly_name_from_alert_policy_title
+      tag: set_armis_alert_friendly_name_from_alert_policy_title_e64923f1
       copy_from: armis.alert.policy_title
       ignore_empty_value: true
   - rename:
       field: json.severity
-      tag: rename_severity
+      tag: rename_severity_34a6b985
       target_field: armis.alert.severity
       ignore_missing: true
   - script:
       lang: painless
       description: Script to set event.severity.
-      tag: set_event_severity
+      tag: set_event_severity_8d987b89
       if: ctx.armis?.alert?.severity instanceof String
       source: |-
         String severity = ctx.armis.alert.severity;
@@ -221,22 +221,22 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_b608e76d
+            tag: append_error_message_8985b3cb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.sourceEndpoints
-      tag: rename_sourceEndpoints
+      tag: rename_sourceEndpoints_27538fe7
       target_field: armis.alert.source_endpoints
       ignore_missing: true
   - rename:
       field: json.status
-      tag: rename_status
+      tag: rename_status_49c9c205
       target_field: armis.alert.status
       ignore_missing: true
   - date:
       field: json.statusChangeTime
-      tag: date_statusChangeTime
+      tag: date_statusChangeTime_51885014
       target_field: armis.alert.status_change_time
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -245,17 +245,17 @@ processors:
       if: ctx.json?.statusChangeTime != null && ctx.json.statusChangeTime != ''
       on_failure:
         - append:
-            tag: append_error_message_9981e61c
+            tag: append_error_message_9b8291d1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_status_change_time
+      tag: set_@timestamp_from_status_change_time_b58429fe
       copy_from: armis.alert.status_change_time
       ignore_empty_value: true
   - date:
       field: json.time
-      tag: date_time
+      tag: date_time_15aea5bd
       target_field: armis.alert.time
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -264,17 +264,17 @@ processors:
       if: ctx.json?.time != null && ctx.json.time != ''
       on_failure:
         - append:
-            tag: append_error_message_7ab96520
+            tag: append_error_message_a4c1ae4a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.title
-      tag: rename_title
+      tag: rename_title_89d82af8
       target_field: armis.alert.title
       ignore_missing: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_6bf00cc7
       target_field: armis.alert.type
       ignore_missing: true
   - remove:
@@ -286,16 +286,16 @@ processors:
         - armis.alert.policy_title
         - armis.alert.status_change_time
         - armis.alert.mitre_attack_labels
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_7784b98f
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -321,18 +321,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -340,10 +340,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -134,7 +134,7 @@ processors:
           allow_duplicates: false
   - foreach:
       field: armis.alert.device_ids
-      tag: foreach_armis_alert_device_ids_4938258b
+      tag: foreach_deviceIds_4938258b
       if: ctx.armis?.alert?.device_ids instanceof List
       processor:
         append:
@@ -332,6 +332,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -342,6 +343,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -42,6 +42,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -76,6 +77,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6bf4e364
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -132,7 +134,7 @@ processors:
           allow_duplicates: false
   - foreach:
       field: armis.alert.device_ids
-      tag: foreach_deviceIds
+      tag: foreach_armis_alert_device_ids_4938258b
       if: ctx.armis?.alert?.device_ids instanceof List
       processor:
         append:
@@ -151,6 +153,7 @@ processors:
       if: ctx.json?.lastAlertUpdateTime != null && ctx.json.lastAlertUpdateTime != ''
       on_failure:
         - append:
+            tag: append_error_message_962c6444
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -218,6 +221,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_b608e76d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -241,6 +245,7 @@ processors:
       if: ctx.json?.statusChangeTime != null && ctx.json.statusChangeTime != ''
       on_failure:
         - append:
+            tag: append_error_message_9981e61c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -259,6 +264,7 @@ processors:
       if: ctx.json?.time != null && ctx.json.time != ''
       on_failure:
         - append:
+            tag: append_error_message_7ab96520
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -319,6 +325,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/device/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/device/elasticsearch/ingest_pipeline/default.yml
@@ -117,14 +117,16 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_firstSeen
                 field: _ingest._value.firstSeen
                 ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_json_dataSources_44a528e5
+      tag: foreach_dataSources_44a528e5
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
+          tag: foreach_ingest_value_instances
           field: _ingest._value.instances
           ignore_failure: true
           processor:
@@ -138,14 +140,16 @@ processors:
                 - ISO8601
               on_failure:
                 - remove:
+                    tag: remove_ingest_value_firstSeen_743481c2
                     field: _ingest._value.firstSeen
                     ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_json_dataSources_80aabde7
+      tag: foreach_dataSources_80aabde7
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
+          tag: foreach_ingest_value_instances_2129e376
           field: _ingest._value.instances
           ignore_failure: true
           processor:
@@ -159,11 +163,12 @@ processors:
                 - ISO8601
               on_failure:
                 - remove:
+                    tag: remove_ingest_value_lastSeen
                     field: _ingest._value.lastSeen
                     ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_json_dataSources_b14257f2
+      tag: foreach_dataSources_b14257f2
       if: ctx.json?.dataSources instanceof List
       processor:
         date:
@@ -176,14 +181,16 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_lastSeen_c3795701
                 field: _ingest._value.lastSeen
                 ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_json_dataSources_23b1bbea
+      tag: foreach_dataSources_23b1bbea
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
+          tag: foreach_ingest_value_instances_20f07e12
           field: _ingest._value.instances
           ignore_failure: true
           processor:
@@ -195,7 +202,7 @@ processors:
               ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_json_dataSources_17aa49c5
+      tag: foreach_dataSources_17aa49c5
       if: ctx.json?.dataSources instanceof List
       processor:
         remove:
@@ -230,7 +237,7 @@ processors:
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_62b39146
+      tag: set_event_start_from_device_first_seen_62b39146
       copy_from: armis.device.first_seen
       ignore_empty_value: true
   - convert:
@@ -268,9 +275,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value
                 field: _ingest._value
                 ignore_missing: true
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -305,9 +314,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_2b6b117d
                 field: _ingest._value
                 ignore_missing: true
             - append:
+                tag: append_error_message_ed446288
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -381,6 +392,7 @@ processors:
           ignore_missing: true
           on_failure:
             - append:
+                tag: append_error_message_808486c0
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -505,6 +517,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_creationTime
                 field: _ingest._value.creationTime
                 ignore_missing: true
   - foreach:
@@ -533,6 +546,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_lastSeenTime
                 field: _ingest._value.lastSeenTime
                 ignore_missing: true
   - foreach:
@@ -725,6 +739,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_dfb15182
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -735,6 +750,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/device/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/device/elasticsearch/ingest_pipeline/default.yml
@@ -42,6 +42,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -120,7 +121,7 @@ processors:
                 ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources
+      tag: foreach_json_dataSources_44a528e5
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
@@ -141,7 +142,7 @@ processors:
                     ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources
+      tag: foreach_json_dataSources_80aabde7
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
@@ -162,7 +163,7 @@ processors:
                     ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources
+      tag: foreach_json_dataSources_b14257f2
       if: ctx.json?.dataSources instanceof List
       processor:
         date:
@@ -179,7 +180,7 @@ processors:
                 ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources
+      tag: foreach_json_dataSources_23b1bbea
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
@@ -194,7 +195,7 @@ processors:
               ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources
+      tag: foreach_json_dataSources_17aa49c5
       if: ctx.json?.dataSources instanceof List
       processor:
         remove:
@@ -224,11 +225,12 @@ processors:
       if: ctx.json?.firstSeen != null && ctx.json.firstSeen != ''
       on_failure:
         - append:
+            tag: append_error_message_3f050535
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_device_first_seen
+      tag: set_event_start_62b39146
       copy_from: armis.device.first_seen
       ignore_empty_value: true
   - convert:
@@ -251,6 +253,7 @@ processors:
       if: ctx.json?.ipAddress instanceof String && ctx.json.ipAddress != ''
       on_failure:
         - append:
+            tag: append_error_message_1ef97379
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -272,7 +275,7 @@ processors:
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: armis.device.ip_address
-      tag: foreach_armis_device_ip_address
+      tag: foreach_armis_device_ip_address_83fc270f
       if: ctx.armis?.device?.ip_address instanceof List
       processor:
         append:
@@ -282,7 +285,7 @@ processors:
           allow_duplicates: false
   - foreach:
       field: armis.device.ip_address
-      tag: foreach_armis_device_ip_address
+      tag: foreach_armis_device_ip_address_cbd753d5
       if: ctx.armis?.device?.ip_address instanceof List
       processor:
         append:
@@ -333,6 +336,7 @@ processors:
       if: ctx.json?.lastSeen != null && ctx.json.lastSeen != ''
       on_failure:
         - append:
+            tag: append_error_message_36ac071d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -349,9 +353,11 @@ processors:
       if: ctx.json?.macAddress instanceof String && ctx.json.macAddress != ''
       on_failure:
         - append:
+            tag: append_error_message_304849a2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_armis_device_mac_address_886e7aa3
       field: armis.device.mac_address
       if: ctx.armis?.device?.mac_address instanceof List
       ignore_failure: true
@@ -362,6 +368,7 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_host_mac_cf1efd0d
       field: host.mac
       if: ctx.host?.mac instanceof List
       ignore_failure: true
@@ -377,6 +384,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_host_mac_15ece91a
       field: host.mac
       if: ctx.host?.mac instanceof List
       ignore_failure: true
@@ -419,9 +427,11 @@ processors:
       if: ctx.json?.names instanceof String && ctx.json.names != ''
       on_failure:
         - append:
+            tag: append_error_message_76b1b9d9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_armis_device_names_01a73f31
       field: armis.device.names
       if: ctx.armis?.device?.names instanceof List
       ignore_failure: true
@@ -441,6 +451,7 @@ processors:
           tag: lowercase_host_name
           ignore_missing: true
   - foreach:
+      tag: foreach_host_name_13da92ce
       field: host.name
       if: ctx.host?.name instanceof List
       ignore_failure: true
@@ -498,7 +509,7 @@ processors:
                 ignore_missing: true
   - foreach:
       field: json.protections
-      tag: foreach_json_protections
+      tag: foreach_json_protections_ab2da63a
       if: ctx.json?.protections instanceof List
       processor:
         convert:
@@ -509,7 +520,7 @@ processors:
           ignore_missing: true
   - foreach:
       field: json.protections
-      tag: foreach_json_protections
+      tag: foreach_json_protections_7ad79d22
       if: ctx.json?.protections instanceof List
       processor:
         date:
@@ -525,6 +536,7 @@ processors:
                 field: _ingest._value.lastSeenTime
                 ignore_missing: true
   - foreach:
+      tag: foreach_json_protections_40ae4388
       field: json.protections
       if: ctx.json?.protections instanceof List
       processor:
@@ -534,6 +546,7 @@ processors:
           target_field: _ingest._value.protection_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_protections_dc8b0544
       field: json.protections
       if: ctx.json?.protections instanceof List
       processor:
@@ -557,6 +570,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_750fa912
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -567,6 +581,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e1222968
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -581,6 +596,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3141b072
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -636,7 +652,7 @@ processors:
           allow_duplicates: false
   - foreach:
       field: armis.device.user_ids
-      tag: foreach_armis_device_user_ids
+      tag: foreach_armis_device_user_ids_eb2fdd9d
       if: ctx.armis?.device?.user_ids instanceof List
       processor:
         append:
@@ -702,6 +718,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/device/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/device/elasticsearch/ingest_pipeline/default.yml
@@ -3,15 +3,15 @@ description: Pipeline for processing Device logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
-      tag: drop_retry_events
+      tag: drop_retry_events_1f05010a
   - remove:
       field:
         - organization
@@ -19,97 +19,97 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
       fields:
         - json.lastSeen
         - json.id
-      tag: fingerprint_device
+      tag: fingerprint_device_fcf3cecb
       target_field: _id
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_event_kind_to_event
+      tag: set_event_kind_to_event_d452ef2c
       value: event
   - append:
       field: event.type
-      tag: append_event_type
+      tag: append_event_type_5eab37e6
       value: info
   - append:
       field: event.category
-      tag: append_event_category
+      tag: append_event_category_5098f71a
       value: host
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_1e721121
       value: Armis
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_4f1031b1
       value: Asset Management and Security
   - rename:
       field: json.accessSwitch
-      tag: rename_accessSwitch
+      tag: rename_accessSwitch_7e57417d
       target_field: armis.device.access_switch
       ignore_missing: true
   - rename:
       field: json.boundaries
-      tag: rename_boundaries
+      tag: rename_boundaries_ae6da29b
       target_field: armis.device.boundaries
       ignore_missing: true
   - rename:
       field: json.businessImpact
-      tag: rename_businessImpact
+      tag: rename_businessImpact_7ed1280e
       target_field: armis.device.business_impact
       ignore_missing: true
   - rename:
       field: json.category
-      tag: rename_category
+      tag: rename_category_4527ef3e
       target_field: armis.device.category
       ignore_missing: true
   - set:
       field: host.type
-      tag: set_event_start_from_device_first_seen
+      tag: set_host_type_from_device_category_835a5a5a
       copy_from: armis.device.category
       ignore_empty_value: true
   - rename:
       field: json.customProperties
-      tag: rename_customProperties
+      tag: rename_customProperties_fe8512d4
       target_field: armis.device.custom_properties
       ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources
+      tag: foreach_dataSources_3b66f9ec
       if: ctx.json?.dataSources instanceof List
       processor:
         date:
           field: _ingest._value.firstSeen
-          tag: date_dataSources_firstSeen
+          tag: date_dataSources_firstSeen_fa0aa546
           target_field: _ingest._value.first_seen
           formats:
             - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -117,22 +117,22 @@ processors:
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_firstSeen
+                tag: remove_ingest_value_firstSeen_961a288c
                 field: _ingest._value.firstSeen
                 ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources_44a528e5
+      tag: foreach_dataSources_b33cbb26
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
-          tag: foreach_ingest_value_instances
+          tag: foreach_ingest_value_instances_4c4f4b0a
           field: _ingest._value.instances
           ignore_failure: true
           processor:
             date:
               field: _ingest._value.firstSeen
-              tag: date_dataSources_instances_firstSeen
+              tag: date_dataSources_instances_firstSeen_af483c50
               target_field: _ingest._value.first_seen
               formats:
                 - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -140,22 +140,22 @@ processors:
                 - ISO8601
               on_failure:
                 - remove:
-                    tag: remove_ingest_value_firstSeen_743481c2
+                    tag: remove_ingest_value_firstSeen_04537305
                     field: _ingest._value.firstSeen
                     ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources_80aabde7
+      tag: foreach_dataSources_b5c9ea75
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
-          tag: foreach_ingest_value_instances_2129e376
+          tag: foreach_ingest_value_instances_a1bc8789
           field: _ingest._value.instances
           ignore_failure: true
           processor:
             date:
               field: _ingest._value.lastSeen
-              tag: date_dataSources_instances_lastSeen
+              tag: date_dataSources_instances_lastSeen_5572b597
               target_field: _ingest._value.last_seen
               formats:
                 - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -163,17 +163,17 @@ processors:
                 - ISO8601
               on_failure:
                 - remove:
-                    tag: remove_ingest_value_lastSeen
+                    tag: remove_ingest_value_lastSeen_d7120d9b
                     field: _ingest._value.lastSeen
                     ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources_b14257f2
+      tag: foreach_dataSources_f5389b51
       if: ctx.json?.dataSources instanceof List
       processor:
         date:
           field: _ingest._value.lastSeen
-          tag: date_dataSources_lastSeen
+          tag: date_dataSources_lastSeen_304d6a5b
           target_field: _ingest._value.last_seen
           formats:
             - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -181,16 +181,16 @@ processors:
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_lastSeen_c3795701
+                tag: remove_ingest_value_lastSeen_085eec64
                 field: _ingest._value.lastSeen
                 ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources_23b1bbea
+      tag: foreach_dataSources_3207fb3a
       if: ctx.json?.dataSources instanceof List
       processor:
         foreach:
-          tag: foreach_ingest_value_instances_20f07e12
+          tag: foreach_ingest_value_instances_c914fc86
           field: _ingest._value.instances
           ignore_failure: true
           processor:
@@ -198,32 +198,32 @@ processors:
               field:
                 - _ingest._value.firstSeen
                 - _ingest._value.lastSeen
-              tag: remove_dataSources_instances
+              tag: remove_dataSources_instances_b8fb7882
               ignore_missing: true
   - foreach:
       field: json.dataSources
-      tag: foreach_dataSources_17aa49c5
+      tag: foreach_dataSources_9ef5e1cd
       if: ctx.json?.dataSources instanceof List
       processor:
         remove:
           field:
             - _ingest._value.firstSeen
             - _ingest._value.lastSeen
-          tag: remove_dataSources
+          tag: remove_dataSources_cd3d55dd
           ignore_missing: true
   - rename:
       field: json.dataSources
-      tag: rename_dataSources
+      tag: rename_dataSources_00cf83b0
       target_field: armis.device.data_sources
       ignore_missing: true
   - rename:
       field: json.displayTitle
-      tag: rename_displayTitle
+      tag: rename_displayTitle_37135cc0
       target_field: armis.device.display_title
       ignore_missing: true
   - date:
       field: json.firstSeen
-      tag: date_firstSeen
+      tag: date_firstSeen_aee83ac6
       target_field: armis.device.first_seen
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -232,113 +232,113 @@ processors:
       if: ctx.json?.firstSeen != null && ctx.json.firstSeen != ''
       on_failure:
         - append:
-            tag: append_error_message_3f050535
+            tag: append_error_message_0097a93c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_device_first_seen_62b39146
+      tag: set_event_start_from_device_first_seen_2b893b8a
       copy_from: armis.device.first_seen
       ignore_empty_value: true
   - convert:
       field: json.id
-      tag: convert_id_to_string
+      tag: convert_id_to_string_a9441eec
       target_field: armis.device.id
       type: string
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_device_id
+      tag: set_host_id_from_device_id_2b6248f0
       copy_from: armis.device.id
       ignore_empty_value: true
   - split:
       field: json.ipAddress
       separator: ', '
-      tag: split_ipAddress
+      tag: split_ipAddress_a3996da5
       target_field: armis.device.ip_address
       ignore_missing: true
       if: ctx.json?.ipAddress instanceof String && ctx.json.ipAddress != ''
       on_failure:
         - append:
-            tag: append_error_message_1ef97379
+            tag: append_error_message_8d28a041
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: armis.device.ip_address
-      tag: foreach_armis_device_ip_address
+      tag: foreach_armis_device_ip_address_7c4bd811
       if: ctx.armis?.device?.ip_address instanceof List
       processor:
         convert:
           field: _ingest._value
-          tag: convert_ip_address_to_ip
+          tag: convert_ip_address_to_ip_de3bf6b9
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value
+                tag: remove_ingest_value_c074057b
                 field: _ingest._value
                 ignore_missing: true
             - append:
-                tag: append_error_message
+                tag: append_error_message_2e352249
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: armis.device.ip_address
-      tag: foreach_armis_device_ip_address_83fc270f
+      tag: foreach_armis_device_ip_address_e8f30162
       if: ctx.armis?.device?.ip_address instanceof List
       processor:
         append:
           field: host.ip
-          tag: append_armis_device_ip_address_into_host_ip
+          tag: append_armis_device_ip_address_into_host_ip_1526220b
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: armis.device.ip_address
-      tag: foreach_armis_device_ip_address_cbd753d5
+      tag: foreach_armis_device_ip_address_1376e630
       if: ctx.armis?.device?.ip_address instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_armis_device_ip_address_into_related_ip
+          tag: append_armis_device_ip_address_into_related_ip_b9d29c99
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: json.ipv6
-      tag: foreach_ipv6
+      tag: foreach_ipv6_b292a2cb
       if: ctx.json?.ipv6 instanceof List
       processor:
         convert:
           field: _ingest._value
-          tag: convert_ipv6_to_ip
+          tag: convert_ipv6_to_ip_71b93569
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_2b6b117d
+                tag: remove_ingest_value_930cd818
                 field: _ingest._value
                 ignore_missing: true
             - append:
-                tag: append_error_message_ed446288
+                tag: append_error_message_1309c10b
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.ipv6
-      tag: rename_ipv6
+      tag: rename_ipv6_feafdcf9
       target_field: armis.device.ip_v6
       ignore_missing: true
   - foreach:
       field: armis.device.ip_v6
-      tag: foreach_armis_device_ip_v6
+      tag: foreach_armis_device_ip_v6_04fe69fe
       if: ctx.armis?.device?.ip_v6 instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_armis_device_user_ids_into_related_ip
+          tag: append_armis_device_user_ids_into_related_ip_f73808d9
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - date:
       field: json.lastSeen
-      tag: date_lastSeen
+      tag: date_lastSeen_f63f951d
       target_field: armis.device.last_seen
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -347,169 +347,169 @@ processors:
       if: ctx.json?.lastSeen != null && ctx.json.lastSeen != ''
       on_failure:
         - append:
-            tag: append_error_message_36ac071d
+            tag: append_error_message_2aa199e6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_device_last_seen
+      tag: set_@timestamp_from_device_last_seen_5369de33
       copy_from: armis.device.last_seen
       ignore_empty_value: true
   - split:
       field: json.macAddress
       separator: ', '
-      tag: split_mac_address
+      tag: split_mac_address_c8604337
       target_field: armis.device.mac_address
       ignore_missing: true
       if: ctx.json?.macAddress instanceof String && ctx.json.macAddress != ''
       on_failure:
         - append:
-            tag: append_error_message_304849a2
+            tag: append_error_message_9dd916b3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_armis_device_mac_address_886e7aa3
+      tag: foreach_armis_device_mac_address_eecd0985
       field: armis.device.mac_address
       if: ctx.armis?.device?.mac_address instanceof List
       ignore_failure: true
       processor:
         append:
           field: host.mac
-          tag: append_armis_device_mac_address_into_host_mac
+          tag: append_armis_device_mac_address_into_host_mac_1a266910
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_host_mac_cf1efd0d
+      tag: foreach_host_mac_f72245a2
       field: host.mac
       if: ctx.host?.mac instanceof List
       ignore_failure: true
       processor:
         gsub:
           field: _ingest._value
-          tag: gsub_host_mac_for_each_mac
+          tag: gsub_host_mac_for_each_mac_7dd8ad91
           pattern: ':'
           replacement: '-'
           ignore_missing: true
           on_failure:
             - append:
-                tag: append_error_message_808486c0
+                tag: append_error_message_94b901ab
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_host_mac_15ece91a
+      tag: foreach_host_mac_de0cd755
       field: host.mac
       if: ctx.host?.mac instanceof List
       ignore_failure: true
       processor:
         uppercase:
           field: _ingest._value
-          tag: uppercase_host_mac_for_each_mac
+          tag: uppercase_host_mac_for_each_mac_ebf4297c
           ignore_missing: true
   - rename:
       field: json.manufacturer
-      tag: rename_manufacturer
+      tag: rename_manufacturer_b46203f6
       target_field: armis.device.manufacturer
       ignore_missing: true
   - set:
       field: device.manufacturer
-      tag: set_device_manufacturer_from_device_manufacturer
+      tag: set_device_manufacturer_from_device_manufacturer_90e232d6
       copy_from: armis.device.manufacturer
       ignore_empty_value: true
   - rename:
       field: json.model
-      tag: rename_model
+      tag: rename_model_78bffe6d
       target_field: armis.device.model
       ignore_missing: true
   - set:
       field: device.model.name
-      tag: set_device_model_name_from_device_model
+      tag: set_device_model_name_from_device_model_2a3620f1
       copy_from: armis.device.model
       ignore_empty_value: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_7782a2e0
       target_field: armis.device.name
       ignore_missing: true
   - split:
       field: json.names
       separator: ','
-      tag: split_names
+      tag: split_names_0e1777f1
       target_field: armis.device.names
       ignore_missing: true
       if: ctx.json?.names instanceof String && ctx.json.names != ''
       on_failure:
         - append:
-            tag: append_error_message_76b1b9d9
+            tag: append_error_message_1e8b6e9f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_armis_device_names_01a73f31
+      tag: foreach_armis_device_names_9f7526b5
       field: armis.device.names
       if: ctx.armis?.device?.names instanceof List
       ignore_failure: true
       processor:
         append:
           field: host.name
-          tag: append_armis_device_names_into_host_name
+          tag: append_armis_device_names_into_host_name_954091d0
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: host.name
-      tag: foreach_host_name
+      tag: foreach_host_name_ca07f4d8
       if: ctx.host?.name instanceof List
       processor:
         lowercase:
           field: _ingest._value
-          tag: lowercase_host_name
+          tag: lowercase_host_name_a483eca9
           ignore_missing: true
   - foreach:
-      tag: foreach_host_name_13da92ce
+      tag: foreach_host_name_3adea8f9
       field: host.name
       if: ctx.host?.name instanceof List
       ignore_failure: true
       processor:
         append:
           field: related.hosts
-          tag: append_host_name_into_related_hosts
+          tag: append_host_name_into_related_hosts_6a520d26
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.operatingSystem
-      tag: rename_operatingSystem
+      tag: rename_operatingSystem_6d3dda96
       target_field: armis.device.operating_system
       ignore_missing: true
   - set:
       field: host.os.family
-      tag: set_host_os_family_from_device_operating_system
+      tag: set_host_os_family_from_device_operating_system_48c49e60
       copy_from: armis.device.operating_system
       ignore_empty_value: true
   - lowercase:
       field: host.os.family
-      tag: lowercase_host_os_family
+      tag: lowercase_host_os_family_8fdfcf7a
       ignore_missing: true
   - set:
       field: host.os.type
-      tag: set_host_os_type_from_host_os_family
+      tag: set_host_os_type_from_host_os_family_b3a835d4
       copy_from: host.os.family
       ignore_empty_value: true
   - rename:
       field: json.operatingSystemVersion
-      tag: rename_operatingSystemVersion
+      tag: rename_operatingSystemVersion_2c464f51
       target_field: armis.device.operating_system_version
       ignore_missing: true
   - set:
       field: host.os.version
-      tag: set_host_os_version_from_device_operating_system_version
+      tag: set_host_os_version_from_device_operating_system_version_e778f52d
       copy_from: armis.device.operating_system_version
       ignore_empty_value: true
   - foreach:
       field: json.protections
-      tag: foreach_json_protections
+      tag: foreach_json_protections_072bd316
       if: ctx.json?.protections instanceof List
       processor:
         date:
           field: _ingest._value.creationTime
-          tag: date_protections_creationTime
+          tag: date_protections_creationTime_c253c9ba
           target_field: _ingest._value.creation_time
           formats:
             - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -517,28 +517,28 @@ processors:
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_creationTime
+                tag: remove_ingest_value_creationTime_4d57dc60
                 field: _ingest._value.creationTime
                 ignore_missing: true
   - foreach:
       field: json.protections
-      tag: foreach_json_protections_ab2da63a
+      tag: foreach_json_protections_6f70a97a
       if: ctx.json?.protections instanceof List
       processor:
         convert:
           field: _ingest._value.deviceId
-          tag: convert_deviceIds_to_string
+          tag: convert_deviceIds_to_string_cef4c108
           target_field: _ingest._value.device_id
           type: string
           ignore_missing: true
   - foreach:
       field: json.protections
-      tag: foreach_json_protections_7ad79d22
+      tag: foreach_json_protections_adbbd5d4
       if: ctx.json?.protections instanceof List
       processor:
         date:
           field: _ingest._value.lastSeenTime
-          tag: date_protections_lastSeenTime
+          tag: date_protections_lastSeenTime_e76ba941
           target_field: _ingest._value.last_seen_time
           formats:
             - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -546,21 +546,21 @@ processors:
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_lastSeenTime
+                tag: remove_ingest_value_lastSeenTime_a2f3a1a8
                 field: _ingest._value.lastSeenTime
                 ignore_missing: true
   - foreach:
-      tag: foreach_json_protections_40ae4388
+      tag: foreach_json_protections_469ea9f9
       field: json.protections
       if: ctx.json?.protections instanceof List
       processor:
         rename:
           field: _ingest._value.protectionName
-          tag: rename_protections_protectionName
+          tag: rename_protections_protectionName_47ec59ac
           target_field: _ingest._value.protection_name
           ignore_missing: true
   - foreach:
-      tag: foreach_json_protections_dc8b0544
+      tag: foreach_json_protections_a3212a20
       field: json.protections
       if: ctx.json?.protections instanceof List
       processor:
@@ -569,114 +569,114 @@ processors:
             - _ingest._value.creationTime
             - _ingest._value.lastSeenTime
             - _ingest._value.deviceId
-          tag: remove_protections
+          tag: remove_protections_a842abc4
           ignore_missing: true
   - rename:
       field: json.protections
-      tag: rename_protections
+      tag: rename_protections_52347b09
       target_field: armis.device.protections
       ignore_missing: true
   - convert:
       field: json.purdueLevel
-      tag: convert_purdueLevel_to_double
+      tag: convert_purdueLevel_to_double_90d3f68d
       target_field: armis.device.purdue_level
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_750fa912
+            tag: append_error_message_ab7e09fe
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.riskLevel
-      tag: convert_riskLevel_to_long
+      tag: convert_riskLevel_to_long_6f02d90f
       target_field: armis.device.risk_level
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_e1222968
+            tag: append_error_message_2d5ed7ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: host.risk.static_score
-      tag: set_host_risk_static_score_from_device_risk_level
+      tag: set_host_risk_static_score_from_device_risk_level_33839526
       copy_from: armis.device.risk_level
       ignore_empty_value: true
   - convert:
       field: host.risk.static_score
-      tag: convert_armis_device_risk_level_to_double
+      tag: convert_armis_device_risk_level_to_double_f8cb2821
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_3141b072
+            tag: append_error_message_9b638634
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.sensor.name
-      tag: rename_sensor_name
+      tag: rename_sensor_name_067ef44c
       target_field: armis.device.sensor.name
       ignore_missing: true
   - rename:
       field: json.sensor.type
-      tag: rename_sensor_type
+      tag: rename_sensor_type_962deb0d
       target_field: armis.device.sensor.type
       ignore_missing: true
   - rename:
       field: json.site.location
-      tag: rename_site_location
+      tag: rename_site_location_861fb09c
       target_field: armis.device.site.location
       ignore_missing: true
   - rename:
       field: json.site.name
-      tag: rename_site_name
+      tag: rename_site_name_a7e7e4c8
       target_field: armis.device.site.name
       ignore_missing: true
   - rename:
       field: json.tags
-      tag: rename_tags
+      tag: rename_tags_fdad5fba
       target_field: armis.device.tags
       ignore_missing: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_8556b451
       target_field: armis.device.type
       ignore_missing: true
   - rename:
       field: json.typeEnum
-      tag: rename_typeEnum
+      tag: rename_typeEnum_aefb1488
       target_field: armis.device.type_enum
       ignore_missing: true
   - convert:
       field: json.userIds
-      tag: convert_userIds
+      tag: convert_userIds_c28d11b3
       target_field: armis.device.user_ids
       type: string
       ignore_missing: true
   - foreach:
       field: armis.device.user_ids
-      tag: foreach_armis_device_user_ids
+      tag: foreach_armis_device_user_ids_989b472b
       if: ctx.armis?.device?.user_ids instanceof List
       processor:
         append:
           field: user.id
-          tag: append_armis_device_user_ids_into_user_id
+          tag: append_armis_device_user_ids_into_user_id_2ae8753e
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: armis.device.user_ids
-      tag: foreach_armis_device_user_ids_eb2fdd9d
+      tag: foreach_armis_device_user_ids_b99bac61
       if: ctx.armis?.device?.user_ids instanceof List
       processor:
         append:
           field: related.user
-          tag: append_armis_device_user_ids_into_related_user
+          tag: append_armis_device_user_ids_into_related_user_193f1038
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.visibility
-      tag: rename_visibility
+      tag: rename_visibility_b21c5fe1
       target_field: armis.device.visibility
       ignore_missing: true
   - remove:
@@ -693,16 +693,16 @@ processors:
         - armis.device.user_ids
         - armis.device.category
         - armis.device.operating_system
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_98ef0dc0
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -728,18 +728,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_dfb15182
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -747,10 +747,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -3,15 +3,15 @@ description: Pipeline for processing Vulnerability logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
-      tag: drop_retry_events
+      tag: drop_retry_events_1f05010a
   - remove:
       field:
         - organization
@@ -19,30 +19,30 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -51,94 +51,94 @@ processors:
         - json.lastDetected
         - json.vulnerability_match.deviceId
         - json.vulnerability_match.lastDetected
-      tag: fingerprint_device
+      tag: fingerprint_device_990a52a5
       target_field: _id
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_event_kind_to_event
+      tag: set_event_kind_to_event_d452ef2c
       value: event
   - append:
       field: event.type
-      tag: append_event_type
+      tag: append_event_type_5eab37e6
       value: info
   - append:
       field: event.category
-      tag: append_event_category
+      tag: append_event_category_30f59663
       value: vulnerability
   - set:
       field: vulnerability.scanner.vendor
-      tag: set_vulnerability_scanner_vendor
+      tag: set_vulnerability_scanner_vendor_d064ef3a
       value: Armis
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_1e721121
       value: Armis
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_4f1031b1
       value: Asset Management and Security
   - convert:
       field: json.affectedDevicesCount
-      tag: convert_affectedDevicesCount_to_long
+      tag: convert_affectedDevicesCount_to_long_79d8203d
       target_field: armis.vulnerability.affected_devices_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5e599058
+            tag: append_error_message_aa7130ca
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.attackComplexity
-      tag: rename_attackComplexity
+      tag: rename_attackComplexity_e26b80a6
       target_field: armis.vulnerability.attack_complexity
       ignore_missing: true
   - rename:
       field: json.attackVector
-      tag: rename_attackVector
+      tag: rename_attackVector_2ad95b1e
       target_field: armis.vulnerability.attack_vector
       ignore_missing: true
   - append:
       field: vulnerability.category
-      tag: append_vulnerability_category
+      tag: append_vulnerability_category_1cfcf316
       value: '{{{armis.vulnerability.attack_vector}}}'
       allow_duplicates: false
       if: ctx.armis.vulnerability.attack_vector != null
   - rename:
       field: json.availabilityImpact
-      tag: rename_availabilityImpact
+      tag: rename_availabilityImpact_a84b3303
       target_field: armis.vulnerability.availability_impact
       ignore_missing: true
   - rename:
       field: json.avmRating
-      tag: rename_avmRating
+      tag: rename_avmRating_b6bbc67a
       target_field: armis.vulnerability.avm_rating
       ignore_missing: true
   - rename:
       field: json.avmRatingManualChangeReason
-      tag: rename_avmRatingManualChangeReason
+      tag: rename_avmRatingManualChangeReason_6731b022
       target_field: armis.vulnerability.avm_rating_manual_change_reason
       ignore_missing: true
   - rename:
       field: json.avmRatingManualChangedBy
-      tag: rename_avmRatingManualChangedBy
+      tag: rename_avmRatingManualChangedBy_ff4309b4
       target_field: armis.vulnerability.avm_rating_manual_changed_by
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_vulnerability_avm_rating_manual_changed_by
+      tag: set_user_name_from_vulnerability_avm_rating_manual_changed_by_5db21395
       copy_from: armis.vulnerability.avm_rating_manual_changed_by
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_related_user
+      tag: append_related_user_575d3878
       value: '{{{armis.vulnerability.avm_rating_manual_changed_by}}}'
       allow_duplicates: false
       if: ctx.armis.vulnerability.avm_rating_manual_changed_by != null
   - date:
       field: json.avmRatingManualUpdateTime
-      tag: date_avmRatingManualUpdateTime
+      tag: date_avmRatingManualUpdateTime_9281ccbf
       target_field: armis.vulnerability.avm_rating_manual_update_time
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -147,17 +147,17 @@ processors:
       if: ctx.json?.avmRatingManualUpdateTime != null && ctx.json.avmRatingManualUpdateTime != ''
       on_failure:
         - append:
-            tag: append_error_message_0aad49ae
+            tag: append_error_message_e1513c67
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.botnets
-      tag: rename_botnets
+      tag: rename_botnets_44d02d2b
       target_field: armis.vulnerability.botnets
       ignore_missing: true
   - date:
       field: json.cisaDueDate
-      tag: date_cisaDueDate
+      tag: date_cisaDueDate_1f8d4514
       target_field: armis.vulnerability.cisa_due_date
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -166,91 +166,91 @@ processors:
       if: ctx.json?.cisaDueDate != null && ctx.json.cisaDueDate != ''
       on_failure:
         - append:
-            tag: append_error_message_1acd96cf
+            tag: append_error_message_a1b9ce16
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.commonName
-      tag: rename_commonName
+      tag: rename_commonName_4c489701
       target_field: armis.vulnerability.common_name
       ignore_missing: true
   - rename:
       field: json.confidentialityImpact
-      tag: rename_confidentialityImpact
+      tag: rename_confidentialityImpact_74709c25
       target_field: armis.vulnerability.confidentiality_impact
       ignore_missing: true
   - rename:
       field: json.cveUid
-      tag: rename_cveUid
+      tag: rename_cveUid_8d8c6fcd
       target_field: armis.vulnerability.cve_uid
       ignore_missing: true
   - convert:
       field: json.cvssScore
-      tag: convert_cvssScore_to_double
+      tag: convert_cvssScore_to_double_220fff89
       target_field: armis.vulnerability.cvss_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_96955690
+            tag: append_error_message_60a3c16c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.cvssScoreV4
-      tag: rename_cvssScoreV4
+      tag: rename_cvssScoreV4_fdd274c7
       target_field: armis.vulnerability.cvss_score_v4
       ignore_missing: true
   - rename:
       field: json.description
-      tag: rename_description
+      tag: rename_description_03abc87a
       target_field: armis.vulnerability.description
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_vulnerability_description
+      tag: set_message_from_vulnerability_description_cdf9c5cb
       copy_from: armis.vulnerability.description
       ignore_empty_value: true
   - set:
       field: vulnerability.description
-      tag: set_vulnerability_description
+      tag: set_vulnerability_description_ee254347
       copy_from: armis.vulnerability.description
       ignore_empty_value: true
   - convert:
       field: json.epssPercentile
-      tag: convert_epssPercentile_to_double
+      tag: convert_epssPercentile_to_double_06d3a76b
       target_field: armis.vulnerability.epss_percentile
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_669a5f43
+            tag: append_error_message_74e862c8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.epssScore
-      tag: convert_epssScore_to_double
+      tag: convert_epssScore_to_double_6dba70f8
       target_field: armis.vulnerability.epss_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f02e1804
+            tag: append_error_message_e0e056c3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.exploitabilityScore
-      tag: convert_exploitabilityScore_to_double
+      tag: convert_exploitabilityScore_to_double_efeb07af
       target_field: armis.vulnerability.exploitability_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2b6ef430
+            tag: append_error_message_8dbb2f9c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.firstDetected
-      tag: date_firstDetected
+      tag: date_firstDetected_2addd4df
       target_field: armis.vulnerability.first_detected
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -259,17 +259,17 @@ processors:
       if: ctx.json?.firstDetected != null && ctx.json.firstDetected != ''
       on_failure:
         - append:
-            tag: append_error_message_5e7ac6c4
+            tag: append_error_message_c2b19fc1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_vulnerability_first_detected
+      tag: set_event_start_from_vulnerability_first_detected_e7ffb662
       copy_from: armis.vulnerability.first_detected
       ignore_empty_value: true
   - date:
       field: json.firstReferencePublishDate
-      tag: date_firstReferencePublishDate
+      tag: date_firstReferencePublishDate_c00911a7
       target_field: armis.vulnerability.first_reference_publish_date
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -278,12 +278,12 @@ processors:
       if: ctx.json?.firstReferencePublishDate != null && ctx.json.firstReferencePublishDate != ''
       on_failure:
         - append:
-            tag: append_error_message_dcf2b6dc
+            tag: append_error_message_aba22d01
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.firstWeaponizedReferencePublishDate
-      tag: date_firstWeaponizedReferencePublishDate
+      tag: date_firstWeaponizedReferencePublishDate_553fc730
       target_field: armis.vulnerability.first_weaponized_reference_publish_date
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -292,65 +292,65 @@ processors:
       if: ctx.json?.firstWeaponizedReferencePublishDate != null && ctx.json.firstWeaponizedReferencePublishDate != ''
       on_failure:
         - append:
-            tag: append_error_message_58d0c6dd
+            tag: append_error_message_b03b8bad
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.hasRansomware
-      tag: convert_hasRansomware_to_boolean
+      tag: convert_hasRansomware_to_boolean_76f3a02c
       target_field: armis.vulnerability.has_ransomware
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_cb6fcfb8
+            tag: append_error_message_0c5d5874
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.hasRemediationInfo
-      tag: rename_hasRemediationInfo
+      tag: rename_hasRemediationInfo_106c1cf8
       target_field: armis.vulnerability.has_remediation_info
       ignore_missing: true
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_966ef157
       target_field: armis.vulnerability.id
       ignore_missing: true
   - set:
       field: vulnerability.id
-      tag: set_vulnerability_id_from_vulnerability_id
+      tag: set_vulnerability_id_from_vulnerability_id_a9b5734b
       copy_from: armis.vulnerability.id
       ignore_empty_value: true
   - convert:
       field: json.impactScore
-      tag: convert_impactScore_to_double
+      tag: convert_impactScore_to_double_a4978586
       target_field: armis.vulnerability.impact_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_31efb147
+            tag: append_error_message_daba4fc9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.integrityImpact
-      tag: rename_integrityImpact
+      tag: rename_integrityImpact_fc63c5d8
       target_field: armis.vulnerability.integrity_impact
       ignore_missing: true
   - convert:
       field: json.isWeaponized
-      tag: convert_isWeaponized_to_boolean
+      tag: convert_isWeaponized_to_boolean_8d7ec3e1
       target_field: armis.vulnerability.is_weaponized
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4e51ce63
+            tag: append_error_message_3a9dc016
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.lastDetected
-      tag: date_lastDetected
+      tag: date_lastDetected_8e26e214
       target_field: armis.vulnerability.last_detected
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -359,12 +359,12 @@ processors:
       if: ctx.json?.lastDetected != null && ctx.json.lastDetected != ''
       on_failure:
         - append:
-            tag: append_error_message_8d9aba08
+            tag: append_error_message_073ca817
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.latestExploitUpdate
-      tag: date_latestExploitUpdate
+      tag: date_latestExploitUpdate_313388e0
       target_field: armis.vulnerability.latest_exploit_update
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -373,39 +373,39 @@ processors:
       if: ctx.json?.latestExploitUpdate != null && ctx.json.latestExploitUpdate != ''
       on_failure:
         - append:
-            tag: append_error_message_593cce52
+            tag: append_error_message_551ed2eb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.numOfExploits
-      tag: convert_numOfExploits_to_long
+      tag: convert_numOfExploits_to_long_bfed991c
       target_field: armis.vulnerability.num_of_exploits
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8ab38101
+            tag: append_error_message_94d87a2f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.numberOfThreatActors
-      tag: convert_numberOfThreatActors_to_long
+      tag: convert_numberOfThreatActors_to_long_b2f3de36
       target_field: armis.vulnerability.number_of_threat_actors
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_9ab7e23d
+            tag: append_error_message_addeee61
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.privilegesRequired
-      tag: rename_privilegesRequired
+      tag: rename_privilegesRequired_27663502
       target_field: armis.vulnerability.privileges_required
       ignore_missing: true
   - date:
       field: json.publishedDate
-      tag: date_publishedDate
+      tag: date_publishedDate_270f164c
       target_field: armis.vulnerability.published_date
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -414,121 +414,121 @@ processors:
       if: ctx.json?.publishedDate != null && ctx.json.publishedDate != ''
       on_failure:
         - append:
-            tag: append_error_message_02b400b2
+            tag: append_error_message_681a0859
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.reportedByGoogleZeroDays
-      tag: convert_reportedByGoogleZeroDays_to_boolean
+      tag: convert_reportedByGoogleZeroDays_to_boolean_bb46e5ed
       target_field: armis.vulnerability.reported_by_google_zero_days
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_3e72b7f2
+            tag: append_error_message_a27de6c4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.scope
-      tag: rename_scope
+      tag: rename_scope_6a3109cd
       target_field: armis.vulnerability.scope
       ignore_missing: true
   - convert:
       field: json.score
-      tag: convert_score_to_double
+      tag: convert_score_to_double_0aa5fb37
       target_field: armis.vulnerability.score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_10fe04c2
+            tag: append_error_message_020275cc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.severity
-      tag: rename_severity
+      tag: rename_severity_084472cd
       target_field: armis.vulnerability.severity
       ignore_missing: true
   - set:
       field: vulnerability.severity
-      tag: set_vulnerability_severity_from_severity
+      tag: set_vulnerability_severity_from_severity_9f481778
       copy_from: armis.vulnerability.severity
       ignore_empty_value: true
   - rename:
       field: json.status
-      tag: rename_status
+      tag: rename_status_5d2aed62
       target_field: armis.vulnerability.status
       ignore_missing: true
   - rename:
       field: json.threatActors
-      tag: rename_threatActors
+      tag: rename_threatActors_c0f8fb9b
       target_field: armis.vulnerability.threat_actors
       ignore_missing: true
   - rename:
       field: json.threatTags
-      tag: rename_threatTags
+      tag: rename_threatTags_aed4f6e3
       target_field: armis.vulnerability.threat_tags
       ignore_missing: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_362cc7b6
       target_field: armis.vulnerability.type
       ignore_missing: true
   - rename:
       field: json.userInteraction
-      tag: rename_userInteraction
+      tag: rename_userInteraction_dbed2d77
       target_field: armis.vulnerability.user_interaction
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.advisoryId
-      tag: rename_vulnerability_match_advisoryId
+      tag: rename_vulnerability_match_advisoryId_6f6a23f4
       target_field: armis.vulnerability.vulnerability_match.advisory_id
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.avmRating
-      tag: rename_vulnerability_match_avmRating
+      tag: rename_vulnerability_match_avmRating_3a8cb911
       target_field: armis.vulnerability.vulnerability_match.avm_rating
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.confidenceLevel
-      tag: rename_vulnerability_match_confidenceLevel
+      tag: rename_vulnerability_match_confidenceLevel_495d19d2
       target_field: armis.vulnerability.vulnerability_match.confidence_level
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.confidenceLevelDescription
-      tag: rename_vulnerability_match_confidenceLevelDescription
+      tag: rename_vulnerability_match_confidenceLevelDescription_27a7dfcb
       target_field: armis.vulnerability.vulnerability_match.confidence_level_description
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.cveUid
-      tag: rename_vulnerability_match_cveUid
+      tag: rename_vulnerability_match_cveUid_50029540
       target_field: armis.vulnerability.vulnerability_match.cve_uid
       ignore_missing: true
   - convert:
       field: json.vulnerability_match.deviceId
-      tag: convert_vulnerability_match_deviceId
+      tag: convert_vulnerability_match_deviceId_5bf84f0f
       target_field: armis.vulnerability.vulnerability_match.device_id
       type: string
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host.id_id_from_vulnerability_vulnerability_match_device_id
+      tag: set_host.id_id_from_vulnerability_vulnerability_match_device_id_039d8aae
       copy_from: armis.vulnerability.vulnerability_match.device_id
       ignore_empty_value: true
   - set:
       field: device.id
-      tag: set_device_id_from_vulnerability_vulnerability_match_device_id
+      tag: set_device_id_from_vulnerability_vulnerability_match_device_id_a4ad5064
       copy_from: armis.vulnerability.vulnerability_match.device_id
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_related_host_from_vulnerability_vulnerability_match_device_id
+      tag: append_related_host_from_vulnerability_vulnerability_match_device_id_4020630d
       value: '{{{armis.vulnerability.vulnerability_match.device_id}}}'
       allow_duplicates: false
       if: ctx.armis.vulnerability.vulnerability_match.device_id != null
   - date:
       field: json.vulnerability_match.firstDetected
-      tag: date_vulnerability_match_firstDetected
+      tag: date_vulnerability_match_firstDetected_8a5c9557
       target_field: armis.vulnerability.vulnerability_match.first_detected
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -537,17 +537,17 @@ processors:
       if: ctx.json?.vulnerability_match?.firstDetected != null && ctx.json.vulnerability_match.firstDetected != ''
       on_failure:
         - append:
-            tag: append_error_message_ddecb674
+            tag: append_error_message_d7a1715f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.vulnerability_match.hasRemediationInfo
-      tag: rename_vulnerability_match_hasRemediationInfo
+      tag: rename_vulnerability_match_hasRemediationInfo_c6ca865a
       target_field: armis.vulnerability.vulnerability_match.has_remediation_info
       ignore_missing: true
   - date:
       field: json.vulnerability_match.lastDetected
-      tag: date_vulnerability_match_lastDetected
+      tag: date_vulnerability_match_lastDetected_bbe9c550
       target_field: armis.vulnerability.vulnerability_match.last_detected
       formats:
         - yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX
@@ -556,47 +556,47 @@ processors:
       if: ctx.json?.vulnerability_match?.lastDetected != null && ctx.json.vulnerability_match.lastDetected != ''
       on_failure:
         - append:
-            tag: append_error_message_1036c2f4
+            tag: append_error_message_94b35f0b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: threat.indicator.last_seen
-      tag: set_threat_indicator_last_seen_from_vulnerability_vulnerability_match_last_detected
+      tag: set_threat_indicator_last_seen_from_vulnerability_vulnerability_match_last_detected_1f3176d4
       copy_from: armis.vulnerability.vulnerability_match.last_detected
       ignore_empty_value: true
   - set:
       field: '@timestamp'
-      tag: set_timestamp_from_vulnerability_vulnerability_match_last_detected
+      tag: set_timestamp_from_vulnerability_vulnerability_match_last_detected_9693605c
       copy_from: armis.vulnerability.vulnerability_match.last_detected
       ignore_empty_value: true
   - rename:
       field: json.vulnerability_match.matchCriteriaString
-      tag: rename_vulnerability_match_matchCriteriaString
+      tag: rename_vulnerability_match_matchCriteriaString_cb852d39
       target_field: armis.vulnerability.vulnerability_match.match_criteria_string
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.recommendedSteps
-      tag: rename_vulnerability_match_recommendedSteps
+      tag: rename_vulnerability_match_recommendedSteps_1b0c32a1
       target_field: armis.vulnerability.vulnerability_match.recommended_steps
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.remediationTypes
-      tag: rename_vulnerability_match_remediationTypes
+      tag: rename_vulnerability_match_remediationTypes_ea2233bb
       target_field: armis.vulnerability.vulnerability_match.remediation_types
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.status
-      tag: rename_vulnerability_match_status
+      tag: rename_vulnerability_match_status_f29b2f56
       target_field: armis.vulnerability.vulnerability_match.status
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.statusChangeReason
-      tag: rename_vulnerability_match_statusChangeReason
+      tag: rename_vulnerability_match_statusChangeReason_d3f6ed13
       target_field: armis.vulnerability.vulnerability_match.status_change_reason
       ignore_missing: true
   - rename:
       field: json.vulnerability_match.statusSource
-      tag: rename_vulnerability_match_statusSource
+      tag: rename_vulnerability_match_statusSource_dc8c3c64
       target_field: armis.vulnerability.vulnerability_match.status_source
       ignore_missing: true
   - remove:
@@ -609,16 +609,16 @@ processors:
         - armis.vulnerability.attack_vector
         - armis.vulnerability.severity
         - armis.vulnerability.vulnerability_match.last_detected
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_5f7d887e
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -644,18 +644,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -663,10 +663,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -655,6 +655,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -665,6 +666,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/armis/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -42,6 +42,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -85,6 +86,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5e599058
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -145,6 +147,7 @@ processors:
       if: ctx.json?.avmRatingManualUpdateTime != null && ctx.json.avmRatingManualUpdateTime != ''
       on_failure:
         - append:
+            tag: append_error_message_0aad49ae
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -163,6 +166,7 @@ processors:
       if: ctx.json?.cisaDueDate != null && ctx.json.cisaDueDate != ''
       on_failure:
         - append:
+            tag: append_error_message_1acd96cf
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -188,6 +192,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_96955690
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -218,6 +223,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_669a5f43
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -228,6 +234,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f02e1804
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -238,6 +245,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2b6ef430
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -251,6 +259,7 @@ processors:
       if: ctx.json?.firstDetected != null && ctx.json.firstDetected != ''
       on_failure:
         - append:
+            tag: append_error_message_5e7ac6c4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -269,6 +278,7 @@ processors:
       if: ctx.json?.firstReferencePublishDate != null && ctx.json.firstReferencePublishDate != ''
       on_failure:
         - append:
+            tag: append_error_message_dcf2b6dc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -282,6 +292,7 @@ processors:
       if: ctx.json?.firstWeaponizedReferencePublishDate != null && ctx.json.firstWeaponizedReferencePublishDate != ''
       on_failure:
         - append:
+            tag: append_error_message_58d0c6dd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -292,6 +303,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_cb6fcfb8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -317,6 +329,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_31efb147
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -332,6 +345,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4e51ce63
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -345,6 +359,7 @@ processors:
       if: ctx.json?.lastDetected != null && ctx.json.lastDetected != ''
       on_failure:
         - append:
+            tag: append_error_message_8d9aba08
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -358,6 +373,7 @@ processors:
       if: ctx.json?.latestExploitUpdate != null && ctx.json.latestExploitUpdate != ''
       on_failure:
         - append:
+            tag: append_error_message_593cce52
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -368,6 +384,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8ab38101
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -378,6 +395,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9ab7e23d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -396,6 +414,7 @@ processors:
       if: ctx.json?.publishedDate != null && ctx.json.publishedDate != ''
       on_failure:
         - append:
+            tag: append_error_message_02b400b2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -406,6 +425,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3e72b7f2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -421,6 +441,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_10fe04c2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -516,6 +537,7 @@ processors:
       if: ctx.json?.vulnerability_match?.firstDetected != null && ctx.json.vulnerability_match.firstDetected != ''
       on_failure:
         - append:
+            tag: append_error_message_ddecb674
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -534,6 +556,7 @@ processors:
       if: ctx.json?.vulnerability_match?.lastDetected != null && ctx.json.vulnerability_match.lastDetected != ''
       on_failure:
         - append:
+            tag: append_error_message_1036c2f4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -625,6 +648,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/armis/manifest.yml
+++ b/packages/armis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: armis
 title: Armis
-version: "0.6.1"
+version: "0.6.2"
 description: Collect logs from Armis with Elastic Agent.
 type: integration
 categories:

--- a/packages/armis/manifest.yml
+++ b/packages/armis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: armis
 title: Armis
-version: "0.6.2"
+version: "0.7.0"
 description: Collect logs from Armis with Elastic Agent.
 type: integration
 categories:

--- a/packages/bitsight/changelog.yml
+++ b/packages/bitsight/changelog.yml
@@ -3,6 +3,9 @@
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20575
+    - description: Stop removing `event.original` in the `vulnerability` data stream. It was removed before the processors that record errors, so `pipeline_error` documents never retained the original payload.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.4.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/bitsight/changelog.yml
+++ b/packages/bitsight/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.4.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/bitsight/changelog.yml
+++ b/packages/bitsight/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.4.2"
+- version: "0.5.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/bitsight/changelog.yml
+++ b/packages/bitsight/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.4.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.4.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -78,7 +78,7 @@ processors:
 
   ##################### Scripts for processing input #####################
   - script:
-      tag: script_82f51bf1
+      tag: script_drops_null_empty_values_recursively_82f51bf1
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -41,13 +41,6 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
-  # Remove event.original unless preserve_original_event tag is present
-  - remove:
-      tag: remove_event_original_2db700f2
-      field: event.original
-      ignore_missing: true
-      if: ctx.tags == null || !ctx.tags.contains('preserve_original_event')
-
   # Set ECS event fields for vulnerability events
   - set:
       tag: set_event_kind_d452ef2c

--- a/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -181,6 +181,7 @@ processors:
 
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -191,6 +192,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -3,6 +3,7 @@ description: Pipeline for processing Bitsight Vulnerability output
 processors:
   # Drop retry continuation events early (before any processing)
   - drop:
+      tag: drop_7397da51
       if: ctx.message == 'retry'
 
   - set:
@@ -36,24 +37,29 @@ processors:
       if: ctx.event?.original instanceof String
       on_failure:
         - append:
+            tag: append_error_message_70ba1955
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   # Remove event.original unless preserve_original_event tag is present
   - remove:
+      tag: remove_event_original_86d11a95
       field: event.original
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_original_event')
 
   # Set ECS event fields for vulnerability events
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - append:
+      tag: append_event_category_914f8241
       field: event.category
       value: vulnerability
       allow_duplicates: false
   - append:
+      tag: append_event_type_3f43a39d
       field: event.type
       value: info
       allow_duplicates: false
@@ -65,12 +71,14 @@ processors:
       target_field: "_id"
       on_failure:
         - append:
+            tag: append_error_message_39122456
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
-  ##################### Scripts for processing input #####################
 
+  ##################### Scripts for processing input #####################
   - script:
+      tag: script_924392cb
       description: Drops null/empty values recursively.
       lang: painless
       source: |
@@ -89,23 +97,27 @@ processors:
         dropEmptyFields(ctx);
 
   - date:
+      tag: date_bitsight_threat_last_seen_date_to_timestamp_67a83afb
       field: bitsight.threat.last_seen_date
       formats: ["yyyy-MM-dd"]
       target_field: '@timestamp'
       ignore_failure: true
 
   - set:
+      tag: set_vulnerability_id_bc0a7786
       field: vulnerability.id
       copy_from: bitsight.threat.name
       ignore_failure: true
 
   - set:
+      tag: set_vulnerability_scanner_vendor_0cbe0ad1
       field: vulnerability.scanner.vendor
       value: "Bitsight"
       ignore_failure: true
 
   # Map Bitsight severity.level → ECS severity
   - script:
+      tag: script_2e28b975
       lang: painless
       source: |
         if (ctx.bitsight?.threat?.severity?.level != null) {
@@ -126,36 +138,42 @@ processors:
 
   # Extract score from severity.details field
   - grok:
+      tag: grok_bitsight_threat_severity_details_debdc64f
       field: bitsight.threat.severity.details
       patterns: ["CVSS %{NUMBER:vulnerability.score.base:float}"]
       ignore_failure: true
 
   # Extract IP from evidence identifier field (e.g., 1.2.3.4:443)
   - remove:
+      tag: remove_host_1655f80e
       field: host
       ignore_failure: true
   - grok:
+      tag: grok_bitsight_evidence_identifier_3419039e
       field: bitsight.evidence.identifier
       patterns: ["%{IP:extracted_ip}:%{NUMBER}"]
       ignore_failure: true
   - append:
+      tag: append_host_ip_b2dd9500
       field: host.ip
       value: "{{{extracted_ip}}}"
       if: ctx.extracted_ip != null
       ignore_failure: true
       allow_duplicates: false
   - remove:
+      tag: remove_extracted_ip_860987b0
       field: extracted_ip
       ignore_failure: true
 
-#################### Error Log fields ####################
 
+  #################### Error Log fields ####################
   - set:
       field: event.kind
       tag: set_pipeline_error_into_event_kind
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitsight/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -3,63 +3,63 @@ description: Pipeline for processing Bitsight Vulnerability output
 processors:
   # Drop retry continuation events early (before any processing)
   - drop:
-      tag: drop_7397da51
+      tag: drop_1f05010a
       if: ctx.message == 'retry'
 
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
 
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
 
   # Store original payload string, then decode to `bitsight`
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_a7b1f822
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
 
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_facc4822
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
 
   - json:
       field: event.original
-      tag: json_event_original_to_bitsight
+      tag: json_event_original_to_bitsight_1deaaacd
       target_field: bitsight
       if: ctx.event?.original instanceof String
       on_failure:
         - append:
-            tag: append_error_message_70ba1955
+            tag: append_error_message_2c3a7686
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   # Remove event.original unless preserve_original_event tag is present
   - remove:
-      tag: remove_event_original_86d11a95
+      tag: remove_event_original_2db700f2
       field: event.original
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_original_event')
 
   # Set ECS event fields for vulnerability events
   - set:
-      tag: set_event_kind_de80643c
+      tag: set_event_kind_d452ef2c
       field: event.kind
       value: event
   - append:
-      tag: append_event_category_914f8241
+      tag: append_event_category_661957f9
       field: event.category
       value: vulnerability
       allow_duplicates: false
   - append:
-      tag: append_event_type_3f43a39d
+      tag: append_event_type_a75e9a8a
       field: event.type
       value: info
       allow_duplicates: false
@@ -67,18 +67,18 @@ processors:
   - fingerprint:
       fields:
         - bitsight
-      tag: fingerprinting
+      tag: fingerprinting_b9be7fb7
       target_field: "_id"
       on_failure:
         - append:
-            tag: append_error_message_39122456
+            tag: append_error_message_4860a627
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
 
   ##################### Scripts for processing input #####################
   - script:
-      tag: script_924392cb
+      tag: script_82f51bf1
       description: Drops null/empty values recursively.
       lang: painless
       source: |
@@ -97,27 +97,27 @@ processors:
         dropEmptyFields(ctx);
 
   - date:
-      tag: date_bitsight_threat_last_seen_date_to_timestamp_67a83afb
+      tag: date_bitsight_threat_last_seen_date_to_timestamp_9e2e1f62
       field: bitsight.threat.last_seen_date
       formats: ["yyyy-MM-dd"]
       target_field: '@timestamp'
       ignore_failure: true
 
   - set:
-      tag: set_vulnerability_id_bc0a7786
+      tag: set_vulnerability_id_af7f34eb
       field: vulnerability.id
       copy_from: bitsight.threat.name
       ignore_failure: true
 
   - set:
-      tag: set_vulnerability_scanner_vendor_0cbe0ad1
+      tag: set_vulnerability_scanner_vendor_32a25515
       field: vulnerability.scanner.vendor
       value: "Bitsight"
       ignore_failure: true
 
   # Map Bitsight severity.level → ECS severity
   - script:
-      tag: script_2e28b975
+      tag: script_c1ae1b94
       lang: painless
       source: |
         if (ctx.bitsight?.threat?.severity?.level != null) {
@@ -138,30 +138,30 @@ processors:
 
   # Extract score from severity.details field
   - grok:
-      tag: grok_bitsight_threat_severity_details_debdc64f
+      tag: grok_bitsight_threat_severity_details_74821bbb
       field: bitsight.threat.severity.details
       patterns: ["CVSS %{NUMBER:vulnerability.score.base:float}"]
       ignore_failure: true
 
   # Extract IP from evidence identifier field (e.g., 1.2.3.4:443)
   - remove:
-      tag: remove_host_1655f80e
+      tag: remove_host_31f5b730
       field: host
       ignore_failure: true
   - grok:
-      tag: grok_bitsight_evidence_identifier_3419039e
+      tag: grok_bitsight_evidence_identifier_3f789709
       field: bitsight.evidence.identifier
       patterns: ["%{IP:extracted_ip}:%{NUMBER}"]
       ignore_failure: true
   - append:
-      tag: append_host_ip_b2dd9500
+      tag: append_host_ip_18b26c26
       field: host.ip
       value: "{{{extracted_ip}}}"
       if: ctx.extracted_ip != null
       ignore_failure: true
       allow_duplicates: false
   - remove:
-      tag: remove_extracted_ip_860987b0
+      tag: remove_extracted_ip_797c6fe4
       field: extracted_ip
       ignore_failure: true
 
@@ -169,11 +169,11 @@ processors:
   #################### Error Log fields ####################
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
@@ -181,7 +181,7 @@ processors:
 
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -189,10 +189,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/bitsight/manifest.yml
+++ b/packages/bitsight/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitsight
 title: "Bitsight"
-version: 0.4.1
+version: 0.4.2
 source:
   license: "Elastic-2.0"
 description: "Ingest data from the Bitsight API."

--- a/packages/bitsight/manifest.yml
+++ b/packages/bitsight/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitsight
 title: "Bitsight"
-version: 0.4.2
+version: 0.5.0
 source:
   license: "Elastic-2.0"
 description: "Ingest data from the Bitsight API."

--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.10.2"
+- version: "0.11.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.10.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.10.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/cyera/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -309,6 +309,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -319,6 +320,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -8,145 +8,145 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - fingerprint:
       fields:
         - json.frontegg_id
         - json.createdAt
-      tag: fingerprint_audit
+      tag: fingerprint_audit_439c7517
       target_field: _id
   - date:
       field: json.createdAt
-      tag: date_createdAt
+      tag: date_createdAt_2367397d
       target_field: '@timestamp'
       formats:
         - ISO8601
       if: ctx.json?.createdAt != null && ctx.json.createdAt != ''
       on_failure:
         - append:
-            tag: append_error_message_79f76e15
+            tag: append_error_message_2c330483
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.updatedAt
-      tag: date_updatedAt
+      tag: date_updatedAt_f1a8c773
       target_field: cyera.audit.updated_at
       formats:
         - ISO8601
       if: ctx.json?.updatedAt != null && ctx.json.updatedAt != ''
       on_failure:
         - append:
-            tag: append_error_message_070d79fb
+            tag: append_error_message_9832bd9f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.action
-      tag: rename_action_to_event_action
+      tag: rename_action_to_event_action_fc793703
       target_field: event.action
       ignore_missing: true
   - rename:
       field: json.description
-      tag: rename_description_to_message
+      tag: rename_description_to_message_e618c2b3
       target_field: message
       ignore_missing: true
   - rename:
       field: json.email
-      tag: rename_email_to_user_email
+      tag: rename_email_to_user_email_c10ae402
       target_field: user.email
       ignore_missing: true
   - append:
       field: related.user
-      tag: append_user_email_into_related_user
+      tag: append_user_email_into_related_user_b9ac313b
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
   - convert:
       field: json.ip
-      tag: convert_ip_to_source_ip
+      tag: convert_ip_to_source_ip_07e29321
       target_field: source.ip
       type: ip
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a364938a
+            tag: append_error_message_a33a6ec1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: related.ip
-      tag: append_source_ip_into_related_ip
+      tag: append_source_ip_into_related_ip_723473d3
       value: '{{{source.ip}}}'
       allow_duplicates: false
       if: ctx.source?.ip != null
   - rename:
       field: json.severity
-      tag: rename_severity_to_log_level
+      tag: rename_severity_to_log_level_83b53102
       target_field: log.level
       ignore_missing: true
   - user_agent:
       field: json.userAgent
-      tag: user_agent_audit_user_agent
+      tag: user_agent_audit_user_agent_10c21a15
       ignore_missing: true
       ignore_failure: true
       if: ctx.json?.userAgent != null
   - rename:
       field: json.environmentName
-      tag: rename_environmentName
+      tag: rename_environmentName_02b13f23
       target_field: cyera.audit.environment_name
       ignore_missing: true
   - rename:
       field: json.frontegg_id
-      tag: rename_frontegg_id_to_event_id
+      tag: rename_frontegg_id_to_event_id_3e0b9e73
       target_field: event.id
       ignore_missing: true
   - rename:
       field: json.tenantId
-      tag: rename_tenantId
+      tag: rename_tenantId_fc46e8b5
       target_field: cyera.audit.tenant_id
       ignore_missing: true
   - rename:
       field: json.vendorId
-      tag: rename_vendorId
+      tag: rename_vendorId_2e09ba55
       target_field: cyera.audit.vendor_id
       ignore_missing: true
   - script:
       lang: painless
-      tag: script_set_ecs_categorization
+      tag: script_set_ecs_categorization_46707bc5
       description: Set ECS categorization fields based on the audit action.
       if: ctx.event?.action != null
       params:
@@ -268,10 +268,10 @@ processors:
         }
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -298,18 +298,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -317,10 +317,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -59,6 +60,7 @@ processors:
       if: ctx.json?.createdAt != null && ctx.json.createdAt != ''
       on_failure:
         - append:
+            tag: append_error_message_79f76e15
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -70,6 +72,7 @@ processors:
       if: ctx.json?.updatedAt != null && ctx.json.updatedAt != ''
       on_failure:
         - append:
+            tag: append_error_message_070d79fb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -101,6 +104,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a364938a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -298,6 +302,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/classification/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/classification/elasticsearch/ingest_pipeline/default.yml
@@ -8,203 +8,203 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_d4003a33
       value: Cyera
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_8e86c1ff
       value: Cyera
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - rename:
       field: json.classificationName
-      tag: rename_classificationName
+      tag: rename_classificationName_0942a42b
       target_field: cyera.classification.classification_name
       ignore_missing: true
   - rename:
       field: json.collections
-      tag: rename_collections
+      tag: rename_collections_f708ebc0
       target_field: cyera.classification.collections
       ignore_missing: true
   - rename:
       field: json.context.businessContext
-      tag: rename_context_businessContext
+      tag: rename_context_businessContext_126b01af
       target_field: cyera.classification.context.business_context
       ignore_missing: true
   - rename:
       field: json.context.dataSubjectAge
-      tag: rename_context_dataSubjectAge
+      tag: rename_context_dataSubjectAge_4f8ac625
       target_field: cyera.classification.context.data_subject_age
       ignore_missing: true
   - rename:
       field: json.context.geoLocations
-      tag: rename_context_geoLocations
+      tag: rename_context_geoLocations_20da6671
       target_field: cyera.classification.context.geo_locations
       ignore_missing: true
   - rename:
       field: json.context.identifiability
-      tag: rename_context_identifiability
+      tag: rename_context_identifiability_7ec99550
       target_field: cyera.classification.context.identifiability
       ignore_missing: true
   - convert:
       field: json.context.identified
-      tag: convert_context_identified_to_boolean
+      tag: convert_context_identified_to_boolean_8e091641
       target_field: cyera.classification.context.identified
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ebd0f3e3
+            tag: append_error_message_79bca353
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.context.role
-      tag: rename_context_role
+      tag: rename_context_role_ebe83bab
       target_field: cyera.classification.context.role
       ignore_missing: true
   - append:
       field: user.roles
-      tag: append_cyera_classification_context_role_into_user_roles
+      tag: append_cyera_classification_context_role_into_user_roles_f8e5258e
       value: '{{{cyera.classification.context.role}}}'
       allow_duplicates: false
       if: ctx.cyera?.classification?.context?.role != null
   - convert:
       field: json.context.synthetic
-      tag: convert_context_synthetic_to_boolean
+      tag: convert_context_synthetic_to_boolean_d792aca3
       target_field: cyera.classification.context.synthetic
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_9c6696b1
+            tag: append_error_message_d623a15d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.context.tokenization
-      tag: rename_context_tokenization
+      tag: rename_context_tokenization_45844a2e
       target_field: cyera.classification.context.tokenization
       ignore_missing: true
   - rename:
       field: json.customCollections
-      tag: rename_customCollections
+      tag: rename_customCollections_2db63bc9
       target_field: cyera.classification.custom_collections
       ignore_missing: true
   - rename:
       field: json.dataCategory
-      tag: rename_dataCategory
+      tag: rename_dataCategory_0950d4fb
       target_field: cyera.classification.data.category
       ignore_missing: true
   - rename:
       field: json.dataClassName
-      tag: rename_dataClassName
+      tag: rename_dataClassName_d50d6dfd
       target_field: cyera.classification.data.class_name
       ignore_missing: true
   - rename:
       field: json.defaultSensitivityDisplayName
-      tag: rename_defaultSensitivityDisplayName
+      tag: rename_defaultSensitivityDisplayName_d91e872e
       target_field: cyera.classification.default_sensitivity.display_name
       ignore_missing: true
   - rename:
       field: json.defaultSensitivity
-      tag: rename_defaultSensitivity
+      tag: rename_defaultSensitivity_6a144c5c
       target_field: cyera.classification.default_sensitivity.value
       ignore_missing: true
   - rename:
       field: json.frameworks
-      tag: rename_frameworks
+      tag: rename_frameworks_59b6e3d8
       target_field: cyera.classification.frameworks
       ignore_missing: true
   - rename:
       field: json.classificationGroup
-      tag: rename_classificationGroup
+      tag: rename_classificationGroup_57480a6a
       target_field: cyera.classification.group
       ignore_missing: true
   - convert:
       field: json.learned
-      tag: convert_learned_to_boolean
+      tag: convert_learned_to_boolean_0f642ecd
       target_field: cyera.classification.learned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_033e2e4f
+            tag: append_error_message_4e9b6de7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.classificationLevel
-      tag: rename_classificationLevel
+      tag: rename_classificationLevel_4901d4d5
       target_field: cyera.classification.level
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_65958241
       target_field: cyera.classification.name
       ignore_missing: true
   - rename:
       field: json.sensitivityDisplayName
-      tag: rename_sensitivityDisplayName
+      tag: rename_sensitivityDisplayName_ff12c82e
       target_field: cyera.classification.sensitivity.display_name
       ignore_missing: true
   - rename:
       field: json.sensitivity
-      tag: rename_sensitivity
+      tag: rename_sensitivity_3bbd0ec5
       target_field: cyera.classification.sensitivity.value
       ignore_missing: true
   - rename:
       field: json.uid
-      tag: rename_uid
+      tag: rename_uid_c6ed18bc
       target_field: cyera.classification.uid
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_classification_uid
+      tag: set_event_id_from_classification_uid_ec452aa7
       copy_from: cyera.classification.uid
       ignore_empty_value: true
   - remove:
       field:
         - cyera.classification.context.role
         - cyera.classification.uid
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_03fba4ca
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -231,18 +231,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -250,10 +250,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/classification/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/classification/elasticsearch/ingest_pipeline/default.yml
@@ -86,6 +86,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ebd0f3e3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -107,6 +108,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9c6696b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -157,6 +159,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_033e2e4f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -232,6 +235,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/classification/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/classification/elasticsearch/ingest_pipeline/default.yml
@@ -242,6 +242,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -252,6 +253,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
@@ -2,7 +2,7 @@
 description: Pipeline for processing Datastore logs.
 processors:
   - drop:
-      tag: drop_8a0518c5
+      tag: drop_aa8574ed
       description: Ignore retry placeholder message.
       if: ctx.message == 'retry'
   - remove:
@@ -12,555 +12,555 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
   - fingerprint:
       fields:
         - json.uid
         - json.lastModifiedTime
         - json.createdDate
-      tag: fingerprint_datastore
+      tag: fingerprint_datastore_d52d7b6b
       target_field: _id
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - rename:
       field: json.account.inPlatformIdentifier
-      tag: rename_account_inPlatformIdentifier
+      tag: rename_account_inPlatformIdentifier_174a532e
       target_field: cyera.datastore.account.in_platform_identifier
       ignore_missing: true
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_datastore_account_in_platform_identifier
+      tag: set_cloud_account_id_from_datastore_account_in_platform_identifier_28ede25f
       copy_from: cyera.datastore.account.in_platform_identifier
       ignore_empty_value: true
   - rename:
       field: json.account.name
-      tag: rename_account_name
+      tag: rename_account_name_80c7dac6
       target_field: cyera.datastore.account.name
       ignore_missing: true
   - set:
       field: cloud.account.name
-      tag: set_cloud_account_name_from_datastore_account_name
+      tag: set_cloud_account_name_from_datastore_account_name_ba115175
       copy_from: cyera.datastore.account.name
       ignore_empty_value: true
   - rename:
       field: json.arn
-      tag: rename_arn
+      tag: rename_arn_aca286c1
       target_field: cyera.datastore.arn
       ignore_missing: true
   - convert:
       field: json.autoScan
-      tag: convert_autoScan_to_boolean
+      tag: convert_autoScan_to_boolean_468b5787
       target_field: cyera.datastore.auto_scan
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_45d7036a
+            tag: append_error_message_35356442
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.azureId
-      tag: rename_azureId
+      tag: rename_azureId_d6e7ba65
       target_field: cyera.datastore.azure_id
       ignore_missing: true
   - rename:
       field: json.classificationGroups
-      tag: rename_classificationGroups
+      tag: rename_classificationGroups_23f6dd76
       target_field: cyera.datastore.classification.groups
       ignore_missing: true
   - rename:
       field: json.classificationLevel
-      tag: rename_classificationLevel
+      tag: rename_classificationLevel_558a0536
       target_field: cyera.datastore.classification.level
       ignore_missing: true
   - rename:
       field: json.cloudProviderTags
-      tag: rename_cloudProviderTags
+      tag: rename_cloudProviderTags_416efceb
       target_field: cyera.datastore.cloud_provider.tags
       ignore_missing: true
   - rename:
       field: json.cloudProviderUrl
-      tag: rename_cloudProviderUrl
+      tag: rename_cloudProviderUrl_eeb1de1b
       target_field: cyera.datastore.cloud_provider.url
       ignore_missing: true
   - rename:
       field: json.collections
-      tag: rename_collections
+      tag: rename_collections_1d75f915
       target_field: cyera.datastore.collections
       ignore_missing: true
   - date:
       field: json.createdDate
-      tag: date_createdDate
+      tag: date_createdDate_d2d11051
       target_field: cyera.datastore.created_date
       formats:
         - ISO8601
       if: ctx.json?.createdDate != null && ctx.json.createdDate != ''
       on_failure:
         - append:
-            tag: append_error_message_e3b068e9
+            tag: append_error_message_79793df3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_datastore_created_date
+      tag: set_event_created_from_datastore_created_date_8069483a
       copy_from: cyera.datastore.created_date
       ignore_empty_value: true
   - rename:
       field: json.customCollections
-      tag: rename_customCollections
+      tag: rename_customCollections_2db423b6
       target_field: cyera.datastore.custom_collections
       ignore_missing: true
   - rename:
       field: json.dataType
-      tag: rename_dataType
+      tag: rename_dataType_6cd6b315
       target_field: cyera.datastore.data_type
       ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_datastoreUid
+      tag: foreach_datastoreOwners_datastoreUid_d17caf59
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         rename:
           field: _ingest._value.datastoreUid
-          tag: rename_datastoreOwners_datastoreUid
+          tag: rename_datastoreOwners_datastoreUid_f2bb2e7d
           target_field: _ingest._value.datastore_uid
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_email
+      tag: foreach_datastoreOwners_email_c2467a54
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
           field: related.user
-          tag: append_datastoreOwners_email_into_related_user
+          tag: append_datastoreOwners_email_into_related_user_fb9dd976
           value: '{{{_ingest._value.email}}}'
           allow_duplicates: false
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_ownerType
+      tag: foreach_datastoreOwners_ownerType_b519bea8
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         rename:
           field: _ingest._value.ownerType
-          tag: rename_datastoreOwners_ownerType
+          tag: rename_datastoreOwners_ownerType_87fc9dbb
           target_field: _ingest._value.owner_type
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_datastoreOwnerUid
+      tag: foreach_datastoreOwners_datastoreOwnerUid_5cbe40aa
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         rename:
           field: _ingest._value.datastoreOwnerUid
-          tag: rename_datastoreOwners_datastoreOwnerUid
+          tag: rename_datastoreOwners_datastoreOwnerUid_cda38674
           target_field: _ingest._value.uid
           ignore_missing: true
   - rename:
       field: json.datastoreOwners
-      tag: rename_datastoreOwners
+      tag: rename_datastoreOwners_078e572f
       target_field: cyera.datastore.datastore.owners
       ignore_missing: true
   - convert:
       field: json.datastoreSizeInGiB
-      tag: convert_datastoreSizeInGiB_to_double
+      tag: convert_datastoreSizeInGiB_to_double_2ecba3e2
       target_field: cyera.datastore.datastore.size_in_gi_b
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0efb3603
+            tag: append_error_message_137761bf
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.discoveredDate
-      tag: date_discoveredDate
+      tag: date_discoveredDate_7c699daa
       target_field: cyera.datastore.discovered_date
       formats:
         - ISO8601
       if: ctx.json?.discoveredDate != null && ctx.json.discoveredDate != ''
       on_failure:
         - append:
-            tag: append_error_message_cd2ce22b
+            tag: append_error_message_e5931fef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.driveId
-      tag: rename_driveId
+      tag: rename_driveId_b0df2b65
       target_field: cyera.datastore.drive_id
       ignore_missing: true
   - convert:
       field: json.encrypted
-      tag: convert_encrypted_to_boolean
+      tag: convert_encrypted_to_boolean_0bf0d429
       target_field: cyera.datastore.encrypted
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4f35a635
+            tag: append_error_message_8578ef56
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.engine
-      tag: rename_engine
+      tag: rename_engine_5c46f585
       target_field: cyera.datastore.engine
       ignore_missing: true
   - rename:
       field: json.frameworks
-      tag: rename_frameworks
+      tag: rename_frameworks_ac8d4bb1
       target_field: cyera.datastore.frameworks
       ignore_missing: true
   - convert:
       field: json.ghost
-      tag: convert_ghost_to_boolean
+      tag: convert_ghost_to_boolean_1f1333f5
       target_field: cyera.datastore.ghost
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_3bdea7e6
+            tag: append_error_message_87cfdc40
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.infrastructure
-      tag: rename_infrastructure
+      tag: rename_infrastructure_5b879219
       target_field: cyera.datastore.infrastructure
       ignore_missing: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name_from_datastore_infrastructure
+      tag: set_cloud_service_name_from_datastore_infrastructure_3e5a7ee2
       copy_from: cyera.datastore.infrastructure
       ignore_empty_value: true
   - convert:
       field: json.issues.closed
-      tag: convert_issues_closed_to_long
+      tag: convert_issues_closed_to_long_ab020d52
       target_field: cyera.datastore.issues.closed
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d8f829ba
+            tag: append_error_message_012b990d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.issues.inProgress
-      tag: convert_issues_inProgress_to_long
+      tag: convert_issues_inProgress_to_long_bea20f39
       target_field: cyera.datastore.issues.in_progress
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_32971783
+            tag: append_error_message_1352ddf3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.issues.open
-      tag: convert_issues_open_to_long
+      tag: convert_issues_open_to_long_8b83cda8
       target_field: cyera.datastore.issues.open
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ce35ec72
+            tag: append_error_message_d47e8aa1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.lastDataRefresh
-      tag: date_lastDataRefresh
+      tag: date_lastDataRefresh_19862368
       target_field: cyera.datastore.last.data_refresh
       formats:
         - ISO8601
       if: ctx.json?.lastDataRefresh != null && ctx.json.lastDataRefresh != ''
       on_failure:
         - append:
-            tag: append_error_message_269ab3c0
+            tag: append_error_message_ebfe9d4f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.lastModifiedTime
-      tag: date_lastModifiedTime
+      tag: date_lastModifiedTime_b16cdfcc
       target_field: cyera.datastore.last.modified_time
       formats:
         - ISO8601
       if: ctx.json?.lastModifiedTime != null && ctx.json.lastModifiedTime != ''
       on_failure:
         - append:
-            tag: append_error_message_4c9672f7
+            tag: append_error_message_51dc07fa
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_datastore_last_modified_time
+      tag: set_@timestamp_from_datastore_last_modified_time_a7a7c42b
       copy_from: cyera.datastore.last.modified_time
       ignore_empty_value: true
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_datastore_created_date
+      tag: set_@timestamp_from_datastore_created_date_451c5bdf
       copy_from: cyera.datastore.created_date
       if: ctx.cyera?.datastore?.last?.modified_time == null
       ignore_empty_value: true
   - convert:
       field: json.learned
-      tag: convert_learned_to_boolean
+      tag: convert_learned_to_boolean_ecc56bd2
       target_field: cyera.datastore.learned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_69afca3a
+            tag: append_error_message_60983174
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.logging
-      tag: rename_logging
+      tag: rename_logging_aab81a8e
       target_field: cyera.datastore.logging
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_c8474a42
       target_field: cyera.datastore.name
       ignore_missing: true
   - set:
       field: service.name
-      tag: set_service_name_from_datastore_name
+      tag: set_service_name_from_datastore_name_7be570b2
       copy_from: cyera.datastore.name
       ignore_empty_value: true
   - rename:
       field: json.owner
-      tag: rename_owner
+      tag: rename_owner_41d28665
       target_field: cyera.datastore.owner
       ignore_missing: true
   - set:
       field: user.email
-      tag: set_user_email_from_datastore_owner
+      tag: set_user_email_from_datastore_owner_34fd3058
       copy_from: cyera.datastore.owner
       ignore_empty_value: true
       if: ctx.cyera?.datastore?.owner != null && ctx.cyera.datastore.owner.contains('@')
   - set:
       field: user.name
-      tag: set_user_name_from_datastore_owner
+      tag: set_user_name_from_datastore_owner_893ada15
       copy_from: cyera.datastore.owner
       ignore_empty_value: true
       if: ctx.user?.email == null
   - dissect:
       field: cyera.datastore.owner
       pattern: '%{user.name}@%{user.domain}'
-      tag: dissect_cyera_datastore_owner
+      tag: dissect_cyera_datastore_owner_394be18b
       ignore_missing: true
       if: ctx.cyera?.datastore?.owner != null && ctx.cyera.datastore.owner.contains('@')
   - append:
       field: related.user
-      tag: append_datastore_owner_into_related_user
+      tag: append_datastore_owner_into_related_user_830754bc
       value: '{{{cyera.datastore.owner}}}'
       allow_duplicates: false
       if: ctx.cyera?.datastore?.owner != null
   - rename:
       field: json.projectIds
-      tag: rename_projectIds
+      tag: rename_projectIds_c79cda35
       target_field: cyera.datastore.project_ids
       ignore_missing: true
   - rename:
       field: json.provider
-      tag: rename_provider
+      tag: rename_provider_1598d955
       target_field: cyera.datastore.provider
       ignore_missing: true
   - set:
       field: cloud.provider
-      tag: set_cloud_provider_from_datastore_provider
+      tag: set_cloud_provider_from_datastore_provider_be3aad95
       copy_from: cyera.datastore.provider
       ignore_empty_value: true
   - lowercase:
       field: cloud.provider
-      tag: lowercase_cloud_provider
+      tag: lowercase_cloud_provider_1a17fc24
       ignore_missing: true
   - rename:
       field: json.publicAccessibilityState
-      tag: rename_publicAccessibilityState
+      tag: rename_publicAccessibilityState_57300fe0
       target_field: cyera.datastore.public_accessibility_state
       ignore_missing: true
   - rename:
       field: json.rdsEndpoint
-      tag: rename_rdsEndpoint
+      tag: rename_rdsEndpoint_a5a6c510
       target_field: cyera.datastore.rds_endpoint
       ignore_missing: true
   - convert:
       field: json.recordCountBySensitivity.Internal
-      tag: convert_recordCountBySensitivity_Internal_to_long
+      tag: convert_recordCountBySensitivity_Internal_to_long_f6a05141
       target_field: cyera.datastore.record_count_by_sensitivity.internal
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_aac85816
+            tag: append_error_message_3eb9d1b7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.recordCountBySensitivity.NotSensitive
-      tag: convert_recordCountBySensitivity_NotSensitive_to_long
+      tag: convert_recordCountBySensitivity_NotSensitive_to_long_4a478219
       target_field: cyera.datastore.record_count_by_sensitivity.not_sensitive
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_041de9d5
+            tag: append_error_message_f6e07797
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.recordCountBySensitivity.Sensitive
-      tag: convert_recordCountBySensitivity_Sensitive_to_long
+      tag: convert_recordCountBySensitivity_Sensitive_to_long_6010efe3
       target_field: cyera.datastore.record_count_by_sensitivity.sensitive
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_93410457
+            tag: append_error_message_264584cb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.recordCountBySensitivity.Unclassified
-      tag: convert_recordCountBySensitivity_Unclassified_to_long
+      tag: convert_recordCountBySensitivity_Unclassified_to_long_92029e7a
       target_field: cyera.datastore.record_count_by_sensitivity.unclassified
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_917f772d
+            tag: append_error_message_6bcf4cb1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.recordCountBySensitivity.VerySensitive
-      tag: convert_recordCountBySensitivity_VerySensitive_to_long
+      tag: convert_recordCountBySensitivity_VerySensitive_to_long_2a1d99c3
       target_field: cyera.datastore.record_count_by_sensitivity.very_sensitive
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_34ec9088
+            tag: append_error_message_3fa7ec8a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.regions
-      tag: foreach_regions
+      tag: foreach_regions_03117b9a
       if: ctx.json?.regions instanceof List
       processor:
         append:
           field: cloud.region
-          tag: append_regions_into_cloud_region
+          tag: append_regions_into_cloud_region_b238a601
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.regions
-      tag: rename_regions
+      tag: rename_regions_b4e39e51
       target_field: cyera.datastore.regions
       ignore_missing: true
   - rename:
       field: json.scanningState
-      tag: rename_scanningState
+      tag: rename_scanningState_2b6f0125
       target_field: cyera.datastore.scanning_state
       ignore_missing: true
   - rename:
       field: json.sensitivityDisplayName
-      tag: rename_sensitivityDisplayName
+      tag: rename_sensitivityDisplayName_ed4b18d8
       target_field: cyera.datastore.sensitivity.display_name
       ignore_missing: true
   - rename:
       field: json.sensitivity
-      tag: rename_sensitivity
+      tag: rename_sensitivity_2b8b3cd2
       target_field: cyera.datastore.sensitivity.value
       ignore_missing: true
   - rename:
       field: json.siteId
-      tag: rename_siteId
+      tag: rename_siteId_b1a04154
       target_field: cyera.datastore.site.id
       ignore_missing: true
   - rename:
       field: json.siteName
-      tag: rename_siteName
+      tag: rename_siteName_aaa48564
       target_field: cyera.datastore.site.name
       ignore_missing: true
   - rename:
       field: json.sslEnforced
-      tag: rename_sslEnforced
+      tag: rename_sslEnforced_7f893f8d
       target_field: cyera.datastore.ssl_enforced
       ignore_missing: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_47061c06
       target_field: cyera.datastore.type
       ignore_missing: true
   - set:
       field: service.type
-      tag: set_service_type_from_datastore_type
+      tag: set_service_type_from_datastore_type_0adf93f3
       copy_from: cyera.datastore.type
       ignore_empty_value: true
   - rename:
       field: json.uid
-      tag: rename_uid
+      tag: rename_uid_e49903dc
       target_field: cyera.datastore.uid
       ignore_missing: true
   - set:
       field: service.id
-      tag: set_service_id_from_datastore_uid
+      tag: set_service_id_from_datastore_uid_568f1c2e
       copy_from: cyera.datastore.uid
       ignore_empty_value: true
   - set:
       field: event.id
-      tag: set_event_id_from_datastore_uid
+      tag: set_event_id_from_datastore_uid_4c9bc91a
       copy_from: cyera.datastore.uid
       ignore_empty_value: true
   - rename:
       field: json.userId
-      tag: rename_userId
+      tag: rename_userId_8e62950e
       target_field: cyera.datastore.user.id
       ignore_missing: true
   - set:
       field: user.id
-      tag: set_user_id_from_datastore_userId
+      tag: set_user_id_from_datastore_userId_6733cff1
       copy_from: cyera.datastore.user.id
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_datastore_user_id_into_related_user
+      tag: append_datastore_user_id_into_related_user_62428ee2
       value: '{{{cyera.datastore.user.id}}}'
       allow_duplicates: false
       if: ctx.cyera?.datastore?.user?.id != null
   - rename:
       field: json.userTags
-      tag: rename_userTags
+      tag: rename_userTags_571abde6
       target_field: cyera.datastore.user.tags
       ignore_missing: true
   - rename:
       field: json.vpc
-      tag: rename_vpc
+      tag: rename_vpc_b08c4c90
       target_field: cyera.datastore.vpc
       ignore_missing: true
   - remove:
@@ -576,15 +576,15 @@ processors:
         - cyera.datastore.type
         - cyera.datastore.uid
         - cyera.datastore.user.id
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_a110d764
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -611,18 +611,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -630,10 +630,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
@@ -622,6 +622,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -632,6 +633,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
@@ -2,7 +2,7 @@
 description: Pipeline for processing Datastore logs.
 processors:
   - drop:
-      tag: drop_aa8574ed
+      tag: drop_ignore_retry_placeholder_message_aa8574ed
       description: Ignore retry placeholder message.
       if: ctx.message == 'retry'
   - remove:

--- a/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/datastore/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for processing Datastore logs.
 processors:
   - drop:
+      tag: drop_8a0518c5
       description: Ignore retry placeholder message.
       if: ctx.message == 'retry'
   - remove:
@@ -84,6 +85,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_45d7036a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -125,6 +127,7 @@ processors:
       if: ctx.json?.createdDate != null && ctx.json.createdDate != ''
       on_failure:
         - append:
+            tag: append_error_message_e3b068e9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -195,6 +198,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0efb3603
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -206,6 +210,7 @@ processors:
       if: ctx.json?.discoveredDate != null && ctx.json.discoveredDate != ''
       on_failure:
         - append:
+            tag: append_error_message_cd2ce22b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -221,6 +226,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4f35a635
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -241,6 +247,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3bdea7e6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -261,6 +268,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d8f829ba
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -271,6 +279,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_32971783
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -281,6 +290,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ce35ec72
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -292,6 +302,7 @@ processors:
       if: ctx.json?.lastDataRefresh != null && ctx.json.lastDataRefresh != ''
       on_failure:
         - append:
+            tag: append_error_message_269ab3c0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -303,6 +314,7 @@ processors:
       if: ctx.json?.lastModifiedTime != null && ctx.json.lastModifiedTime != ''
       on_failure:
         - append:
+            tag: append_error_message_4c9672f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -324,6 +336,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_69afca3a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -407,6 +420,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_aac85816
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -417,6 +431,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_041de9d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -427,6 +442,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_93410457
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -437,6 +453,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_917f772d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -447,6 +464,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_34ec9088
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -597,6 +615,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -103,15 +103,17 @@ processors:
       processor:
         convert:
           field: _ingest._value.recordsCount.recordsCount
-          tag: convert_affectedDataClassAppearances_recordsCount_recordsCount _to_long
+          tag: convert_affectedDataClassAppearances_recordsCount_recordsCount_to_long
           target_field: _ingest._value.records_count.value
           type: long
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_recordsCount_recordsCount
                 field: _ingest._value.recordsCount.recordsCount
                 ignore_missing: true
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -676,6 +678,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_c14f7af1
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -686,6 +689,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -135,6 +136,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_46ec7dbe
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -145,6 +147,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4d974a04
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -155,6 +158,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0ada6d1e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -229,6 +233,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c37c421d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -260,6 +265,7 @@ processors:
       if: ctx.json?.date != null && ctx.json.date != ''
       on_failure:
         - append:
+            tag: append_error_message_a2c9ac5b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -291,6 +297,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_994f3e70
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -301,6 +308,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a15a8f4f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -321,6 +329,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_573c6c2d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -331,6 +340,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ac684c14
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -341,6 +351,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b972221c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -536,6 +547,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c052db5e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -657,6 +669,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -8,619 +8,619 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_ab1166ce
       value: alert
   - fingerprint:
       fields:
         - json.uid
         - json.date
-      tag: fingerprint_issue
+      tag: fingerprint_issue_accc8c7c
       target_field: _id
   - rename:
       field: json.account.name
-      tag: rename_account_name
+      tag: rename_account_name_a3291b28
       target_field: cyera.event.account.name
       ignore_missing: true
   - set:
       field: cloud.account.name
-      tag: set_cloud_account_name_from_event_account_name
+      tag: set_cloud_account_name_from_event_account_name_cb801973
       copy_from: cyera.event.account.name
       ignore_empty_value: true
   - rename:
       field: json.account.platform
-      tag: rename_account_platform
+      tag: rename_account_platform_b4c4ce3e
       target_field: cyera.event.account.platform
       ignore_missing: true
   - rename:
       field: json.account.uid
-      tag: rename_account_uid
+      tag: rename_account_uid_3eaf0155
       target_field: cyera.event.account.uid
       ignore_missing: true
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_event_account_uid
+      tag: set_cloud_account_id_from_event_account_uid_07fa9487
       copy_from: cyera.event.account.uid
       ignore_empty_value: true
   - foreach:
       field: json.affectedDataClassAppearances
-      tag: foreach_affectedDataClassAppearances_recordsCount_dataClass_classificationName
+      tag: foreach_affectedDataClassAppearances_recordsCount_dataClass_classificationName_b1b2b04b
       if: ctx.json?.affectedDataClassAppearances instanceof List
       processor:
         rename:
           field: _ingest._value.recordsCount.dataClass.classificationName
-          tag: rename_affectedDataClassAppearances_recordsCount_dataClass_classificationName
+          tag: rename_affectedDataClassAppearances_recordsCount_dataClass_classificationName_fabf1b40
           target_field: _ingest._value.records_count.data_class.classification_name
           ignore_missing: true
   - foreach:
       field: json.affectedDataClassAppearances
-      tag: foreach_affectedDataClassAppearances_recordsCount_dataClass_uid
+      tag: foreach_affectedDataClassAppearances_recordsCount_dataClass_uid_ab3ee529
       if: ctx.json?.affectedDataClassAppearances instanceof List
       processor:
         rename:
           field: _ingest._value.recordsCount.dataClass.uid
-          tag: rename_affectedDataClassAppearances_recordsCount_dataClass_uid
+          tag: rename_affectedDataClassAppearances_recordsCount_dataClass_uid_0be0d374
           target_field: _ingest._value.records_count.data_class.uid
           ignore_missing: true
   - foreach:
       field: json.affectedDataClassAppearances
-      tag: foreach_affectedDataClassAppearances_recordsCount_recordsCount
+      tag: foreach_affectedDataClassAppearances_recordsCount_recordsCount_b76536bf
       if: ctx.json?.affectedDataClassAppearances instanceof List
       processor:
         convert:
           field: _ingest._value.recordsCount.recordsCount
-          tag: convert_affectedDataClassAppearances_recordsCount_recordsCount_to_long
+          tag: convert_affectedDataClassAppearances_recordsCount_recordsCount_to_long_71a34cb8
           target_field: _ingest._value.records_count.value
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_recordsCount_recordsCount
+                tag: remove_ingest_value_recordsCount_recordsCount_8175f2ec
                 field: _ingest._value.recordsCount.recordsCount
                 ignore_missing: true
             - append:
-                tag: append_error_message
+                tag: append_error_message_fbff5bdd
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.affectedDataClassAppearances
-      tag: foreach_affectedDataClassAppearances
+      tag: foreach_affectedDataClassAppearances_b2011f87
       if: ctx.json?.affectedDataClassAppearances instanceof List
       processor:
         remove:
           field: _ingest._value.recordsCount.recordsCount
-          tag: remove_affectedDataClassAppearances
+          tag: remove_affectedDataClassAppearances_1e353d09
           ignore_missing: true
   - rename:
       field: json.affectedDataClassAppearances
-      tag: rename_affectedDataClassAppearances
+      tag: rename_affectedDataClassAppearances_4a37bbd6
       target_field: cyera.event.affected.data_class_appearances
       ignore_missing: true
   - convert:
       field: json.affectedObjectsCount
-      tag: convert_affectedObjectsCount_to_long
+      tag: convert_affectedObjectsCount_to_long_538200a2
       target_field: cyera.event.affected.objects_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_46ec7dbe
+            tag: append_error_message_3ba399f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.affectedObjectsDiff
-      tag: convert_affectedObjectsDiff_to_long
+      tag: convert_affectedObjectsDiff_to_long_554e0912
       target_field: cyera.event.affected.objects_diff
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4d974a04
+            tag: append_error_message_fd046bc9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.affectedRecordsDiff
-      tag: convert_affectedRecordsDiff_to_long
+      tag: convert_affectedRecordsDiff_to_long_5a5ca13b
       target_field: cyera.event.affected.records_diff
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0ada6d1e
+            tag: append_error_message_7a8d72f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.automaticScanning
-      tag: rename_automaticScanning
+      tag: rename_automaticScanning_c1b20a75
       target_field: cyera.event.automatic_scanning
       ignore_missing: true
   - rename:
       field: json.changedClassificationUid
-      tag: rename_changedClassificationUid
+      tag: rename_changedClassificationUid_fc0d8f0d
       target_field: cyera.event.changed_classification_uid
       ignore_missing: true
   - rename:
       field: json.classificationName
-      tag: rename_classificationName
+      tag: rename_classificationName_092ba92f
       target_field: cyera.event.classification_name
       ignore_missing: true
   - foreach:
       field: json.classifications
-      tag: foreach_classifications_classificationName
+      tag: foreach_classifications_classificationName_37bc6c66
       if: ctx.json?.classifications instanceof List
       processor:
         rename:
           field: _ingest._value.classificationName
-          tag: rename_classifications_classificationName
+          tag: rename_classifications_classificationName_3ef8a7c8
           target_field: _ingest._value.name
           ignore_missing: true
   - rename:
       field: json.classifications
-      tag: rename_classifications
+      tag: rename_classifications_c8faf9ec
       target_field: cyera.event.classifications
       ignore_missing: true
   - rename:
       field: json.cloudProvider
-      tag: rename_cloudProvider
+      tag: rename_cloudProvider_34c686eb
       target_field: cyera.event.cloud_provider
       ignore_missing: true
   - set:
       field: cloud.provider
-      tag: set_cloud_provider_from_event_cloud_provider
+      tag: set_cloud_provider_from_event_cloud_provider_e6857285
       copy_from: cyera.event.cloud_provider
       ignore_empty_value: true
   - lowercase:
       field: cloud.provider
-      tag: lowercase_cloud_provider
+      tag: lowercase_cloud_provider_1a17fc24
       ignore_missing: true
   - rename:
       field: json.datastore.dataOwner
-      tag: rename_datastore_dataOwner
+      tag: rename_datastore_dataOwner_990a1061
       target_field: cyera.event.datastore.data_owner
       ignore_missing: true
   - rename:
       field: json.datastore.infrastructure
-      tag: rename_datastore_infrastructure
+      tag: rename_datastore_infrastructure_3cddd0ba
       target_field: cyera.event.datastore.infrastructure
       ignore_missing: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name_from_event_datastore_infrastructure
+      tag: set_cloud_service_name_from_event_datastore_infrastructure_4b342eee
       copy_from: cyera.event.datastore.infrastructure
       ignore_empty_value: true
   - rename:
       field: json.datastore.name
-      tag: rename_datastore_name
+      tag: rename_datastore_name_527876e7
       target_field: cyera.event.datastore.name
       ignore_missing: true
   - convert:
       field: json.datastore.recordsAtHighRisk
-      tag: convert_datastore_recordsAtHighRisk_to_long
+      tag: convert_datastore_recordsAtHighRisk_to_long_394730d0
       target_field: cyera.event.datastore.records_at_high_risk
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c37c421d
+            tag: append_error_message_0bda7e70
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.datastore.uid
-      tag: rename_datastore_uid
+      tag: rename_datastore_uid_f9e496bb
       target_field: cyera.event.datastore.uid
       ignore_missing: true
   - rename:
       field: json.datastore.userTags
-      tag: rename_datastore_userTags
+      tag: rename_datastore_userTags_9dececb5
       target_field: cyera.event.datastore.tags.user_tags
       ignore_missing: true
   - rename:
       field: json.datastoreUserTags
-      tag: rename_datastoreUserTags
+      tag: rename_datastoreUserTags_fda13742
       target_field: cyera.event.datastore.user_tags
       ignore_missing: true
   - rename:
       field: json.datastore.vpcId
-      tag: rename_datastore_vpcId
+      tag: rename_datastore_vpcId_ba06f4b3
       target_field: cyera.event.datastore.vpc_id
       ignore_missing: true
   - date:
       field: json.date
-      tag: date_date
+      tag: date_date_fdcfaee1
       target_field: cyera.event.date
       formats:
         - ISO8601
       if: ctx.json?.date != null && ctx.json.date != ''
       on_failure:
         - append:
-            tag: append_error_message_a2c9ac5b
+            tag: append_error_message_cfcfb843
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_event_date
+      tag: set_@timestamp_from_event_date_f86ea7ca
       copy_from: cyera.event.date
       ignore_empty_value: true
   - rename:
       field: json.deploymentName
-      tag: rename_deploymentName
+      tag: rename_deploymentName_e18d9c8a
       target_field: cyera.event.deployment_name
       ignore_missing: true
   - rename:
       field: json.domainName
-      tag: rename_domainName
+      tag: rename_domainName_22158608
       target_field: cyera.event.domain_name
       ignore_missing: true
   - append:
       field: related.hosts
-      tag: append_event_domain_name_into_related_hosts
+      tag: append_event_domain_name_into_related_hosts_ec168636
       value: '{{{cyera.event.domain_name}}}'
       allow_duplicates: false
       if: ctx.cyera?.event?.domain_name != null
   - convert:
       field: json.expectedM365SensitivityLabelAssignmentsCount
-      tag: convert_expectedM365SensitivityLabelAssignmentsCount_to_long
+      tag: convert_expectedM365SensitivityLabelAssignmentsCount_to_long_e0a52d80
       target_field: cyera.event.expected_m365_sensitivity_label_assignments_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_994f3e70
+            tag: append_error_message_c1a3cddc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.failedM365SensitivityLabelAssignmentsCount
-      tag: convert_failedM365SensitivityLabelAssignmentsCount_to_long
+      tag: convert_failedM365SensitivityLabelAssignmentsCount_to_long_0d6becc9
       target_field: cyera.event.failed_m365_sensitivity_label_assignments_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a15a8f4f
+            tag: append_error_message_0cf42fc8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.frequency
-      tag: rename_frequency
+      tag: rename_frequency_3a5cbee5
       target_field: cyera.event.frequency
       ignore_missing: true
   - rename:
       field: json.inPlatformIdentifier
-      tag: rename_inPlatformIdentifier
+      tag: rename_inPlatformIdentifier_acc9eda7
       target_field: cyera.event.in_platform_identifier
       ignore_missing: true
   - convert:
       field: json.isDomainTrusted
-      tag: convert_isDomainTrusted_to_boolean
+      tag: convert_isDomainTrusted_to_boolean_fd93830c
       target_field: cyera.event.is_domain_trusted
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_573c6c2d
+            tag: append_error_message_9e9ec5ff
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.isReportDeleted
-      tag: convert_isReportDeleted_to_boolean
+      tag: convert_isReportDeleted_to_boolean_f65f50d1
       target_field: cyera.event.is_report.deleted
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ac684c14
+            tag: append_error_message_7eebdbc9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.isReportExpired
-      tag: convert_isReportExpired_to_boolean
+      tag: convert_isReportExpired_to_boolean_47ba1c2f
       target_field: cyera.event.is_report.expired
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b972221c
+            tag: append_error_message_b3b2f0bf
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.issueName
-      tag: rename_issueName
+      tag: rename_issueName_64bcec89
       target_field: cyera.event.issue_name
       ignore_missing: true
   - rename:
       field: json.issue.policy.name
-      tag: rename_issue_policy_name
+      tag: rename_issue_policy_name_2dbe144f
       target_field: cyera.event.issue.policy.name
       ignore_missing: true
   - rename:
       field: json.issue.policy.uid
-      tag: rename_issue_policy_uid
+      tag: rename_issue_policy_uid_e5fa70e1
       target_field: cyera.event.issue.policy.uid
       ignore_missing: true
   - rename:
       field: json.issue.policy.useCases
-      tag: rename_issue_policy_useCases
+      tag: rename_issue_policy_useCases_7815452a
       target_field: cyera.event.issue.policy.use_cases
       ignore_missing: true
   - rename:
       field: json.issue.resolutionNote
-      tag: rename_issue_resolutionNote
+      tag: rename_issue_resolutionNote_5a0a6a0b
       target_field: cyera.event.issue.resolution.note
       ignore_missing: true
   - rename:
       field: json.issue.resolution
-      tag: rename_issue_resolution
+      tag: rename_issue_resolution_b9145e11
       target_field: cyera.event.issue.resolution.value
       ignore_missing: true
   - rename:
       field: json.issue.riskStatus
-      tag: rename_issue_riskStatus
+      tag: rename_issue_riskStatus_2d0b5f92
       target_field: cyera.event.issue.risk_status
       ignore_missing: true
   - rename:
       field: json.issueUid
-      tag: rename_issueUid
+      tag: rename_issueUid_bdee6e9b
       target_field: cyera.event.issue_uid
       ignore_missing: true
   - rename:
       field: json.issue.uid
-      tag: rename_issue_uid
+      tag: rename_issue_uid_57bf3597
       target_field: cyera.event.issue.uid
       ignore_missing: true
   - foreach:
       field: json.issues
-      tag: foreach_issues_policy_useCases
+      tag: foreach_issues_policy_useCases_3897c765
       if: ctx.json?.issues instanceof List
       processor:
         rename:
           field: _ingest._value.policy.useCases
-          tag: rename_issues_policy_useCases
+          tag: rename_issues_policy_useCases_c4515807
           target_field: _ingest._value.policy.use_cases
           ignore_missing: true
   - foreach:
       field: json.issues
-      tag: foreach_issues_resolutionNote
+      tag: foreach_issues_resolutionNote_11d1b87b
       if: ctx.json?.issues instanceof List
       processor:
         rename:
           field: _ingest._value.resolutionNote
-          tag: rename_issues_resolutionNote
+          tag: rename_issues_resolutionNote_2979487d
           target_field: _ingest._value.resolution_note
           ignore_missing: true
   - foreach:
       field: json.issues
-      tag: foreach_issues_resolution
+      tag: foreach_issues_resolution_4f784727
       if: ctx.json?.issues instanceof List
       processor:
         rename:
           field: _ingest._value.resolution
-          tag: rename_issues_resolution
+          tag: rename_issues_resolution_b5625e6e
           target_field: _ingest._value.resolution_value
           ignore_missing: true
   - foreach:
       field: json.issues
-      tag: foreach_issues_riskStatus
+      tag: foreach_issues_riskStatus_3c74ab63
       if: ctx.json?.issues instanceof List
       processor:
         rename:
           field: _ingest._value.riskStatus
-          tag: rename_issues_riskStatus
+          tag: rename_issues_riskStatus_3a559782
           target_field: _ingest._value.risk_status
           ignore_missing: true
   - rename:
       field: json.issues
-      tag: rename_issues
+      tag: rename_issues_6b95278f
       target_field: cyera.event.issues
       ignore_missing: true
   - rename:
       field: json.m365AssignedSensitivityLabelName
-      tag: rename_m365AssignedSensitivityLabelName
+      tag: rename_m365AssignedSensitivityLabelName_526de9e8
       target_field: cyera.event.m365_assigned_sensitivity_label_name
       ignore_missing: true
   - rename:
       field: json.originalSensitivityDisplayName
-      tag: rename_originalSensitivityDisplayName
+      tag: rename_originalSensitivityDisplayName_39a01a7b
       target_field: cyera.event.original_sensitivity.display_name
       ignore_missing: true
   - rename:
       field: json.originalSensitivity
-      tag: rename_originalSensitivity
+      tag: rename_originalSensitivity_22000e4c
       target_field: cyera.event.original_sensitivity.value
       ignore_missing: true
   - rename:
       field: json.policy.name
-      tag: rename_policy_name
+      tag: rename_policy_name_7a586f78
       target_field: cyera.event.policy.name
       ignore_missing: true
   - rename:
       field: json.policy.uid
-      tag: rename_policy_uid
+      tag: rename_policy_uid_856c66d3
       target_field: cyera.event.policy.uid
       ignore_missing: true
   - rename:
       field: json.policy.useCases
-      tag: rename_policy_useCases
+      tag: rename_policy_useCases_731b5211
       target_field: cyera.event.policy.use_cases
       ignore_missing: true
   - rename:
       field: json.projectName
-      tag: rename_projectName
+      tag: rename_projectName_e258c2aa
       target_field: cyera.event.project.name
       ignore_missing: true
   - rename:
       field: json.projectUid
-      tag: rename_projectUid
+      tag: rename_projectUid_106445dd
       target_field: cyera.event.project.uid
       ignore_missing: true
   - rename:
       field: json.recipients
-      tag: rename_recipients
+      tag: rename_recipients_ee3f6633
       target_field: cyera.event.recipients
       ignore_missing: true
   - rename:
       field: json.reportFileName
-      tag: rename_reportFileName
+      tag: rename_reportFileName_0640f893
       target_field: cyera.event.report.file_name
       ignore_missing: true
   - rename:
       field: json.reportInstanceUid
-      tag: rename_reportInstanceUid
+      tag: rename_reportInstanceUid_c545f9f7
       target_field: cyera.event.report.instance_uid
       ignore_missing: true
   - rename:
       field: json.reportJobUid
-      tag: rename_reportJobUid
+      tag: rename_reportJobUid_c434b68e
       target_field: cyera.event.report.job_uid
       ignore_missing: true
   - rename:
       field: json.reportName
-      tag: rename_reportName
+      tag: rename_reportName_5eb43571
       target_field: cyera.event.report.name
       ignore_missing: true
   - rename:
       field: json.reportType
-      tag: rename_reportType
+      tag: rename_reportType_75f6c077
       target_field: cyera.event.report.type
       ignore_missing: true
   - rename:
       field: json.sku
-      tag: rename_sku
+      tag: rename_sku_cdc92c7f
       target_field: cyera.event.sku
       ignore_missing: true
   - foreach:
       field: json.sourceClassifications
-      tag: foreach_sourceClassifications_classificationName
+      tag: foreach_sourceClassifications_classificationName_c2d972e3
       if: ctx.json?.sourceClassifications instanceof List
       processor:
         rename:
           field: _ingest._value.classificationName
-          tag: rename_sourceClassifications_classificationName
+          tag: rename_sourceClassifications_classificationName_6664143c
           target_field: _ingest._value.name
           ignore_missing: true
   - rename:
       field: json.sourceClassifications
-      tag: rename_sourceClassifications
+      tag: rename_sourceClassifications_8579b714
       target_field: cyera.event.source_classifications
       ignore_missing: true
   - rename:
       field: json.subscriptionUid
-      tag: rename_subscriptionUid
+      tag: rename_subscriptionUid_cb496c45
       target_field: cyera.event.subscription_uid
       ignore_missing: true
   - convert:
       field: json.successfulM365SensitivityLabelAssignmentsCount
-      tag: convert_successfulM365SensitivityLabelAssignmentsCount_to_long
+      tag: convert_successfulM365SensitivityLabelAssignmentsCount_to_long_22d7bf88
       target_field: cyera.event.successful_m365_sensitivity_label_assignments_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c052db5e
+            tag: append_error_message_f30a7f35
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.targetClassifications
-      tag: foreach_targetClassifications_classificationName
+      tag: foreach_targetClassifications_classificationName_0f7b7d93
       if: ctx.json?.targetClassifications instanceof List
       processor:
         rename:
           field: _ingest._value.classificationName
-          tag: rename_targetClassifications_classificationName
+          tag: rename_targetClassifications_classificationName_27e38eb1
           target_field: _ingest._value.name
           ignore_missing: true
   - rename:
       field: json.targetClassifications
-      tag: rename_targetClassifications
+      tag: rename_targetClassifications_bbf29d2b
       target_field: cyera.event.target_classifications
       ignore_missing: true
   - rename:
       field: json.targetSensitivityDisplayName
-      tag: rename_targetSensitivityDisplayName
+      tag: rename_targetSensitivityDisplayName_60f802ec
       target_field: cyera.event.target_sensitivity.display_name
       ignore_missing: true
   - rename:
       field: json.targetSensitivity
-      tag: rename_targetSensitivity
+      tag: rename_targetSensitivity_36031717
       target_field: cyera.event.target_sensitivity.value
       ignore_missing: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_fe7e1b28
       target_field: cyera.event.type
       ignore_missing: true
   - rename:
       field: json.uid
-      tag: rename_uid
+      tag: rename_uid_98fc55bd
       target_field: cyera.event.uid
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_event_uid
+      tag: set_event_id_from_event_uid_1dff8237
       copy_from: cyera.event.uid
       ignore_empty_value: true
   - rename:
       field: json.user
-      tag: rename_user
+      tag: rename_user_065f1aea
       target_field: cyera.event.user
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_event_user
+      tag: set_user_name_from_event_user_3c73601f
       copy_from: cyera.event.user
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_event_user_into_related_user
+      tag: append_event_user_into_related_user_698449a9
       value: '{{{cyera.event.user}}}'
       allow_duplicates: false
       if: ctx.cyera?.event?.user != null
   - rename:
       field: json.vendorLink
-      tag: rename_vendorLink
+      tag: rename_vendorLink_fca8a3b5
       target_field: cyera.event.vendor.link
       ignore_missing: true
   - rename:
       field: json.vendorStatus
-      tag: rename_vendorStatus
+      tag: rename_vendorStatus_d1006449
       target_field: cyera.event.vendor.status
       ignore_missing: true
   - rename:
       field: json.vendorTicketId
-      tag: rename_vendorTicketId
+      tag: rename_vendorTicketId_dc8fd0c9
       target_field: cyera.event.vendor.ticket_id
       ignore_missing: true
   - remove:
@@ -632,15 +632,15 @@ processors:
         - cyera.event.date
         - cyera.event.uid
         - cyera.event.user
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_d753b9ba
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -667,18 +667,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_c14f7af1
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -686,10 +686,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
@@ -8,376 +8,376 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_ab1166ce
       value: alert
   - fingerprint:
       fields:
         - json.uid
         - json.updatedDate
-      tag: fingerprint_issue
+      tag: fingerprint_issue_fbbcda24
       target_field: _id
   - rename:
       field: json.account.inPlatformIdentifier
-      tag: rename_account_inPlatformIdentifier
+      tag: rename_account_inPlatformIdentifier_bec2cfad
       target_field: cyera.issue.account.in_platform_identifier
       ignore_missing: true
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_issue_account_in_platform_identifier
+      tag: set_cloud_account_id_from_issue_account_in_platform_identifier_26255309
       copy_from: cyera.issue.account.in_platform_identifier
       ignore_empty_value: true
   - rename:
       field: json.account.name
-      tag: rename_account_name
+      tag: rename_account_name_a2e4463a
       target_field: cyera.issue.account.name
       ignore_missing: true
   - set:
       field: cloud.account.name
-      tag: set_cloud_account_name_from_issue_account_name
+      tag: set_cloud_account_name_from_issue_account_name_62bfa149
       copy_from: cyera.issue.account.name
       ignore_empty_value: true
   - rename:
       field: json.classificationGroups
-      tag: rename_classificationGroups
+      tag: rename_classificationGroups_f90d3d42
       target_field: cyera.issue.classification_groups
       ignore_missing: true
   - rename:
       field: json.cloudProviderTags
-      tag: rename_cloudProviderTags
+      tag: rename_cloudProviderTags_64da5509
       target_field: cyera.issue.cloud_provider_tags
       ignore_missing: true
   - date:
       field: json.createdDate
-      tag: date_createdDate
+      tag: date_createdDate_b3dcb772
       target_field: cyera.issue.created_date
       formats:
         - ISO8601
       if: ctx.json?.createdDate != null && ctx.json.createdDate != ''
       on_failure:
         - append:
-            tag: append_error_message_3e918fdb
+            tag: append_error_message_29922a23
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_issue_created_date
+      tag: set_event_created_from_issue_created_date_9df95781
       copy_from: cyera.issue.created_date
       ignore_empty_value: true
   - convert:
       field: json.data.affectedRecords
-      tag: convert_data_affectedRecords_to_long
+      tag: convert_data_affectedRecords_to_long_df98bb11
       target_field: cyera.issue.data.affected_records
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_deeefde3
+            tag: append_error_message_b52811b5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.data.dataClassesUids
-      tag: rename_data_dataClassesUids
+      tag: rename_data_dataClassesUids_22425ed1
       target_field: cyera.issue.data.data_classes_uids
       ignore_missing: true
   - convert:
       field: json.data.objectsAtRisk
-      tag: convert_data_objectsAtRisk_to_long
+      tag: convert_data_objectsAtRisk_to_long_7d5cf7a1
       target_field: cyera.issue.data.objects_at_risk
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_cf579102
+            tag: append_error_message_556d22f0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.data.recordsAtRisk
-      tag: convert_data_recordsAtRisk_to_long
+      tag: convert_data_recordsAtRisk_to_long_7cf515b3
       target_field: cyera.issue.data.records_at_risk
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5bf6fb88
+            tag: append_error_message_6e8c8f62
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.datastoreCloudProviderTags
-      tag: rename_datastoreCloudProviderTags
+      tag: rename_datastoreCloudProviderTags_89ecdfe1
       target_field: cyera.issue.datastore_cloud_provider_tags
       ignore_missing: true
   - rename:
       field: json.datastoreName
-      tag: rename_datastoreName
+      tag: rename_datastoreName_a08dbaaf
       target_field: cyera.issue.datastore_name
       ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_datastoreOwnerUid
+      tag: foreach_datastoreOwners_datastoreOwnerUid_0fe7d637
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         rename:
           field: _ingest._value.datastoreOwnerUid
-          tag: rename_datastoreOwners_datastoreOwnerUid
+          tag: rename_datastoreOwners_datastoreOwnerUid_d6facdca
           target_field: _ingest._value.datastore_owner_uid
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_datastoreOwnerUid_b7acef9e
+      tag: foreach_datastoreOwners_datastoreOwnerUid_55be59dd
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
           field: related.user
-          tag: append_datastoreOwners_datastoreOwnerUid_into_related_user
+          tag: append_datastoreOwners_datastoreOwnerUid_into_related_user_fcdf8e87
           value: '{{{_ingest._value.datastore_owner_uid}}}'
           allow_duplicates: false
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_email
+      tag: foreach_datastoreOwners_email_c2467a54
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
           field: related.user
-          tag: append_datastoreOwners_email_into_related_user
+          tag: append_datastoreOwners_email_into_related_user_fb9dd976
           value: '{{{_ingest._value.email}}}'
           allow_duplicates: false
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_ownerType
+      tag: foreach_datastoreOwners_ownerType_b519bea8
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         rename:
           field: _ingest._value.ownerType
-          tag: rename_datastoreOwners_ownerType
+          tag: rename_datastoreOwners_ownerType_87fc9dbb
           target_field: _ingest._value.owner_type
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_ownerType_920ad464
+      tag: foreach_datastoreOwners_ownerType_e037941c
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
           field: user.roles
-          tag: append_datastoreOwners_ownerType_into_user_roles
+          tag: append_datastoreOwners_ownerType_into_user_roles_95e5e1f1
           value: '{{{_ingest._value.owner_type}}}'
           allow_duplicates: false
   - rename:
       field: json.datastoreOwners
-      tag: rename_datastoreOwners
+      tag: rename_datastoreOwners_50039653
       target_field: cyera.issue.datastore_owners
       ignore_missing: true
   - rename:
       field: json.datastoreUid
-      tag: rename_datastoreUid
+      tag: rename_datastoreUid_ec07ba9b
       target_field: cyera.issue.datastore_uid
       ignore_missing: true
   - rename:
       field: json.datastoreUserTags
-      tag: rename_datastoreUserTags
+      tag: rename_datastoreUserTags_7d870b26
       target_field: cyera.issue.datastore_user_tags
       ignore_missing: true
   - rename:
       field: json.engine
-      tag: rename_engine
+      tag: rename_engine_0f2aacee
       target_field: cyera.issue.engine
       ignore_missing: true
   - rename:
       field: json.infrastructure
-      tag: rename_infrastructure
+      tag: rename_infrastructure_fa6644c8
       target_field: cyera.issue.infrastructure
       ignore_missing: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name_from_issue_infrastructure
+      tag: set_cloud_service_name_from_issue_infrastructure_e1398555
       copy_from: cyera.issue.infrastructure
       ignore_empty_value: true
   - foreach:
       field: json.itsmTickets
-      tag: foreach_itsmTickets_vendorLink
+      tag: foreach_itsmTickets_vendorLink_629b2498
       if: ctx.json?.itsmTickets instanceof List
       processor:
         rename:
           field: _ingest._value.vendorLink
-          tag: rename_itsmTickets_vendorLink
+          tag: rename_itsmTickets_vendorLink_462174db
           target_field: _ingest._value.vendor.link
           ignore_missing: true
   - foreach:
       field: json.itsmTickets
-      tag: foreach_itsmTickets_vendorStatus
+      tag: foreach_itsmTickets_vendorStatus_3420fc56
       if: ctx.json?.itsmTickets instanceof List
       processor:
         rename:
           field: _ingest._value.vendorStatus
-          tag: rename_itsmTickets_vendorStatus
+          tag: rename_itsmTickets_vendorStatus_b26e71f8
           target_field: _ingest._value.vendor.status
           ignore_missing: true
   - foreach:
       field: json.itsmTickets
-      tag: foreach_itsmTickets_vendorTicketId
+      tag: foreach_itsmTickets_vendorTicketId_73c8f646
       if: ctx.json?.itsmTickets instanceof List
       processor:
         rename:
           field: _ingest._value.vendorTicketId
-          tag: rename_itsmTickets_vendorTicketId
+          tag: rename_itsmTickets_vendorTicketId_a9877877
           target_field: _ingest._value.vendor.ticket_id
           ignore_missing: true
   - rename:
       field: json.itsmTickets
-      tag: rename_itsmTickets
+      tag: rename_itsmTickets_b8854de2
       target_field: cyera.issue.itsm_tickets
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_bcde3f44
       target_field: cyera.issue.name
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_issue_name
+      tag: set_message_from_issue_name_9a9b564f
       copy_from: cyera.issue.name
       ignore_empty_value: true
   - rename:
       field: json.owner
-      tag: rename_owner
+      tag: rename_owner_918685cc
       target_field: cyera.issue.owner
       ignore_missing: true
   - set:
       field: user.email
-      tag: set_user_email_from_issue_owner
+      tag: set_user_email_from_issue_owner_e1fc5b5b
       copy_from: cyera.issue.owner
       ignore_empty_value: true
       if: ctx.cyera?.issue?.owner != null && ctx.cyera.issue.owner.contains('@')
   - set:
       field: user.name
-      tag: set_user_name_from_issue_owner
+      tag: set_user_name_from_issue_owner_bb98661b
       copy_from: cyera.issue.owner
       ignore_empty_value: true
       if: ctx.user?.email == null
   - dissect:
       field: cyera.issue.owner
       pattern: '%{user.name}@%{user.domain}'
-      tag: dissect_cyera_issue_owner
+      tag: dissect_cyera_issue_owner_285bc8d4
       ignore_missing: true
       if: ctx.cyera?.issue?.owner != null && ctx.cyera.issue.owner.contains('@')
   - append:
       field: related.user
-      tag: append_issue_owner_into_related_user
+      tag: append_issue_owner_into_related_user_4c462c44
       value: '{{{cyera.issue.owner}}}'
       allow_duplicates: false
       if: ctx.cyera?.issue?.owner != null
   - rename:
       field: json.policyUid
-      tag: rename_policyUid
+      tag: rename_policyUid_ba5229f7
       target_field: cyera.issue.policy_uid
       ignore_missing: true
   - rename:
       field: json.provider
-      tag: rename_provider
+      tag: rename_provider_ce608412
       target_field: cyera.issue.provider
       ignore_missing: true
   - set:
       field: cloud.provider
-      tag: set_cloud_provider_from_issue_provider
+      tag: set_cloud_provider_from_issue_provider_ced60145
       copy_from: cyera.issue.provider
       ignore_empty_value: true
   - lowercase:
       field: cloud.provider
-      tag: lowercase_cloud_provider
+      tag: lowercase_cloud_provider_1a17fc24
       ignore_missing: true
   - foreach:
       field: json.regions
-      tag: foreach_regions
+      tag: foreach_regions_03117b9a
       if: ctx.json?.regions instanceof List
       processor:
         append:
           field: cloud.region
-          tag: append_regions_into_cloud_region
+          tag: append_regions_into_cloud_region_b238a601
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.regions
-      tag: rename_regions
+      tag: rename_regions_b66a987c
       target_field: cyera.issue.regions
       ignore_missing: true
   - rename:
       field: json.remediationAdvice
-      tag: rename_remediationAdvice
+      tag: rename_remediationAdvice_723ef6b3
       target_field: cyera.issue.remediation_advice
       ignore_missing: true
   - rename:
       field: json.resolution
-      tag: rename_resolution
+      tag: rename_resolution_00200240
       target_field: cyera.issue.resolution
       ignore_missing: true
   - rename:
       field: json.resolutionNote
-      tag: rename_resolutionNote
+      tag: rename_resolutionNote_86237938
       target_field: cyera.issue.resolution_note
       ignore_missing: true
   - rename:
       field: json.risk.description
-      tag: rename_risk_description
+      tag: rename_risk_description_3dc7ef2f
       target_field: cyera.issue.risk.description
       ignore_missing: true
   - rename:
       field: json.risk.frameworks
-      tag: rename_risk_frameworks
+      tag: rename_risk_frameworks_a0c49a29
       target_field: cyera.issue.risk.frameworks
       ignore_missing: true
   - rename:
       field: json.risk.policyUid
-      tag: rename_risk_policyUid
+      tag: rename_risk_policyUid_03446e91
       target_field: cyera.issue.risk.policy_uid
       ignore_missing: true
   - rename:
       field: json.risk.useCases
-      tag: rename_risk_useCases
+      tag: rename_risk_useCases_670b18f9
       target_field: cyera.issue.risk.use_cases
       ignore_missing: true
   - rename:
       field: json.riskStatus
-      tag: rename_riskStatus
+      tag: rename_riskStatus_3e11daa5
       target_field: cyera.issue.risk_status
       ignore_missing: true
   - rename:
       field: json.severity
-      tag: rename_severity
+      tag: rename_severity_7cc53bc8
       target_field: cyera.issue.severity
       ignore_missing: true
   - script:
       lang: painless
       description: Script to set event.severity.
-      tag: set_event_severity
+      tag: set_event_severity_f1874545
       if: ctx.cyera?.issue?.severity instanceof String
       source: |-
         ctx.event = ctx.event ?: [:];
@@ -393,44 +393,44 @@ processors:
         }
   - rename:
       field: json.status
-      tag: rename_status
+      tag: rename_status_667c88ce
       target_field: cyera.issue.status
       ignore_missing: true
   - rename:
       field: json.uid
-      tag: rename_uid
+      tag: rename_uid_ba6bbb48
       target_field: cyera.issue.uid
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_issue_uid
+      tag: set_event_id_from_issue_uid_17ee29ef
       copy_from: cyera.issue.uid
       ignore_empty_value: true
   - date:
       field: json.updatedDate
-      tag: date_updatedDate
+      tag: date_updatedDate_30b90811
       target_field: cyera.issue.updated_date
       formats:
         - ISO8601
       if: ctx.json?.updatedDate != null && ctx.json.updatedDate != ''
       on_failure:
         - append:
-            tag: append_error_message_0fd23ee0
+            tag: append_error_message_44569488
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_issue_updated_date
+      tag: set_@timestamp_from_issue_updated_date_1e1c02f4
       copy_from: cyera.issue.updated_date
       ignore_empty_value: true
   - foreach:
       field: cyera.issue.datastore_owners
-      tag: foreach_cyera_issue_datastore_owners
+      tag: foreach_cyera_issue_datastore_owners_6a0c14d6
       if: ctx.cyera?.issue?.datastore_owners instanceof List
       processor:
         remove:
           field: _ingest._value.owner_type
-          tag: remove_custom_duplicate_fields_from_cyera_issue_datastore_owners
+          tag: remove_custom_duplicate_fields_from_cyera_issue_datastore_owners_ac1bc86c
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
@@ -444,15 +444,15 @@ processors:
         - cyera.issue.regions
         - cyera.issue.uid
         - cyera.issue.updated_date
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_67cbcf60
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -479,18 +479,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -498,10 +498,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
@@ -85,6 +85,7 @@ processors:
       if: ctx.json?.createdDate != null && ctx.json.createdDate != ''
       on_failure:
         - append:
+            tag: append_error_message_3e918fdb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -100,6 +101,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_deeefde3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -115,6 +117,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_cf579102
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -125,6 +128,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5bf6fb88
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -149,7 +153,7 @@ processors:
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_datastoreOwnerUid
+      tag: foreach_json_datastoreOwners_b7acef9e
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
@@ -179,7 +183,7 @@ processors:
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_datastoreOwners_ownerType
+      tag: foreach_json_datastoreOwners_920ad464
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
@@ -411,6 +415,7 @@ processors:
       if: ctx.json?.updatedDate != null && ctx.json.updatedDate != ''
       on_failure:
         - append:
+            tag: append_error_message_0fd23ee0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -478,6 +483,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyera/data_stream/issue/elasticsearch/ingest_pipeline/default.yml
@@ -153,7 +153,7 @@ processors:
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_json_datastoreOwners_b7acef9e
+      tag: foreach_datastoreOwners_datastoreOwnerUid_b7acef9e
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
@@ -183,7 +183,7 @@ processors:
           ignore_missing: true
   - foreach:
       field: json.datastoreOwners
-      tag: foreach_json_datastoreOwners_920ad464
+      tag: foreach_datastoreOwners_ownerType_920ad464
       if: ctx.json?.datastoreOwners instanceof List
       processor:
         append:
@@ -490,6 +490,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -500,6 +501,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cyera/manifest.yml
+++ b/packages/cyera/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyera
 title: Cyera
-version: 0.10.2
+version: 0.11.0
 description: Collect logs from Cyera with Elastic Agent.
 type: integration
 categories:

--- a/packages/cyera/manifest.yml
+++ b/packages/cyera/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyera
 title: Cyera
-version: 0.10.1
+version: 0.10.2
 description: Collect logs from Cyera with Elastic Agent.
 type: integration
 categories:

--- a/packages/entro/changelog.yml
+++ b/packages/entro/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.4.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/entro/changelog.yml
+++ b/packages/entro/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.4.2"
+- version: "0.5.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/entro/changelog.yml
+++ b/packages/entro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.4.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -3,10 +3,10 @@ description: Pipeline for processing and enriching Entro audit logs according to
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: '8.17.0'
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - date:
@@ -15,14 +15,14 @@ processors:
       formats:
         - ISO8601
       timezone: UTC
-      tag: date_parse_timestamp
+      tag: date_parse_timestamp_6a33e08a
       if: ctx.date != null
       on_failure:
         - remove:
-            tag: remove_date_1a15cc9b
+            tag: remove_date_42d31a68
             field: date
         - append:
-            tag: append_error_message_bf1997ac
+            tag: append_error_message_6d328dab
             field: error.message
             value: >-
                 Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -34,53 +34,53 @@ processors:
         - secret_type
         - exposed_value
         - date
-      tag: fingerprint
+      tag: fingerprint_df5b820d
       target_field: _id
       ignore_missing: true
   - set:
-      tag: set_event_id_7cf3f855
+      tag: set_event_id_1a7342bb
       field: event.id
       copy_from: request_id
       ignore_empty_value: true
   - set:
-      tag: set_vulnerability_value_d873757a
+      tag: set_vulnerability_value_fa04a43a
       field: vulnerability.value
       copy_from: exposed_value
       ignore_empty_value: true
   - set:
-      tag: set_log_origin_file_line_d1fd2935
+      tag: set_log_origin_file_line_d5b1440d
       field: log.origin.file.line
       copy_from: line_number
       ignore_empty_value: true
   - set:
-      tag: set_vulnerability_category_31985606
+      tag: set_vulnerability_category_6b2c33ed
       field: vulnerability.category
       value: ["Secret"]
       ignore_empty_value: true
       if: ctx.secret_type != null
   - set:
-      tag: set_vulnerability_description_a3826a5e
+      tag: set_vulnerability_description_cdcd2049
       field: vulnerability.description
       copy_from: secret_type
       ignore_empty_value: true
   - set:
-      tag: set_event_kind_de80643c
+      tag: set_event_kind_d452ef2c
       field: event.kind
       value: event
   - set:
-      tag: set_event_category_13b30ef2
+      tag: set_event_category_f174b464
       field: event.category
       value: ["vulnerability"]
   - set:
-      tag: set_event_type_ec95f7f2
+      tag: set_event_type_8bf4a5be
       field: event.type
       value: ["info"]
   - set:
-      tag: set_event_dataset_d3e82901
+      tag: set_event_dataset_5e226b9a
       field: event.dataset
       value: "entro.audit"
   - remove:
-      tag: remove_07170528
+      tag: remove_60df4cd4
       field:
         - date
         - request_id
@@ -90,16 +90,16 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
-      tag: set_event_kind
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -90,13 +90,16 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      tag: set_event_kind
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -34,7 +34,7 @@ processors:
         - secret_type
         - exposed_value
         - date
-      tag: fingerprint_df5b820d
+      tag: fingerprint_to_id_df5b820d
       target_field: _id
       ignore_missing: true
   - set:

--- a/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/entro/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -19,8 +19,10 @@ processors:
       if: ctx.date != null
       on_failure:
         - remove:
+            tag: remove_date_1a15cc9b
             field: date
         - append:
+            tag: append_error_message_bf1997ac
             field: error.message
             value: >-
                 Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -36,39 +38,49 @@ processors:
       target_field: _id
       ignore_missing: true
   - set:
+      tag: set_event_id_7cf3f855
       field: event.id
       copy_from: request_id
       ignore_empty_value: true
   - set:
+      tag: set_vulnerability_value_d873757a
       field: vulnerability.value
       copy_from: exposed_value
       ignore_empty_value: true
   - set:
+      tag: set_log_origin_file_line_d1fd2935
       field: log.origin.file.line
       copy_from: line_number
       ignore_empty_value: true
   - set:
+      tag: set_vulnerability_category_31985606
       field: vulnerability.category
       value: ["Secret"]
       ignore_empty_value: true
       if: ctx.secret_type != null
   - set:
+      tag: set_vulnerability_description_a3826a5e
       field: vulnerability.description
       copy_from: secret_type
       ignore_empty_value: true
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_category_13b30ef2
       field: event.category
       value: ["vulnerability"]
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: ["info"]
   - set:
+      tag: set_event_dataset_d3e82901
       field: event.dataset
       value: "entro.audit"
   - remove:
+      tag: remove_07170528
       field:
         - date
         - request_id

--- a/packages/entro/manifest.yml
+++ b/packages/entro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: entro
 title: "Entro"
-version: 0.4.1
+version: 0.4.2
 description: "Collect logs from Entro with Elastic Agent."
 type: integration
 categories:

--- a/packages/entro/manifest.yml
+++ b/packages/entro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: entro
 title: "Entro"
-version: 0.4.2
+version: 0.5.0
 description: "Collect logs from Entro with Elastic Agent."
 type: integration
 categories:

--- a/packages/extrahop/changelog.yml
+++ b/packages/extrahop/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.3"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.3.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/extrahop/changelog.yml
+++ b/packages/extrahop/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.3.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/extrahop/changelog.yml
+++ b/packages/extrahop/changelog.yml
@@ -1,8 +1,11 @@
 # newer versions go on top
-- version: "0.3.3"
+- version: "0.4.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/20575
+    - description: Correct the `detection` data stream's `participants.id` `on_failure` handler, which removed the unrelated `object_id` field. The handler is unreachable today, so there is no change in behaviour.
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/20575
 - version: "0.3.2"
   changes:

--- a/packages/extrahop/data_stream/detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/extrahop/data_stream/detection/elasticsearch/ingest_pipeline/default.yml
@@ -241,9 +241,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_external
                 field: _ingest._value.external
                 ignore_missing: true
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -268,9 +270,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_object_id
                 field: _ingest._value.object_id
                 ignore_missing: true
             - append:
+                tag: append_error_message_f958f5ab
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -285,9 +289,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_object_id_98106835
                 field: _ingest._value.object_id
                 ignore_missing: true
             - append:
+                tag: append_error_message_78c8443e
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -302,14 +308,16 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_object_value
                 field: _ingest._value.object_value
                 ignore_missing: true
             - append:
+                tag: append_error_message_ea51762b
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.participants
-      tag: foreach_json_participants_a474cd8b
+      tag: foreach_participants_object_value_a474cd8b
       if: ctx.json?.participants instanceof List
       processor:
         append:
@@ -566,6 +574,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_872cfe3d
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -576,6 +585,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/extrahop/data_stream/detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/extrahop/data_stream/detection/elasticsearch/ingest_pipeline/default.yml
@@ -3,10 +3,10 @@ description: Pipeline for processing detection logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -16,482 +16,482 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
   - fingerprint:
       fields:
         - json.id
         - json.mod_time
-      tag: fingerprint_extrahop_detection
+      tag: fingerprint_extrahop_detection_bade400b
       target_field: _id
       ignore_missing: true
   - append:
       field: event.category
-      tag: append_threat_into_event_category
+      tag: append_threat_into_event_category_4039b90d
       value: threat
   - append:
       field: event.type
-      tag: append_indicator_into_event_type
+      tag: append_indicator_into_event_type_d4da06cc
       value: indicator
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - convert:
       field: json.appliance_id
-      tag: convert_appliance_id_to_string
+      tag: convert_appliance_id_to_string_a6a29509
       target_field: extrahop.detection.appliance_id
       type: string
       ignore_missing: true
   - set:
       field: device.id
-      tag: set_device_id_from_detection_appliance_id
+      tag: set_device_id_from_detection_appliance_id_46b978ad
       copy_from: extrahop.detection.appliance_id
       ignore_empty_value: true
   - rename:
       field: json.assignee
-      tag: rename_assignee
+      tag: rename_assignee_3a315993
       target_field: extrahop.detection.assignee
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_detection_assignee
+      tag: set_user_name_from_detection_assignee_692e4f29
       copy_from: extrahop.detection.assignee
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_detection_assignee_into_related_user
+      tag: append_detection_assignee_into_related_user_719d5f5b
       value: '{{{extrahop.detection.assignee}}}'
       allow_duplicates: false
       if: ctx.extrahop?.detection?.assignee != null
   - rename:
       field: json.categories
-      tag: rename_categories
+      tag: rename_categories_32151236
       target_field: extrahop.detection.categories
       ignore_missing: true
   - date:
       field: json.create_time
-      tag: date_create_time
+      tag: date_create_time_6486b980
       target_field: extrahop.detection.create_time
       formats:
         - UNIX_MS
       if: ctx.json?.create_time != null && ctx.json.create_time != ''
       on_failure:
         - append:
-            tag: append_error_message_b79de794
+            tag: append_error_message_6cfe60bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_detection_create_time
+      tag: set_event_created_from_detection_create_time_52192785
       copy_from: extrahop.detection.create_time
       ignore_empty_value: true
   - rename:
       field: json.description
-      tag: rename_description
+      tag: rename_description_2a883e9f
       target_field: extrahop.detection.description
       ignore_missing: true
   - set:
       field: threat.indicator.description
-      tag: set_threat_indicator_description_from_detection_description
+      tag: set_threat_indicator_description_from_detection_description_6e8f0793
       copy_from: extrahop.detection.description
       ignore_empty_value: true
   - convert:
       field: json.id
-      tag: convert_id_to_string
+      tag: convert_id_to_string_ad6b3da8
       target_field: extrahop.detection.id
       type: string
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_detection_id_and_mod_time
+      tag: set_event_id_from_detection_id_and_mod_time_a9af49f3
       value: '{{{extrahop.detection.id}}}-{{{json.mod_time}}}'
       if: ctx.extrahop?.detection?.id != null && ctx.json?.mod_time != null
   - convert:
       field: json.is_user_created
-      tag: convert_is_user_created_to_boolean
+      tag: convert_is_user_created_to_boolean_97f539f0
       target_field: extrahop.detection.is_user_created
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_35ae4b39
+            tag: append_error_message_fca0f33a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.mitre_tactics
-      tag: foreach_mitre_tactics_id
+      tag: foreach_mitre_tactics_id_62b3a565
       if: ctx.json?.mitre_tactics instanceof List
       processor:
         append:
           field: threat.tactic.id
-          tag: append_mitre_tactics_id_into_threat_tactic_id
+          tag: append_mitre_tactics_id_into_threat_tactic_id_0fcae94f
           value: '{{{_ingest._value.id}}}'
           allow_duplicates: false
   - foreach:
       field: json.mitre_tactics
-      tag: foreach_mitre_tactics_name
+      tag: foreach_mitre_tactics_name_17519cb3
       if: ctx.json?.mitre_tactics instanceof List
       processor:
         append:
           field: threat.tactic.name
-          tag: append_mitre_tactics_name_into_threat_tactic_name
+          tag: append_mitre_tactics_name_into_threat_tactic_name_fd792bba
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
       field: json.mitre_tactics
-      tag: foreach_mitre_tactics_url
+      tag: foreach_mitre_tactics_url_eeeffd93
       if: ctx.json?.mitre_tactics instanceof List
       processor:
         append:
           field: threat.tactic.reference
-          tag: append_mitre_tactics_url_into_threat_tactic_reference
+          tag: append_mitre_tactics_url_into_threat_tactic_reference_d98149ec
           value: '{{{_ingest._value.url}}}'
           allow_duplicates: false
   - rename:
       field: json.mitre_tactics
-      tag: rename_mitre_tactics
+      tag: rename_mitre_tactics_dd48c179
       target_field: extrahop.detection.mitre_tactics
       ignore_missing: true
   - foreach:
       field: json.mitre_techniques
-      tag: foreach_mitre_techniques_id
+      tag: foreach_mitre_techniques_id_d7d0a272
       if: ctx.json?.mitre_techniques instanceof List
       processor:
         append:
           field: threat.technique.id
-          tag: append_mitre_techniques_id_into_threat_technique_id
+          tag: append_mitre_techniques_id_into_threat_technique_id_48cd089c
           value: '{{{_ingest._value.id}}}'
           allow_duplicates: false
   - foreach:
       field: json.mitre_techniques
-      tag: foreach_mitre_techniques_name
+      tag: foreach_mitre_techniques_name_2e509121
       if: ctx.json?.mitre_techniques instanceof List
       processor:
         append:
           field: threat.technique.name
-          tag: append_mitre_techniques_name_into_threat_technique_name
+          tag: append_mitre_techniques_name_into_threat_technique_name_5c606258
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
       field: json.mitre_techniques
-      tag: foreach_mitre_techniques_url
+      tag: foreach_mitre_techniques_url_f840c727
       if: ctx.json?.mitre_techniques instanceof List
       processor:
         append:
           field: threat.technique.reference
-          tag: append_mitre_techniques_url_into_threat_technique_reference
+          tag: append_mitre_techniques_url_into_threat_technique_reference_e907f390
           value: '{{{_ingest._value.url}}}'
           allow_duplicates: false
   - rename:
       field: json.mitre_techniques
-      tag: rename_mitre_techniques
+      tag: rename_mitre_techniques_77e7f94a
       target_field: extrahop.detection.mitre_techniques
       ignore_missing: true
   - date:
       field: json.mod_time
-      tag: date_mod_time
+      tag: date_mod_time_d7b917c1
       target_field: extrahop.detection.mod_time
       formats:
         - UNIX_MS
       if: ctx.json?.mod_time != null && ctx.json.mod_time != ''
       on_failure:
         - append:
-            tag: append_error_message_99c360ce
+            tag: append_error_message_a07c41a3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_detection_mod_time
+      tag: set_@timestamp_from_detection_mod_time_a70d0cc8
       copy_from: extrahop.detection.mod_time
       ignore_empty_value: true
   - set:
       field: threat.indicator.modified_at
-      tag: set_threat_indicator_modified_at_from_detection_mod_time
+      tag: set_threat_indicator_modified_at_from_detection_mod_time_dc64a666
       copy_from: extrahop.detection.mod_time
       ignore_empty_value: true
   - foreach:
       field: json.participants
-      tag: foreach_participants_external
+      tag: foreach_participants_external_cd11b69e
       if: ctx.json?.participants instanceof List
       processor:
         convert:
           field: _ingest._value.external
-          tag: convert_participants_external_to_boolean
+          tag: convert_participants_external_to_boolean_e21b4f91
           type: boolean
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_external
+                tag: remove_ingest_value_external_a6fc0a9a
                 field: _ingest._value.external
                 ignore_missing: true
             - append:
-                tag: append_error_message
+                tag: append_error_message_cd7926ec
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.participants
-      tag: foreach_participants_hostname
+      tag: foreach_participants_hostname_148a7f46
       if: ctx.json?.participants instanceof List
       processor:
         append:
           field: related.hosts
-          tag: append_participants_hostname_into_related_hosts
+          tag: append_participants_hostname_into_related_hosts_f7160d8b
           value: '{{{_ingest._value.hostname}}}'
           allow_duplicates: false
   - foreach:
       field: json.participants
-      tag: foreach_participants_id
+      tag: foreach_participants_id_95edfb0b
       if: ctx.json?.participants instanceof List
       processor:
         convert:
           field: _ingest._value.id
-          tag: convert_participants_id_to_keyword
+          tag: convert_participants_id_to_keyword_d9b5b05f
           type: string
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_object_id
-                field: _ingest._value.object_id
+                tag: remove_ingest_value_id_14109861
+                field: _ingest._value.id
                 ignore_missing: true
             - append:
-                tag: append_error_message_f958f5ab
+                tag: append_error_message_e7292467
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.participants
-      tag: foreach_participants_object_id
+      tag: foreach_participants_object_id_d1578965
       if: ctx.json?.participants instanceof List
       processor:
         convert:
           field: _ingest._value.object_id
-          tag: convert_participants_object_id_to_keyword
+          tag: convert_participants_object_id_to_keyword_f6b26fc5
           type: string
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_object_id_98106835
+                tag: remove_ingest_value_object_id_6ba34a64
                 field: _ingest._value.object_id
                 ignore_missing: true
             - append:
-                tag: append_error_message_78c8443e
+                tag: append_error_message_0245a4de
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.participants
-      tag: foreach_participants_object_value
+      tag: foreach_participants_object_value_80f7cb16
       if: ctx.json?.participants instanceof List
       processor:
         convert:
           field: _ingest._value.object_value
-          tag: convert_participants_object_value_to_ip
+          tag: convert_participants_object_value_to_ip_63e5e2d2
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_object_value
+                tag: remove_ingest_value_object_value_f8a01b1a
                 field: _ingest._value.object_value
                 ignore_missing: true
             - append:
-                tag: append_error_message_ea51762b
+                tag: append_error_message_5b1418a1
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.participants
-      tag: foreach_participants_object_value_a474cd8b
+      tag: foreach_participants_object_value_73d8193c
       if: ctx.json?.participants instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_participants_object_value_into_related_ip
+          tag: append_participants_object_value_into_related_ip_0530d842
           value: '{{{_ingest._value.object_value}}}'
           allow_duplicates: false
   - foreach:
       field: json.participants
-      tag: foreach_participants_username
+      tag: foreach_participants_username_33a38056
       if: ctx.json?.participants instanceof List
       processor:
         append:
           field: related.user
-          tag: append_participants_username_into_related_user
+          tag: append_participants_username_into_related_user_069696d5
           value: '{{{_ingest._value.username}}}'
           allow_duplicates: false
   - rename:
       field: json.participants
-      tag: rename_participants
+      tag: rename_participants_1924b492
       target_field: extrahop.detection.participants
       ignore_missing: true
   - rename:
       field: json.properties.certificate
-      tag: rename_properties_certificate
+      tag: rename_properties_certificate_ad58a1d6
       target_field: extrahop.detection.properties.certificate
       ignore_missing: true
   - convert:
       field: json.properties.client_port
-      tag: convert_properties_client_port_to_long
+      tag: convert_properties_client_port_to_long_b39a1fdb
       target_field: extrahop.detection.properties.client_port
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_15c50513
+            tag: append_error_message_e6ebee4e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
-      tag: set_source_port_from_detection_properties_client_port
+      tag: set_source_port_from_detection_properties_client_port_305c23f4
       copy_from: extrahop.detection.properties.client_port
       ignore_empty_value: true
   - rename:
       field: json.properties.hacking_tool_name
-      tag: rename_properties_hacking_tool_name
+      tag: rename_properties_hacking_tool_name_263472d9
       target_field: extrahop.detection.properties.hacking_tool_name
       ignore_missing: true
   - convert:
       field: json.properties.server_port
-      tag: convert_properties_server_port_to_long
+      tag: convert_properties_server_port_to_long_6e6d2f95
       target_field: extrahop.detection.properties.server_port
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_9419db17
+            tag: append_error_message_758fa191
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
-      tag: set_destination_port_from_detection_properties_server_port
+      tag: set_destination_port_from_detection_properties_server_port_30699bf4
       copy_from: extrahop.detection.properties.server_port
       ignore_empty_value: true
   - convert:
       field: json.recommended
-      tag: convert_recommended_to_boolean
+      tag: convert_recommended_to_boolean_446e4893
       target_field: extrahop.detection.recommended
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5ba0a5d7
+            tag: append_error_message_90f47850
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.recommended_factors
-      tag: rename_recommended_factors
+      tag: rename_recommended_factors_22ad4020
       target_field: extrahop.detection.recommended_factors
       ignore_missing: true
   - rename:
       field: json.resolution
-      tag: rename_resolution
+      tag: rename_resolution_ee2dc0be
       target_field: extrahop.detection.resolution
       ignore_missing: true
   - convert:
       field: json.risk_score
-      tag: convert_risk_score_to_long
+      tag: convert_risk_score_to_long_af693304
       target_field: extrahop.detection.risk_score
       type: float
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_25b11484
+            tag: append_error_message_161d6cfe
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.risk_score
-      tag: set_event_risk_score_from_detection_risk_score
+      tag: set_event_risk_score_from_detection_risk_score_43ea11e3
       copy_from: extrahop.detection.risk_score
       ignore_empty_value: true
   - date:
       field: json.start_time
-      tag: date_start_time
+      tag: date_start_time_fd73089d
       target_field: extrahop.detection.start_time
       formats:
         - UNIX_MS
       if: ctx.json?.start_time != null && ctx.json.start_time != ''
       on_failure:
         - append:
-            tag: append_error_message_268c6652
+            tag: append_error_message_b545cd32
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_detection_start_time
+      tag: set_event_start_from_detection_start_time_d425cdfa
       copy_from: extrahop.detection.start_time
       ignore_empty_value: true
   - rename:
       field: json.status
-      tag: rename_status
+      tag: rename_status_16ecf195
       target_field: extrahop.detection.status
       ignore_missing: true
   - convert:
       field: json.ticket_id
-      tag: convert_ticket_id_to_string
+      tag: convert_ticket_id_to_string_e152e6b6
       target_field: extrahop.detection.ticket_id
       type: string
       ignore_missing: true
   - rename:
       field: json.ticket_url
-      tag: rename_ticket_url
+      tag: rename_ticket_url_fc57ccdb
       target_field: extrahop.detection.ticket_url
       ignore_missing: true
   - rename:
       field: json.title
-      tag: rename_title
+      tag: rename_title_4597622a
       target_field: extrahop.detection.title
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_detection_title
+      tag: set_message_from_detection_title_44202249
       copy_from: extrahop.detection.title
       ignore_empty_value: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_c295626b
       target_field: extrahop.detection.type
       ignore_missing: true
   - date:
       field: json.update_time
-      tag: date_update_time
+      tag: date_update_time_b909992d
       target_field: extrahop.detection.update_time
       formats:
         - UNIX_MS
       if: ctx.json?.update_time != null && ctx.json.update_time != ''
       on_failure:
         - append:
-            tag: append_error_message_424508fd
+            tag: append_error_message_ea84024b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.url
-      tag: rename_url
+      tag: rename_url_7f5cf0f9
       target_field: extrahop.detection.url
       ignore_missing: true
   - set:
       field: event.url
-      tag: set_event_url_from_detection_url
+      tag: set_event_url_from_detection_url_b4fffe0d
       copy_from: extrahop.detection.url
       ignore_empty_value: true
   - foreach:
       field: extrahop.detection.mitre_tactics
-      tag: foreach_extrahop_detection_mitre_tactics
+      tag: foreach_extrahop_detection_mitre_tactics_9b6ec51f
       if: ctx.extrahop?.detection?.mitre_tactics instanceof List
       processor:
         remove:
@@ -499,12 +499,12 @@ processors:
             - _ingest._value.id
             - _ingest._value.name
             - _ingest._value.url
-          tag: remove_custom_duplicate_fields_from_extrahop_detection_mitre_tactics
+          tag: remove_custom_duplicate_fields_from_extrahop_detection_mitre_tactics_b792804b
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - foreach:
       field: extrahop.detection.mitre_techniques
-      tag: foreach_extrahop_detection_mitre_techniques
+      tag: foreach_extrahop_detection_mitre_techniques_a60f4370
       if: ctx.extrahop?.detection?.mitre_techniques instanceof List
       processor:
         remove:
@@ -512,7 +512,7 @@ processors:
             - _ingest._value.id
             - _ingest._value.name
             - _ingest._value.url
-          tag: remove_custom_duplicate_fields_from_extrahop_detection_mitre_techniques
+          tag: remove_custom_duplicate_fields_from_extrahop_detection_mitre_techniques_635bed4b
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
@@ -528,15 +528,15 @@ processors:
         - extrahop.detection.start_time
         - extrahop.detection.title
         - extrahop.detection.url
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_baf3056a
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -563,18 +563,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_872cfe3d
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -582,10 +582,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/extrahop/data_stream/detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/extrahop/data_stream/detection/elasticsearch/ingest_pipeline/default.yml
@@ -97,6 +97,7 @@ processors:
       if: ctx.json?.create_time != null && ctx.json.create_time != ''
       on_failure:
         - append:
+            tag: append_error_message_b79de794
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -133,6 +134,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_35ae4b39
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -214,6 +216,7 @@ processors:
       if: ctx.json?.mod_time != null && ctx.json.mod_time != ''
       on_failure:
         - append:
+            tag: append_error_message_99c360ce
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -306,7 +309,7 @@ processors:
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.participants
-      tag: foreach_participants_object_value
+      tag: foreach_json_participants_a474cd8b
       if: ctx.json?.participants instanceof List
       processor:
         append:
@@ -342,6 +345,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_15c50513
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -362,6 +366,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9419db17
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -377,6 +382,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5ba0a5d7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -397,6 +403,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_25b11484
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -413,6 +420,7 @@ processors:
       if: ctx.json?.start_time != null && ctx.json.start_time != ''
       on_failure:
         - append:
+            tag: append_error_message_268c6652
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -460,6 +468,7 @@ processors:
       if: ctx.json?.update_time != null && ctx.json.update_time != ''
       on_failure:
         - append:
+            tag: append_error_message_424508fd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -550,6 +559,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/extrahop/data_stream/investigation/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/extrahop/data_stream/investigation/elasticsearch/ingest_pipeline/default.yml
@@ -285,6 +285,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -295,6 +296,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/extrahop/data_stream/investigation/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/extrahop/data_stream/investigation/elasticsearch/ingest_pipeline/default.yml
@@ -3,10 +3,10 @@ description: Pipeline for processing investigation logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -16,118 +16,118 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata, as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_fbecee35
       target_field: extrahop.investigation
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_a75e9a8a
       value: info
       allow_duplicates: false
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: related.user
-      tag: append_investigation_assignee_into_related_user
+      tag: append_investigation_assignee_into_related_user_9fcc2c98
       value: '{{{extrahop.investigation.assignee}}}'
       allow_duplicates: false
       if: ctx.extrahop?.investigation?.assignee != null
   - dissect:
       field: extrahop.investigation.created_by
-      tag: dissect_created_by
+      tag: dissect_created_by_7098e09a
       description: Extract username and domain from created_by.
       pattern: '%{user.name}@%{user.domain}'
       if: ctx.extrahop?.investigation?.created_by != null
       ignore_failure: true
   - append:
       field: related.user
-      tag: append_investigation_created_by_into_related_user
+      tag: append_investigation_created_by_into_related_user_3c50f393
       value: '{{{extrahop.investigation.created_by}}}'
       allow_duplicates: false
       if: ctx.extrahop?.investigation?.created_by != null
   - date:
       field: extrahop.investigation.creation_time
-      tag: date_creation_time
+      tag: date_creation_time_ec1e5759
       target_field: extrahop.investigation.creation_time
       formats:
         - UNIX_MS
       if: ctx.extrahop?.investigation.creation_time != null && ctx.extrahop.investigation.creation_time != ''
       on_failure:
         - remove:
-            tag: remove_extrahop_investigation_creation_time_d079ba15
+            tag: remove_extrahop_investigation_creation_time_863f252e
             field: extrahop.investigation.creation_time
             ignore_missing: true
         - append:
-            tag: append_error_message_c14230aa
+            tag: append_error_message_98f8b6a4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_investigation_creation_time
+      tag: set_event_created_from_investigation_creation_time_fe73919d
       copy_from: extrahop.investigation.creation_time
       ignore_empty_value: true
   - convert:
       field: extrahop.investigation.detections
-      tag: convert_class_uid_to_string
+      tag: convert_class_uid_to_string_bd32e311
       if: ctx.extrahop?.investigation.detections != null && !ctx.extrahop.investigation.detections.contains(null)
       type: string
       target_field: extrahop.investigation.detections
       ignore_missing: true
   - date:
       field: extrahop.investigation.end_time
-      tag: date_end_time
+      tag: date_end_time_51181d36
       target_field: extrahop.investigation.end_time
       formats:
         - UNIX_MS
       if: ctx.extrahop?.investigation.end_time != null && ctx.extrahop.investigation.end_time != ''
       on_failure:
         - remove:
-            tag: remove_extrahop_investigation_end_time_2a782657
+            tag: remove_extrahop_investigation_end_time_d063f4dc
             field: extrahop.investigation.end_time
             ignore_missing: true
         - append:
-            tag: append_error_message_c69749f0
+            tag: append_error_message_649d89ca
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.end
-      tag: set_event_end_from_investigation_end_time
+      tag: set_event_end_from_investigation_end_time_9f30dec4
       copy_from: extrahop.investigation.end_time
       ignore_empty_value: true
   - convert:
       field: extrahop.investigation.id
-      tag: convert_id_to_string
+      tag: convert_id_to_string_6c2044e1
       target_field: extrahop.investigation.id
       type: string
       ignore_missing: true
   - set:
       field: temp.ingest_time
-      tag: set_temp_timestamp
+      tag: set_temp_timestamp_64d6a330
       value: '{{{_ingest.timestamp}}}'
       ignore_empty_value: true
   - script:
       description: Set event.id using extrahop.investigation.id and _ingest.timestamp.
       lang: painless
-      tag: set_event_id_from_ID_and_ingest_timestamp
+      tag: set_event_id_from_ID_and_ingest_timestamp_a000e3de
       if: ctx.extrahop?.investigation.id != null && ctx.temp?.ingest_time != null
       source: |
         def isoString = ctx.temp.ingest_time;
@@ -140,76 +140,76 @@ processors:
         ctx.event.id = jsonId + '-' + epochMillis;
       on_failure:
         - append:
-            tag: append_error_message_3542463b
+            tag: append_error_message_6c9a9b3f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
       field: temp
-      tag: remove_tempfield
+      tag: remove_tempfield_4c2cc505
       ignore_missing: true
   - convert:
       field: extrahop.investigation.is_user_created
-      tag: convert_is_user_created_to_boolean
+      tag: convert_is_user_created_to_boolean_60f2ad39
       target_field: extrahop.investigation.is_user_created
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_986710ed
+            tag: append_error_message_25458391
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: related.user
-      tag: append_investigation_last_interaction_by_into_related_user
+      tag: append_investigation_last_interaction_by_into_related_user_67547a44
       value: '{{{extrahop.investigation.last_interaction_by}}}'
       allow_duplicates: false
       if: ctx.extrahop?.investigation?.last_interaction_by != null
   - date:
       field: extrahop.investigation.last_interaction_time
-      tag: date_last_interaction_time
+      tag: date_last_interaction_time_106c8c20
       target_field: extrahop.investigation.last_interaction_time
       formats:
         - UNIX_MS
       if: ctx.extrahop?.investigation.last_interaction_time != null && ctx.extrahop.investigation.last_interaction_time != ''
       on_failure:
         - remove:
-            tag: remove_extrahop_investigation_last_interaction_time_a52688f7
+            tag: remove_extrahop_investigation_last_interaction_time_f3a695d9
             field: extrahop.investigation.last_interaction_time
             ignore_missing: true
         - append:
-            tag: append_error_message_19da6556
+            tag: append_error_message_ccd31996
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: message
-      tag: set_message_from_investigation_name
+      tag: set_message_from_investigation_name_e9617312
       copy_from: extrahop.investigation.name
       ignore_empty_value: true
   - date:
       field: extrahop.investigation.start_time
-      tag: date_start_time
+      tag: date_start_time_05137a1f
       target_field: extrahop.investigation.start_time
       formats:
         - UNIX_MS
       if: ctx.extrahop?.investigation.start_time != null && ctx.extrahop.investigation.start_time != ''
       on_failure:
         - remove:
-            tag: remove_extrahop_investigation_start_time_578b29b8
+            tag: remove_extrahop_investigation_start_time_4507bb4a
             field: extrahop.investigation.start_time
             ignore_missing: true
         - append:
-            tag: append_error_message_7d54302c
+            tag: append_error_message_384e87d2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_investigation_start_time
+      tag: set_event_start_from_investigation_start_time_d71f19e7
       copy_from: extrahop.investigation.start_time
       ignore_empty_value: true
   # Calculate event.duration from event.start and event.end
   - script:
       lang: painless
-      tag: calculate_event_duration
+      tag: calculate_event_duration_96bca688
       if: ctx.event?.start != null && ctx.event?.end != null
       source: >-
         Instant eventstart = Instant.parse(ctx.event?.start);
@@ -217,23 +217,23 @@ processors:
         ctx.event['duration'] = ChronoUnit.NANOS.between(eventstart, eventend);
   - date:
       field: extrahop.investigation.update_time
-      tag: date_update_time
+      tag: date_update_time_623b5a9c
       target_field: extrahop.investigation.update_time
       formats:
         - UNIX_MS
       if: ctx.extrahop?.investigation.update_time != null && ctx.extrahop.investigation.update_time != ''
       on_failure:
         - remove:
-            tag: remove_extrahop_investigation_update_time_bc6d79a5
+            tag: remove_extrahop_investigation_update_time_09ff1e6a
             field: extrahop.investigation.update_time
             ignore_missing: true
         - append:
-            tag: append_error_message_0f683842
+            tag: append_error_message_77655dfc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.url
-      tag: set_event_url_from_investigation_url
+      tag: set_event_url_from_investigation_url_375f87b4
       copy_from: extrahop.investigation.url
       ignore_empty_value: true
   - remove:
@@ -243,11 +243,11 @@ processors:
         - extrahop.investigation.name
         - extrahop.investigation.start_time
         - extrahop.investigation.url
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_0594062d
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -274,18 +274,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -293,10 +293,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/extrahop/data_stream/investigation/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/extrahop/data_stream/investigation/elasticsearch/ingest_pipeline/default.yml
@@ -73,9 +73,11 @@ processors:
       if: ctx.extrahop?.investigation.creation_time != null && ctx.extrahop.investigation.creation_time != ''
       on_failure:
         - remove:
+            tag: remove_extrahop_investigation_creation_time_d079ba15
             field: extrahop.investigation.creation_time
             ignore_missing: true
         - append:
+            tag: append_error_message_c14230aa
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -99,9 +101,11 @@ processors:
       if: ctx.extrahop?.investigation.end_time != null && ctx.extrahop.investigation.end_time != ''
       on_failure:
         - remove:
+            tag: remove_extrahop_investigation_end_time_2a782657
             field: extrahop.investigation.end_time
             ignore_missing: true
         - append:
+            tag: append_error_message_c69749f0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -136,6 +140,7 @@ processors:
         ctx.event.id = jsonId + '-' + epochMillis;
       on_failure:
         - append:
+            tag: append_error_message_3542463b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -150,6 +155,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_986710ed
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -167,9 +173,11 @@ processors:
       if: ctx.extrahop?.investigation.last_interaction_time != null && ctx.extrahop.investigation.last_interaction_time != ''
       on_failure:
         - remove:
+            tag: remove_extrahop_investigation_last_interaction_time_a52688f7
             field: extrahop.investigation.last_interaction_time
             ignore_missing: true
         - append:
+            tag: append_error_message_19da6556
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -186,9 +194,11 @@ processors:
       if: ctx.extrahop?.investigation.start_time != null && ctx.extrahop.investigation.start_time != ''
       on_failure:
         - remove:
+            tag: remove_extrahop_investigation_start_time_578b29b8
             field: extrahop.investigation.start_time
             ignore_missing: true
         - append:
+            tag: append_error_message_7d54302c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -214,9 +224,11 @@ processors:
       if: ctx.extrahop?.investigation.update_time != null && ctx.extrahop.investigation.update_time != ''
       on_failure:
         - remove:
+            tag: remove_extrahop_investigation_update_time_bc6d79a5
             field: extrahop.investigation.update_time
             ignore_missing: true
         - append:
+            tag: append_error_message_0f683842
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -266,6 +278,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/extrahop/manifest.yml
+++ b/packages/extrahop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: extrahop
 title: ExtraHop
-version: 0.3.3
+version: 0.4.0
 description: Collect logs from ExtraHop RevealX 360 with Elastic Agent.
 type: integration
 categories:

--- a/packages/extrahop/manifest.yml
+++ b/packages/extrahop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: extrahop
 title: ExtraHop
-version: 0.3.2
+version: 0.3.3
 description: Collect logs from ExtraHop RevealX 360 with Elastic Agent.
 type: integration
 categories:

--- a/packages/neon_cyber/changelog.yml
+++ b/packages/neon_cyber/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.2.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/neon_cyber/changelog.yml
+++ b/packages/neon_cyber/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.2.2"
+- version: "0.3.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/neon_cyber/changelog.yml
+++ b/packages/neon_cyber/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.2.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/neon_cyber/data_stream/detections/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/neon_cyber/data_stream/detections/elasticsearch/ingest_pipeline/default.yml
@@ -4,35 +4,35 @@ processors:
     - set:
           field: ecs.version
           value: 8.17.0
-          tag: set_ecs_version
+          tag: set_ecs_version_dbf680ba
     - terminate:
           if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
           description: error message set and no data to process.
-          tag: data_collection_error
+          tag: data_collection_error_4bdbb3d0
     - set:
           field: event.kind
           value: alert
-          tag: set_event_kind
+          tag: set_event_kind_ab1166ce
     - append:
           field: event.category
           value: network
-          tag: append_event_category
+          tag: append_event_category_a9b06a9f
     - append:
           field: event.type
           value: info
-          tag: append_event_type
+          tag: append_event_type_5eab37e6
     - rename:
           field: message
           target_field: event.original
           ignore_missing: true
           if: ctx.event?.original == null
-          tag: rename_message_original
+          tag: rename_message_original_a7b1f822
     - remove:
           field: message
           ignore_missing: true
           if: 'ctx.event?.original != null'
           description: 'The `message` field is no longer required if the document has an `event.original` field.'
-          tag: remove_field_message
+          tag: remove_field_message_facc4822
     - remove:
           field:
               - organization
@@ -43,260 +43,260 @@ processors:
           description: >-
               Removes the fields added by Agentless as metadata,
               as they can collide with ECS fields.
-          tag: remove_agentless_fields
+          tag: remove_agentless_fields_e6856012
     - json:
           field: event.original
           target_field: json
-          tag: json_parse_original
+          tag: json_parse_original_74d23cc2
     - fingerprint:
           fields:
               - json.inserted_at
               - json.updated_at
               - json.id
           target_field: _id
-          tag: fingerprint_id_field
+          tag: fingerprint_id_field_39f71340
     - date:
           field: json.detection_timestamp
           target_field: neon_cyber.detections.detection_timestamp
-          tag: date_detection_timestamp
+          tag: date_detection_timestamp_fa3a6102
           formats:
               - ISO8601
           on_failure:
               - append:
-                    tag: append_error_message_bd48fdd8
+                    tag: append_error_message_72e33eae
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - date:
           field: json.detection_timestamp
           target_field: '@timestamp'
-          tag: date_timestamp
+          tag: date_timestamp_1e7ff7dd
           formats:
               - ISO8601
           on_failure:
               - append:
-                    tag: append_error_message_33d49aba
+                    tag: append_error_message_2d9b2e57
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - rename:
           field: json.id
           target_field: neon_cyber.detections.id
-          tag: rename_detection_id
+          tag: rename_detection_id_c071bd2f
     - rename:
           field: json.deployment_id
           target_field: neon_cyber.detections.deployment_id
-          tag: rename_deployment_id
+          tag: rename_deployment_id_59537413
     - rename:
           field: json.client_id
           target_field: neon_cyber.detections.client_id
-          tag: rename_client_id
+          tag: rename_client_id_7353b324
     - rename:
           field: json.registration_id
           target_field: neon_cyber.detections.registration_id
-          tag: rename_registration_id
+          tag: rename_registration_id_b0ca9a6a
     - rename:
           field: json.detection_type
           target_field: neon_cyber.detections.detection_type
-          tag: rename_detection_type
+          tag: rename_detection_type_cc0ba998
     - rename:
           field: json.detection_subtype
           target_field: neon_cyber.detections.detection_subtype
           ignore_missing: true
-          tag: rename_detection_subtype
+          tag: rename_detection_subtype_39586ddb
     - rename:
           field: json.source
           target_field: neon_cyber.detections.source
           ignore_missing: true
-          tag: rename_detection_source
+          tag: rename_detection_source_93547aca
     - rename:
           field: json.agent
           target_field: neon_cyber.detections.agent
           ignore_missing: true
-          tag: rename_neon_agent
+          tag: rename_neon_agent_48d98dec
     - rename:
           field: json.description
           target_field: neon_cyber.detections.description
           ignore_missing: true
-          tag: rename_detection_description
+          tag: rename_detection_description_ecf3843a
     - rename:
           field: json.url
           target_field: neon_cyber.detections.url
           ignore_missing: true
-          tag: rename_detection_url
+          tag: rename_detection_url_591b6c0e
     - uri_parts:
           field: neon_cyber.detections.url
           ignore_missing: true
-          tag: uri_parts_detections_url
+          tag: uri_parts_detections_url_d95462b6
     - rename:
           field: json.filename
           target_field: neon_cyber.detections.filename
           ignore_missing: true
-          tag: rename_detection_filename
+          tag: rename_detection_filename_2f9d0069
     - rename:
           field: json.mime
           target_field: neon_cyber.detections.mime
           ignore_missing: true
-          tag: rename_detection_mime
+          tag: rename_detection_mime_28c7bbf1
     - rename:
           field: json.incognito
           target_field: neon_cyber.detections.incognito
           ignore_missing: true
-          tag: rename_detection_incognito
+          tag: rename_detection_incognito_43b5d233
     - rename:
           field: json.referrer
           target_field: neon_cyber.detections.referrer
           ignore_missing: true
-          tag: rename_detection_referrer
+          tag: rename_detection_referrer_19a1f855
     - rename:
           field: json.danger
           target_field: neon_cyber.detections.danger
           ignore_missing: true
-          tag: rename_detection_danger
+          tag: rename_detection_danger_2008dc83
     - rename:
           field: json.total_bytes
           target_field: neon_cyber.detections.total_bytes
           ignore_missing: true
-          tag: rename_detection_total_bytes
+          tag: rename_detection_total_bytes_f307d999
     - rename:
           field: json.action
           target_field: neon_cyber.detections.action
           ignore_missing: true
-          tag: rename_detection_action
+          tag: rename_detection_action_a3ff23cd
     - rename:
           field: json.email
           target_field: neon_cyber.detections.email
           ignore_missing: true
-          tag: rename_detection_email
+          tag: rename_detection_email_25f2f0a8
     - rename:
           field: json.password
           target_field: neon_cyber.detections.password
           ignore_missing: true
-          tag: rename_detection_password
+          tag: rename_detection_password_fdfc5499
     - rename:
           field: json.pii
           target_field: neon_cyber.detections.pii
           ignore_missing: true
-          tag: rename_detection_pii
+          tag: rename_detection_pii_4833c2b5
     - rename:
           field: json.compromised
           target_field: neon_cyber.detections.compromised
           ignore_missing: true
-          tag: rename_detection_compromised
+          tag: rename_detection_compromised_fd12a5b6
     - rename:
           field: json.tab_id
           target_field: neon_cyber.detections.tab_id
           ignore_missing: true
-          tag: rename_detection_tab_id
+          tag: rename_detection_tab_id_96c87799
     - rename:
           field: json.autofill
           target_field: neon_cyber.detections.autofill
           ignore_missing: true
-          tag: rename_detection_autofill
+          tag: rename_detection_autofill_58c9382e
     - rename:
           field: json.catalog_id
           target_field: neon_cyber.detections.catalog_id
           ignore_missing: true
-          tag: rename_detection_catalog_id
+          tag: rename_detection_catalog_id_e80d9a1d
     - rename:
           field: json.arch
           target_field: host.architecture
           ignore_missing: true
-          tag: rename_host_architecture
+          tag: rename_host_architecture_613c2e0c
     - rename:
           field: json.os
           target_field: host.os.platform
           ignore_missing: true
-          tag: rename_host_os_platform
+          tag: rename_host_os_platform_1d19818f
     - rename:
           field: json.latitude
           target_field: host.geo.location.lat
           ignore_missing: true
-          tag: rename_host_geo_lat
+          tag: rename_host_geo_lat_39539031
     - rename:
           field: json.longitude
           target_field: host.geo.location.lon
           ignore_missing: true
-          tag: rename_host_geo_lon
+          tag: rename_host_geo_lon_6198d4e6
     - rename:
           field: json.ip
           target_field: client.nat.ip
           ignore_missing: true
-          tag: rename_client_nat_ip
+          tag: rename_client_nat_ip_ad6ebffb
     - rename:
           field: json.ip_latitude
           target_field: client.geo.location.lat
           ignore_missing: true
-          tag: rename_client_geo_lat
+          tag: rename_client_geo_lat_4e5d6ee3
     - rename:
           field: json.ip_longitude
           target_field: client.geo.location.lon
           ignore_missing: true
-          tag: rename_client_geo_lon
+          tag: rename_client_geo_lon_a65e3f8e
     - rename:
           field: json.city
           target_field: client.geo.city_name
           ignore_missing: true
-          tag: rename_client_city_name
+          tag: rename_client_city_name_c1ca9cba
     - rename:
           field: json.country
           target_field: client.geo.country_name
           ignore_missing: true
-          tag: rename_client_country
+          tag: rename_client_country_c75de64e
     - rename:
           field: json.postal_code
           target_field: client.geo.postal_code
           ignore_missing: true
-          tag: rename_client_postal_code
+          tag: rename_client_postal_code_0dd2c3ed
     - rename:
           field: json.region_code
           target_field: client.geo.region_iso_code
           ignore_missing: true
-          tag: rename_client_iso_code
+          tag: rename_client_iso_code_ab271217
     - rename:
           field: json.region_name
           target_field: client.geo.region_name
           ignore_missing: true
-          tag: rename_client_region_name
+          tag: rename_client_region_name_1652b0d3
     - rename:
           field: json.asn
           target_field: client.as.number
           ignore_missing: true
-          tag: rename_client_as_number
+          tag: rename_client_as_number_31c2b9e1
     - rename:
           field: json.asn_isp
           target_field: client.as.organization.name
           ignore_missing: true
-          tag: rename_client_as_organization
+          tag: rename_client_as_organization_48646f82
     - rename:
           field: json.name
           target_field: user_agent.name
           ignore_missing: true
-          tag: rename_user_agent_name
+          tag: rename_user_agent_name_d49131ac
     - rename:
           field: json.version
           target_field: user_agent.version
           ignore_missing: true
-          tag: rename_user_agent_version
+          tag: rename_user_agent_version_0630bbfa
     - rename:
           field: json.ua
           target_field: user_agent.original
           ignore_missing: true
-          tag: rename_user_agent_original
+          tag: rename_user_agent_original_399a53f4
     - rename:
           field: json.display
           target_field: neon_cyber.detections.display
           ignore_missing: true
-          tag: rename_detections_display
+          tag: rename_detections_display_d37623a1
     - remove:
           field: json.detection_timestamp
-          tag: remove_detection_timestamp
+          tag: remove_detection_timestamp_46bbabb3
     - remove:
           field: json.inserted_at
-          tag: remove_inserted_at
+          tag: remove_inserted_at_c7bba212
     - remove:
           field: json.updated_at
-          tag: remove_updated_at
+          tag: remove_updated_at_a8e3ca54
     - script:
-          tag: drop_nulls
+          tag: drop_nulls_6bfa31e7
           description: Drops null/empty values recursively.
           lang: painless
           source: |
@@ -317,13 +317,13 @@ on_failure:
     - append:
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-          tag: append_error_message
+          tag: append_error_message_6906b116
     - set:
           field: event.kind
           value: pipeline_error
-          tag: set_pipeline_error_to_event_kind
+          tag: set_pipeline_error_to_event_kind_72b1902f
     - append:
           field: tags
           value: preserve_original_event
           allow_duplicates: false
-          tag: append_tags
+          tag: append_tags_279d5a5c

--- a/packages/neon_cyber/data_stream/detections/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/neon_cyber/data_stream/detections/elasticsearch/ingest_pipeline/default.yml
@@ -63,6 +63,7 @@ processors:
               - ISO8601
           on_failure:
               - append:
+                    tag: append_error_message_bd48fdd8
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - date:
@@ -73,6 +74,7 @@ processors:
               - ISO8601
           on_failure:
               - append:
+                    tag: append_error_message_33d49aba
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - rename:

--- a/packages/neon_cyber/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/neon_cyber/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -63,16 +63,18 @@ processors:
               - ISO8601
           on_failure:
               - append:
+                    tag: append_error_message_aecb25a8
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - date:
           field: json.event_timestamp
           target_field: '@timestamp'
-          tag: date_event_timestamp
+          tag: date_json_event_timestamp_to_timestamp_40752292
           formats:
               - ISO8601
           on_failure:
               - append:
+                    tag: append_error_message_6164d83c
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - rename:

--- a/packages/neon_cyber/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/neon_cyber/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -69,7 +69,7 @@ processors:
     - date:
           field: json.event_timestamp
           target_field: '@timestamp'
-          tag: date_json_event_timestamp_to_timestamp_40752292
+          tag: date_event_timestamp_40752292
           formats:
               - ISO8601
           on_failure:

--- a/packages/neon_cyber/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/neon_cyber/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -4,35 +4,35 @@ processors:
     - set:
           field: ecs.version
           value: 8.17.0
-          tag: set_ecs_version
+          tag: set_ecs_version_dbf680ba
     - terminate:
           if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
           description: error message set and no data to process.
-          tag: data_collection_error
+          tag: data_collection_error_4bdbb3d0
     - set:
           field: event.kind
           value: event
-          tag: set_event_kind
+          tag: set_event_kind_d452ef2c
     - append:
           field: event.category
           value: network
-          tag: append_event_category
+          tag: append_event_category_a9b06a9f
     - append:
           field: event.type
           value: info
-          tag: append_event_type
+          tag: append_event_type_5eab37e6
     - rename:
           field: message
           target_field: event.original
           ignore_missing: true
           if: ctx.event?.original == null
-          tag: rename_message_original
+          tag: rename_message_original_a7b1f822
     - remove:
           field: message
           ignore_missing: true
           if: 'ctx.event?.original != null'
           description: 'The `message` field is no longer required if the document has an `event.original` field.'
-          tag: remove_field_message
+          tag: remove_field_message_facc4822
     - remove:
           field:
               - organization
@@ -43,343 +43,343 @@ processors:
           description: >-
               Removes the fields added by Agentless as metadata,
               as they can collide with ECS fields.
-          tag: remove_agentless_fields
+          tag: remove_agentless_fields_e6856012
     - json:
           field: event.original
           target_field: json
-          tag: json_parse_original
+          tag: json_parse_original_74d23cc2
     - fingerprint:
           fields:
               - json.inserted_at
               - json.updated_at
               - json.id
           target_field: _id
-          tag: fingerprint_id_field
+          tag: fingerprint_id_field_39f71340
     - date:
           field: json.event_timestamp
           target_field: neon_cyber.events.event_timestamp
-          tag: date_event_timestamp
+          tag: date_event_timestamp_bc171e42
           formats:
               - ISO8601
           on_failure:
               - append:
-                    tag: append_error_message_aecb25a8
+                    tag: append_error_message_62608852
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - date:
           field: json.event_timestamp
           target_field: '@timestamp'
-          tag: date_event_timestamp_40752292
+          tag: date_event_timestamp_28033f70
           formats:
               - ISO8601
           on_failure:
               - append:
-                    tag: append_error_message_6164d83c
+                    tag: append_error_message_d4e01b41
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
     - rename:
           field: json.id
           target_field: neon_cyber.events.id
-          tag: rename_events_id
+          tag: rename_events_id_3ccebdd3
     - rename:
           field: json.deployment_id
           target_field: neon_cyber.events.deployment_id
-          tag: rename_deployment_id
+          tag: rename_deployment_id_a720206d
     - rename:
           field: json.client_id
           target_field: neon_cyber.events.client_id
-          tag: rename_client_id
+          tag: rename_client_id_be4790db
     - rename:
           field: json.registration_id
           target_field: neon_cyber.events.registration_id
-          tag: rename_registration_id
+          tag: rename_registration_id_4cde5c1b
     - rename:
           field: json.event_type
           target_field: neon_cyber.events.event_type
-          tag: rename_event_type
+          tag: rename_event_type_4d2d4b50
     - rename:
           field: json.arch
           target_field: host.architecture
           ignore_missing: true
-          tag: rename_host_architecture
+          tag: rename_host_architecture_613c2e0c
     - rename:
           field: json.os
           target_field: host.os.platform
           ignore_missing: true
-          tag: rename_host_os_platform
+          tag: rename_host_os_platform_1d19818f
     - rename:
           field: json.latitude
           target_field: host.geo.location.lat
           ignore_missing: true
-          tag: rename_host_geo_lat
+          tag: rename_host_geo_lat_39539031
     - rename:
           field: json.longitude
           target_field: host.geo.location.lon
           ignore_missing: true
-          tag: rename_host_geo_lon
+          tag: rename_host_geo_lon_6198d4e6
     - rename:
           field: json.ip
           target_field: client.nat.ip
           ignore_missing: true
-          tag: rename_client_nat_ip
+          tag: rename_client_nat_ip_ad6ebffb
     - rename:
           field: json.ip_latitude
           target_field: client.geo.location.lat
           ignore_missing: true
-          tag: rename_client_geo_lat
+          tag: rename_client_geo_lat_4e5d6ee3
     - rename:
           field: json.ip_longitude
           target_field: client.geo.location.lon
           ignore_missing: true
-          tag: rename_client_geo_lon
+          tag: rename_client_geo_lon_a65e3f8e
     - rename:
           field: json.city
           target_field: client.geo.city_name
           ignore_missing: true
-          tag: rename_client_city_name
+          tag: rename_client_city_name_c1ca9cba
     - rename:
           field: json.country
           target_field: client.geo.country_name
           ignore_missing: true
-          tag: rename_client_country
+          tag: rename_client_country_c75de64e
     - rename:
           field: json.postal_code
           target_field: client.geo.postal_code
           ignore_missing: true
-          tag: rename_client_postal_code
+          tag: rename_client_postal_code_0dd2c3ed
     - rename:
           field: json.region_code
           target_field: client.geo.region_iso_code
           ignore_missing: true
-          tag: rename_client_iso_code
+          tag: rename_client_iso_code_ab271217
     - rename:
           field: json.region_name
           target_field: client.geo.region_name
           ignore_missing: true
-          tag: rename_client_region_name
+          tag: rename_client_region_name_1652b0d3
     - rename:
           field: json.asn
           target_field: client.as.number
           ignore_missing: true
-          tag: rename_client_as_number
+          tag: rename_client_as_number_31c2b9e1
     - rename:
           field: json.asn_isp
           target_field: client.as.organization.name
           ignore_missing: true
-          tag: rename_client_as_organization
+          tag: rename_client_as_organization_48646f82
     - rename:
           field: json.name
           target_field: user_agent.name
           ignore_missing: true
-          tag: rename_user_agent_name
+          tag: rename_user_agent_name_d49131ac
     - rename:
           field: json.version
           target_field: user_agent.version
           ignore_missing: true
-          tag: rename_user_agent_version
+          tag: rename_user_agent_version_0630bbfa
     - rename:
           field: json.ua
           target_field: user_agent.original
           ignore_missing: true
-          tag: rename_user_agent_original
+          tag: rename_user_agent_original_399a53f4
     - rename:
           field: json.url
           target_field: neon_cyber.events.url
           ignore_missing: true
-          tag: rename_events_url
+          tag: rename_events_url_2d295ecc
     - uri_parts:
           field: neon_cyber.detections.url
           ignore_missing: true
-          tag: uri_parts_detections_url
+          tag: uri_parts_detections_url_d95462b6
     - rename:
           field: json.agent
           target_field: neon_cyber.events.agent
           ignore_missing: true
-          tag: rename_neon_agent
+          tag: rename_neon_agent_c035c75b
     - rename:
           field: json.display
           target_field: neon_cyber.events.display
           ignore_missing: true
-          tag: rename_events_display
+          tag: rename_events_display_00c61bbe
     - rename:
           field: json.tab_id
           target_field: neon_cyber.events.tab_id
           ignore_missing: true
-          tag: rename_events_tab_id
+          tag: rename_events_tab_id_6f90f5a1
     - rename:
           field: json.frame_id
           target_field: neon_cyber.events.frame_id
           ignore_missing: true
-          tag: rename_events_frame_id
+          tag: rename_events_frame_id_388691fd
     - rename:
           field: json.parent_frame_id
           target_field: neon_cyber.events.parent_frame_id
           ignore_missing: true
-          tag: rename_events_parent_frame_id
+          tag: rename_events_parent_frame_id_ab21b6fb
     - rename:
           field: json.download_id
           target_field: neon_cyber.events.download_id
           ignore_missing: true
-          tag: rename_events_download_id
+          tag: rename_events_download_id_2d91fb13
     - rename:
           field: json.filename
           target_field: neon_cyber.events.filename
           ignore_missing: true
-          tag: rename_events_filename
+          tag: rename_events_filename_e63847d5
     - rename:
           field: json.mime
           target_field: neon_cyber.events.mime
           ignore_missing: true
-          tag: rename_events_mime
+          tag: rename_events_mime_fb0967bf
     - rename:
           field: json.incognito
           target_field: neon_cyber.events.incognito
           ignore_missing: true
-          tag: rename_events_incognito
+          tag: rename_events_incognito_f9b591bb
     - rename:
           field: json.referrer
           target_field: neon_cyber.events.referrer
           ignore_missing: true
-          tag: rename_events_referrer
+          tag: rename_events_referrer_4b0abd38
     - rename:
           field: json.danger
           target_field: neon_cyber.events.danger
           ignore_missing: true
-          tag: rename_events_danger
+          tag: rename_events_danger_edd8a34e
     - rename:
           field: json.total_bytes
           target_field: neon_cyber.events.total_bytes
           ignore_missing: true
-          tag: rename_events_total_bytes
+          tag: rename_events_total_bytes_b7f29546
     - rename:
           field: json.description
           target_field: neon_cyber.events.description
           ignore_missing: true
-          tag: rename_events_description
+          tag: rename_events_description_adeed6d1
     - rename:
           field: json.catalog_id
           target_field: neon_cyber.events.catalog_id
           ignore_missing: true
-          tag: rename_events_catalog_id
+          tag: rename_events_catalog_id_a8441e77
     - rename:
           field: json.catalog_name
           target_field: neon_cyber.events.catalog_name
           ignore_missing: true
-          tag: rename_events_catalog_name
+          tag: rename_events_catalog_name_b044db09
     - rename:
           field: json.domains
           target_field: neon_cyber.events.domains
           ignore_missing: true
-          tag: rename_events_domains
+          tag: rename_events_domains_7119c62b
     - date:
           field: json.start_timestamp
           target_field: neon_cyber.events.start_timestamp
           formats:
               - ISO8601
           if: ctx.json?.start_timestamp != null
-          tag: date_events_start_timestamp
+          tag: date_events_start_timestamp_6cc91b69
     - date:
           field: json.end_timestamp
           target_field: neon_cyber.events.end_timestamp
           formats:
               - ISO8601
           if: ctx.json?.end_timestamp != null
-          tag: date_events_end_timestamp
+          tag: date_events_end_timestamp_b0ebb518
     - rename:
           field: json.cumulative
           target_field: neon_cyber.events.cumulative
           ignore_missing: true
-          tag: rename_events_cumulative
+          tag: rename_events_cumulative_ceee38fb
     - rename:
           field: json.auth_method
           target_field: neon_cyber.events.auth_method
           ignore_missing: true
-          tag: rename_events_auth_method
+          tag: rename_events_auth_method_dc8e4f97
     - rename:
           field: json.login
           target_field: neon_cyber.events.login
           ignore_missing: true
-          tag: rename_events_login
+          tag: rename_events_login_e166b9ac
     - rename:
           field: json.mfa
           target_field: neon_cyber.events.mfa
           ignore_missing: true
-          tag: rename_events_mfa
+          tag: rename_events_mfa_a7537a97
     - rename:
           field: json.email
           target_field: neon_cyber.events.email
           ignore_missing: true
-          tag: rename_events_email
+          tag: rename_events_email_b2b9bdcc
     - rename:
           field: json.autofill
           target_field: neon_cyber.events.autofill
           ignore_missing: true
-          tag: rename_events_autofill
+          tag: rename_events_autofill_ed0bcbd3
     - rename:
           field: json.filehash
           target_field: neon_cyber.events.filehash
           ignore_missing: true
-          tag: rename_events_filehash
+          tag: rename_events_filehash_b5a0ba6f
     - rename:
           field: json.extensions
           target_field: neon_cyber.events.extensions
           if: ctx.json.extensions != null
           ignore_failure: true
-          tag: rename_events_extensions
+          tag: rename_events_extensions_ccb34124
     - rename:
           field: json.ext_id
           target_field: neon_cyber.events.ext_id
           ignore_missing: true
-          tag: rename_events_ext_id
+          tag: rename_events_ext_id_6d7797ac
     - rename:
           field: json.ext_name
           target_field: neon_cyber.events.ext_name
           ignore_missing: true
-          tag: rename_events_ext_name
+          tag: rename_events_ext_name_2576e34b
     - rename:
           field: json.ext_enabled
           target_field: neon_cyber.events.ext_enabled
           ignore_missing: true
-          tag: rename_events_ext_enabled
+          tag: rename_events_ext_enabled_9fa7bf17
     - rename:
           field: json.ext_description
           target_field: neon_cyber.events.ext_description
           ignore_missing: true
-          tag: rename_events_ext_description
+          tag: rename_events_ext_description_64f600ce
     - rename:
           field: json.ext_install_type
           target_field: neon_cyber.events.ext_install_type
           ignore_missing: true
-          tag: rename_events_ext_install_type
+          tag: rename_events_ext_install_type_ca7a7f35
     - rename:
           field: json.ext_host_permissions
           target_field: neon_cyber.events.ext_host_permissions
           ignore_missing: true
-          tag: rename_events_ext_host_permissions
+          tag: rename_events_ext_host_permissions_a139a8c6
     - rename:
           field: json.ext_permissions
           target_field: neon_cyber.events.ext_permissions
           ignore_missing: true
-          tag: rename_events_ext_permissions
+          tag: rename_events_ext_permissions_c4ae3123
     - remove:
           field: json.event_timestamp
-          tag: remove_event_timestamp
+          tag: remove_event_timestamp_d8002d42
     - remove:
           field: json.inserted_at
-          tag: remove_inserted_at
+          tag: remove_inserted_at_c7bba212
     - remove:
           field: json.updated_at
-          tag: remove_updated_at
+          tag: remove_updated_at_a8e3ca54
     - remove:
           field: json.start_timestamp
           if: ctx.json?.start_timestamp != null
-          tag: remove_start_timestamp
+          tag: remove_start_timestamp_509cc21e
     - remove:
           field: json.end_timestamp
           if: ctx.json?.end_timestamp != null
-          tag: remove_ent_timestamp
+          tag: remove_ent_timestamp_2fc7f033
     - script:
-          tag: drop_nulls
+          tag: drop_nulls_a52f0a7e
           description: Drops null/empty values recursively.
           lang: painless
           source: |
@@ -400,13 +400,13 @@ on_failure:
     - append:
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-          tag: append_error_message
+          tag: append_error_message_6906b116
     - set:
           field: event.kind
           value: pipeline_error
-          tag: set_pipeline_error_to_event_kind
+          tag: set_pipeline_error_to_event_kind_72b1902f
     - append:
           field: tags
           value: preserve_original_event
           allow_duplicates: false
-          tag: append_tags
+          tag: append_tags_279d5a5c

--- a/packages/neon_cyber/manifest.yml
+++ b/packages/neon_cyber/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: neon_cyber
 title: 'Neon Cyber'
-version: 0.2.1
+version: 0.2.2
 source:
     license: 'Elastic-2.0'
 description: 'The Neon Cyber integration for the Elastic Stack'

--- a/packages/neon_cyber/manifest.yml
+++ b/packages/neon_cyber/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: neon_cyber
 title: 'Neon Cyber'
-version: 0.2.2
+version: 0.3.0
 source:
     license: 'Elastic-2.0'
 description: 'The Neon Cyber integration for the Elastic Stack'

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.3.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.2"
+- version: "0.4.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.3.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -875,6 +875,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -885,6 +886,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -3,17 +3,17 @@ description: Pipeline for processing alert logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -23,28 +23,28 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_ab1166ce
       value: alert
   - fingerprint:
       fields:
@@ -52,188 +52,188 @@ processors:
         - json.time
         - json.created_time
         - json.record_created_at
-      tag: fingerprint_nozomi_networks_alert
+      tag: fingerprint_nozomi_networks_alert_0298cae6
       target_field: _id
       ignore_missing: true
   - convert:
       field: json.ack
-      tag: convert_ack_to_boolean
+      tag: convert_ack_to_boolean_f20c30b7
       target_field: nozomi_networks.alert.ack
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5c2b6b95
+            tag: append_error_message_eecd812a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.appliance_host
-      tag: rename_appliance_host
+      tag: rename_appliance_host_0731dfbc
       target_field: nozomi_networks.alert.appliance_host
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_alert_appliance_host
+      tag: set_host_hostname_from_alert_appliance_host_ae446d85
       copy_from: nozomi_networks.alert.appliance_host
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_alert_appliance_host_into_related_hosts
+      tag: append_alert_appliance_host_into_related_hosts_18f7cc31
       value: '{{{nozomi_networks.alert.appliance_host}}}'
       allow_duplicates: false
   - rename:
       field: json.appliance_id
-      tag: rename_appliance_id
+      tag: rename_appliance_id_8fcc7875
       target_field: nozomi_networks.alert.appliance_id
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_alert_appliance_id
+      tag: set_host_id_from_alert_appliance_id_1212b6b6
       copy_from: nozomi_networks.alert.appliance_id
       ignore_empty_value: true
   - convert:
       field: json.appliance_ip
-      tag: convert_appliance_ip_to_ip
+      tag: convert_appliance_ip_to_ip_8bf99eb1
       target_field: nozomi_networks.alert.appliance_ip
       type: ip
       ignore_missing: true
       if: ctx.json?.appliance_ip != ''
       on_failure:
         - append:
-            tag: append_error_message_d7422d5f
+            tag: append_error_message_ffaf1331
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: host.ip
-      tag: append_nozomi_networks_alert_appliance_ip_into_host_ip
+      tag: append_nozomi_networks_alert_appliance_ip_into_host_ip_47c4d839
       value: '{{{nozomi_networks.alert.appliance_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.appliance_ip != null
   - append:
       field: related.ip
-      tag: append_alert_appliance_ip_into_related_ip
+      tag: append_alert_appliance_ip_into_related_ip_20b10cb4
       value: '{{{nozomi_networks.alert.appliance_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.appliance_ip != null
   - rename:
       field: json.appliance_site
-      tag: rename_appliance_site
+      tag: rename_appliance_site_6f0de5ed
       target_field: nozomi_networks.alert.appliance_site
       ignore_missing: true
   - rename:
       field: json.bpf_filter
-      tag: rename_bpf_filter
+      tag: rename_bpf_filter_80d5a71c
       target_field: nozomi_networks.alert.bpf_filter
       ignore_missing: true
   - rename:
       field: json.capture_device
-      tag: rename_capture_device
+      tag: rename_capture_device_1d9242a7
       target_field: nozomi_networks.alert.capture_device
       ignore_missing: true
   - rename:
       field: json.close_option
-      tag: rename_close_option
+      tag: rename_close_option_f39a8449
       target_field: nozomi_networks.alert.close_option
       ignore_missing: true
   - date:
       field: json.closed_time
-      tag: date_closed_time
+      tag: date_closed_time_f0f28614
       target_field: nozomi_networks.alert.closed_time
       formats:
         - UNIX_MS
       if: ctx.json?.closed_time != null && ctx.json.closed_time != 0
       on_failure:
         - append:
-            tag: append_error_message_e36cb724
+            tag: append_error_message_836a2f69
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.created_time
-      tag: date_created_time
+      tag: date_created_time_684f9956
       target_field: nozomi_networks.alert.created_time
       formats:
         - UNIX_MS
       if: ctx.json?.created_time != null
       on_failure:
         - append:
-            tag: append_error_message_09dfb237
+            tag: append_error_message_3732c285
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_alert_created_time
+      tag: set_event_created_from_alert_created_time_922223b2
       copy_from: nozomi_networks.alert.created_time
       ignore_empty_value: true
   - rename:
       field: json.custom_fields_dst
-      tag: rename_custom_fields_dst
+      tag: rename_custom_fields_dst_44b0bff0
       target_field: nozomi_networks.alert.custom_fields_dst
       ignore_missing: true
   - rename:
       field: json.custom_fields_src
-      tag: rename_custom_fields_src
+      tag: rename_custom_fields_src_e6467241
       target_field: nozomi_networks.alert.custom_fields_src
       ignore_missing: true
   - rename:
       field: json.description
-      tag: rename_description
+      tag: rename_description_ce8a1c47
       target_field: nozomi_networks.alert.description
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_alert_description
+      tag: set_message_from_alert_description_cb10d62e
       copy_from: nozomi_networks.alert.description
       ignore_empty_value: true
   - rename:
       field: json.dst_roles
-      tag: rename_dst_roles
+      tag: rename_dst_roles_59b217c1
       target_field: nozomi_networks.alert.dst_roles
       ignore_missing: true
   - append:
       field: destination.user.roles
-      tag: append_nozomi_networks_alert_dst_roles_into_destination_user_roles
+      tag: append_nozomi_networks_alert_dst_roles_into_destination_user_roles_4dd26d2c
       value: '{{{nozomi_networks.alert.dst_roles}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.dst_roles != null
   - convert:
       field: json.grouped_visible
-      tag: convert_grouped_visible_to_boolean
+      tag: convert_grouped_visible_to_boolean_bdb31fe1
       target_field: nozomi_networks.alert.grouped_visible
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_af2c512f
+            tag: append_error_message_38c5e707
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_cae111bc
       target_field: nozomi_networks.alert.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_alert_id
+      tag: set_event_id_from_alert_id_e689896e
       copy_from: nozomi_networks.alert.id
       ignore_empty_value: true
   - rename:
       field: json.id_dst
-      tag: rename_id_dst
+      tag: rename_id_dst_696559d0
       target_field: nozomi_networks.alert.id_dst
       ignore_missing: true
   - rename:
       field: json.id_src
-      tag: rename_id_src
+      tag: rename_id_src_0a11a723
       target_field: nozomi_networks.alert.id_src
       ignore_missing: true
   - rename:
       field: json.incident_keys
-      tag: rename_incident_keys
+      tag: rename_incident_keys_444dfbec
       target_field: nozomi_networks.alert.incident_keys
       ignore_missing: true
   - convert:
       field: json.ip_dst
-      tag: convert_ip_dst_to_ip
+      tag: convert_ip_dst_to_ip_d12461e9
       target_field: nozomi_networks.alert.destination_ip
       type: ip
       ignore_missing: true
@@ -241,21 +241,21 @@ processors:
       on_failure:
         - rename:
             field: json.ip_dst
-            tag: rename_ip_dst
+            tag: rename_ip_dst_2846b000
             target_field: nozomi_networks.alert.ip_dst
             ignore_missing: true
   - set:
       field: destination.ip
-      tag: set_destination_ip_from_alert_destination_ip
+      tag: set_destination_ip_from_alert_destination_ip_36ee251c
       copy_from: nozomi_networks.alert.destination_ip
       ignore_empty_value: true
   - geoip:
-      tag: geoip_destination_ip_to_destination_geo_ab5e2968
+      tag: geoip_destination_ip_to_destination_geo_71881fab
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   - geoip:
-      tag: geoip_destination_ip_to_destination_as_8a007787
+      tag: geoip_destination_ip_to_destination_as_4e3ec16d
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -265,23 +265,23 @@ processors:
       ignore_missing: true
   - rename:
       field: destination.as.asn
-      tag: rename_destination_as_asn
+      tag: rename_destination_as_asn_4968f9c8
       target_field: destination.as.number
       ignore_missing: true
   - rename:
       field: destination.as.organization_name
-      tag: rename_destination_as_organization_name
+      tag: rename_destination_as_organization_name_fb88b41e
       target_field: destination.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_alert_destination_ip_into_related_ip
+      tag: append_alert_destination_ip_into_related_ip_4c19e2b2
       value: '{{{nozomi_networks.alert.destination_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.destination_ip != null
   - convert:
       field: json.ip_src
-      tag: convert_ip_src_to_ip
+      tag: convert_ip_src_to_ip_33bb69e1
       target_field: nozomi_networks.alert.source_ip
       type: ip
       ignore_missing: true
@@ -289,21 +289,21 @@ processors:
       on_failure:
         - rename:
             field: json.ip_src
-            tag: rename_ip_src
+            tag: rename_ip_src_c00cb156
             target_field: nozomi_networks.alert.ip_src
             ignore_missing: true
   - set:
       field: source.ip
-      tag: set_source_ip_from_alert_ip_src
+      tag: set_source_ip_from_alert_ip_src_e9bce668
       copy_from: nozomi_networks.alert.source_ip
       ignore_empty_value: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
-      tag: geoip_source_ip_to_source_as_28d69883
+      tag: geoip_source_ip_to_source_as_58199963
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -313,61 +313,61 @@ processors:
       ignore_missing: true
   - rename:
       field: source.as.asn
-      tag: rename_source_as_asn
+      tag: rename_source_as_asn_168bbbaf
       target_field: source.as.number
       ignore_missing: true
   - rename:
       field: source.as.organization_name
-      tag: rename_source_as_organization_name
+      tag: rename_source_as_organization_name_aa06a00b
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_alert_source_ip_into_related_ip
+      tag: append_alert_source_ip_into_related_ip_06a9229b
       value: '{{{nozomi_networks.alert.source_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.source_ip != null
   - convert:
       field: json.is_incident
-      tag: convert_is_incident_to_boolean
+      tag: convert_is_incident_to_boolean_6d4e9443
       target_field: nozomi_networks.alert.is_incident
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_90f56253
+            tag: append_error_message_8cadd8fc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_security
-      tag: convert_is_security_to_boolean
+      tag: convert_is_security_to_boolean_7a4ea547
       target_field: nozomi_networks.alert.is_security
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ee62e357
+            tag: append_error_message_ba79646b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.label_dst
-      tag: rename_label_dst
+      tag: rename_label_dst_13ca5c00
       target_field: nozomi_networks.alert.label_dst
       ignore_missing: true
   - append:
       field: related.hosts
-      tag: append_alert_label_dst_into_related_hosts
+      tag: append_alert_label_dst_into_related_hosts_1fd05561
       value: '{{{nozomi_networks.alert.label_dst}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.label_dst != null
   - rename:
       field: json.label_src
-      tag: rename_label_src
+      tag: rename_label_src_873e0263
       target_field: nozomi_networks.alert.label_src
       ignore_missing: true
   - append:
       field: related.hosts
-      tag: append_alert_label_src_into_related_hosts
+      tag: append_alert_label_src_into_related_hosts_2f16a0ad
       value: '{{{nozomi_networks.alert.label_src}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.label_src != null
@@ -375,314 +375,314 @@ processors:
       field: json.mac_dst
       pattern: '[:.]'
       replacement: '-'
-      tag: gsub_mac_dst
+      tag: gsub_mac_dst_6f8f1b1e
       target_field: destination.mac
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_15a1da31
+            tag: append_error_message_d6b73a0b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
       field: destination.mac
-      tag: uppercase_mac_dst
+      tag: uppercase_mac_dst_af527142
       ignore_missing: true
       if: ctx.destination?.mac != ''
       on_failure:
         - append:
-            tag: append_error_message_9c70d5b1
+            tag: append_error_message_f2ab613e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.mac_dst
-      tag: rename_mac_dst
+      tag: rename_mac_dst_52e84968
       target_field: nozomi_networks.alert.mac_dst
       ignore_missing: true
   - gsub:
       field: json.mac_src
       pattern: '[:.]'
       replacement: '-'
-      tag: gsub_src_mac
+      tag: gsub_src_mac_017e62d1
       target_field: source.mac
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_7d3d9226
+            tag: append_error_message_85048ce1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
       field: source.mac
-      tag: uppercase_src_mac
+      tag: uppercase_src_mac_0eb9b30a
       ignore_missing: true
       if: ctx.source?.mac != ''
       on_failure:
         - append:
-            tag: append_error_message_bdc871d0
+            tag: append_error_message_a9c8910e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.mac_src
-      tag: rename_mac_src
+      tag: rename_mac_src_4dd3b46f
       target_field: nozomi_networks.alert.mac_src
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_659277e0
       target_field: nozomi_networks.alert.name
       ignore_missing: true
   - rename:
       field: json.note
-      tag: rename_note
+      tag: rename_note_13148930
       target_field: nozomi_networks.alert.note
       ignore_missing: true
   - rename:
       field: json.parents
-      tag: rename_parents
+      tag: rename_parents_89db4e20
       target_field: nozomi_networks.alert.parents
       ignore_missing: true
   - rename:
       field: json.playbook_contents
-      tag: rename_playbook_contents
+      tag: rename_playbook_contents_05a58570
       target_field: nozomi_networks.alert.playbook_contents
       ignore_missing: true
   - convert:
       field: json.port_dst
-      tag: convert_port_dst_to_long
+      tag: convert_port_dst_to_long_8dbc0600
       target_field: nozomi_networks.alert.port_dst
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c18fd4e5
+            tag: append_error_message_927d1e31
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
-      tag: set_destination_port_from_alert_port_dst
+      tag: set_destination_port_from_alert_port_dst_5474d58e
       copy_from: nozomi_networks.alert.port_dst
       ignore_empty_value: true
   - convert:
       field: json.port_src
-      tag: convert_port_src_to_long
+      tag: convert_port_src_to_long_9e12083f
       target_field: nozomi_networks.alert.port_src
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_42e49728
+            tag: append_error_message_63082343
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
-      tag: set_source_port_from_alert_port_src
+      tag: set_source_port_from_alert_port_src_c45d168e
       copy_from: nozomi_networks.alert.port_src
       ignore_empty_value: true
   - convert:
       field: json.properties.base_risk
-      tag: convert_properties_base_risk_to_long
+      tag: convert_properties_base_risk_to_long_e3ef7c09
       target_field: nozomi_networks.alert.properties.base_risk
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_3a78e55b
+            tag: append_error_message_7b20ab09
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.properties.from_id
-      tag: rename_properties_from_id
+      tag: rename_properties_from_id_01c65eef
       target_field: nozomi_networks.alert.properties.from_id
       ignore_missing: true
   - convert:
       field: json.properties.is_dst_node_learned
-      tag: convert_properties_is_dst_node_learned_to_boolean
+      tag: convert_properties_is_dst_node_learned_to_boolean_652f0029
       target_field: nozomi_networks.alert.properties.is_dst_node_learned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_27d60d07
+            tag: append_error_message_b962a1dc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.properties.is_dst_public
-      tag: convert_properties_is_dst_public_to_boolean
+      tag: convert_properties_is_dst_public_to_boolean_b50cf6f1
       target_field: nozomi_networks.alert.properties.is_dst_public
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_3f70bf6c
+            tag: append_error_message_2c43702f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.properties.is_dst_reputation_bad
-      tag: convert_properties_is_dst_reputation_bad_to_boolean
+      tag: convert_properties_is_dst_reputation_bad_to_boolean_0e5cfeaa
       target_field: nozomi_networks.alert.properties.is_dst_reputation_bad
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_877cad46
+            tag: append_error_message_c53b508c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.properties.is_src_node_learned
-      tag: convert_properties_is_src_node_learned_to_boolean
+      tag: convert_properties_is_src_node_learned_to_boolean_719d75e8
       target_field: nozomi_networks.alert.properties.is_src_node_learned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0a0eee5e
+            tag: append_error_message_087572d6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.properties.is_src_public
-      tag: convert_properties_is_src_public_to_boolean
+      tag: convert_properties_is_src_public_to_boolean_5bdc28dc
       target_field: nozomi_networks.alert.properties.is_src_public
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0a9f77b5
+            tag: append_error_message_cf277441
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.properties.is_src_reputation_bad
-      tag: convert_properties_is_src_reputation_bad_to_boolean
+      tag: convert_properties_is_src_reputation_bad_to_boolean_10e07965
       target_field: nozomi_networks.alert.properties.is_src_reputation_bad
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f445747f
+            tag: append_error_message_e6f4c739
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.properties.mitre_attack_for_ics.destination.levels
-      tag: rename_properties_mitre_attack_for_ics_destination_levels
+      tag: rename_properties_mitre_attack_for_ics_destination_levels_6d67cc59
       target_field: nozomi_networks.alert.properties.mitre_attack_for_ics.destination.levels
       ignore_missing: true
   - rename:
       field: json.properties.mitre_attack_for_ics.destination.types
-      tag: rename_properties_mitre_attack_for_ics_destination_types
+      tag: rename_properties_mitre_attack_for_ics_destination_types_de8da717
       target_field: nozomi_networks.alert.properties.mitre_attack_for_ics.destination.types
       ignore_missing: true
   - rename:
       field: json.properties.mitre_attack_for_ics.source.levels
-      tag: rename_properties_mitre_attack_for_ics_source_levels
+      tag: rename_properties_mitre_attack_for_ics_source_levels_0c9f6d66
       target_field: nozomi_networks.alert.properties.mitre_attack_for_ics.source.levels
       ignore_missing: true
   - rename:
       field: json.properties.mitre_attack_for_ics.source.types
-      tag: rename_properties_mitre_attack_for_ics_source_types
+      tag: rename_properties_mitre_attack_for_ics_source_types_7b5bf4f0
       target_field: nozomi_networks.alert.properties.mitre_attack_for_ics.source.types
       ignore_missing: true
   - rename:
       field: json.properties.n2os_version
-      tag: rename_properties_n2os_version
+      tag: rename_properties_n2os_version_ff5579b1
       target_field: nozomi_networks.alert.properties.n2os_version
       ignore_missing: true
   - rename:
       field: json.properties.raised_by
-      tag: rename_properties_raised_by
+      tag: rename_properties_raised_by_cd3b1d77
       target_field: nozomi_networks.alert.properties.raised_by
       ignore_missing: true
   - rename:
       field: json.properties.to_id
-      tag: rename_properties_to_id
+      tag: rename_properties_to_id_e0930671
       target_field: nozomi_networks.alert.properties.to_id
       ignore_missing: true
   - rename:
       field: json.protocol
-      tag: rename_protocol
+      tag: rename_protocol_80477e96
       target_field: nozomi_networks.alert.protocol
       ignore_missing: true
   - set:
       field: network.protocol
-      tag: set_network_protocol_from_alert_protocol
+      tag: set_network_protocol_from_alert_protocol_21874771
       copy_from: nozomi_networks.alert.protocol
       ignore_empty_value: true
   - lowercase:
       field: network.protocol
-      tag: lowercase_network_protocol
+      tag: lowercase_network_protocol_12733ef1
       ignore_missing: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_0faf7525
       target_field: nozomi_networks.alert.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
-            tag: append_error_message_0bc498e7
+            tag: append_error_message_57388c58
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_alert_record_created_at
+      tag: set_@timestamp_from_alert_record_created_at_553bb006
       copy_from: nozomi_networks.alert.record_created_at
       ignore_empty_value: true
   - convert:
       field: json.replicated
-      tag: convert_replicated_to_boolean
+      tag: convert_replicated_to_boolean_d8a076c1
       target_field: nozomi_networks.alert.replicated
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8dc7a83d
+            tag: append_error_message_e13da966
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk
-      tag: convert_risk_to_double
+      tag: convert_risk_to_double_854af7bd
       target_field: nozomi_networks.alert.risk
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_e9612755
+            tag: append_error_message_21104a1c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.risk_score
-      tag: set_event_risk_score_from_alert_risk
+      tag: set_event_risk_score_from_alert_risk_23040057
       copy_from: nozomi_networks.alert.risk
       ignore_empty_value: true
   - convert:
       field: json.sec_profile_visible
-      tag: convert_sec_profile_visible_to_boolean
+      tag: convert_sec_profile_visible_to_boolean_d55a193c
       target_field: nozomi_networks.alert.sec_profile_visible
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b064be8e
+            tag: append_error_message_ed81c7f3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.session_id
-      tag: rename_session_id
+      tag: rename_session_id_c271a226
       target_field: nozomi_networks.alert.session_id
       ignore_missing: true
   - convert:
       field: json.severity
-      tag: convert_severity_to_long
+      tag: convert_severity_to_long_1fb877e1
       target_field: nozomi_networks.alert.severity
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_331466bd
+            tag: append_error_message_d903ddef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       lang: painless
       description: Script to set event severity and label based on numeric severity scale.
-      tag: set_event_severity_and_label
+      tag: set_event_severity_and_label_dffd1326
       if: ctx.nozomi_networks?.alert?.severity != null
       source: |-
         def severity = ctx.nozomi_networks.alert.severity;
@@ -698,115 +698,115 @@ processors:
           }
   - rename:
       field: json.src_roles
-      tag: rename_src_roles
+      tag: rename_src_roles_cff937df
       target_field: nozomi_networks.alert.src_roles
       ignore_missing: true
   - append:
       field: source.user.roles
-      tag: append_nozomi_networks_alert_src_roles_into_source_user_roles
+      tag: append_nozomi_networks_alert_src_roles_into_source_user_roles_9a8fe1c7
       value: '{{{nozomi_networks.alert.src_roles}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.alert?.src_roles != null
   - rename:
       field: json.status
-      tag: rename_status
+      tag: rename_status_d2f16b83
       target_field: nozomi_networks.alert.status
       ignore_missing: true
   - convert:
       field: json.synchronized
-      tag: convert_synchronized_to_boolean
+      tag: convert_synchronized_to_boolean_1f2c476d
       target_field: nozomi_networks.alert.synchronized
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f7963078
+            tag: append_error_message_c7102e73
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.threat_name
-      tag: rename_threat_name
+      tag: rename_threat_name_cb08083d
       target_field: nozomi_networks.alert.threat_name
       ignore_missing: true
   - rename:
       field: json.ti_source
-      tag: rename_ti_source
+      tag: rename_ti_source_eace2282
       target_field: nozomi_networks.alert.ti_source
       ignore_missing: true
   - date:
       field: json.time
-      tag: date_time
+      tag: date_time_bb710a68
       target_field: nozomi_networks.alert.time
       formats:
         - UNIX_MS
       if: ctx.json?.time != null
       on_failure:
         - append:
-            tag: append_error_message_8cc9de5b
+            tag: append_error_message_f1ec92ea
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.trace_sha1
-      tag: rename_trace_sha1
+      tag: rename_trace_sha1_24ca436a
       target_field: nozomi_networks.alert.trace_sha1
       ignore_missing: true
   - rename:
       field: json.trace_status
-      tag: rename_trace_status
+      tag: rename_trace_status_72155c51
       target_field: nozomi_networks.alert.trace_status
       ignore_missing: true
   - rename:
       field: json.transport_protocol
-      tag: rename_transport_protocol
+      tag: rename_transport_protocol_e1dd4e6d
       target_field: nozomi_networks.alert.transport_protocol
       ignore_missing: true
   - set:
       field: network.transport
-      tag: set_network_transport_from_alert_transport_protocol
+      tag: set_network_transport_from_alert_transport_protocol_bf7243e5
       copy_from: nozomi_networks.alert.transport_protocol
       ignore_empty_value: true
   - lowercase:
       field: network.transport
-      tag: lowercase_network_transport
+      tag: lowercase_network_transport_f67defdb
       ignore_missing: true
   - rename:
       field: json.trigger_id
-      tag: rename_trigger_id
+      tag: rename_trigger_id_190c9d87
       target_field: nozomi_networks.alert.trigger_id
       ignore_missing: true
   - set:
       field: rule.id
-      tag: set_rule_id_from_alert_trigger_id
+      tag: set_rule_id_from_alert_trigger_id_3a428bef
       copy_from: nozomi_networks.alert.trigger_id
       ignore_empty_value: true
   - rename:
       field: json.trigger_type
-      tag: rename_trigger_type
+      tag: rename_trigger_type_60403b45
       target_field: nozomi_networks.alert.trigger_type
       ignore_missing: true
   - set:
       field: rule.name
-      tag: set_rule_name_from_alert_trigger_type
+      tag: set_rule_name_from_alert_trigger_type_b457d003
       copy_from: nozomi_networks.alert.trigger_type
       ignore_empty_value: true
   - rename:
       field: json.type_id
-      tag: rename_type_id
+      tag: rename_type_id_e682b885
       target_field: nozomi_networks.alert.type_id
       ignore_missing: true
   - rename:
       field: json.type_name
-      tag: rename_type_name
+      tag: rename_type_name_4f8398c1
       target_field: nozomi_networks.alert.type_name
       ignore_missing: true
   - rename:
       field: json.zone_dst
-      tag: rename_zone_dst
+      tag: rename_zone_dst_1925687d
       target_field: nozomi_networks.alert.zone_dst
       ignore_missing: true
   - rename:
       field: json.zone_src
-      tag: rename_zone_src
+      tag: rename_zone_src_901ff74d
       target_field: nozomi_networks.alert.zone_src
       ignore_missing: true
   - remove:
@@ -829,15 +829,15 @@ processors:
         - nozomi_networks.alert.transport_protocol
         - nozomi_networks.alert.trigger_id
         - nozomi_networks.alert.trigger_type
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_b19c0f2f
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -864,18 +864,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -883,10 +883,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -62,6 +63,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5c2b6b95
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -98,6 +100,7 @@ processors:
       if: ctx.json?.appliance_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_d7422d5f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -141,6 +144,7 @@ processors:
       if: ctx.json?.closed_time != null && ctx.json.closed_time != 0
       on_failure:
         - append:
+            tag: append_error_message_e36cb724
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -152,6 +156,7 @@ processors:
       if: ctx.json?.created_time != null
       on_failure:
         - append:
+            tag: append_error_message_09dfb237
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -198,6 +203,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_af2c512f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -244,10 +250,12 @@ processors:
       copy_from: nozomi_networks.alert.destination_ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_ab5e2968
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -290,10 +298,12 @@ processors:
       copy_from: nozomi_networks.alert.source_ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -325,6 +335,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_90f56253
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -335,6 +346,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ee62e357
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -368,6 +380,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_15a1da31
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
@@ -377,6 +390,7 @@ processors:
       if: ctx.destination?.mac != ''
       on_failure:
         - append:
+            tag: append_error_message_9c70d5b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -393,6 +407,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7d3d9226
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
@@ -402,6 +417,7 @@ processors:
       if: ctx.source?.mac != ''
       on_failure:
         - append:
+            tag: append_error_message_bdc871d0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -437,6 +453,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c18fd4e5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -452,6 +469,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_42e49728
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -467,6 +485,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3a78e55b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -482,6 +501,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_27d60d07
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -492,6 +512,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3f70bf6c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -502,6 +523,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_877cad46
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -512,6 +534,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0a0eee5e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -522,6 +545,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0a9f77b5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -532,6 +556,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f445747f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -592,6 +617,7 @@ processors:
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
+            tag: append_error_message_0bc498e7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -607,6 +633,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8dc7a83d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -617,6 +644,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e9612755
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -632,6 +660,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b064be8e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -647,6 +676,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_331466bd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -690,6 +720,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f7963078
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -711,6 +742,7 @@ processors:
       if: ctx.json?.time != null
       on_failure:
         - append:
+            tag: append_error_message_8cc9de5b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -836,6 +868,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -3,17 +3,17 @@ description: Pipeline for processing asset logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -23,37 +23,37 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_cbc3f167
       value: host
       allow_duplicates: false
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_a75e9a8a
       value: info
       allow_duplicates: false
   - fingerprint:
@@ -63,248 +63,248 @@ processors:
         - json.created_at
         - json.last_activity_time
         - json.record_created_at
-      tag: fingerprint_nozomi_networks_asset
+      tag: fingerprint_nozomi_networks_asset_bbc68b05
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.activity_times
-      tag: rename_activity_times
+      tag: rename_activity_times_2ebe7f07
       target_field: nozomi_networks.asset.activity_times
       ignore_missing: true
   - foreach:
       field: json.appliance_hosts
       if: ctx.json?.appliance_hosts instanceof List
-      tag: foreach_appliance_hosts_append_to_hostname
+      tag: foreach_appliance_hosts_append_to_hostname_67a8a483
       processor:
         append:
           field: host.hostname
-          tag: append_appliance_hosts_into_host_hostname
+          tag: append_appliance_hosts_into_host_hostname_44796772
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: json.appliance_hosts
       if: ctx.json?.appliance_hosts instanceof List
-      tag: foreach_appliance_hosts_append_to_related_hosts
+      tag: foreach_appliance_hosts_append_to_related_hosts_545313f5
       processor:
         append:
           field: related.hosts
-          tag: append_appliance_hosts_into_related_hosts
+          tag: append_appliance_hosts_into_related_hosts_555536c8
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.appliance_hosts
-      tag: rename_appliance_hosts
+      tag: rename_appliance_hosts_f8f94784
       target_field: nozomi_networks.asset.appliance_hosts
       ignore_missing: true
   - rename:
       field: json._asset_kb_id
-      tag: rename__asset_kb_id
+      tag: rename__asset_kb_id_a8e64ec3
       target_field: nozomi_networks.asset.asset_kb_id
       ignore_missing: true
   - rename:
       field: json.capture_device
-      tag: rename_capture_device
+      tag: rename_capture_device_bbb95706
       target_field: nozomi_networks.asset.capture_device
       ignore_missing: true
   - date:
       field: json.created_at
-      tag: date_created_at
+      tag: date_created_at_52fca50c
       target_field: nozomi_networks.asset.created_at
       formats:
         - UNIX_MS
       if: ctx.json?.created_at != null
       on_failure:
         - append:
-            tag: append_error_message_38bf5935
+            tag: append_error_message_5404f063
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_asset_created_at
+      tag: set_@timestamp_from_asset_created_at_69081e54
       copy_from: nozomi_networks.asset.created_at
       ignore_empty_value: true
   - rename:
       field: json.custom_fields
-      tag: rename_custom_fields
+      tag: rename_custom_fields_e6bbc0c2
       target_field: nozomi_networks.asset.custom_fields
       ignore_missing: true
   - rename:
       field: json.device_id
-      tag: rename_device_id
+      tag: rename_device_id_8edd4802
       target_field: nozomi_networks.asset.device_id
       ignore_missing: true
   - set:
       field: device.id
-      tag: set_device_id_from_asset_device_id
+      tag: set_device_id_from_asset_device_id_53ffc830
       copy_from: nozomi_networks.asset.device_id
       ignore_empty_value: true
   - date:
       field: json.end_of_sale_date
-      tag: date_end_of_sale_date
+      tag: date_end_of_sale_date_5f7fa86a
       target_field: nozomi_networks.asset.end_of_sale_date
       formats:
         - UNIX_MS
       if: ctx.json?.end_of_sale_date != null
       on_failure:
         - append:
-            tag: append_error_message_1bc4e565
+            tag: append_error_message_f4e6e5a6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.end_of_sale_date:info
-      tag: rename_end_of_sale_date:info
+      tag: rename_end_of_sale_date:info_3842ce5a
       target_field: nozomi_networks.asset.end_of_sale_date_info
       ignore_missing: true
   - date:
       field: json.end_of_support_date
-      tag: date_end_of_support_date
+      tag: date_end_of_support_date_b1e7f4d9
       target_field: nozomi_networks.asset.end_of_support_date
       formats:
         - UNIX_MS
       if: ctx.json?.end_of_support_date != null
       on_failure:
         - append:
-            tag: append_error_message_ddcc5931
+            tag: append_error_message_3082c155
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.end_of_support_date:info
-      tag: rename_end_of_support_date:info
+      tag: rename_end_of_support_date:info_893a5892
       target_field: nozomi_networks.asset.end_of_support_date_info
       ignore_missing: true
   - rename:
       field: json.firmware_version
-      tag: rename_firmware_version
+      tag: rename_firmware_version_423482f1
       target_field: nozomi_networks.asset.firmware_version
       ignore_missing: true
   - rename:
       field: json.firmware_version:info
-      tag: rename_firmware_version:info
+      tag: rename_firmware_version:info_b9886f93
       target_field: nozomi_networks.asset.firmware_version_info
       ignore_missing: true
   - convert:
       field: json.has_remediations
-      tag: convert_has_remediations_to_boolean
+      tag: convert_has_remediations_to_boolean_c662f4ca
       target_field: nozomi_networks.asset.has_remediations
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b3ece5b1
+            tag: append_error_message_4c21e090
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_c8d61f52
       target_field: nozomi_networks.asset.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_asset_id
+      tag: set_event_id_from_asset_id_f8180a9b
       copy_from: nozomi_networks.asset.id
       ignore_empty_value: true
   - foreach:
       field: json.ip
       if: ctx.json?.ip instanceof List
-      tag: foreach_ip_convert_ip
+      tag: foreach_ip_convert_ip_dc828c52
       processor:
         convert:
           field: _ingest._value
-          tag: convert_ip_to_ip
+          tag: convert_ip_to_ip_4c8f48d5
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value
+                tag: remove_ingest_value_267368ff
                 field: _ingest._value
             - append:
-                tag: append_error_message
+                tag: append_error_message_a6fc499e
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.ip
       if: ctx.json?.ip instanceof List
-      tag: foreach_ip_append_to_host_ip
+      tag: foreach_ip_append_to_host_ip_b7bbfb34
       processor:
         append:
           field: host.ip
-          tag: append_ip_into_host_ip
+          tag: append_ip_into_host_ip_a3785714
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: json.ip
       if: ctx.json?.ip instanceof List
-      tag: foreach_ip_append_to_related_ip
+      tag: foreach_ip_append_to_related_ip_04f3ad1b
       processor:
         append:
           field: related.ip
-          tag: append_ip_into_related_ip
+          tag: append_ip_into_related_ip_8478449e
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.ip
-      tag: rename_ip
+      tag: rename_ip_dc3086fa
       target_field: nozomi_networks.asset.ip
       ignore_missing: true
   - convert:
       field: json.is_ai_enriched
-      tag: convert_is_ai_enriched_to_boolean
+      tag: convert_is_ai_enriched_to_boolean_687d7923
       target_field: nozomi_networks.asset.is_ai_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8a1b4c60
+            tag: append_error_message_2e550a62
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_arc_enriched
-      tag: convert_is_arc_enriched_to_boolean
+      tag: convert_is_arc_enriched_to_boolean_efc380be
       target_field: nozomi_networks.asset.is_arc_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_9863ca62
+            tag: append_error_message_2d30fa9b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_sp_enriched
-      tag: convert_is_sp_enriched_to_boolean
+      tag: convert_is_sp_enriched_to_boolean_bc37a1f6
       target_field: nozomi_networks.asset.is_sp_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_13d2fac5
+            tag: append_error_message_534b6753
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_ti_enriched
-      tag: convert_is_ti_enriched_to_boolean
+      tag: convert_is_ti_enriched_to_boolean_e05d87ca
       target_field: nozomi_networks.asset.is_ti_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_047e3765
+            tag: append_error_message_c36a6f06
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.last_activity_time
-      tag: date_last_activity_time
+      tag: date_last_activity_time_8a5fbe80
       target_field: nozomi_networks.asset.last_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_activity_time != null
       on_failure:
         - append:
-            tag: append_error_message_243cc535
+            tag: append_error_message_cd38197b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       description: Calculate host uptime in seconds.
-      tag: calculate_host_uptime
+      tag: calculate_host_uptime_e3210bfe
       lang: painless
       if: ctx.json?.last_activity_time != null && ctx.json.created_at != null
       source: |-
@@ -316,49 +316,49 @@ processors:
         ctx.host.uptime = uptimeSeconds;
   - rename:
       field: json.level
-      tag: rename_level
+      tag: rename_level_66c1e856
       target_field: nozomi_networks.asset.level
       ignore_missing: true
   - rename:
       field: json.lifecycle
-      tag: rename_lifecycle
+      tag: rename_lifecycle_ea0dbdf9
       target_field: nozomi_networks.asset.lifecycle
       ignore_missing: true
   - rename:
       field: json.lifecycle:info
-      tag: rename_lifecycle:info
+      tag: rename_lifecycle:info_47d43574
       target_field: nozomi_networks.asset.lifecycle_info
       ignore_missing: true
   - rename:
       field: json.location:info
-      tag: rename_location:info
+      tag: rename_location:info_f466d5f3
       target_field: nozomi_networks.asset.location_info
       ignore_missing: true
   - convert:
       field: json.latitude
-      tag: convert_latitude_to_double
+      tag: convert_latitude_to_double_07215764
       target_field: nozomi_networks.asset.latitude
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2a43a51c
+            tag: append_error_message_2a74134f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.longitude
-      tag: convert_longitude_to_double
+      tag: convert_longitude_to_double_3c211ec2
       target_field: nozomi_networks.asset.longitude
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_eda36d6f
+            tag: append_error_message_d37526fb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       description: Map host.geo.location field.
-      tag: map_host_geo_location
+      tag: map_host_geo_location_d7eb0c46
       lang: painless
       if: ctx.nozomi_networks?.asset?.latitude != null && ctx.nozomi_networks?.asset?.longitude != null
       source: |-
@@ -370,598 +370,598 @@ processors:
         ctx.host.geo.location = locationList;
       on_failure:
         - append:
-            tag: append_error_message_d15cf3f9
+            tag: append_error_message_21900e96
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.mac_address
       if: ctx.json?.mac_address instanceof List
-      tag: foreach_mac_address_append_to_host_mac
+      tag: foreach_mac_address_append_to_host_mac_957f0a08
       processor:
         append:
           field: host.mac
-          tag: append_mac_address_into_host_mac
+          tag: append_mac_address_into_host_mac_fe44d824
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - gsub:
       field: host.mac
-      tag: gsub_host_mac
+      tag: gsub_host_mac_2712428d
       target_field: host.mac
       pattern: '[-:.]'
       replacement: '-'
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c4e630a3
+            tag: append_error_message_3497ed77
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
       field: host.mac
-      tag: uppercase_host_mac
+      tag: uppercase_host_mac_c3a0758f
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f58efe9c
+            tag: append_error_message_e46643b6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.mac_address
-      tag: rename_mac_address
+      tag: rename_mac_address_5a88d651
       target_field: nozomi_networks.asset.mac_address
       ignore_missing: true
   - rename:
       field: json.mac_address_level
-      tag: rename_mac_address_level
+      tag: rename_mac_address_level_2fe4afd7
       target_field: nozomi_networks.asset.mac_address_level
       ignore_missing: true
   - rename:
       field: json.mac_vendor
-      tag: rename_mac_vendor
+      tag: rename_mac_vendor_07db7b03
       target_field: nozomi_networks.asset.mac_vendor
       ignore_missing: true
   - rename:
       field: json.mobility
-      tag: rename_mobility
+      tag: rename_mobility_739668f8
       target_field: nozomi_networks.asset.mobility
       ignore_missing: true
   - rename:
       field: json.mobility:info
-      tag: rename_mobility:info
+      tag: rename_mobility:info_63697e7a
       target_field: nozomi_networks.asset.mobility_info
       ignore_missing: true
   - rename:
       field: json.mobility_votes.asset-kb
-      tag: rename_mobility_votes_asset-kb
+      tag: rename_mobility_votes_asset-kb_3527f4c1
       target_field: nozomi_networks.asset.mobility_votes.asset-kb
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_f6ba8ebf
       target_field: nozomi_networks.asset.name
       ignore_missing: true
   - rename:
       field: json.nodes
-      tag: rename_nodes
+      tag: rename_nodes_df02e902
       target_field: nozomi_networks.asset.nodes
       ignore_missing: true
   - convert:
       field: json.nozomi_risk
-      tag: convert_nozomi_risk_to_double
+      tag: convert_nozomi_risk_to_double_07d297f7
       target_field: nozomi_networks.asset.nozomi_risk
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_575e817c
+            tag: append_error_message_9cc2c3d9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: risk.calculated_score
-      tag: set_risk_calculated_score_from_asset_nozomi_risk
+      tag: set_risk_calculated_score_from_asset_nozomi_risk_5a1c7887
       copy_from: nozomi_networks.asset.nozomi_risk
       ignore_empty_value: true
   - rename:
       field: json.os
-      tag: rename_os
+      tag: rename_os_87f7f507
       target_field: nozomi_networks.asset.os
       ignore_missing: true
   - set:
       field: host.os.name
-      tag: set_host_os_name_from_asset_os
+      tag: set_host_os_name_from_asset_os_e62e44a4
       copy_from: nozomi_networks.asset.os
       ignore_empty_value: true
   - rename:
       field: json.os:info
-      tag: rename_os:info
+      tag: rename_os:info_660c1c01
       target_field: nozomi_networks.asset.os_info
       ignore_missing: true
   - rename:
       field: json.os_or_firmware
-      tag: rename_os_or_firmware
+      tag: rename_os_or_firmware_925b8701
       target_field: nozomi_networks.asset.os_or_firmware
       ignore_missing: true
   - rename:
       field: json.os_or_firmware:info
-      tag: rename_os_or_firmware:info
+      tag: rename_os_or_firmware:info_c6fa1dff
       target_field: nozomi_networks.asset.os_or_firmware_info
       ignore_missing: true
   - rename:
       field: json.product_name
-      tag: rename_product_name
+      tag: rename_product_name_3e674c1a
       target_field: nozomi_networks.asset.product_name
       ignore_missing: true
   - rename:
       field: json.product_name:info
-      tag: rename_product_name:info
+      tag: rename_product_name:info_a80d8cd1
       target_field: nozomi_networks.asset.product_name_info
       ignore_missing: true
   - rename:
       field: json.properties
-      tag: rename_properties
+      tag: rename_properties_75e845a6
       target_field: nozomi_networks.asset.properties
       ignore_missing: true
   - foreach:
       field: json.protocols
       if: ctx.json?.protocols instanceof List
-      tag: foreach_protocols
+      tag: foreach_protocols_59834087
       processor:
         append:
           field: network.protocol
-          tag: append_protocols_into_network_protocol
+          tag: append_protocols_into_network_protocol_55d5916a
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.protocols
-      tag: rename_protocols
+      tag: rename_protocols_7cd963c2
       target_field: nozomi_networks.asset.protocols
       ignore_missing: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_24e7d021
       target_field: nozomi_networks.asset.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
-            tag: append_error_message_f1a97165
+            tag: append_error_message_dffda6d7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.remediations_signatures
-      tag: rename_remediations_signatures
+      tag: rename_remediations_signatures_c39fb3e0
       target_field: nozomi_networks.asset.remediations_signatures
       ignore_missing: true
   - convert:
       field: json.risk
-      tag: convert_risk_to_double
+      tag: convert_risk_to_double_9b9656f7
       target_field: nozomi_networks.asset.risk
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_09f36983
+            tag: append_error_message_778faaa2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.risk_score
-      tag: set_event_risk_score_from_asset_risk
+      tag: set_event_risk_score_from_asset_risk_9bc793d7
       copy_from: nozomi_networks.asset.risk
       ignore_empty_value: true
   - convert:
       field: json.risk_configuration.ai_risk_weight
-      tag: convert_risk_configuration_ai_risk_weight_to_long
+      tag: convert_risk_configuration_ai_risk_weight_to_long_a0b7088c
       target_field: nozomi_networks.asset.risk_configuration.ai_risk_weight
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_fa103412
+            tag: append_error_message_3d2fd419
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.alerts_risk_weight
-      tag: convert_risk_configuration_alerts_risk_weight_to_double
+      tag: convert_risk_configuration_alerts_risk_weight_to_double_d6575dd1
       target_field: nozomi_networks.asset.risk_configuration.alerts_risk_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b2b240df
+            tag: append_error_message_7c66e200
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.asset_criticality
-      tag: convert_risk_configuration_asset_criticality_to_long
+      tag: convert_risk_configuration_asset_criticality_to_long_452e5de8
       target_field: nozomi_networks.asset.risk_configuration.asset_criticality
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4040d2ef
+            tag: append_error_message_c1d0a27d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.asset_criticality_factor
-      tag: convert_risk_configuration_asset_criticality_factor_to_double
+      tag: convert_risk_configuration_asset_criticality_factor_to_double_e905e2d1
       target_field: nozomi_networks.asset.risk_configuration.asset_criticality_factor
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_53a97965
+            tag: append_error_message_04db0b11
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.asset_criticality_weight
-      tag: convert_risk_configuration_asset_criticality_weight_to_double
+      tag: convert_risk_configuration_asset_criticality_weight_to_double_88c8cc31
       target_field: nozomi_networks.asset.risk_configuration.asset_criticality_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_32e48a10
+            tag: append_error_message_9fdace07
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.communication_risk_weight
-      tag: convert_risk_configuration_communication_risk_weight_to_double
+      tag: convert_risk_configuration_communication_risk_weight_to_double_899ad43c
       target_field: nozomi_networks.asset.risk_configuration.communication_risk_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4f99c624
+            tag: append_error_message_56d4e5b4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.compensating_control
-      tag: convert_risk_configuration_compensating_control_to_long
+      tag: convert_risk_configuration_compensating_control_to_long_e88850f3
       target_field: nozomi_networks.asset.risk_configuration.compensating_control
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6f950d6b
+            tag: append_error_message_b16d7075
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.compensating_control_weight
-      tag: convert_risk_configuration_compensating_control_weight_to_double
+      tag: convert_risk_configuration_compensating_control_weight_to_double_0c253706
       target_field: nozomi_networks.asset.risk_configuration.compensating_control_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_af26f970
+            tag: append_error_message_053eb56b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.connection_type_weight
-      tag: convert_risk_configuration_connection_type_weight_to_double
+      tag: convert_risk_configuration_connection_type_weight_to_double_71c56d7f
       target_field: nozomi_networks.asset.risk_configuration.connection_type_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_faa2b171
+            tag: append_error_message_0562956f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.critical_vulnerabilities_weight
-      tag: convert_risk_configuration_critical_vulnerabilities_weight_to_double
+      tag: convert_risk_configuration_critical_vulnerabilities_weight_to_double_00a61c42
       target_field: nozomi_networks.asset.risk_configuration.critical_vulnerabilities_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a8449afe
+            tag: append_error_message_c223fcf6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.device_risk_weight
-      tag: convert_risk_configuration_device_risk_weight_to_double
+      tag: convert_risk_configuration_device_risk_weight_to_double_4c1f87ff
       target_field: nozomi_networks.asset.risk_configuration.device_risk_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a4cd558c
+            tag: append_error_message_3644403f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.exploitable_vulnerabilities_epss_score
-      tag: convert_risk_configuration_exploitable_vulnerabilities_epss_score_to_double
+      tag: convert_risk_configuration_exploitable_vulnerabilities_epss_score_to_double_d7a7d4e1
       target_field: nozomi_networks.asset.risk_configuration.exploitable_vulnerabilities_epss_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_612c300c
+            tag: append_error_message_a7e2ddbf
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.exploitable_vulnerabilities_weight
-      tag: convert_risk_configuration_exploitable_vulnerabilities_weight_to_double
+      tag: convert_risk_configuration_exploitable_vulnerabilities_weight_to_double_18aa4405
       target_field: nozomi_networks.asset.risk_configuration.exploitable_vulnerabilities_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b2d994f6
+            tag: append_error_message_916079f5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.high_risk_alert_level
-      tag: convert_risk_configuration_high_risk_alert_level_to_long
+      tag: convert_risk_configuration_high_risk_alert_level_to_long_00e925a5
       target_field: nozomi_networks.asset.risk_configuration.high_risk_alert_level
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_e8ad85d9
+            tag: append_error_message_2168740d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.high_risk_alerts_weight
-      tag: convert_risk_configuration_high_risk_alerts_weight_to_double
+      tag: convert_risk_configuration_high_risk_alerts_weight_to_double_8cc7e548
       target_field: nozomi_networks.asset.risk_configuration.high_risk_alerts_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_3c2e2a76
+            tag: append_error_message_80af31fb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.high_risk_vulnerabilities_level
-      tag: convert_risk_configuration_high_risk_vulnerabilities_level_to_long
+      tag: convert_risk_configuration_high_risk_vulnerabilities_level_to_long_80d37312
       target_field: nozomi_networks.asset.risk_configuration.high_risk_vulnerabilities_level
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_210d965d
+            tag: append_error_message_df2a0488
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.internet_exposure_weight
-      tag: convert_risk_configuration_internet_exposure_weight_to_double
+      tag: convert_risk_configuration_internet_exposure_weight_to_double_18694eb9
       target_field: nozomi_networks.asset.risk_configuration.internet_exposure_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c8f3407f
+            tag: append_error_message_24cda5e1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.lifecycle_weight
-      tag: convert_risk_configuration_lifecycle_weight_to_double
+      tag: convert_risk_configuration_lifecycle_weight_to_double_cda8f609
       target_field: nozomi_networks.asset.risk_configuration.lifecycle_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a2e2e320
+            tag: append_error_message_18593360
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.network_activity_weight
-      tag: convert_risk_configuration_network_activity_weight_to_double
+      tag: convert_risk_configuration_network_activity_weight_to_double_63fdfda8
       target_field: nozomi_networks.asset.risk_configuration.network_activity_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_abfdb1d0
+            tag: append_error_message_0908ed53
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.open_alerts_weight
-      tag: convert_risk_configuration_open_alerts_weight_to_double
+      tag: convert_risk_configuration_open_alerts_weight_to_double_083deefa
       target_field: nozomi_networks.asset.risk_configuration.open_alerts_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6b4541de
+            tag: append_error_message_ad895b03
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.open_vulnerabilities_likelihood
-      tag: convert_risk_configuration_open_vulnerabilities_likelihood_to_double
+      tag: convert_risk_configuration_open_vulnerabilities_likelihood_to_double_cdc28221
       target_field: nozomi_networks.asset.risk_configuration.open_vulnerabilities_likelihood
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a9ecf72f
+            tag: append_error_message_4be2b948
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.open_vulnerabilities_weight
-      tag: convert_risk_configuration_open_vulnerabilities_weight_to_double
+      tag: convert_risk_configuration_open_vulnerabilities_weight_to_double_7678036c
       target_field: nozomi_networks.asset.risk_configuration.open_vulnerabilities_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_361d6329
+            tag: append_error_message_1f73b7e3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.risk_mitigation_factor
-      tag: convert_risk_configuration_risk_mitigation_factor_to_double
+      tag: convert_risk_configuration_risk_mitigation_factor_to_double_63e04ec7
       target_field: nozomi_networks.asset.risk_configuration.risk_mitigation_factor
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a36cd84a
+            tag: append_error_message_9f9e67af
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.suboptimal_management_weight
-      tag: convert_risk_configuration_suboptimal_management_weight_to_double
+      tag: convert_risk_configuration_suboptimal_management_weight_to_double_1c5129f6
       target_field: nozomi_networks.asset.risk_configuration.suboptimal_management_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ca9b6956
+            tag: append_error_message_5237e5af
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.technology_category_weight
-      tag: convert_risk_configuration_technology_category_weight_to_double
+      tag: convert_risk_configuration_technology_category_weight_to_double_cf333544
       target_field: nozomi_networks.asset.risk_configuration.technology_category_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_1ee2611f
+            tag: append_error_message_7ec69e02
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.type_weight
-      tag: convert_risk_configuration_type_weight_to_double
+      tag: convert_risk_configuration_type_weight_to_double_c485c802
       target_field: nozomi_networks.asset.risk_configuration.type_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4c5120be
+            tag: append_error_message_e5053922
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.risk_configuration.unsafe_countries_list
-      tag: rename_risk_configuration_unsafe_countries_list
+      tag: rename_risk_configuration_unsafe_countries_list_c77db5c1
       target_field: nozomi_networks.asset.risk_configuration.unsafe_countries_list
       ignore_missing: true
   - convert:
       field: json.risk_configuration.unsafe_countries_weight
-      tag: convert_risk_configuration_unsafe_countries_weight_to_double
+      tag: convert_risk_configuration_unsafe_countries_weight_to_double_ef0f249f
       target_field: nozomi_networks.asset.risk_configuration.unsafe_countries_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_31d18f8f
+            tag: append_error_message_3f8bdbd8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.risk_configuration.unsafe_protocols_list
-      tag: rename_risk_configuration_unsafe_protocols_list
+      tag: rename_risk_configuration_unsafe_protocols_list_81818bbb
       target_field: nozomi_networks.asset.risk_configuration.unsafe_protocols_list
       ignore_missing: true
   - convert:
       field: json.risk_configuration.unsafe_protocols_weight
-      tag: convert_risk_configuration_unsafe_protocols_weight_to_double
+      tag: convert_risk_configuration_unsafe_protocols_weight_to_double_c100a320
       target_field: nozomi_networks.asset.risk_configuration.unsafe_protocols_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d3e25e76
+            tag: append_error_message_3adcde72
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.risk_configuration.vulnerabilities_risk_weight
-      tag: convert_risk_configuration_vulnerabilities_risk_weight_to_double
+      tag: convert_risk_configuration_vulnerabilities_risk_weight_to_double_37af63df
       target_field: nozomi_networks.asset.risk_configuration.vulnerabilities_risk_weight
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0ba34c2e
+            tag: append_error_message_f8052065
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.roles
-      tag: rename_roles
+      tag: rename_roles_e301e664
       target_field: nozomi_networks.asset.roles
       ignore_missing: true
   - rename:
       field: json.serial_number
-      tag: rename_serial_number
+      tag: rename_serial_number_f21d4164
       target_field: nozomi_networks.asset.serial_number
       ignore_missing: true
   - rename:
       field: json.serial_number:info
-      tag: rename_serial_number:info
+      tag: rename_serial_number:info_d8354002
       target_field: nozomi_networks.asset.serial_number_info
       ignore_missing: true
   - foreach:
       field: json.tags
       if: ctx.json?.tags instanceof List
-      tag: foreach_tags
+      tag: foreach_tags_5a1d8c27
       processor:
         append:
           field: tags
-          tag: append_nozomi_networks_asset_tags_into_tags
+          tag: append_nozomi_networks_asset_tags_into_tags_7d531aae
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.tags
-      tag: rename_tags
+      tag: rename_tags_bb7e759b
       target_field: nozomi_networks.asset.tags
       ignore_missing: true
   - rename:
       field: json.technology_category
-      tag: rename_technology_category
+      tag: rename_technology_category_f631b429
       target_field: nozomi_networks.asset.technology_category
       ignore_missing: true
   - date:
       field: json.time
-      tag: date_time
+      tag: date_time_36b6a820
       target_field: nozomi_networks.asset.time
       formats:
         - UNIX_MS
       if: ctx.json?.time != null
       on_failure:
         - append:
-            tag: append_error_message_b681cb9d
+            tag: append_error_message_bc22b542
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_37660510
       target_field: nozomi_networks.asset.type
       ignore_missing: true
   - rename:
       field: json.type:info
-      tag: rename_type:info
+      tag: rename_type:info_ba410cb9
       target_field: nozomi_networks.asset.type_info
       ignore_missing: true
   - rename:
       field: json.vendor
-      tag: rename_vendor
+      tag: rename_vendor_68954a26
       target_field: nozomi_networks.asset.vendor
       ignore_missing: true
   - rename:
       field: json.vendor:info
-      tag: rename_vendor:info
+      tag: rename_vendor:info_c81ba197
       target_field: nozomi_networks.asset.vendor_info
       ignore_missing: true
   - foreach:
       field: json.vlan_id
       if: ctx.json?.vlan_id instanceof List
-      tag: foreach_vlan_id
+      tag: foreach_vlan_id_df350da8
       processor:
         append:
           field: network.vlan.id
-          tag: append_vlan_id_into_network_vlan_id
+          tag: append_vlan_id_into_network_vlan_id_0236ae67
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.vlan_id
-      tag: rename_vlan_id
+      tag: rename_vlan_id_45d2b520
       target_field: nozomi_networks.asset.vlan_id
       ignore_missing: true
   - rename:
       field: json.zones
-      tag: rename_zones
+      tag: rename_zones_66925d0e
       target_field: nozomi_networks.asset.zones
       ignore_missing: true
   - remove:
@@ -977,15 +977,15 @@ processors:
         - nozomi_networks.asset.protocols
         - nozomi_networks.asset.risk
         - nozomi_networks.asset.vlan_id
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_804efd08
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -1012,18 +1012,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_4575403f
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -1031,10 +1031,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -114,6 +115,7 @@ processors:
       if: ctx.json?.created_at != null
       on_failure:
         - append:
+            tag: append_error_message_38bf5935
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -145,6 +147,7 @@ processors:
       if: ctx.json?.end_of_sale_date != null
       on_failure:
         - append:
+            tag: append_error_message_1bc4e565
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -161,6 +164,7 @@ processors:
       if: ctx.json?.end_of_support_date != null
       on_failure:
         - append:
+            tag: append_error_message_ddcc5931
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -186,6 +190,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b3ece5b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -247,6 +252,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8a1b4c60
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -257,6 +263,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9863ca62
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -267,6 +274,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_13d2fac5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -277,6 +285,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_047e3765
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -288,6 +297,7 @@ processors:
       if: ctx.json?.last_activity_time != null
       on_failure:
         - append:
+            tag: append_error_message_243cc535
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -330,6 +340,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2a43a51c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -340,6 +351,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_eda36d6f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -356,6 +368,7 @@ processors:
         ctx.host.geo.location = locationList;
       on_failure:
         - append:
+            tag: append_error_message_d15cf3f9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -377,6 +390,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c4e630a3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
@@ -385,6 +399,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f58efe9c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -435,6 +450,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_575e817c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -506,6 +522,7 @@ processors:
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
+            tag: append_error_message_f1a97165
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -521,6 +538,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_09f36983
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -536,6 +554,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fa103412
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -546,6 +565,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b2b240df
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -556,6 +576,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4040d2ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -566,6 +587,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_53a97965
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -576,6 +598,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_32e48a10
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -586,6 +609,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4f99c624
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -596,6 +620,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6f950d6b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -606,6 +631,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_af26f970
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -616,6 +642,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_faa2b171
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -626,6 +653,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a8449afe
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -636,6 +664,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a4cd558c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -646,6 +675,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_612c300c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -656,6 +686,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b2d994f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -666,6 +697,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e8ad85d9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -676,6 +708,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3c2e2a76
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -686,6 +719,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_210d965d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -696,6 +730,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c8f3407f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -706,6 +741,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a2e2e320
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -716,6 +752,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_abfdb1d0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -726,6 +763,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6b4541de
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -736,6 +774,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a9ecf72f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -746,6 +785,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_361d6329
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -756,6 +796,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a36cd84a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -766,6 +807,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ca9b6956
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -776,6 +818,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1ee2611f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -786,6 +829,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4c5120be
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -801,6 +845,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_31d18f8f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -816,6 +861,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d3e25e76
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -826,6 +872,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0ba34c2e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -872,6 +919,7 @@ processors:
       if: ctx.json?.time != null
       on_failure:
         - append:
+            tag: append_error_message_b681cb9d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -966,6 +1014,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -215,8 +215,10 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value
                 field: _ingest._value
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1021,6 +1023,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_4575403f
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -1031,6 +1034,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -3,10 +3,10 @@ description: Pipeline for processing audit logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -16,141 +16,141 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - fingerprint:
       fields:
         - json.id
         - json.record_created_at
         - json.time
-      tag: fingerprint_nozomi_networks_audit
+      tag: fingerprint_nozomi_networks_audit_788c9add
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.action
-      tag: rename_action
+      tag: rename_action_9eec9447
       target_field: nozomi_networks.audit.action
       ignore_missing: true
   - set:
       field: event.action
-      tag: set_event_action_from_audit_action
+      tag: set_event_action_from_audit_action_7addd2f4
       copy_from: nozomi_networks.audit.action
       ignore_empty_value: true
   - lowercase:
       field: event.action
-      tag: lowercase_event_action
+      tag: lowercase_event_action_945f0fcf
       ignore_missing: true
   - gsub:
       field: event.action
-      tag: gsub_event_action
+      tag: gsub_event_action_b6ce8b0e
       target_field: event.action
       pattern: '[/:-]'
       replacement: ''
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_01b68fd4
+            tag: append_error_message_b90ca501
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.browser
-      tag: rename_browser
+      tag: rename_browser_635b85b0
       target_field: nozomi_networks.audit.browser
       ignore_missing: true
   - user_agent:
-      tag: user_agent_nozomi_networks_audit_browser_aa9d400c
+      tag: user_agent_nozomi_networks_audit_browser_39d5b9c6
       field: nozomi_networks.audit.browser
       ignore_missing: true
   - set:
       field: user_agent.original
-      tag: set_user_agent_original
+      tag: set_user_agent_original_77fbebeb
       copy_from: nozomi_networks.audit.browser
       if: ctx.user_agent?.original == null
       ignore_empty_value: true
   - rename:
       field: json.controller
-      tag: rename_controller
+      tag: rename_controller_01861d24
       target_field: nozomi_networks.audit.controller
       ignore_missing: true
   - rename:
       field: json.details
-      tag: rename_details
+      tag: rename_details_43d75ba7
       target_field: nozomi_networks.audit.details
       ignore_missing: true
   - rename:
       field: json.event
-      tag: rename_event
+      tag: rename_event_1bc781d9
       target_field: nozomi_networks.audit.event
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_audit_event
+      tag: set_message_from_audit_event_780798ec
       copy_from: nozomi_networks.audit.event
       ignore_empty_value: true
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_8145c33f
       target_field: nozomi_networks.audit.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_audit_id
+      tag: set_event_id_from_audit_id_9da1ec1e
       copy_from: nozomi_networks.audit.id
       ignore_empty_value: true
   - convert:
       field: json.ip_address
-      tag: convert_ip_address_to_ip
+      tag: convert_ip_address_to_ip_7b12390a
       target_field: nozomi_networks.audit.ip_address
       type: ip
       ignore_missing: true
       if: ctx.json?.ip_address != ''
       on_failure:
         - append:
-            tag: append_error_message_614c3056
+            tag: append_error_message_b2440624
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
-      tag: set_source_ip_from_audit_ip_address
+      tag: set_source_ip_from_audit_ip_address_c2d9cc45
       copy_from: nozomi_networks.audit.ip_address
       ignore_empty_value: true
   - geoip:
       field: source.ip
-      tag: geoip_source_ip
+      tag: geoip_source_ip_9a2d4d31
       target_field: source.geo
       ignore_missing: true
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
-      tag: geoip_source_as
+      tag: geoip_source_as_58199963
       target_field: source.as
       properties:
         - asn
@@ -158,79 +158,79 @@ processors:
       ignore_missing: true
   - rename:
       field: source.as.asn
-      tag: rename_source_as_asn
+      tag: rename_source_as_asn_168bbbaf
       target_field: source.as.number
       ignore_missing: true
   - rename:
       field: source.as.organization_name
-      tag: rename_source_as_organization_name
+      tag: rename_source_as_organization_name_aa06a00b
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_audit_ip_address_into_related_ip
+      tag: append_audit_ip_address_into_related_ip_42b296ba
       value: '{{{nozomi_networks.audit.ip_address}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.audit?.ip_address != null
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_a9688855
       target_field: nozomi_networks.audit.name
       ignore_missing: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_4bb0d840
       target_field: nozomi_networks.audit.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null && ctx.json.record_created_at != ''
       on_failure:
         - append:
-            tag: append_error_message_b668c849
+            tag: append_error_message_2f043cff
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_audit_record_created_at
+      tag: set_@timestamp_from_audit_record_created_at_ed82f4a7
       copy_from: nozomi_networks.audit.record_created_at
       ignore_empty_value: true
   - date:
       field: json.time
-      tag: date_time
+      tag: date_time_cd64cea5
       target_field: nozomi_networks.audit.time
       formats:
         - UNIX_MS
       if: ctx.json?.time != null && ctx.json.time != ''
       on_failure:
         - append:
-            tag: append_error_message_cadec2e8
+            tag: append_error_message_756af335
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.username
-      tag: rename_username
+      tag: rename_username_6972b53b
       target_field: nozomi_networks.audit.username
       ignore_missing: true
   - grok:
       field: nozomi_networks.audit.username
-      tag: grok_nozomi_networks_audit_username
+      tag: grok_nozomi_networks_audit_username_fda7f751
       patterns:
         - '^%{EMAILADDRESS:user.email} %{DATA}$'
       ignore_failure: true
   - dissect:
       if: ctx.user?.email != null && ctx.user.email.contains('@')
-      tag: dissect_user_email
+      tag: dissect_user_email_71c776e8
       field: user.email
       pattern: '%{user.name}@%{user.domain}'
   - append:
       field: related.user
-      tag: append_audit_username_into_related_user
+      tag: append_audit_username_into_related_user_325195a6
       value: '{{{user.name}}}'
       allow_duplicates: false
       if: ctx.user?.name != null
   - append:
       field: related.user
-      tag: append_audit_username_into_related_user_fc96f0f9
+      tag: append_audit_username_into_related_user_b9ac313b
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
@@ -241,15 +241,15 @@ processors:
         - nozomi_networks.audit.id
         - nozomi_networks.audit.ip_address
         - nozomi_networks.audit.record_created_at
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_dd4e9478
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -276,18 +276,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -295,10 +295,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -230,7 +230,7 @@ processors:
       if: ctx.user?.name != null
   - append:
       field: related.user
-      tag: append_related_user_fc96f0f9
+      tag: append_audit_username_into_related_user_fc96f0f9
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
@@ -287,6 +287,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -297,6 +298,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -76,6 +77,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_01b68fd4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -84,6 +86,7 @@ processors:
       target_field: nozomi_networks.audit.browser
       ignore_missing: true
   - user_agent:
+      tag: user_agent_nozomi_networks_audit_browser_aa9d400c
       field: nozomi_networks.audit.browser
       ignore_missing: true
   - set:
@@ -131,6 +134,7 @@ processors:
       if: ctx.json?.ip_address != ''
       on_failure:
         - append:
+            tag: append_error_message_614c3056
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -182,6 +186,7 @@ processors:
       if: ctx.json?.record_created_at != null && ctx.json.record_created_at != ''
       on_failure:
         - append:
+            tag: append_error_message_b668c849
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -198,6 +203,7 @@ processors:
       if: ctx.json?.time != null && ctx.json.time != ''
       on_failure:
         - append:
+            tag: append_error_message_cadec2e8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -224,7 +230,7 @@ processors:
       if: ctx.user?.name != null
   - append:
       field: related.user
-      tag: append_audit_username_into_related_user
+      tag: append_related_user_fc96f0f9
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
@@ -274,6 +280,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -75,7 +76,7 @@ processors:
       ignore_empty_value: true
   - set:
       field: host.name
-      tag: set_host_hostname_from_health_appliance_host
+      tag: set_host_name_c1844dfc
       copy_from: nozomi_networks.health.appliance_host
       ignore_empty_value: true
   - append:
@@ -109,6 +110,7 @@ processors:
       if: ctx.json?.appliance_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_31f7cbc5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -147,6 +149,7 @@ processors:
       if: ctx.json?.record_created_at != null && ctx.json.record_created_at != ''
       on_failure:
         - append:
+            tag: append_error_message_a59536ce
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -167,6 +170,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_eff5d58d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -214,6 +218,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c0388d50
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -225,6 +230,7 @@ processors:
       if: ctx.json?.time != null && ctx.json.time != ''
       on_failure:
         - append:
+            tag: append_error_message_a0512bc1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -275,6 +281,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -76,7 +76,7 @@ processors:
       ignore_empty_value: true
   - set:
       field: host.name
-      tag: set_host_name_c1844dfc
+      tag: set_host_hostname_from_health_appliance_host_c1844dfc
       copy_from: nozomi_networks.health.appliance_host
       ignore_empty_value: true
   - append:
@@ -288,6 +288,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -298,6 +299,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -3,10 +3,10 @@ description: Pipeline for processing health logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -16,44 +16,44 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_cbc3f167
       value: host
       allow_duplicates: false
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_a75e9a8a
       value: info
       allow_duplicates: false
   - fingerprint:
@@ -61,176 +61,176 @@ processors:
         - json.id
         - json.record_created_at
         - json.time
-      tag: fingerprint_nozomi_networks_health
+      tag: fingerprint_nozomi_networks_health_788c9add
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.appliance_host
-      tag: rename_appliance_host
+      tag: rename_appliance_host_ca618294
       target_field: nozomi_networks.health.appliance_host
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_health_appliance_host
+      tag: set_host_hostname_from_health_appliance_host_2ba174bd
       copy_from: nozomi_networks.health.appliance_host
       ignore_empty_value: true
   - set:
       field: host.name
-      tag: set_host_hostname_from_health_appliance_host_c1844dfc
+      tag: set_host_name_from_health_appliance_host_adea30d1
       copy_from: nozomi_networks.health.appliance_host
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_health_appliance_host_into_related_hosts
+      tag: append_health_appliance_host_into_related_hosts_f05406c8
       value: '{{{nozomi_networks.health.appliance_host}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.health?.appliance_host != null
   - rename:
       field: json.appliance_id
-      tag: rename_appliance_id
+      tag: rename_appliance_id_7a7577d1
       target_field: nozomi_networks.health.appliance_id
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_health_appliance_id
+      tag: set_host_id_from_health_appliance_id_d3386f4d
       copy_from: nozomi_networks.health.appliance_id
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_health_appliance_id_into_related_hosts
+      tag: append_health_appliance_id_into_related_hosts_607728ae
       value: '{{{nozomi_networks.health.appliance_id}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.health?.appliance_id != null
   - convert:
       field: json.appliance_ip
-      tag: convert_appliance_ip_to_ip
+      tag: convert_appliance_ip_to_ip_0173bbdb
       target_field: nozomi_networks.health.appliance_ip
       type: ip
       ignore_missing: true
       if: ctx.json?.appliance_ip != ''
       on_failure:
         - append:
-            tag: append_error_message_31f7cbc5
+            tag: append_error_message_293a22c2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: host.ip
-      tag: append_nozomi_networks_health_appliance_ip_into_host_ip
+      tag: append_nozomi_networks_health_appliance_ip_into_host_ip_49008c8c
       value: '{{{nozomi_networks.health.appliance_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.health?.appliance_ip != null
   - append:
       field: related.ip
-      tag: append_health_appliance_ip_into_related_ip
+      tag: append_health_appliance_ip_into_related_ip_9f83ca39
       value: '{{{nozomi_networks.health.appliance_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.health?.appliance_ip != null
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_206636db
       target_field: nozomi_networks.health.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_health_id
+      tag: set_event_id_from_health_id_de56a3cd
       copy_from: nozomi_networks.health.id
       ignore_empty_value: true
   - rename:
       field: json.info
-      tag: rename_info
+      tag: rename_info_7306f195
       target_field: nozomi_networks.health.info
       ignore_missing: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_c0ff446c
       target_field: nozomi_networks.health.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null && ctx.json.record_created_at != ''
       on_failure:
         - append:
-            tag: append_error_message_a59536ce
+            tag: append_error_message_21ea7df0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_health_record_created_at
+      tag: set_@timestamp_from_health_record_created_at_514a2e6d
       copy_from: nozomi_networks.health.record_created_at
       ignore_empty_value: true
   - set:
       field: event.created
-      tag: set_event_created_from_health_record_created_at
+      tag: set_event_created_from_health_record_created_at_9ecbe575
       copy_from: nozomi_networks.health.record_created_at
       ignore_empty_value: true
   - convert:
       field: json.replicated
-      tag: convert_replicated_to_boolean
+      tag: convert_replicated_to_boolean_11bb91d5
       target_field: nozomi_networks.health.replicated
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_eff5d58d
+            tag: append_error_message_20f0625d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.sensor_appliance_type
-      tag: rename_sensor_appliance_type
+      tag: rename_sensor_appliance_type_2b612b46
       target_field: nozomi_networks.health.sensor_appliance_type
       ignore_missing: true
   - rename:
       field: json.sensor_host
-      tag: rename_sensor_host
+      tag: rename_sensor_host_e177f547
       target_field: nozomi_networks.health.sensor_host
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_health_sensor_host
+      tag: set_host_hostname_from_health_sensor_host_7c0d514c
       copy_from: nozomi_networks.health.sensor_host
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_health_sensor_host_into_related_hosts
+      tag: append_health_sensor_host_into_related_hosts_32b9025c
       value: '{{{nozomi_networks.health.sensor_host}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.health?.sensor_host != null
   - rename:
       field: json.sensor_id
-      tag: rename_sensor_id
+      tag: rename_sensor_id_e7b77a30
       target_field: nozomi_networks.health.sensor_id
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_health_sensor_host
+      tag: set_host_id_from_health_sensor_host_fb5c1277
       copy_from: nozomi_networks.health.sensor_id
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_health_sensor_id_into_related_hosts
+      tag: append_health_sensor_id_into_related_hosts_d9fc8903
       value: '{{{nozomi_networks.health.sensor_id}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.health?.sensor_id != null
   - convert:
       field: json.synchronized
-      tag: convert_synchronized_to_boolean
+      tag: convert_synchronized_to_boolean_07c24882
       target_field: nozomi_networks.health.synchronized
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c0388d50
+            tag: append_error_message_02f4fa9c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.time
-      tag: date_time
+      tag: date_time_10cb249d
       target_field: nozomi_networks.health.time
       formats:
         - UNIX_MS
       if: ctx.json?.time != null && ctx.json.time != ''
       on_failure:
         - append:
-            tag: append_error_message_a0512bc1
+            tag: append_error_message_9e271141
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -242,15 +242,15 @@ processors:
         - nozomi_networks.health.record_created_at
         - nozomi_networks.health.sensor_host
         - nozomi_networks.health.sensor_id
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_341386c0
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -277,18 +277,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -296,10 +296,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
@@ -1072,6 +1072,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -1082,6 +1083,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
@@ -3,17 +3,17 @@ description: Pipeline for processing node logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -23,42 +23,42 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - dot_expander:
-      tag: dot_expander_*_6cdde46d
+      tag: dot_expander_*_df970cfa
       field: "*"
       path: json
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_cbc3f167
       value: host
       allow_duplicates: false
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_a75e9a8a
       value: info
       allow_duplicates: false
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - fingerprint:
       fields:
@@ -67,187 +67,187 @@ processors:
         - json.created_at
         - json.last_activity_time
         - json.record_created_at
-      tag: fingerprint_nozomi_networks_node
+      tag: fingerprint_nozomi_networks_node_52018380
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.appliance_host
-      tag: rename_appliance_host
+      tag: rename_appliance_host_cd407804
       target_field: nozomi_networks.node.appliance_host
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_node_appliance_host
+      tag: set_host_hostname_from_node_appliance_host_6f058a01
       copy_from: nozomi_networks.node.appliance_host
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_node_appliance_host_into_related_hosts
+      tag: append_node_appliance_host_into_related_hosts_651dbda8
       value: '{{{nozomi_networks.node.appliance_host}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node?.appliance_host != null
   - rename:
       field: json._asset_kb_id
-      tag: rename__asset_kb_id
+      tag: rename__asset_kb_id_8b25cb92
       target_field: nozomi_networks.node.asset_kb_id
       ignore_missing: true
   - rename:
       field: json.bpf_filter
-      tag: rename_bpf_filter
+      tag: rename_bpf_filter_5f3ffc3d
       target_field: nozomi_networks.node.bpf_filter
       ignore_missing: true
   - rename:
       field: json.capture_device
-      tag: rename_capture_device
+      tag: rename_capture_device_e9e19dac
       target_field: nozomi_networks.node.capture_device
       ignore_missing: true
   - date:
       field: json.created_at
-      tag: date_created_at
+      tag: date_created_at_440369fc
       target_field: nozomi_networks.node.created_at
       formats:
         - UNIX_MS
       if: ctx.json?.created_at != null
       on_failure:
         - append:
-            tag: append_error_message_d7f1b993
+            tag: append_error_message_4372e20c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_node_created_at
+      tag: set_event_created_from_node_created_at_1ba74acb
       copy_from: nozomi_networks.node.created_at
       ignore_empty_value: true
   - rename:
       field: json.custom_fields
-      tag: rename_custom_fields
+      tag: rename_custom_fields_ef93e40c
       target_field: nozomi_networks.node.custom_fields
       ignore_missing: true
   - rename:
       field: json.device_id
-      tag: rename_device_id
+      tag: rename_device_id_f17a295f
       target_field: nozomi_networks.node.device_id
       ignore_missing: true
   - rename:
       field: json.device_modules.children.cip
-      tag: rename_device_modules_children_cip
+      tag: rename_device_modules_children_cip_ecb1c5d0
       target_field: nozomi_networks.node.device_modules.children.cip
       ignore_missing: true
   - rename:
       field: json.device_modules.firmware_version
-      tag: rename_device_modules_firmware_version
+      tag: rename_device_modules_firmware_version_c83305af
       target_field: nozomi_networks.node.device_modules.firmware_version
       ignore_missing: true
   - rename:
       field: json.device_modules.product_name
-      tag: rename_device_modules_product_name
+      tag: rename_device_modules_product_name_8f0ebf3a
       target_field: nozomi_networks.node.device_modules.product_name
       ignore_missing: true
   - rename:
       field: json.device_modules.serial_number
-      tag: rename_device_modules_serial_number
+      tag: rename_device_modules_serial_number_c0a0f665
       target_field: nozomi_networks.node.device_modules.serial_number
       ignore_missing: true
   - rename:
       field: json.device_modules.vendor
-      tag: rename_device_modules_vendor
+      tag: rename_device_modules_vendor_2aa8eef2
       target_field: nozomi_networks.node.device_modules.vendor
       ignore_missing: true
   - date:
       field: json.end_of_sale_date
-      tag: date_end_of_sale_date
+      tag: date_end_of_sale_date_7b37584c
       target_field: nozomi_networks.node.end_of_sale_date
       formats:
         - UNIX_MS
       if: ctx.json?.end_of_sale_date != null
       on_failure:
         - append:
-            tag: append_error_message_ee567b43
+            tag: append_error_message_21be898e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.end_of_sale_date:info
-      tag: rename_end_of_sale_date:info
+      tag: rename_end_of_sale_date:info_e24d2646
       target_field: nozomi_networks.node.end_of_sale_date_info
       ignore_missing: true
   - date:
       field: json.end_of_support_date
-      tag: date_end_of_support_date
+      tag: date_end_of_support_date_0ba5ca13
       target_field: nozomi_networks.node.end_of_support_date
       formats:
         - UNIX_MS
       if: ctx.json?.end_of_support_date != null
       on_failure:
         - append:
-            tag: append_error_message_adfa3437
+            tag: append_error_message_f54897b2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.end_of_support_date:info
-      tag: rename_end_of_support_date:info
+      tag: rename_end_of_support_date:info_0b630224
       target_field: nozomi_networks.node.end_of_support_date_info
       ignore_missing: true
   - rename:
       field: json.firmware_version
-      tag: rename_firmware_version
+      tag: rename_firmware_version_3fd14aac
       target_field: nozomi_networks.node.firmware_version
       ignore_missing: true
   - rename:
       field: json.firmware_version:info
-      tag: rename_firmware_version:info
+      tag: rename_firmware_version:info_8046d211
       target_field: nozomi_networks.node.firmware_version_info
       ignore_missing: true
   - date:
       field: json.first_activity_time
-      tag: date_first_activity_time
+      tag: date_first_activity_time_0ca1fbfe
       target_field: nozomi_networks.node.first_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.first_activity_time != null
       on_failure:
         - append:
-            tag: append_error_message_9f47bd0f
+            tag: append_error_message_3b768721
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_node_first_activity_time
+      tag: set_event_start_from_node_first_activity_time_86135628
       copy_from: nozomi_networks.node.first_activity_time
       ignore_empty_value: true
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_0185547a
       target_field: nozomi_networks.node.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_node_id
+      tag: set_event_id_from_node_id_ae4b3e48
       copy_from: nozomi_networks.node.id
       ignore_empty_value: true
   - convert:
       field: json.ip
-      tag: convert_ip_to_ip
+      tag: convert_ip_to_ip_b3885dba
       target_field: nozomi_networks.node.ip
       type: ip
       ignore_missing: true
       if: ctx.json?.ip != ''
       on_failure:
         - append:
-            tag: append_error_message_cc9e6593
+            tag: append_error_message_5b6e8bf8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
-      tag: set_source_ip_from_node_ip
+      tag: set_source_ip_from_node_ip_94c57502
       copy_from: nozomi_networks.node.ip
       ignore_empty_value: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
-      tag: geoip_source_ip_to_source_as_28d69883
+      tag: geoip_source_ip_to_source_as_58199963
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -257,177 +257,177 @@ processors:
       ignore_missing: true
   - rename:
       field: source.as.asn
-      tag: rename_source_as_asn
+      tag: rename_source_as_asn_168bbbaf
       target_field: source.as.number
       ignore_missing: true
   - rename:
       field: source.as.organization_name
-      tag: rename_source_as_organization_name
+      tag: rename_source_as_organization_name_aa06a00b
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_node_ip_into_related_ip
+      tag: append_node_ip_into_related_ip_0f102c60
       value: '{{{nozomi_networks.node.ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node?.ip != null
   - convert:
       field: json.is_ai_enriched
-      tag: convert_is_ai_enriched_to_boolean
+      tag: convert_is_ai_enriched_to_boolean_7104cb20
       target_field: nozomi_networks.node.is_ai_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8c0b7fbc
+            tag: append_error_message_4f63064f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_arc_enriched
-      tag: convert_is_arc_enriched_to_boolean
+      tag: convert_is_arc_enriched_to_boolean_90458f81
       target_field: nozomi_networks.node.is_arc_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_87bd3fca
+            tag: append_error_message_db89f7c3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_broadcast
-      tag: convert_is_broadcast_to_boolean
+      tag: convert_is_broadcast_to_boolean_ad670a29
       target_field: nozomi_networks.node.is_broadcast
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_72cc354c
+            tag: append_error_message_e29c829f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_compromised
-      tag: convert_is_compromised_to_boolean
+      tag: convert_is_compromised_to_boolean_284103ed
       target_field: nozomi_networks.node.is_compromised
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_fa77f2e7
+            tag: append_error_message_15bd03e9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_confirmed
-      tag: convert_is_confirmed_to_boolean
+      tag: convert_is_confirmed_to_boolean_934a508a
       target_field: nozomi_networks.node.is_confirmed
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_331db07e
+            tag: append_error_message_9fc42427
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_disabled
-      tag: convert_is_disabled_to_boolean
+      tag: convert_is_disabled_to_boolean_54f5f7b6
       target_field: nozomi_networks.node.is_disabled
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_1e23eaa3
+            tag: append_error_message_4c143a00
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_fully_learned
-      tag: convert_is_fully_learned_to_boolean
+      tag: convert_is_fully_learned_to_boolean_007d6d08
       target_field: nozomi_networks.node.is_fully_learned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_9f26f801
+            tag: append_error_message_b90d229e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_learned
-      tag: convert_is_learned_to_boolean
+      tag: convert_is_learned_to_boolean_58336c31
       target_field: nozomi_networks.node.is_learned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_81d22460
+            tag: append_error_message_6a47a994
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json._is_licensed
-      tag: convert__is_licensed_to_boolean
+      tag: convert__is_licensed_to_boolean_6db65da0
       target_field: nozomi_networks.node.is_licensed
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5ca62aee
+            tag: append_error_message_1be4de60
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_public
-      tag: convert_is_public_to_boolean
+      tag: convert_is_public_to_boolean_ce8b2181
       target_field: nozomi_networks.node.is_public
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ee9773ca
+            tag: append_error_message_323bdbe0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_sp_enriched
-      tag: convert_is_sp_enriched_to_boolean
+      tag: convert_is_sp_enriched_to_boolean_ba888e45
       target_field: nozomi_networks.node.is_sp_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_1a636b45
+            tag: append_error_message_16e8a0d4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_ti_enriched
-      tag: convert_is_ti_enriched_to_boolean
+      tag: convert_is_ti_enriched_to_boolean_e95c65da
       target_field: nozomi_networks.node.is_ti_enriched
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_017c48e5
+            tag: append_error_message_bb2b1713
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.label
-      tag: rename_label
+      tag: rename_label_92e1f67a
       target_field: nozomi_networks.node.label
       ignore_missing: true
   - rename:
       field: json.label:info
-      tag: rename_label:info
+      tag: rename_label:info_0489dd4f
       target_field: nozomi_networks.node.label_info
       ignore_missing: true
   - date:
       field: json.last_activity_time
-      tag: date_last_activity_time
+      tag: date_last_activity_time_09812d3e
       target_field: nozomi_networks.node.last_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_activity_time != null
       on_failure:
         - append:
-            tag: append_error_message_2c4e8b3b
+            tag: append_error_message_d01df94d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       description: Calculate host uptime in seconds.
-      tag: calculate_host_uptime
+      tag: calculate_host_uptime_e3210bfe
       lang: painless
       if: ctx.json?.last_activity_time != null && ctx.json.created_at != null
       source: |-
@@ -439,571 +439,571 @@ processors:
         ctx.host.uptime = uptimeSeconds;
   - set:
       field: event.end
-      tag: set_event_end_from_node_last_activity_time
+      tag: set_event_end_from_node_last_activity_time_afb8e94b
       copy_from: nozomi_networks.node.last_activity_time
       ignore_empty_value: true
   - convert:
       field: json.level
-      tag: convert_level_to_long
+      tag: convert_level_to_long_23cae381
       target_field: nozomi_networks.node.level
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b84dfd09
+            tag: append_error_message_e56efca3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.lifecycle
-      tag: rename_lifecycle
+      tag: rename_lifecycle_bd695f6c
       target_field: nozomi_networks.node.lifecycle
       ignore_missing: true
   - rename:
       field: json.lifecycle:info
-      tag: rename_lifecycle:info
+      tag: rename_lifecycle:info_679c954b
       target_field: nozomi_networks.node.lifecycle_info
       ignore_missing: true
   - rename:
       field: json.links
-      tag: rename_links
+      tag: rename_links_eb23c3b8
       target_field: nozomi_networks.node.links
       ignore_missing: true
   - convert:
       field: json.links_count
-      tag: convert_links_count_to_long
+      tag: convert_links_count_to_long_abea8819
       target_field: nozomi_networks.node.links_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_fc6de26d
+            tag: append_error_message_2f498a40
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.mac_address
-      tag: rename_mac_address
+      tag: rename_mac_address_13cb3f0c
       target_field: nozomi_networks.node.mac_address
       ignore_missing: true
   - set:
       field: source.mac
-      tag: set_source_mac_from_node_mac_address
+      tag: set_source_mac_from_node_mac_address_10b6b568
       copy_from: nozomi_networks.node.mac_address
       ignore_empty_value: true
   - gsub:
       field: source.mac
-      tag: gsub_source_mac
+      tag: gsub_source_mac_fd97e82c
       target_field: source.mac
       pattern: '[-:.]'
       replacement: '-'
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_aed5673a
+            tag: append_error_message_4416105b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
       field: source.mac
-      tag: uppercase_source_mac
+      tag: uppercase_source_mac_560987b8
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4c748822
+            tag: append_error_message_d9f51a49
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.mac_address:info
-      tag: rename_mac_address:info
+      tag: rename_mac_address:info_9014d554
       target_field: nozomi_networks.node.mac_address_info
       ignore_missing: true
   - rename:
       field: json.mac_vendor
-      tag: rename_mac_vendor
+      tag: rename_mac_vendor_3634e6a4
       target_field: nozomi_networks.node.mac_vendor
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_4ba2f3b4
       target_field: nozomi_networks.node.name
       ignore_missing: true
   - rename:
       field: json.os
-      tag: rename_os
+      tag: rename_os_9f452383
       target_field: nozomi_networks.node.os
       ignore_missing: true
   - set:
       field: host.os.full
-      tag: set_host_os_full_from_node_os
+      tag: set_host_os_full_from_node_os_f7679527
       copy_from: nozomi_networks.node.os
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_node_os_into_related_hosts
+      tag: append_node_os_into_related_hosts_26080a56
       value: '{{{nozomi_networks.node.os}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node?.os != null
   - rename:
       field: json.os:info
-      tag: rename_os:info
+      tag: rename_os:info_907f1755
       target_field: nozomi_networks.node.os_info
       ignore_missing: true
   - rename:
       field: json._private_status
-      tag: rename__private_status
+      tag: rename__private_status_54997040
       target_field: nozomi_networks.node.private_status
       ignore_missing: true
   - rename:
       field: json.product_name
-      tag: rename_product_name
+      tag: rename_product_name_aa934f59
       target_field: nozomi_networks.node.product_name
       ignore_missing: true
   - set:
       field: service.node.name
-      tag: set_service_node_name_from_node_product_name
+      tag: set_service_node_name_from_node_product_name_54fe4053
       copy_from: nozomi_networks.node.product_name
       ignore_empty_value: true
   - rename:
       field: json.product_name:info
-      tag: rename_product_name:info
+      tag: rename_product_name:info_12cd2004
       target_field: nozomi_networks.node.product_name_info.source
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/device_type
-      tag: rename_properties_ethernetip/device_type
+      tag: rename_properties_ethernetip/device_type_bd3e1b19
       target_field: nozomi_networks.node.properties.ethernetip_device_type
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/device_type_id
-      tag: rename_properties_ethernetip/device_type_id
+      tag: rename_properties_ethernetip/device_type_id_dbdbd0f4
       target_field: nozomi_networks.node.properties.ethernetip_device_type_id
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/firmware_version
-      tag: rename_properties_ethernetip/firmware_version
+      tag: rename_properties_ethernetip/firmware_version_f335d010
       target_field: nozomi_networks.node.properties.ethernetip_firmware_version
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/product_code
-      tag: rename_properties_ethernetip/product_code
+      tag: rename_properties_ethernetip/product_code_cceca6f8
       target_field: nozomi_networks.node.properties.ethernetip_product_code
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/product_name
-      tag: rename_properties_ethernetip/product_name
+      tag: rename_properties_ethernetip/product_name_ee5ff5f3
       target_field: nozomi_networks.node.properties.ethernetip_product_name
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/serial_number
-      tag: rename_properties_ethernetip/serial_number
+      tag: rename_properties_ethernetip/serial_number_c913c3ca
       target_field: nozomi_networks.node.properties.ethernetip_serial_number
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/vendor
-      tag: rename_properties_ethernetip/vendor
+      tag: rename_properties_ethernetip/vendor_570f5128
       target_field: nozomi_networks.node.properties.ethernetip_vendor
       ignore_missing: true
   - rename:
       field: json.properties.ethernetip/vendor_id
-      tag: rename_properties_ethernetip/vendor_id
+      tag: rename_properties_ethernetip/vendor_id_4192235c
       target_field: nozomi_networks.node.properties.ethernetip_vendor_id
       ignore_missing: true
   - rename:
       field: json.properties._product_name.passive
-      tag: rename_properties__product_name_passive
+      tag: rename_properties__product_name_passive_66e47c39
       target_field: nozomi_networks.node.properties.product_name.passive
       ignore_missing: true
   - rename:
       field: json.properties._type.passive
-      tag: rename_properties__type_passive
+      tag: rename_properties__type_passive_dabd9b78
       target_field: nozomi_networks.node.properties.type.passive
       ignore_missing: true
   - rename:
       field: json.properties._vendor.passive
-      tag: rename_properties__vendor_passive
+      tag: rename_properties__vendor_passive_95dfdb3f
       target_field: nozomi_networks.node.properties.vendor.passive
       ignore_missing: true
   - foreach:
-      tag: foreach_json_protocols_8ec97444
+      tag: foreach_json_protocols_59834087
       field: json.protocols
       if: ctx.json?.protocols instanceof List
       processor:
         append:
           field: network.protocol
-          tag: append_protocols_into_network_protocol
+          tag: append_protocols_into_network_protocol_55d5916a
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.protocols
-      tag: rename_protocols
+      tag: rename_protocols_4a19f071
       target_field: nozomi_networks.node.protocols
       ignore_missing: true
   - convert:
       field: json.received.bytes
-      tag: convert_received_bytes_to_long
+      tag: convert_received_bytes_to_long_242cc90c
       target_field: nozomi_networks.node.received.bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8d099267
+            tag: append_error_message_cd52426c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.bytes
-      tag: set_destination_bytes_from_node_received_bytes
+      tag: set_destination_bytes_from_node_received_bytes_5d05c513
       copy_from: nozomi_networks.node.received.bytes
       ignore_empty_value: true
   - convert:
       field: json.received.last_15m_bytes
-      tag: convert_received_last_15m_bytes_to_long
+      tag: convert_received_last_15m_bytes_to_long_7548af6e
       target_field: nozomi_networks.node.received.last_15m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6d38eaec
+            tag: append_error_message_7e6450e4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.received.last_1d_bytes
-      tag: convert_received_last_1d_bytes_to_long
+      tag: convert_received_last_1d_bytes_to_long_9d5b6be0
       target_field: nozomi_networks.node.received.last_1d_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_965fc860
+            tag: append_error_message_3c75db51
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.received.last_1h_bytes
-      tag: convert_received_last_1h_bytes_to_long
+      tag: convert_received_last_1h_bytes_to_long_beb15a12
       target_field: nozomi_networks.node.received.last_1h_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_43e99a64
+            tag: append_error_message_fdc4435f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.received.last_1w_bytes
-      tag: convert_received_last_1w_bytes_to_long
+      tag: convert_received_last_1w_bytes_to_long_ede5c569
       target_field: nozomi_networks.node.received.last_1w_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6687e5d5
+            tag: append_error_message_16e032e8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.received.last_30m_bytes
-      tag: convert_received_last_30m_bytes_to_long
+      tag: convert_received_last_30m_bytes_to_long_6567febe
       target_field: nozomi_networks.node.received.last_30m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6914c11d
+            tag: append_error_message_9fcaa18c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.received.last_5m_bytes
-      tag: convert_received_last_5m_bytes_to_long
+      tag: convert_received_last_5m_bytes_to_long_22c6badd
       target_field: nozomi_networks.node.received.last_5m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2b658d47
+            tag: append_error_message_2a523610
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.received.packets
-      tag: convert_received_packets_to_long
+      tag: convert_received_packets_to_long_de5659f5
       target_field: nozomi_networks.node.received.packets
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_be493279
+            tag: append_error_message_f4325de5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.packets
-      tag: set_destination_packets_from_node_received_packets
+      tag: set_destination_packets_from_node_received_packets_478b15df
       copy_from: nozomi_networks.node.received.packets
       ignore_empty_value: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_b67b2a46
       target_field: nozomi_networks.node.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
-            tag: append_error_message_f132d3cb
+            tag: append_error_message_a31b64d6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_node_created_at
+      tag: set_@timestamp_from_node_created_at_fc7a9cf7
       copy_from: nozomi_networks.node.record_created_at
       ignore_empty_value: true
   - rename:
       field: json.reputation
-      tag: rename_reputation
+      tag: rename_reputation_0c50383c
       target_field: nozomi_networks.node.reputation
       ignore_missing: true
   - foreach:
-      tag: foreach_json_roles_005f44b1
+      tag: foreach_json_roles_3fa1f56c
       field: json.roles
       if: ctx.json?.roles instanceof List
       processor:
         append:
           field: service.node.roles
-          tag: append_roles_into_service_node_roles
+          tag: append_roles_into_service_node_roles_06bdb0d9
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.roles
-      tag: rename_roles
+      tag: rename_roles_8d114553
       target_field: nozomi_networks.node.roles
       ignore_missing: true
   - convert:
       field: json.sent.bytes
-      tag: convert_sent_bytes_to_long
+      tag: convert_sent_bytes_to_long_5efb0fc6
       target_field: nozomi_networks.node.sent.bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a90c730a
+            tag: append_error_message_62faefc2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.bytes
-      tag: set_source_bytes_from_node_sent_bytes
+      tag: set_source_bytes_from_node_sent_bytes_dcdc4424
       copy_from: nozomi_networks.node.sent.bytes
       ignore_empty_value: true
   - convert:
       field: json.sent.last_15m_bytes
-      tag: convert_sent_last_15m_bytes_to_long
+      tag: convert_sent_last_15m_bytes_to_long_441a5334
       target_field: nozomi_networks.node.sent.last_15m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_182e9459
+            tag: append_error_message_be6fd71f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.sent.last_1d_bytes
-      tag: convert_sent_last_1d_bytes_to_long
+      tag: convert_sent_last_1d_bytes_to_long_469bcdd0
       target_field: nozomi_networks.node.sent.last_1d_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_68e131d1
+            tag: append_error_message_d9024aa6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.sent.last_1h_bytes
-      tag: convert_sent_last_1h_bytes_to_long
+      tag: convert_sent_last_1h_bytes_to_long_f0faf34b
       target_field: nozomi_networks.node.sent.last_1h_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_dc20b845
+            tag: append_error_message_bd23f181
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.sent.last_1w_bytes
-      tag: convert_sent_last_1w_bytes_to_long
+      tag: convert_sent_last_1w_bytes_to_long_60c407ed
       target_field: nozomi_networks.node.sent.last_1w_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0204958c
+            tag: append_error_message_064b4cbf
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.sent.last_30m_bytes
-      tag: convert_sent_last_30m_bytes_to_long
+      tag: convert_sent_last_30m_bytes_to_long_6d418007
       target_field: nozomi_networks.node.sent.last_30m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6c55d538
+            tag: append_error_message_aa533e6a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.sent.last_5m_bytes
-      tag: convert_sent_last_5m_bytes_to_long
+      tag: convert_sent_last_5m_bytes_to_long_c6a8fb7a
       target_field: nozomi_networks.node.sent.last_5m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_195dbb7a
+            tag: append_error_message_f2f38899
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.sent.packets
-      tag: convert_sent_packets_to_long
+      tag: convert_sent_packets_to_long_6229a9d7
       target_field: nozomi_networks.node.sent.packets
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5acbe9a0
+            tag: append_error_message_17a79b5c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.packets
-      tag: set_source_packets_from_node_sent_packets
+      tag: set_source_packets_from_node_sent_packets_936c1a20
       copy_from: nozomi_networks.node.sent.packets
       ignore_empty_value: true
   - rename:
       field: json.serial_number
-      tag: rename_serial_number
+      tag: rename_serial_number_0b6adb3b
       target_field: nozomi_networks.node.serial_number
       ignore_missing: true
   - rename:
       field: json.serial_number:info
-      tag: rename_serial_number:info
+      tag: rename_serial_number:info_67b259fc
       target_field: nozomi_networks.node.serial_number_info
       ignore_missing: true
   - rename:
       field: json.subnet
-      tag: rename_subnet
+      tag: rename_subnet_3b20a16e
       target_field: nozomi_networks.node.subnet
       ignore_missing: true
   - convert:
       field: json.tcp_retransmission.bytes
-      tag: convert_tcp_retransmission_bytes_to_long
+      tag: convert_tcp_retransmission_bytes_to_long_0edb510f
       target_field: nozomi_networks.node.tcp_retransmission.bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_70868625
+            tag: append_error_message_daf5af16
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.tcp_retransmission.last_15m_bytes
-      tag: convert_tcp_retransmission_last_15m_bytes_to_long
+      tag: convert_tcp_retransmission_last_15m_bytes_to_long_7902f2f5
       target_field: nozomi_networks.node.tcp_retransmission.last_15m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b5721366
+            tag: append_error_message_fbbfa02f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.tcp_retransmission.last_30m_bytes
-      tag: convert_tcp_retransmission_last_30m_bytes_to_long
+      tag: convert_tcp_retransmission_last_30m_bytes_to_long_26b7bdd5
       target_field: nozomi_networks.node.tcp_retransmission.last_30m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_13c4386b
+            tag: append_error_message_818e02d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.tcp_retransmission.last_5m_bytes
-      tag: convert_tcp_retransmission_last_5m_bytes_to_long
+      tag: convert_tcp_retransmission_last_5m_bytes_to_long_0307b51c
       target_field: nozomi_networks.node.tcp_retransmission.last_5m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_7c042765
+            tag: append_error_message_bed5ceb8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.tcp_retransmission.packets
-      tag: convert_tcp_retransmission_packets_to_long
+      tag: convert_tcp_retransmission_packets_to_long_e86ca86f
       target_field: nozomi_networks.node.tcp_retransmission.packets
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a4134bdb
+            tag: append_error_message_76803717
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.tcp_retransmission.percent
-      tag: convert_tcp_retransmission_percent_to_double
+      tag: convert_tcp_retransmission_percent_to_double_8e0671bc
       target_field: nozomi_networks.node.tcp_retransmission.percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0b547d65
+            tag: append_error_message_0c683db4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_9b080089
       target_field: nozomi_networks.node.type
       ignore_missing: true
   - set:
       field: service.type
-      tag: set_service_type_from_node_type
+      tag: set_service_type_from_node_type_3d69807a
       copy_from: nozomi_networks.node.type
       ignore_empty_value: true
   - rename:
       field: json.type:info
-      tag: rename_type:info
+      tag: rename_type:info_ae9b25a3
       target_field: nozomi_networks.node.type_info
       ignore_missing: true
   - convert:
       field: json.variables_count
-      tag: convert_variables_count_to_long
+      tag: convert_variables_count_to_long_1015e5bf
       target_field: nozomi_networks.node.variables_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_aa2a4b8d
+            tag: append_error_message_0499db68
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.vendor
-      tag: rename_vendor
+      tag: rename_vendor_df59e3cf
       target_field: nozomi_networks.node.vendor
       ignore_missing: true
   - rename:
       field: json.vendor:info
-      tag: rename_vendor:info
+      tag: rename_vendor:info_55b7df96
       target_field: nozomi_networks.node.vendor_info
       ignore_missing: true
   - rename:
       field: json.vlan_id
-      tag: rename_vlan_id
+      tag: rename_vlan_id_72f88db8
       target_field: nozomi_networks.node.vlan_id
       ignore_missing: true
   - set:
       field: network.vlan.id
-      tag: set_network_vlan_id_from_node_vlan_id
+      tag: set_network_vlan_id_from_node_vlan_id_540fb8f1
       copy_from: nozomi_networks.node.vlan_id
       ignore_empty_value: true
   - rename:
       field: json.vlan_id:info
-      tag: rename_vlan_id:info
+      tag: rename_vlan_id:info_ff2d5e4a
       target_field: nozomi_networks.node.vlan_id_info
       ignore_missing: true
   - rename:
       field: json.zone
-      tag: rename_zone
+      tag: rename_zone_8bb5b9df
       target_field: nozomi_networks.node.zone
       ignore_missing: true
   - remove:
@@ -1026,15 +1026,15 @@ processors:
         - nozomi_networks.node.sent.packets
         - nozomi_networks.node.type
         - nozomi_networks.node.vlan_id
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_64f96e4f
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -1061,18 +1061,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -1080,10 +1080,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node/elasticsearch/ingest_pipeline/default.yml
@@ -39,9 +39,11 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - dot_expander:
+      tag: dot_expander_*_6cdde46d
       field: "*"
       path: json
   - append:
@@ -108,6 +110,7 @@ processors:
       if: ctx.json?.created_at != null
       on_failure:
         - append:
+            tag: append_error_message_d7f1b993
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -159,6 +162,7 @@ processors:
       if: ctx.json?.end_of_sale_date != null
       on_failure:
         - append:
+            tag: append_error_message_ee567b43
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -175,6 +179,7 @@ processors:
       if: ctx.json?.end_of_support_date != null
       on_failure:
         - append:
+            tag: append_error_message_adfa3437
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -201,6 +206,7 @@ processors:
       if: ctx.json?.first_activity_time != null
       on_failure:
         - append:
+            tag: append_error_message_9f47bd0f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -227,6 +233,7 @@ processors:
       if: ctx.json?.ip != ''
       on_failure:
         - append:
+            tag: append_error_message_cc9e6593
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -235,10 +242,12 @@ processors:
       copy_from: nozomi_networks.node.ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -270,6 +279,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8c0b7fbc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -280,6 +290,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_87bd3fca
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -290,6 +301,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_72cc354c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -300,6 +312,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fa77f2e7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -310,6 +323,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_331db07e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -320,6 +334,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1e23eaa3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -330,6 +345,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9f26f801
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -340,6 +356,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_81d22460
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -350,6 +367,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5ca62aee
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -360,6 +378,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ee9773ca
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -370,6 +389,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1a636b45
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -380,6 +400,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_017c48e5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -401,6 +422,7 @@ processors:
       if: ctx.json?.last_activity_time != null
       on_failure:
         - append:
+            tag: append_error_message_2c4e8b3b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -428,6 +450,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b84dfd09
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -453,6 +476,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fc6de26d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -474,6 +498,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_aed5673a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - uppercase:
@@ -482,6 +507,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4c748822
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -596,6 +622,7 @@ processors:
       target_field: nozomi_networks.node.properties.vendor.passive
       ignore_missing: true
   - foreach:
+      tag: foreach_json_protocols_8ec97444
       field: json.protocols
       if: ctx.json?.protocols instanceof List
       processor:
@@ -617,6 +644,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8d099267
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -632,6 +660,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6d38eaec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -642,6 +671,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_965fc860
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -652,6 +682,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_43e99a64
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -662,6 +693,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6687e5d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -672,6 +704,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6914c11d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -682,6 +715,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2b658d47
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -692,6 +726,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_be493279
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -708,6 +743,7 @@ processors:
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
+            tag: append_error_message_f132d3cb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -721,6 +757,7 @@ processors:
       target_field: nozomi_networks.node.reputation
       ignore_missing: true
   - foreach:
+      tag: foreach_json_roles_005f44b1
       field: json.roles
       if: ctx.json?.roles instanceof List
       processor:
@@ -742,6 +779,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a90c730a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -757,6 +795,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_182e9459
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -767,6 +806,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_68e131d1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -777,6 +817,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_dc20b845
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -787,6 +828,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0204958c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -797,6 +839,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6c55d538
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -807,6 +850,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_195dbb7a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -817,6 +861,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5acbe9a0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -847,6 +892,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_70868625
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -857,6 +903,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b5721366
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -867,6 +914,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_13c4386b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -877,6 +925,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7c042765
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -887,6 +936,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a4134bdb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -897,6 +947,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0b547d65
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -922,6 +973,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_aa2a4b8d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -1013,6 +1065,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
@@ -3,17 +3,17 @@ description: Pipeline for processing node cve logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -23,37 +23,37 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_ab1166ce
       value: alert
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_661957f9
       value: vulnerability
       allow_duplicates: false
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_a75e9a8a
       value: info
       allow_duplicates: false
   - fingerprint:
@@ -62,87 +62,87 @@ processors:
         - json.time
         - json.cve_update_time
         - json.record_created_at
-      tag: fingerprint_nozomi_networks_node_cve
+      tag: fingerprint_nozomi_networks_node_cve_452b4622
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.appliance_host
-      tag: rename_appliance_host
+      tag: rename_appliance_host_5166b3fd
       target_field: nozomi_networks.node_cve.appliance_host
       ignore_missing: true
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_node_cve_appliance_host
+      tag: set_host_hostname_from_node_cve_appliance_host_680d820d
       copy_from: nozomi_networks.node_cve.appliance_host
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_node_cve_appliance_host_into_related_hosts
+      tag: append_node_cve_appliance_host_into_related_hosts_fc0744b1
       value: '{{{nozomi_networks.node_cve.appliance_host}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node_cve?.appliance_host != null
   - rename:
       field: json.appliance_id
-      tag: rename_appliance_id
+      tag: rename_appliance_id_1dfbbd91
       target_field: nozomi_networks.node_cve.appliance_id
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_node_cve_appliance_id
+      tag: set_host_id_from_node_cve_appliance_id_44ae139a
       copy_from: nozomi_networks.node_cve.appliance_id
       ignore_empty_value: true
   - convert:
       field: json.appliance_ip
-      tag: convert_appliance_ip_to_ip
+      tag: convert_appliance_ip_to_ip_b3313175
       target_field: nozomi_networks.node_cve.appliance_ip
       type: ip
       ignore_missing: true
       if: ctx.json?.appliance_ip != ''
       on_failure:
         - append:
-            tag: append_error_message_16856a80
+            tag: append_error_message_8e78a64a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: host.ip
-      tag: append_nozomi_networks_node_cve_appliance_ip_into_host_ip
+      tag: append_nozomi_networks_node_cve_appliance_ip_into_host_ip_2f58a468
       value: '{{{nozomi_networks.node_cve.appliance_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node_cve?.appliance_ip != null
   - append:
       field: related.ip
-      tag: append_node_cve_appliance_ip_into_related_ip
+      tag: append_node_cve_appliance_ip_into_related_ip_80a9492e
       value: '{{{nozomi_networks.node_cve.appliance_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node_cve?.appliance_ip != null
   - rename:
       field: json.asset_id
-      tag: rename_asset_id
+      tag: rename_asset_id_57d59987
       target_field: nozomi_networks.node_cve.asset_id
       ignore_missing: true
   - set:
       field: device.id
-      tag: set_device_id_from_node_cve_asset_id
+      tag: set_device_id_from_node_cve_asset_id_1c4f8020
       copy_from: nozomi_networks.node_cve.asset_id
       ignore_empty_value: true
   - rename:
       field: json.cve
-      tag: rename_cve
+      tag: rename_cve_98e15b10
       target_field: nozomi_networks.node_cve.cve
       ignore_missing: true
   - set:
       field: vulnerability.id
-      tag: set_vulnerability_id_from_node_cve_cve
+      tag: set_vulnerability_id_from_node_cve_cve_9ee57e5e
       copy_from: nozomi_networks.node_cve.cve
       ignore_empty_value: true
   - set:
       field: vulnerability.reference
-      tag: set_vulnerability_reference_from_vulnerability_id
+      tag: set_vulnerability_reference_from_vulnerability_id_83631fb7
       value: https://www.cve.org/CVERecord?id={{{vulnerability.id}}}
       if: ctx.vulnerability?.id != null && ctx.vulnerability.id.contains('CVE')
   - script:
       description: Dynamically set cve.enumeration values.
-      tag: script_map_vulnerability_id
+      tag: script_map_vulnerability_id_733ab8eb
       lang: painless
       if: ctx.vulnerability?.id != null
       params:
@@ -159,374 +159,374 @@ processors:
         }
   - date:
       field: json.cve_creation_time
-      tag: date_cve_creation_time
+      tag: date_cve_creation_time_fbb5414e
       target_field: nozomi_networks.node_cve.cve_creation_time
       formats:
         - UNIX_MS
       if: ctx.json?.cve_creation_time != null
       on_failure:
         - append:
-            tag: append_error_message_ddb21cda
+            tag: append_error_message_9d142f38
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: vulnerability.published_date
-      tag: set_vulnerability_published_date_from_node_cve_cve_creation_time
+      tag: set_vulnerability_published_date_from_node_cve_cve_creation_time_02ca6ac5
       copy_from: nozomi_networks.node_cve.cve_creation_time
       ignore_empty_value: true
   - set:
       field: event.start
-      tag: set_event_start_from_node_cve_cve_creation_time
+      tag: set_event_start_from_node_cve_cve_creation_time_fdeaed0c
       copy_from: nozomi_networks.node_cve.cve_creation_time
       ignore_empty_value: true
   - convert:
       field: json.cve_epss_score
-      tag: convert_cve_epss_score_to_double
+      tag: convert_cve_epss_score_to_double_2105d4ca
       target_field: nozomi_networks.node_cve.cve_epss_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_fc5f4766
+            tag: append_error_message_e2def845
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.cve_references
-      tag: rename_cve_references
+      tag: rename_cve_references_36fc5f1e
       target_field: nozomi_networks.node_cve.cve_references
       ignore_missing: true
   - convert:
       field: json.cve_score
-      tag: convert_cve_score_to_double
+      tag: convert_cve_score_to_double_2a8032e0
       target_field: nozomi_networks.node_cve.cve_score
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b015c1c8
+            tag: append_error_message_e643e70d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: vulnerability.score.base
-      tag: set_vulnerability_score_base_from_node_cve_cve_score
+      tag: set_vulnerability_score_base_from_node_cve_cve_score_157e5b6b
       copy_from: nozomi_networks.node_cve.cve_score
       ignore_empty_value: true
   - rename:
       field: json.cve_source
-      tag: rename_cve_source
+      tag: rename_cve_source_7b559add
       target_field: nozomi_networks.node_cve.cve_source
       ignore_missing: true
   - rename:
       field: json.cve_summary
-      tag: rename_cve_summary
+      tag: rename_cve_summary_b0983a12
       target_field: nozomi_networks.node_cve.cve_summary
       ignore_missing: true
   - set:
       field: vulnerability.description
-      tag: set_vulnerability_description_from_node_cve_cve_summary
+      tag: set_vulnerability_description_from_node_cve_cve_summary_3e4dfbba
       copy_from: nozomi_networks.node_cve.cve_summary
       ignore_empty_value: true
   - set:
       field: message
-      tag: set_message_from_node_cve_cve_summary
+      tag: set_message_from_node_cve_cve_summary_f838d452
       copy_from: nozomi_networks.node_cve.cve_summary
       ignore_empty_value: true
   - date:
       field: json.cve_update_time
-      tag: date_cve_update_time
+      tag: date_cve_update_time_7c12b66b
       target_field: nozomi_networks.node_cve.cve_update_time
       formats:
         - UNIX_MS
       if: ctx.json?.cve_update_time != null
       on_failure:
         - append:
-            tag: append_error_message_852435e2
+            tag: append_error_message_853a0a5e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.end
-      tag: set_event_end_from_node_cve_cve_update_time
+      tag: set_event_end_from_node_cve_cve_update_time_31dedc1f
       copy_from: nozomi_networks.node_cve.cve_update_time
       ignore_empty_value: true
   - rename:
       field: json.cwe_id
-      tag: rename_cwe_id
+      tag: rename_cwe_id_ece12b7f
       target_field: nozomi_networks.node_cve.cwe_id
       ignore_missing: true
   - rename:
       field: json.cwe_name
-      tag: rename_cwe_name
+      tag: rename_cwe_name_e3da74e5
       target_field: nozomi_networks.node_cve.cwe_name
       ignore_missing: true
   - append:
       field: vulnerability.category
-      tag: append_nozomi_networks_node_cve_cwe_name_into_vulnerability_category
+      tag: append_nozomi_networks_node_cve_cwe_name_into_vulnerability_category_51016a3b
       value: '{{{nozomi_networks.node_cve.cwe_name}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.node_cve?.cwe_name != null
   - rename:
       field: json.firmware_version
-      tag: rename_firmware_version
+      tag: rename_firmware_version_558b7220
       target_field: nozomi_networks.node_cve.firmware_version
       ignore_missing: true
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_7b65fdf9
       target_field: nozomi_networks.node_cve.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_node_cve_id
+      tag: set_event_id_from_node_cve_id_94e3b0aa
       copy_from: nozomi_networks.node_cve.id
       ignore_empty_value: true
   - rename:
       field: json.installed_on
-      tag: rename_installed_on
+      tag: rename_installed_on_3c0c7dd3
       target_field: nozomi_networks.node_cve.installed_on
       ignore_missing: true
   - convert:
       field: json.is_kev
-      tag: convert_is_kev_to_boolean
+      tag: convert_is_kev_to_boolean_5bc419d1
       target_field: nozomi_networks.node_cve.is_kev
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2b1ee6da
+            tag: append_error_message_3b96c873
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.latest_hotfix
-      tag: rename_latest_hotfix
+      tag: rename_latest_hotfix_a9313c22
       target_field: nozomi_networks.node_cve.latest_hotfix
       ignore_missing: true
   - convert:
       field: json.likelihood
-      tag: convert_likelihood_to_double
+      tag: convert_likelihood_to_double_99cf26da
       target_field: nozomi_networks.node_cve.likelihood
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f1824bcb
+            tag: append_error_message_e4d8218a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.matching_cpes
-      tag: rename_matching_cpes
+      tag: rename_matching_cpes_7d445ff3
       target_field: nozomi_networks.node_cve.matching_cpes
       ignore_missing: true
   - rename:
       field: json.minimum_hotfix
-      tag: rename_minimum_hotfix
+      tag: rename_minimum_hotfix_f77476b9
       target_field: nozomi_networks.node_cve.minimum_hotfix
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_02e6f8f6
       target_field: nozomi_networks.node_cve.name
       ignore_missing: true
   - rename:
       field: json.node_firmware_version
-      tag: rename_node_firmware_version
+      tag: rename_node_firmware_version_398549f5
       target_field: nozomi_networks.node_cve.node_firmware_version
       ignore_missing: true
   - rename:
       field: json.node_id
-      tag: rename_node_id
+      tag: rename_node_id_209b3a76
       target_field: nozomi_networks.node_cve.node_id
       ignore_missing: true
   - rename:
       field: json.node_label
-      tag: rename_node_label
+      tag: rename_node_label_d7c9d887
       target_field: nozomi_networks.node_cve.node_label
       ignore_missing: true
   - rename:
       field: json.node_os
-      tag: rename_node_os
+      tag: rename_node_os_c7a6d05b
       target_field: nozomi_networks.node_cve.node_os
       ignore_missing: true
   - rename:
       field: json.node_product_name
-      tag: rename_node_product_name
+      tag: rename_node_product_name_60dc1e74
       target_field: nozomi_networks.node_cve.node_product_name
       ignore_missing: true
   - rename:
       field: json.node_type
-      tag: rename_node_type
+      tag: rename_node_type_fc2de95b
       target_field: nozomi_networks.node_cve.node_type
       ignore_missing: true
   - rename:
       field: json.node_vendor
-      tag: rename_node_vendor
+      tag: rename_node_vendor_dd9932a5
       target_field: nozomi_networks.node_cve.node_vendor
       ignore_missing: true
   - foreach:
       field: json.nodes
-      tag: foreach_nodes
+      tag: foreach_nodes_f3a223cf
       if: ctx.json?.nodes instanceof List
       processor:
         convert:
           field: _ingest._value
-          tag: convert_nodes_to_ip
+          tag: convert_nodes_to_ip_0d056542
           type: ip
           ignore_missing: true
           on_failure:
             - append:
                 field: nozomi_networks.node_cve.nodes_hosts
-                tag: append_nodes_into_nodes_hosts
+                tag: append_nodes_into_nodes_hosts_51a0d571
                 value: '{{{_ingest._value}}}'
                 allow_duplicates: false
             - append:
                 field: related.hosts
-                tag: append_nodes_into_related_hosts
+                tag: append_nodes_into_related_hosts_4a0d4e9f
                 value: '{{{_ingest._value}}}'
                 allow_duplicates: false
             - remove:
-                tag: remove_ingest_value
+                tag: remove_ingest_value_647d7131
                 field: _ingest._value
                 ignore_missing: true
   - foreach:
       field: json.nodes
-      tag: foreach_nodes_98ad5bbe
+      tag: foreach_nodes_e47b1ba2
       if: ctx.json?.nodes instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_nodes_into_related_ip
+          tag: append_nodes_into_related_ip_23919f65
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.nodes
-      tag: rename_nodes
+      tag: rename_nodes_b3bb0a93
       target_field: nozomi_networks.node_cve.nodes_ip
       ignore_missing: true
   - rename:
       field: json.os
-      tag: rename_os
+      tag: rename_os_701039e3
       target_field: nozomi_networks.node_cve.os
       ignore_missing: true
   - set:
       field: host.os.family
-      tag: set_host_os_family_from_node_cve_os
+      tag: set_host_os_family_from_node_cve_os_792a9842
       copy_from: nozomi_networks.node_cve.os
       if: ctx.nozomi_networks?.node_cve?.firmware_version == ''
       ignore_empty_value: true
   - rename:
       field: json.probability
-      tag: rename_probability
+      tag: rename_probability_04c94387
       target_field: nozomi_networks.node_cve.probability
       ignore_missing: true
   - rename:
       field: json.product_name
-      tag: rename_product_name
+      tag: rename_product_name_118fccea
       target_field: nozomi_networks.node_cve.product_name
       ignore_missing: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_5688d3ce
       target_field: nozomi_networks.node_cve.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
-            tag: append_error_message_2f4057a2
+            tag: append_error_message_41a64567
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_record_created_at
+      tag: set_@timestamp_from_record_created_at_0b2d56d2
       copy_from: nozomi_networks.node_cve.record_created_at
       ignore_empty_value: true
   - foreach:
       field: json.references
-      tag: foreach_references_source
+      tag: foreach_references_source_fc0bfb60
       if: ctx.json?.references instanceof List
       processor:
         append:
           field: vulnerability.scanner.vendor
-          tag: append_references_source_into_threat_indicator_provider
+          tag: append_references_source_into_threat_indicator_provider_2f314c69
           value: '{{{_ingest._value.source}}}'
           allow_duplicates: false
   - foreach:
       field: json.references
-      tag: foreach_references_url
+      tag: foreach_references_url_f92cbcc1
       if: ctx.json?.references instanceof List
       processor:
         append:
           field: vulnerability.reference
-          tag: append_references_url_into_threat_indicator_reference
+          tag: append_references_url_into_threat_indicator_reference_190f995c
           value: '{{{_ingest._value.url}}}'
           allow_duplicates: false
   - rename:
       field: json.references
-      tag: rename_references
+      tag: rename_references_6f9a8fca
       target_field: nozomi_networks.node_cve.references
       ignore_missing: true
   - rename:
       field: json.resolution_reason
-      tag: rename_resolution_reason
+      tag: rename_resolution_reason_3cc035a9
       target_field: nozomi_networks.node_cve.resolution_reason
       ignore_missing: true
   - convert:
       field: json.resolved
-      tag: convert_resolved_to_boolean
+      tag: convert_resolved_to_boolean_ed4b7b56
       target_field: nozomi_networks.node_cve.resolved
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ac02d355
+            tag: append_error_message_97388af3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.resolved_source
-      tag: rename_resolved_source
+      tag: rename_resolved_source_d9d1099c
       target_field: nozomi_networks.node_cve.resolved_source
       ignore_missing: true
   - date:
       field: json.time
-      tag: date_time
+      tag: date_time_2d9b5f63
       target_field: nozomi_networks.node_cve.time
       formats:
         - UNIX_MS
       if: ctx.json?.time != null
       on_failure:
         - append:
-            tag: append_error_message_21155f8e
+            tag: append_error_message_dd4a3c12
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_26a12ea9
       target_field: nozomi_networks.node_cve.type
       ignore_missing: true
   - rename:
       field: json.vendor
-      tag: rename_vendor
+      tag: rename_vendor_759bcd97
       target_field: nozomi_networks.node_cve.vendor
       ignore_missing: true
   - rename:
       field: json.zone
-      tag: rename_zone
+      tag: rename_zone_07c7831b
       target_field: nozomi_networks.node_cve.zone
       ignore_missing: true
   - rename:
       field: json.zones
-      tag: rename_zones
+      tag: rename_zones_2ba2a4c3
       target_field: nozomi_networks.node_cve.zones
       ignore_missing: true
   - foreach:
       field: nozomi_networks.node_cve.references
-      tag: foreach_nozomi_networks_node_cve_references
+      tag: foreach_nozomi_networks_node_cve_references_fec685a7
       if: ctx.nozomi_networks?.node_cve?.references instanceof List
       processor:
         remove:
           field:
             - _ingest._value.url
             - _ingest._value.source
-          tag: remove_custom_duplicate_fields_from_nozomi_networks_node_cve_references
+          tag: remove_custom_duplicate_fields_from_nozomi_networks_node_cve_references_5801c03b
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
@@ -543,15 +543,15 @@ processors:
         - nozomi_networks.node_cve.cwe_name
         - nozomi_networks.node_cve.id
         - nozomi_networks.node_cve.record_created_at
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_e1825359
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -578,18 +578,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -597,10 +597,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
@@ -383,11 +383,12 @@ processors:
                 value: '{{{_ingest._value}}}'
                 allow_duplicates: false
             - remove:
+                tag: remove_ingest_value
                 field: _ingest._value
                 ignore_missing: true
   - foreach:
       field: json.nodes
-      tag: foreach_json_nodes_98ad5bbe
+      tag: foreach_nodes_98ad5bbe
       if: ctx.json?.nodes instanceof List
       processor:
         append:
@@ -588,6 +589,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -598,6 +600,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/node_cve/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -99,6 +100,7 @@ processors:
       if: ctx.json?.appliance_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_16856a80
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -164,6 +166,7 @@ processors:
       if: ctx.json?.cve_creation_time != null
       on_failure:
         - append:
+            tag: append_error_message_ddb21cda
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -184,6 +187,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fc5f4766
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -199,6 +203,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b015c1c8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -235,6 +240,7 @@ processors:
       if: ctx.json?.cve_update_time != null
       on_failure:
         - append:
+            tag: append_error_message_852435e2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -286,6 +292,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2b1ee6da
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -301,6 +308,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f1824bcb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -379,7 +387,7 @@ processors:
                 ignore_missing: true
   - foreach:
       field: json.nodes
-      tag: foreach_nodes
+      tag: foreach_json_nodes_98ad5bbe
       if: ctx.json?.nodes instanceof List
       processor:
         append:
@@ -422,6 +430,7 @@ processors:
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
+            tag: append_error_message_2f4057a2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -467,6 +476,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ac02d355
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -483,6 +493,7 @@ processors:
       if: ctx.json?.time != null
       on_failure:
         - append:
+            tag: append_error_message_21155f8e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -570,6 +581,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -74,6 +75,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_491a95b2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -85,6 +87,7 @@ processors:
       if: ctx.json?.first_activity_time != null && ctx.json.first_activity_time != ''
       on_failure:
         - append:
+            tag: append_error_message_61d7c9bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -104,7 +107,7 @@ processors:
             field: json.from
             tag: rename_from
             target_field: nozomi_networks.session.from
-            ignore_missing: true  
+            ignore_missing: true
   - set:
       field: source.ip
       tag: set_source_ip_from_session_from_ip
@@ -148,6 +151,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_95d318fc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -178,6 +182,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ff33d54c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -188,6 +193,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_53f57b49
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -198,6 +204,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c9e57efc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -214,6 +221,7 @@ processors:
       if: ctx.json?.last_activity_time != null && ctx.json.last_activity_time != ''
       on_failure:
         - append:
+            tag: append_error_message_51f9f088
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -244,6 +252,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2e3debf6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -258,7 +267,7 @@ processors:
             field: json.to
             tag: rename_to
             target_field: nozomi_networks.session.to
-            ignore_missing: true  
+            ignore_missing: true
   - set:
       field: destination.ip
       tag: set_destination_ip_from_session_to_ip
@@ -302,6 +311,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_56003859
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -327,6 +337,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f8d7c2a5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -337,6 +348,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_581bd59b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -347,6 +359,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5cac166e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -362,6 +375,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a31366e7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -372,6 +386,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_59df363c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -382,6 +397,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d891896e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -392,6 +408,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bef28c40
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -407,6 +424,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_23f08fbd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -485,6 +503,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
@@ -510,6 +510,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -520,6 +521,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/session/elasticsearch/ingest_pipeline/default.yml
@@ -3,10 +3,10 @@ description: Pipeline for processing session logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -16,88 +16,88 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.type
-      tag: append_connection_into_event_type
+      tag: append_connection_into_event_type_e2d7507e
       value: connection
   - append:
       field: event.category
-      tag: append_network_into_event_category
+      tag: append_network_into_event_category_a9b06a9f
       value: network
   - fingerprint:
       fields:
         - json.id
         - json.first_activity_time
         - json.last_activity_time
-      tag: fingerprint_nozomi_networks_session
+      tag: fingerprint_nozomi_networks_session_9cb94bf1
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.bpf_filter
-      tag: rename_bpf_filter
+      tag: rename_bpf_filter_82ef7b40
       target_field: nozomi_networks.session.bpf_filter
       ignore_missing: true
   - convert:
       field: json.direction_is_known
-      tag: convert_direction_is_known_to_boolean
+      tag: convert_direction_is_known_to_boolean_06c74dcc
       target_field: nozomi_networks.session.direction_is_known
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_491a95b2
+            tag: append_error_message_d2e99da8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.first_activity_time
-      tag: date_first_activity_time
+      tag: date_first_activity_time_902bf3eb
       target_field: nozomi_networks.session.first_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.first_activity_time != null && ctx.json.first_activity_time != ''
       on_failure:
         - append:
-            tag: append_error_message_61d7c9bc
+            tag: append_error_message_3e0302d2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_session_first_activity_time
+      tag: set_event_start_from_session_first_activity_time_6fc607fb
       copy_from: nozomi_networks.session.first_activity_time
       ignore_empty_value: true
   - convert:
       field: json.from
-      tag: convert_from_to_ip
+      tag: convert_from_to_ip_a5d0459f
       target_field: nozomi_networks.session.from_ip
       type: ip
       ignore_missing: true
@@ -105,23 +105,23 @@ processors:
       on_failure:
         - rename:
             field: json.from
-            tag: rename_from
+            tag: rename_from_60ce7412
             target_field: nozomi_networks.session.from
             ignore_missing: true
   - set:
       field: source.ip
-      tag: set_source_ip_from_session_from_ip
+      tag: set_source_ip_from_session_from_ip_5e7637eb
       copy_from: nozomi_networks.session.from_ip
       ignore_empty_value: true
   - geoip:
       field: source.ip
-      tag: geoip_source_ip
+      tag: geoip_source_ip_9a2d4d31
       target_field: source.geo
       ignore_missing: true
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
-      tag: geoip_source_as
+      tag: geoip_source_as_58199963
       target_field: source.as
       properties:
         - asn
@@ -129,135 +129,135 @@ processors:
       ignore_missing: true
   - rename:
       field: source.as.asn
-      tag: rename_source_as_asn
+      tag: rename_source_as_asn_168bbbaf
       target_field: source.as.number
       ignore_missing: true
   - rename:
       field: source.as.organization_name
-      tag: rename_source_as_organization_name
+      tag: rename_source_as_organization_name_aa06a00b
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_session_from_into_related_ip
+      tag: append_session_from_into_related_ip_0b1f5576
       value: '{{{nozomi_networks.session.from_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.session?.from_ip != null
   - convert:
       field: json.from_port
-      tag: convert_from_port_to_long
+      tag: convert_from_port_to_long_ee1f09ce
       target_field: nozomi_networks.session.from_port
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_95d318fc
+            tag: append_error_message_dc876aff
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
-      tag: set_source_port_from_session_from_port
+      tag: set_source_port_from_session_from_port_c5c0640e
       copy_from: nozomi_networks.session.from_port
       ignore_empty_value: true
   - rename:
       field: json.from_zone
-      tag: rename_from_zone
+      tag: rename_from_zone_8872d2c1
       target_field: nozomi_networks.session.from_zone
       ignore_missing: true
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_eec7c190
       target_field: nozomi_networks.session.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_session_id
+      tag: set_event_id_from_session_id_c3862fae
       copy_from: nozomi_networks.session.id
       ignore_empty_value: true
   - convert:
       field: json.is_broadcast
-      tag: convert_is_broadcast_to_boolean
+      tag: convert_is_broadcast_to_boolean_0485c22d
       target_field: nozomi_networks.session.is_broadcast
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ff33d54c
+            tag: append_error_message_b514703e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_from_public
-      tag: convert_is_from_public_to_boolean
+      tag: convert_is_from_public_to_boolean_4774bf55
       target_field: nozomi_networks.session.is_from_public
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_53f57b49
+            tag: append_error_message_2189e20a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_to_public
-      tag: convert_is_to_public_to_boolean
+      tag: convert_is_to_public_to_boolean_36a1b8dd
       target_field: nozomi_networks.session.is_to_public
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c9e57efc
+            tag: append_error_message_937edb82
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.key
-      tag: rename_key
+      tag: rename_key_4cd992c7
       target_field: nozomi_networks.session.key
       ignore_missing: true
   - date:
       field: json.last_activity_time
-      tag: date_last_activity_time
+      tag: date_last_activity_time_60d2a422
       target_field: nozomi_networks.session.last_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_activity_time != null && ctx.json.last_activity_time != ''
       on_failure:
         - append:
-            tag: append_error_message_51f9f088
+            tag: append_error_message_fd1c4eef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.end
-      tag: set_event_end_from_session_last_activity_time
+      tag: set_event_end_from_session_last_activity_time_93379d15
       copy_from: nozomi_networks.session.last_activity_time
       ignore_empty_value: true
   - set:
       field: '@timestamp'
-      tag: set_timestamp_from_session_last_activity_time
+      tag: set_timestamp_from_session_last_activity_time_0a66ce82
       copy_from: nozomi_networks.session.last_activity_time
       ignore_empty_value: true
   - rename:
       field: json.protocol
-      tag: rename_protocol
+      tag: rename_protocol_64f8ae02
       target_field: nozomi_networks.session.protocol
       ignore_missing: true
   - rename:
       field: json.status
-      tag: rename_status
+      tag: rename_status_3bf00613
       target_field: nozomi_networks.session.status
       ignore_missing: true
   - convert:
       field: json.throughput_speed
-      tag: convert_throughput_speed_to_double
+      tag: convert_throughput_speed_to_double_4f0dbba0
       target_field: nozomi_networks.session.throughput_speed
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2e3debf6
+            tag: append_error_message_d33c3d7e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.to
-      tag: convert_to_to_ip
+      tag: convert_to_to_ip_0d9533ff
       target_field: nozomi_networks.session.to_ip
       type: ip
       ignore_missing: true
@@ -265,23 +265,23 @@ processors:
       on_failure:
         - rename:
             field: json.to
-            tag: rename_to
+            tag: rename_to_5ee5662d
             target_field: nozomi_networks.session.to
             ignore_missing: true
   - set:
       field: destination.ip
-      tag: set_destination_ip_from_session_to_ip
+      tag: set_destination_ip_from_session_to_ip_2c29a37e
       copy_from: nozomi_networks.session.to_ip
       ignore_empty_value: true
   - geoip:
       field: destination.ip
-      tag: geoip_destination_ip
+      tag: geoip_destination_ip_71881fab
       target_field: destination.geo
       ignore_missing: true
   - geoip:
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
-      tag: geoip_destination_as
+      tag: geoip_destination_as_4e3ec16d
       target_field: destination.as
       properties:
         - asn
@@ -289,166 +289,166 @@ processors:
       ignore_missing: true
   - rename:
       field: destination.as.asn
-      tag: rename_destination_as_asn
+      tag: rename_destination_as_asn_4968f9c8
       target_field: destination.as.number
       ignore_missing: true
   - rename:
       field: destination.as.organization_name
-      tag: rename_destination_as_organization_name
+      tag: rename_destination_as_organization_name_fb88b41e
       target_field: destination.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_session_to_into_related_ip
+      tag: append_session_to_into_related_ip_c7940036
       value: '{{{nozomi_networks.session.to_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.session?.to_ip != null
   - convert:
       field: json.to_port
-      tag: convert_to_port_to_long
+      tag: convert_to_port_to_long_8f669447
       target_field: nozomi_networks.session.to_port
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_56003859
+            tag: append_error_message_f37594ae
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
-      tag: set_destination_port_from_session_to_port
+      tag: set_destination_port_from_session_to_port_ca0846f1
       copy_from: nozomi_networks.session.to_port
       ignore_empty_value: true
   - rename:
       field: json.to_zone
-      tag: rename_to_zone
+      tag: rename_to_zone_88f7b7db
       target_field: nozomi_networks.session.to_zone
       ignore_missing: true
   - dot_expander:
       field: "*"
-      tag: dot_expander_json
+      tag: dot_expander_json_d05a7f8c
       path: json
       ignore_failure: true
   - convert:
       field: json.transferred.avg_packet_bytes
-      tag: convert_transferred_avg_packet_bytes_to_long
+      tag: convert_transferred_avg_packet_bytes_to_long_879c82c1
       target_field: nozomi_networks.session.transferred.avg_packet_bytes
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f8d7c2a5
+            tag: append_error_message_7247c6c0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.transferred.biggest_packet_bytes
-      tag: convert_transferred_biggest_packet_bytes_to_long
+      tag: convert_transferred_biggest_packet_bytes_to_long_fd36d52f
       target_field: nozomi_networks.session.transferred.biggest_packet_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_581bd59b
+            tag: append_error_message_e438b389
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.transferred.bytes
-      tag: convert_transferred_bytes_to_long
+      tag: convert_transferred_bytes_to_long_346acf45
       target_field: nozomi_networks.session.transferred.bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_5cac166e
+            tag: append_error_message_5704618a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: network.bytes
-      tag: set_network_bytes_from_session_transferred_bytes
+      tag: set_network_bytes_from_session_transferred_bytes_ef54611b
       copy_from: nozomi_networks.session.transferred.bytes
       ignore_empty_value: true
   - convert:
       field: json.transferred.last_15m_bytes
-      tag: convert_transferred_last_15m_bytes_to_long
+      tag: convert_transferred_last_15m_bytes_to_long_8085ca9d
       target_field: nozomi_networks.session.transferred.last_15m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a31366e7
+            tag: append_error_message_54a2c9e5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.transferred.last_30m_bytes
-      tag: convert_transferred_last_30m_bytes_to_long
+      tag: convert_transferred_last_30m_bytes_to_long_39c7739a
       target_field: nozomi_networks.session.transferred.last_30m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_59df363c
+            tag: append_error_message_34b8dfb8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.transferred.last_5m_bytes
-      tag: convert_transferred_last_5m_bytes_to_long
+      tag: convert_transferred_last_5m_bytes_to_long_fdf477c2
       target_field: nozomi_networks.session.transferred.last_5m_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d891896e
+            tag: append_error_message_05fa1f2d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.transferred.packets
-      tag: convert_transferred_packets_to_long
+      tag: convert_transferred_packets_to_long_2db91f1e
       target_field: nozomi_networks.session.transferred.packets
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_bef28c40
+            tag: append_error_message_011366d9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: network.packets
-      tag: set_network_packets_from_session_transferred_packets
+      tag: set_network_packets_from_session_transferred_packets_b7c7ffac
       copy_from: nozomi_networks.session.transferred.packets
       ignore_empty_value: true
   - convert:
       field: json.transferred.smallest_packet_bytes
-      tag: convert_transferred_smallest_packet_bytes_to_long
+      tag: convert_transferred_smallest_packet_bytes_to_long_3db74387
       target_field: nozomi_networks.session.transferred.smallest_packet_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_23f08fbd
+            tag: append_error_message_beb097f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.transport_protocol
-      tag: rename_transport_protocol
+      tag: rename_transport_protocol_6f5375d0
       target_field: nozomi_networks.session.transport_protocol
       ignore_missing: true
   - set:
       field: network.transport
-      tag: set_network_transport_from_session_transport_protocol
+      tag: set_network_transport_from_session_transport_protocol_284e49a6
       copy_from: nozomi_networks.session.transport_protocol
       ignore_empty_value: true
   - lowercase:
       field: network.transport
-      tag: lowercase_network_transport
+      tag: lowercase_network_transport_f67defdb
       ignore_missing: true
   - rename:
       field: json.vlan_id
-      tag: rename_vlan_id
+      tag: rename_vlan_id_fd9bb48a
       target_field: nozomi_networks.session.vlan_id
       ignore_missing: true
   - set:
       field: network.vlan.id
-      tag: set_network_vlan_id_from_session_vlan_id
+      tag: set_network_vlan_id_from_session_vlan_id_2086eb6a
       copy_from: nozomi_networks.session.vlan_id
       ignore_empty_value: true
   - remove:
@@ -464,15 +464,15 @@ processors:
         - nozomi_networks.session.transferred.packets
         - nozomi_networks.session.transport_protocol
         - nozomi_networks.session.vlan_id
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_484eb699
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -499,18 +499,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -518,10 +518,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
@@ -66,7 +66,7 @@ processors:
         - json.last_update_time
         - json.last_activity_time
         - json.record_created_at
-      tag: fingerprint_nozomi_networks_node_cve_497947fd
+      tag: fingerprint_nozomi_networks_variable_497947fd
       target_field: _id
       ignore_missing: true
   - rename:

--- a/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
@@ -3,17 +3,17 @@ description: Pipeline for processing variable logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -23,41 +23,41 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - dot_expander:
-      tag: dot_expander_*_6cdde46d
+      tag: dot_expander_*_df970cfa
       field: "*"
       path: json
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_2c621924
       value: network
       allow_duplicates: false
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_a75e9a8a
       value: info
       allow_duplicates: false
   - fingerprint:
@@ -66,115 +66,115 @@ processors:
         - json.last_update_time
         - json.last_activity_time
         - json.record_created_at
-      tag: fingerprint_nozomi_networks_node_cve
+      tag: fingerprint_nozomi_networks_node_cve_497947fd
       target_field: _id
       ignore_missing: true
   - rename:
       field: json.active_checks
-      tag: rename_active_checks
+      tag: rename_active_checks_80098377
       target_field: nozomi_networks.variable.active_checks
       ignore_missing: true
   - rename:
       field: json.bit_value
-      tag: rename_bit_value
+      tag: rename_bit_value_49532fe1
       target_field: nozomi_networks.variable.bit_value
       ignore_missing: true
   - convert:
       field: json.changes_count
-      tag: convert_changes_count_to_long
+      tag: convert_changes_count_to_long_e942eb52
       target_field: nozomi_networks.variable.changes_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4f547c71
+            tag: append_error_message_f3fe96de
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.first_activity_time
-      tag: date_first_activity_time
+      tag: date_first_activity_time_3476ae19
       target_field: nozomi_networks.variable.first_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.first_activity_time != null
       on_failure:
         - append:
-            tag: append_error_message_ec4d3fa7
+            tag: append_error_message_928b4e78
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.start
-      tag: set_event_start_from_variable_first_activity_time
+      tag: set_event_start_from_variable_first_activity_time_698d8b9a
       copy_from: nozomi_networks.variable.first_activity_time
       ignore_empty_value: true
   - rename:
       field: json.flow_anomalies
-      tag: rename_flow_anomalies
+      tag: rename_flow_anomalies_7595147b
       target_field: nozomi_networks.variable.flow_anomalies
       ignore_missing: true
   - convert:
       field: json.flow_anomaly_in_progress
-      tag: convert_flow_anomaly_in_progress_to_boolean
+      tag: convert_flow_anomaly_in_progress_to_boolean_f41b4064
       target_field: nozomi_networks.variable.flow_anomaly_in_progress
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6947b9e2
+            tag: append_error_message_f66272a1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.flow_hiccups_percent
-      tag: convert_flow_hiccups_percent_to_double
+      tag: convert_flow_hiccups_percent_to_double_a9a466ad
       target_field: nozomi_networks.variable.flow_hiccups_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_fc26db2e
+            tag: append_error_message_025998bb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.flow_stats.avg
-      tag: convert_flow_stats_avg_to_double
+      tag: convert_flow_stats_avg_to_double_368ef7b8
       target_field: nozomi_networks.variable.flow_stats.avg
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_4e52b8a5
+            tag: append_error_message_9666efcd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.flow_stats.var
-      tag: convert_flow_stats_var_to_double
+      tag: convert_flow_stats_var_to_double_8238d5fd
       target_field: nozomi_networks.variable.flow_stats.var
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c7c7db78
+            tag: append_error_message_2331c873
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.flow_status
-      tag: rename_flow_status
+      tag: rename_flow_status_6e9a2cb5
       target_field: nozomi_networks.variable.flow_status
       ignore_missing: true
   - convert:
       field: json.history_status
-      tag: convert_history_status_to_boolean
+      tag: convert_history_status_to_boolean_9fb56fbe
       target_field: nozomi_networks.variable.history_status
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2521cab1
+            tag: append_error_message_f70c02f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.host
-      tag: convert_host_to_ip
+      tag: convert_host_to_ip_4786f2d6
       target_field: nozomi_networks.variable.host_ip
       type: ip
       ignore_missing: true
@@ -182,94 +182,94 @@ processors:
       on_failure:
         - rename:
             field: json.host
-            tag: rename_host
+            tag: rename_host_5bbc9173
             target_field: nozomi_networks.variable.host
             ignore_missing: true
         - append:
             field: related.hosts
-            tag: append_host_into_related_hosts
+            tag: append_host_into_related_hosts_21e58ecc
             value: '{{{nozomi_networks.variable.host}}}'
             allow_duplicates: false
             if: ctx.nozomi_networks?.variable?.host != null
   - append:
       field: host.ip
-      tag: append_nozomi_networks_variable_host_into_host_ip
+      tag: append_nozomi_networks_variable_host_into_host_ip_7c7adfe6
       value: '{{{nozomi_networks.variable.host_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.variable?.host_ip != null
   - append:
       field: related.ip
-      tag: append_variable_host_into_related_ip
+      tag: append_variable_host_into_related_ip_716bb180
       value: '{{{nozomi_networks.variable.host_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.variable?.host_ip != null
   - rename:
       field: json.host_label
-      tag: rename_host_label
+      tag: rename_host_label_da125dac
       target_field: nozomi_networks.variable.host_label
       ignore_missing: true
   - set:
       field: host.name
-      tag: set_host_name_from_variable_host_label
+      tag: set_host_name_from_variable_host_label_a0ad135c
       copy_from: nozomi_networks.variable.host_label
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_variable_host_label_into_related_hosts
+      tag: append_variable_host_label_into_related_hosts_3833edea
       value: '{{{nozomi_networks.variable.host_label}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.variable?.host_label != null
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_0f125d59
       target_field: nozomi_networks.variable.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_variable_id
+      tag: set_event_id_from_variable_id_7fe8e85b
       copy_from: nozomi_networks.variable.id
       ignore_empty_value: true
   - convert:
       field: json.is_numeric
-      tag: convert_is_numeric_to_boolean
+      tag: convert_is_numeric_to_boolean_d667cec5
       target_field: nozomi_networks.variable.is_numeric
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_63b1adf8
+            tag: append_error_message_548e452a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.label
-      tag: rename_label
+      tag: rename_label_1d7312e4
       target_field: nozomi_networks.variable.label
       ignore_missing: true
   - date:
       field: json.last_activity_time
-      tag: date_last_activity_time
+      tag: date_last_activity_time_10d8d533
       target_field: nozomi_networks.variable.last_activity_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_activity_time != null
       on_failure:
         - append:
-            tag: append_error_message_0f83a2fb
+            tag: append_error_message_0dcd7f01
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.end
-      tag: set_event_end_from_variable_last_activity_time
+      tag: set_event_end_from_variable_last_activity_time_f7adff41
       copy_from: nozomi_networks.variable.last_activity_time
       ignore_empty_value: true
   - rename:
       field: json.last_cause
-      tag: rename_last_cause
+      tag: rename_last_cause_3bcf85d4
       target_field: nozomi_networks.variable.last_cause
       ignore_missing: true
   - convert:
       field: json.last_client
-      tag: convert_last_client_to_ip
+      tag: convert_last_client_to_ip_f42e8847
       target_field: nozomi_networks.variable.last_client_ip
       type: ip
       ignore_missing: true
@@ -277,27 +277,27 @@ processors:
       on_failure:
         - rename:
             field: json.last_client
-            tag: rename_last_client
+            tag: rename_last_client_5d4d4753
             target_field: nozomi_networks.variable.last_client_host
             ignore_missing: true
         - append:
             field: related.hosts
-            tag: append_last_client_into_related_hosts
+            tag: append_last_client_into_related_hosts_f3754f13
             value: '{{{nozomi_networks.variable.last_client_host}}}'
             allow_duplicates: false
             if: ctx.nozomi_networks?.variable?.last_client_host != null
   - set:
       field: source.ip
-      tag: set_source_ip_from_variable_last_client
+      tag: set_source_ip_from_variable_last_client_f1faf0e1
       copy_from: nozomi_networks.variable.last_client_ip
       ignore_empty_value: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
-      tag: geoip_source_ip_to_source_as_28d69883
+      tag: geoip_source_ip_to_source_as_58199963
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -307,186 +307,186 @@ processors:
       ignore_missing: true
   - rename:
       field: source.as.asn
-      tag: rename_source_as_asn
+      tag: rename_source_as_asn_168bbbaf
       target_field: source.as.number
       ignore_missing: true
   - rename:
       field: source.as.organization_name
-      tag: rename_source_as_organization_name
+      tag: rename_source_as_organization_name_aa06a00b
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_variable_last_client_into_related_ip
+      tag: append_variable_last_client_into_related_ip_f118fb1f
       value: '{{{nozomi_networks.variable.last_client_ip}}}'
       allow_duplicates: false
       if: ctx.nozomi_networks?.variable?.last_client_ip != null
   - rename:
       field: json.last_function_code
-      tag: rename_last_function_code
+      tag: rename_last_function_code_82934d44
       target_field: nozomi_networks.variable.last_function_code
       ignore_missing: true
   - rename:
       field: json.last_function_code_info
-      tag: rename_last_function_code_info
+      tag: rename_last_function_code_info_c509638a
       target_field: nozomi_networks.variable.last_function_code_info
       ignore_missing: true
   - date:
       field: json.last_range_change_time
-      tag: date_last_range_change_time
+      tag: date_last_range_change_time_0ea2aaf0
       target_field: nozomi_networks.variable.last_range_change_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_range_change_time != null
       on_failure:
         - append:
-            tag: append_error_message_fc9252d5
+            tag: append_error_message_1c6b981c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.last_update_time
-      tag: date_last_update_time
+      tag: date_last_update_time_926ee309
       target_field: nozomi_networks.variable.last_update_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_update_time != null
       on_failure:
         - append:
-            tag: append_error_message_2b15f5bb
+            tag: append_error_message_1e9bceb0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.last_valid_quality_time
-      tag: date_last_valid_quality_time
+      tag: date_last_valid_quality_time_89a60f17
       target_field: nozomi_networks.variable.last_valid_quality_time
       formats:
         - UNIX_MS
       if: ctx.json?.last_valid_quality_time != null
       on_failure:
         - append:
-            tag: append_error_message_db48a421
+            tag: append_error_message_39605cb8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.last_value
-      tag: convert_last_value_to_double
+      tag: convert_last_value_to_double_dd797d57
       target_field: nozomi_networks.variable.last_value
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_7cbfc84c
+            tag: append_error_message_457ba4f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.last_value_is_valid
-      tag: convert_last_value_is_valid_to_boolean
+      tag: convert_last_value_is_valid_to_boolean_8d26feba
       target_field: nozomi_networks.variable.last_value_is_valid
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_e2a6b838
+            tag: append_error_message_dc82d0d6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.last_value_quality
-      tag: rename_last_value_quality
+      tag: rename_last_value_quality_48c11ac2
       target_field: nozomi_networks.variable.last_value_quality
       ignore_missing: true
   - rename:
       field: json.latest_bit_change
-      tag: rename_latest_bit_change
+      tag: rename_latest_bit_change_cade5dce
       target_field: nozomi_networks.variable.latest_bit_change
       ignore_missing: true
   - rename:
       field: json.max_value
-      tag: rename_max_value
+      tag: rename_max_value_927f3898
       target_field: nozomi_networks.variable.max_value
       ignore_missing: true
   - rename:
       field: json.min_value
-      tag: rename_min_value
+      tag: rename_min_value_d15f3676
       target_field: nozomi_networks.variable.min_value
       ignore_missing: true
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_f9e06fc9
       target_field: nozomi_networks.variable.name
       ignore_missing: true
   - rename:
       field: json.namespace
-      tag: rename_namespace
+      tag: rename_namespace_1d079872
       target_field: nozomi_networks.variable.namespace
       ignore_missing: true
   - rename:
       field: json.offset
-      tag: rename_offset
+      tag: rename_offset_43219f3b
       target_field: nozomi_networks.variable.offset
       ignore_missing: true
   - rename:
       field: json.protocol
-      tag: rename_protocol
+      tag: rename_protocol_1774b06b
       target_field: nozomi_networks.variable.protocol
       ignore_missing: true
   - date:
       field: json.record_created_at
-      tag: date_record_created_at
+      tag: date_record_created_at_331a65a5
       target_field: nozomi_networks.variable.record_created_at
       formats:
         - UNIX_MS
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
-            tag: append_error_message_98be4593
+            tag: append_error_message_9e0fe6f3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_variable_record_created_at
+      tag: set_@timestamp_from_variable_record_created_at_ebacd134
       copy_from: nozomi_networks.variable.record_created_at
       ignore_empty_value: true
   - convert:
       field: json.request_count
-      tag: convert_request_count_to_long
+      tag: convert_request_count_to_long_f178ee7f
       target_field: nozomi_networks.variable.request_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0c5a5209
+            tag: append_error_message_9a5cb699
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.scale
-      tag: rename_scale
+      tag: rename_scale_a9f62ef0
       target_field: nozomi_networks.variable.scale
       ignore_missing: true
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_105a63da
       target_field: nozomi_networks.variable.type
       ignore_missing: true
   - rename:
       field: json.unit
-      tag: rename_unit
+      tag: rename_unit_8caed500
       target_field: nozomi_networks.variable.unit
       ignore_missing: true
   - convert:
       field: json.value
-      tag: convert_value_to_double
+      tag: convert_value_to_double_fa9d87d8
       target_field: nozomi_networks.variable.value
       type: double
       if: ctx.json?.value != ""
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b0c60597
+            tag: append_error_message_824b38a2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.var_key
-      tag: rename_var_key
+      tag: rename_var_key_cc1bb7f0
       target_field: nozomi_networks.variable.var_key
       ignore_missing: true
   - remove:
@@ -496,15 +496,15 @@ processors:
         - nozomi_networks.variable.id
         - nozomi_networks.variable.last_activity_time
         - nozomi_networks.variable.record_created_at
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_ad9af7e4
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -531,18 +531,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -550,10 +550,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
@@ -39,9 +39,11 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - dot_expander:
+      tag: dot_expander_*_6cdde46d
       field: "*"
       path: json
   - set:
@@ -85,6 +87,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4f547c71
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -96,6 +99,7 @@ processors:
       if: ctx.json?.first_activity_time != null
       on_failure:
         - append:
+            tag: append_error_message_ec4d3fa7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -116,6 +120,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6947b9e2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -126,6 +131,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fc26db2e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -136,6 +142,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4e52b8a5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -146,6 +153,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c7c7db78
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -161,6 +169,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2521cab1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -228,6 +237,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_63b1adf8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -244,6 +254,7 @@ processors:
       if: ctx.json?.last_activity_time != null
       on_failure:
         - append:
+            tag: append_error_message_0f83a2fb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -281,10 +292,12 @@ processors:
       copy_from: nozomi_networks.variable.last_client_ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -327,6 +340,7 @@ processors:
       if: ctx.json?.last_range_change_time != null
       on_failure:
         - append:
+            tag: append_error_message_fc9252d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -338,6 +352,7 @@ processors:
       if: ctx.json?.last_update_time != null
       on_failure:
         - append:
+            tag: append_error_message_2b15f5bb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -349,6 +364,7 @@ processors:
       if: ctx.json?.last_valid_quality_time != null
       on_failure:
         - append:
+            tag: append_error_message_db48a421
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -359,6 +375,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7cbfc84c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -369,6 +386,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e2a6b838
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -420,6 +438,7 @@ processors:
       if: ctx.json?.record_created_at != null
       on_failure:
         - append:
+            tag: append_error_message_98be4593
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -435,6 +454,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0c5a5209
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -461,6 +481,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b0c60597
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -514,6 +535,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nozomi_networks/data_stream/variable/elasticsearch/ingest_pipeline/default.yml
@@ -542,6 +542,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -552,6 +553,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.3.2
+version: 0.4.0
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.3.1
+version: 0.3.2
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_gav/changelog.yml
+++ b/packages/qualys_gav/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.9.3"
+- version: "0.10.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/qualys_gav/changelog.yml
+++ b/packages/qualys_gav/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.3"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.9.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/qualys_gav/changelog.yml
+++ b/packages/qualys_gav/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.9.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/qualys_gav/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_gav/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -19,6 +19,7 @@ processors:
       if: ctx.interval_start != null && ctx.interval_start != ''
       on_failure:
         - append:
+            tag: append_error_message_3cdc5092
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -43,25 +44,29 @@ processors:
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
-
   # Set up tag logic for choosing which cloud metadata to include.
   - append:
+      tag: append_tags_ae765f40
       field: tags
       value: ["elastic_cloud_data", "provider_cloud_data"]
       if: ctx.tags?.contains('both') == true
   - script:
+      tag: script_023c6838
       lang: painless
       if: ctx.tags?.contains('both') == true
       source: ctx.tags.remove(ctx.tags.indexOf('both'));
   - script:
+      tag: script_cfa1c445
       lang: painless
       if: ctx.cloud == null && ctx.tags?.contains('elastic_cloud_data') == true
       source: ctx.tags.remove(ctx.tags.indexOf('elastic_cloud_data'));
   - set:
+      tag: set__conf_want_provider_cloud_4bad817b
       field: _conf.want_provider_cloud
       value: true
       if: ctx.tags?.contains('provider_cloud_data') == true
   - remove:
+      tag: remove_cloud_ddf0b5c6
       description: Remove elastic agent-provided cloud metadata fields if not requested.
       field: cloud
       if: ctx.tags != null && !ctx.tags.contains('elastic_cloud_data')
@@ -170,8 +175,10 @@ processors:
       if: ctx.qualys_gav?.asset?.address != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_address_0d5a702a
             field: qualys_gav.asset.address
         - append:
+            tag: append_error_message_549e6416
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -194,8 +201,10 @@ processors:
       if: ctx.qualys_gav?.asset?.agent?.connected_from != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_agent_connected_from_db5636ff
             field: qualys_gav.asset.agent.connected_from
         - append:
+            tag: append_error_message_9aa308a0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
@@ -214,8 +223,10 @@ processors:
       if: ctx.qualys_gav?.asset?.agent?.last_activity != null && ctx.qualys_gav.asset.agent.last_activity != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_agent_last_activity_eb3052f4
             field: qualys_gav.asset.agent.last_activity
         - append:
+            tag: append_error_message_f3dd5d7b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -228,8 +239,10 @@ processors:
       if: ctx.qualys_gav?.asset?.agent?.last_checked_in != null && ctx.qualys_gav.asset.agent.last_checked_in != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_agent_last_checked_in_6c5fd0ec
             field: qualys_gav.asset.agent.last_checked_in
         - append:
+            tag: append_error_message_f7b4d077
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -242,8 +255,10 @@ processors:
       if: ctx.qualys_gav?.asset?.agent?.last_inventory != null && ctx.qualys_gav.asset.agent.last_inventory != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_agent_last_inventory_13c41b13
             field: qualys_gav.asset.agent.last_inventory
         - append:
+            tag: append_error_message_6c5f5583
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -254,8 +269,10 @@ processors:
       if: ctx.qualys_gav?.asset?.agent?.udc_manifest_assigned != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_agent_udc_manifest_assigned_c69b65f0
             field: qualys_gav.asset.agent.udc_manifest_assigned
         - append:
+            tag: append_error_message_cd44145c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -266,8 +283,10 @@ processors:
       if: ctx.qualys_gav?.asset?.agent?.error_status != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_agent_error_status_b1c7fde8
             field: qualys_gav.asset.agent.error_status
         - append:
+            tag: append_error_message_3fc99ffa
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Remove fields having 0 value
@@ -288,8 +307,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_vmscan != null && ctx.qualys_gav.asset.sensor.last_vmscan != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_vmscan_808540e4
             field: qualys_gav.asset.sensor.last_vmscan
         - append:
+            tag: append_error_message_cfb15aeb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -302,8 +323,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_compliance_scan != null && ctx.qualys_gav.asset.sensor.last_compliance_scan != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_compliance_scan_c14e34ae
             field: qualys_gav.asset.sensor.last_compliance_scan
         - append:
+            tag: append_error_message_15802628
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -316,8 +339,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_full_scan != null && ctx.qualys_gav.asset.sensor.last_full_scan != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_full_scan_b7013a00
             field: qualys_gav.asset.sensor.last_full_scan
         - append:
+            tag: append_error_message_6dc15e9c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -330,8 +355,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_vm_scan_date_scanner != null && ctx.qualys_gav.asset.sensor.last_vm_scan_date_scanner != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_vm_scan_date_scanner_83b1afac
             field: qualys_gav.asset.sensor.last_vm_scan_date_scanner
         - append:
+            tag: append_error_message_4b7cdc22
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -344,8 +371,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.first_easm_scan_date != null && ctx.qualys_gav.asset.sensor.first_easm_scan_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_first_easm_scan_date_38825704
             field: qualys_gav.asset.sensor.first_easm_scan_date
         - append:
+            tag: append_error_message_575d7e2c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -358,8 +387,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_vm_scan_date_agent != null && ctx.qualys_gav.asset.sensor.last_vm_scan_date_agent != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_vm_scan_date_agent_cfcc4641
             field: qualys_gav.asset.sensor.last_vm_scan_date_agent
         - append:
+            tag: append_error_message_df5d0892
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -372,8 +403,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_pc_scan_date_scanner != null && ctx.qualys_gav.asset.sensor.last_pc_scan_date_scanner != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_pc_scan_date_scanner_2c1f4aec
             field: qualys_gav.asset.sensor.last_pc_scan_date_scanner
         - append:
+            tag: append_error_message_43d142be
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -386,8 +419,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_pc_scan_date_agent != null && ctx.qualys_gav.asset.sensor.last_pc_scan_date_agent != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_pc_scan_date_agent_5153e27d
             field: qualys_gav.asset.sensor.last_pc_scan_date_agent
         - append:
+            tag: append_error_message_01013632
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -400,8 +435,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor?.last_easm_scan_date != null && ctx.qualys_gav.asset.sensor.last_easm_scan_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_easm_scan_date_800b1ff2
             field: qualys_gav.asset.sensor.last_easm_scan_date
         - append:
+            tag: append_error_message_870aea82
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -459,8 +496,10 @@ processors:
       if: ctx.qualys_gav?.asset?.container?.no_of_containers != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_container_no_of_containers_d939893f
             field: qualys_gav.asset.container.no_of_containers
         - append:
+            tag: append_error_message_806d532c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -471,8 +510,10 @@ processors:
       if: ctx.qualys_gav?.asset?.container?.no_of_images != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_container_no_of_images_063a2749
             field: qualys_gav.asset.container.no_of_images
         - append:
+            tag: append_error_message_2e6f2388
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -483,8 +524,10 @@ processors:
       if: ctx.qualys_gav?.asset?.cpu_count != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_cpu_count_aaa21c40
             field: qualys_gav.asset.cpu_count
         - append:
+            tag: append_error_message_c214ca06
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -497,8 +540,10 @@ processors:
       if: ctx.qualys_gav?.asset?.created_date != null && ctx.qualys_gav.asset.created_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_created_date_705df3ae
             field: qualys_gav.asset.created_date
         - append:
+            tag: append_error_message_95b697b7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -514,8 +559,10 @@ processors:
       if: ctx.qualys_gav?.asset?.criticality?.is_default != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_criticality_is_default_636ba50b
             field: qualys_gav.asset.criticality.is_default
         - append:
+            tag: append_error_message_2e07343c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -528,8 +575,10 @@ processors:
       if: ctx.qualys_gav?.asset?.criticality?.last_updated != null && ctx.qualys_gav.asset.criticality.last_updated != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_criticality_last_updated_181d4b3e
             field: qualys_gav.asset.criticality.last_updated
         - append:
+            tag: append_error_message_47c3d483
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -540,8 +589,10 @@ processors:
       if: ctx.qualys_gav?.asset?.criticality?.score != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_criticality_score_f0c6a845
             field: qualys_gav.asset.criticality.score
         - append:
+            tag: append_error_message_a4fb47ea
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -595,8 +646,10 @@ processors:
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.eos_date != null && ctx.qualys_gav.asset.hardware.lifecycle.eos_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_hardware_lifecycle_eos_date_5b63d3fd
             field: qualys_gav.asset.hardware.lifecycle.eos_date
         - append:
+            tag: append_error_message_bc086db7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -609,8 +662,10 @@ processors:
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.ga_date != null && ctx.qualys_gav.asset.hardware.lifecycle.ga_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_hardware_lifecycle_ga_date_c3032b5e
             field: qualys_gav.asset.hardware.lifecycle.ga_date
         - append:
+            tag: append_error_message_26629491
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -623,8 +678,10 @@ processors:
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.intro_date != null && ctx.qualys_gav.asset.hardware.lifecycle.intro_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_hardware_lifecycle_intro_date_f47bf89c
             field: qualys_gav.asset.hardware.lifecycle.intro_date
         - append:
+            tag: append_error_message_4e6e69df
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -637,8 +694,10 @@ processors:
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.obsolete_date != null && ctx.qualys_gav.asset.hardware.lifecycle.obsolete_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_hardware_lifecycle_obsolete_date_4c168eb9
             field: qualys_gav.asset.hardware.lifecycle.obsolete_date
         - append:
+            tag: append_error_message_3d56f317
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -677,8 +736,10 @@ processors:
       if: ctx.qualys_gav?.asset?.inventory?.created != null && ctx.qualys_gav.asset.inventory.created != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_inventory_created_3621ec17
             field: qualys_gav.asset.inventory.created
         - append:
+            tag: append_error_message_c79758e5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -691,8 +752,10 @@ processors:
       if: ctx.qualys_gav?.asset?.inventory?.last_updated != null && ctx.qualys_gav.asset.inventory.last_updated != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_inventory_last_updated_76692d3f
             field: qualys_gav.asset.inventory.last_updated
         - append:
+            tag: append_error_message_8b25398b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -737,8 +800,10 @@ processors:
       if: ctx.qualys_gav?.asset?.activity?.last_scanned_date != null && ctx.qualys_gav.asset.activity.last_scanned_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_activity_last_scanned_date_83ecfaee
             field: qualys_gav.asset.activity.last_scanned_date
         - append:
+            tag: append_error_message_cf33fa95
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -749,8 +814,10 @@ processors:
       if: ctx.qualys_gav?.asset?.is_container_host != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_is_container_host_df8f9173
             field: qualys_gav.asset.is_container_host
         - append:
+            tag: append_error_message_0472b0ba
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -763,8 +830,10 @@ processors:
       if: ctx.qualys_gav?.asset?.last_boot != null && ctx.qualys_gav.asset.last_boot != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_last_boot_fb1aa69a
             field: qualys_gav.asset.last_boot
         - append:
+            tag: append_error_message_295822fd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -1047,12 +1116,12 @@ processors:
       lang: painless
       if: ctx.qualys_gav?.asset?.operating_system?.category1 != null
       params:
-        macos : macos
-        linux : linux
-        unix : unix
-        windows : windows
-        ios : ios
-        android : android
+        macos: macos
+        linux: linux
+        unix: unix
+        windows: windows
+        ios: ios
+        android: android
       source: |
         def os_type = ctx.qualys_gav.asset.operating_system.category1.toLowerCase();
 
@@ -1084,8 +1153,10 @@ processors:
       if: ctx.qualys_gav?.asset?.operating_system?.install_date != null && ctx.qualys_gav.asset.operating_system.install_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_operating_system_install_date_dd332c8a
             field: qualys_gav.asset.operating_system.install_date
         - append:
+            tag: append_error_message_e86e0da1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -1098,8 +1169,10 @@ processors:
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.eol_date != null && ctx.qualys_gav.asset.operating_system.lifecycle.eol_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_eol_date_5ea340ed
             field: qualys_gav.asset.operating_system.lifecycle.eol_date
         - append:
+            tag: append_error_message_b203b637
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -1112,8 +1185,10 @@ processors:
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.eos_date != null && ctx.qualys_gav.asset.operating_system.lifecycle.eos_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_eos_date_29ce926e
             field: qualys_gav.asset.operating_system.lifecycle.eos_date
         - append:
+            tag: append_error_message_8b8c416f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -1126,8 +1201,10 @@ processors:
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.ga_date != null && ctx.qualys_gav.asset.operating_system.lifecycle.ga_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_ga_date_6efa9a05
             field: qualys_gav.asset.operating_system.lifecycle.ga_date
         - append:
+            tag: append_error_message_1ac03533
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1138,8 +1215,10 @@ processors:
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.detection_score != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_detection_score_4b9ccf3d
             field: qualys_gav.asset.operating_system.lifecycle.detection_score
         - append:
+            tag: append_error_message_86dace88
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -1181,9 +1260,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_has_agent_0cdce69b
             field: qualys_gav.asset.cloud_provider.aws.ec2.has_agent
             ignore_missing: true
         - append:
+            tag: append_error_message_63a1c0be
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -1196,9 +1277,11 @@ processors:
       if: ctx.qualys_gav?.asset?.cloud_provider?.aws?.ec2?.launchdate != null && ctx.qualys_gav.asset.cloud_provider.aws.ec2.launchdate != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_launchdate_8e78ea70
             field: qualys_gav.asset.cloud_provider.aws.ec2.launchdate
             ignore_missing: true
         - append:
+            tag: append_error_message_3bfa46e8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1208,9 +1291,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_qualys_scanner_f49466f1
             field: qualys_gav.asset.cloud_provider.aws.ec2.qualys_scanner
             ignore_missing: true
         - append:
+            tag: append_error_message_5ae5e698
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1220,9 +1305,11 @@ processors:
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_spot_instance_cdbd0f4b
             field: qualys_gav.asset.cloud_provider.aws.ec2.spot_instance
             ignore_missing: true
         - append:
+            tag: append_error_message_ecb043c2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -1302,7 +1389,7 @@ processors:
       ignore_empty_value: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name
+      tag: set_cloud_service_name_6f4b3b6c
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'azure' && ctx.qualys_gav?.asset?.cloud_provider?.azure?.vm != null
       value: vm
 
@@ -1352,11 +1439,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e21b85a8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name
+      tag: set_cloud_service_name_dcdaf8c0
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'gcp' && ctx.qualys_gav?.asset?.cloud_provider?.gcp?.compute != null
       value: compute
 
@@ -1371,7 +1459,7 @@ processors:
       tag: convert_qualys_gav_asset_cloud_provider_ibm_virtual_server_ibm_id_to_string
       type: string
       ignore_missing: true
-  
+
   # Map/Convert IBM specific fields to ECS fields
   - set:
       field: cloud.account.id
@@ -1399,7 +1487,7 @@ processors:
       ignore_empty_value: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name
+      tag: set_cloud_service_name_93672477
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'azure' && ctx.qualys_gav?.asset?.cloud_provider?.ibm?.virtual_server != null
       value: virtual_server
 
@@ -1412,8 +1500,10 @@ processors:
       if: ctx.qualys_gav?.asset?.risk_score != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_risk_score_46898134
             field: qualys_gav.asset.risk_score
         - append:
+            tag: append_error_message_4bc086e0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -1441,8 +1531,10 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor_last_updated_date != null && ctx.qualys_gav.asset.sensor_last_updated_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_sensor_last_updated_date_e7aa2ebb
             field: qualys_gav.asset.sensor_last_updated_date
         - append:
+            tag: append_error_message_18f0e285
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1824,8 +1916,10 @@ processors:
       if: ctx.qualys_gav?.asset?.threads_per_core != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_threads_per_core_2144e1fc
             field: qualys_gav.asset.threads_per_core
         - append:
+            tag: append_error_message_abc82d01
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -1841,8 +1935,10 @@ processors:
       if: ctx.qualys_gav?.asset?.total_memory != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_total_memory_d78e6fd6
             field: qualys_gav.asset.total_memory
         - append:
+            tag: append_error_message_730ab154
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1947,8 +2043,10 @@ processors:
       if: ctx.qualys_gav?.asset?.last_modified_date != null && ctx.qualys_gav.asset.last_modified_date != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_last_modified_date_ca6e9e50
             field: qualys_gav.asset.last_modified_date
         - append:
+            tag: append_error_message_52a15937
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1959,8 +2057,10 @@ processors:
       if: ctx.qualys_gav?.asset?.processor?.speed != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_processor_speed_36a66ad5
             field: qualys_gav.asset.processor.speed
         - append:
+            tag: append_error_message_c0a0bad4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1971,8 +2071,10 @@ processors:
       if: ctx.qualys_gav?.asset?.processor?.num_cpus != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_processor_num_cpus_ee19437d
             field: qualys_gav.asset.processor.num_cpus
         - append:
+            tag: append_error_message_281bd05f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1983,8 +2085,10 @@ processors:
       if: ctx.qualys_gav?.asset?.processor?.no_of_socket != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_processor_no_of_socket_d60370fa
             field: qualys_gav.asset.processor.no_of_socket
         - append:
+            tag: append_error_message_065b4e21
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -1995,8 +2099,10 @@ processors:
       if: ctx.qualys_gav?.asset?.processor?.threads_per_core != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_processor_threads_per_core_b07b85e8
             field: qualys_gav.asset.processor.threads_per_core
         - append:
+            tag: append_error_message_8ab88271
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -2007,8 +2113,10 @@ processors:
       if: ctx.qualys_gav?.asset?.processor?.cores_per_socket != ''
       on_failure:
         - remove:
+            tag: remove_qualys_gav_asset_processor_cores_per_socket_13389faf
             field: qualys_gav.asset.processor.cores_per_socket
         - append:
+            tag: append_error_message_2c067477
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -2115,6 +2223,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/qualys_gav/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_gav/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -772,6 +772,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_created
                 field: _ingest._value.created
                 ignore_missing: true
   - foreach:
@@ -788,6 +789,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_last_updated
                 field: _ingest._value.last_updated
                 ignore_missing: true
   - date:
@@ -885,6 +887,7 @@ processors:
           ignore_missing: true
           on_failure:
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -918,9 +921,11 @@ processors:
               ignore_missing: true
               on_failure:
                 - remove:
+                    tag: remove_ingest_value
                     field: _ingest._value
                     ignore_missing: true
                 - append:
+                    tag: append_error_message_4411f124
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -930,7 +935,7 @@ processors:
       processor:
         foreach:
           field: _ingest._value.address_ip_v4
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4_43ff8a28
           ignore_failure: true
           processor:
             append:
@@ -951,6 +956,7 @@ processors:
           ignore_missing: true
           on_failure:
             - append:
+                tag: append_error_message_143963e5
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -984,6 +990,7 @@ processors:
           ignore_missing: true
           on_failure:
             - append:
+                tag: append_error_message_7d48ee26
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1003,9 +1010,11 @@ processors:
               ignore_missing: true
               on_failure:
                 - remove:
+                    tag: remove_ingest_value_dfc3b655
                     field: _ingest._value
                     ignore_missing: true
                 - append:
+                    tag: append_error_message_e03cc8cb
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1015,7 +1024,7 @@ processors:
       processor:
         foreach:
           field: _ingest._value.address_ip_v6
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v6
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v6_dfc35121
           ignore_failure: true
           processor:
             append:
@@ -1037,6 +1046,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_mac_vendor_intro_date
                 field: _ingest._value.mac_vendor_intro_date
                 ignore_missing: true
   - foreach:
@@ -1051,9 +1061,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_port
                 field: _ingest._value.port
                 ignore_missing: true
             - append:
+                tag: append_error_message_d6899848
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1068,9 +1080,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_detection_score
                 field: _ingest._value.detection_score
                 ignore_missing: true
             - append:
+                tag: append_error_message_8da8184e
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1087,6 +1101,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_first_found
                 field: _ingest._value.first_found
                 ignore_missing: true
   - foreach:
@@ -1103,6 +1118,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_last_updated_dcfad241
                 field: _ingest._value.last_updated
                 ignore_missing: true
   - set:
@@ -1565,7 +1581,7 @@ processors:
       processor:
         append:
           field: package.type
-          tag: append_sofware_list_data_software_name_into_package_name
+          tag: append_sofware_list_data_software_name_into_package_name_f09d95a0
           value: '{{{_ingest._value.software_type}}}'
           allow_duplicates: false
   - foreach:
@@ -1580,9 +1596,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_is_ignored
                 field: _ingest._value.is_ignored
                 ignore_missing: true
             - append:
+                tag: append_error_message_5639bfa9
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1619,6 +1637,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_install_date
                 field: _ingest._value.install_date
                 ignore_missing: true
   - foreach:
@@ -1655,6 +1674,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_last_updated_48fae1a8
                 field: _ingest._value.last_updated
                 ignore_missing: true
   - foreach:
@@ -1671,6 +1691,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_last_use_date
                 field: _ingest._value.last_use_date
                 ignore_missing: true
   - foreach:
@@ -1685,9 +1706,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_is_package
                 field: _ingest._value.is_package
                 ignore_missing: true
             - append:
+                tag: append_error_message_e8e14e4a
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1702,9 +1725,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_is_package_component
                 field: _ingest._value.is_package_component
                 ignore_missing: true
             - append:
+                tag: append_error_message_a4ddfd07
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1731,6 +1756,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_lifecycle_ga_date
                 field: _ingest._value.lifecycle.ga_date
                 ignore_missing: true
   - foreach:
@@ -1747,6 +1773,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_lifecycle_eol_date
                 field: _ingest._value.lifecycle.eol_date
                 ignore_missing: true
   - foreach:
@@ -1763,6 +1790,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_lifecycle_eos_date
                 field: _ingest._value.lifecycle.eos_date
                 ignore_missing: true
   - foreach:
@@ -1777,9 +1805,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_lifecycle_detection_score
                 field: _ingest._value.lifecycle.detection_score
                 ignore_missing: true
             - append:
+                tag: append_error_message_f6de18a6
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1799,7 +1829,7 @@ processors:
       processor:
         append:
           field: package.license
-          tag: append_software_list_data_software_support_stage_desc
+          tag: append_software_list_data_software_support_stage_desc_bbaeff2d
           value: '{{{_ingest._value.license.category}}}'
           allow_duplicates: false
   - foreach:
@@ -1814,9 +1844,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_authorization_detection_score
                 field: _ingest._value.authorization_detection_score
                 ignore_missing: true
             - append:
+                tag: append_error_message_f296c5ec
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1838,6 +1870,7 @@ processors:
                 - ISO8601
               on_failure:
                 - remove:
+                    tag: remove_ingest_value_first_seen
                     field: _ingest._value.first_seen
                     ignore_missing: true
   - foreach:
@@ -1859,6 +1892,7 @@ processors:
                 - ISO8601
               on_failure:
                 - remove:
+                    tag: remove_ingest_value_last_seen
                     field: _ingest._value.last_seen
                     ignore_missing: true
   - foreach:
@@ -1873,9 +1907,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_criticality_score
                 field: _ingest._value.criticality_score
                 ignore_missing: true
             - append:
+                tag: append_error_message_dfdfe4bf
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1953,9 +1989,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_free
                 field: _ingest._value.free
                 ignore_missing: true
             - append:
+                tag: append_error_message_8c49b7cd
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1970,9 +2008,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_size
                 field: _ingest._value.size
                 ignore_missing: true
             - append:
+                tag: append_error_message_47b2d786
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -1989,6 +2029,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_created_date
                 field: _ingest._value.created_date
                 ignore_missing: true
   - foreach:
@@ -2005,6 +2046,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_expiration_date
                 field: _ingest._value.expiration_date
                 ignore_missing: true
   - foreach:
@@ -2021,6 +2063,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_updated_date
                 field: _ingest._value.updated_date
                 ignore_missing: true
   - foreach:
@@ -2230,6 +2273,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_30479dff
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -2240,6 +2284,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/qualys_gav/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_gav/data_stream/asset/elasticsearch/ingest_pipeline/default.yml
@@ -3,32 +3,32 @@ description: Pipeline for processing asset logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: interval_id
-      tag: rename_interval_id
+      tag: rename_interval_id_cdd42385
       target_field: qualys_gav.asset.interval_id
       ignore_missing: true
   - date:
       field: interval_start
-      tag: date_interval_start
+      tag: date_interval_start_718f7fe5
       target_field: qualys_gav.asset.interval_start
       formats:
         - ISO8601
       if: ctx.interval_start != null && ctx.interval_start != ''
       on_failure:
         - append:
-            tag: append_error_message_3cdc5092
+            tag: append_error_message_62d5b4a0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
-      tag: remove_interval_start
+      tag: remove_interval_start_080d07be
       field:
         - interval_start
       ignore_missing: true
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
 
@@ -40,33 +40,33 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   # Set up tag logic for choosing which cloud metadata to include.
   - append:
-      tag: append_tags_ae765f40
+      tag: append_tags_8889e0bc
       field: tags
       value: ["elastic_cloud_data", "provider_cloud_data"]
       if: ctx.tags?.contains('both') == true
   - script:
-      tag: script_023c6838
+      tag: script_50fcbb73
       lang: painless
       if: ctx.tags?.contains('both') == true
       source: ctx.tags.remove(ctx.tags.indexOf('both'));
   - script:
-      tag: script_cfa1c445
+      tag: script_c700db75
       lang: painless
       if: ctx.cloud == null && ctx.tags?.contains('elastic_cloud_data') == true
       source: ctx.tags.remove(ctx.tags.indexOf('elastic_cloud_data'));
   - set:
-      tag: set__conf_want_provider_cloud_4bad817b
+      tag: set__conf_want_provider_cloud_791fe766
       field: _conf.want_provider_cloud
       value: true
       if: ctx.tags?.contains('provider_cloud_data') == true
   - remove:
-      tag: remove_cloud_ddf0b5c6
+      tag: remove_cloud_61d5aaea
       description: Remove elastic agent-provided cloud metadata fields if not requested.
       field: cloud
       if: ctx.tags != null && !ctx.tags.contains('elastic_cloud_data')
@@ -76,25 +76,25 @@ processors:
   # parse the event JSON
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_74d23cc2
       target_field: json
 
   # rename to snake case
   - script:
-      tag: script_convert_camelcase_to_snake_case
+      tag: script_convert_camelcase_to_snake_case_e887f140
       lang: painless
       description: Convert camelCase to snake_case
       source: |
@@ -147,151 +147,151 @@ processors:
   # Set observer.* and event.* fields
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_2b19d651
       value: Qualys
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_15805b0d
       value: Global AssetView
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - append:
       field: event.category
-      tag: append_host_into_event_category
+      tag: append_host_into_event_category_5098f71a
       value: host
   - append:
       field: event.type
-      tag: append_info_into_event_type
+      tag: append_info_into_event_type_5eab37e6
       value: info
 
   # Convert values into appropriate type and do ECS mapping
   - convert:
       field: qualys_gav.asset.address
-      tag: convert_address_to_ip
+      tag: convert_address_to_ip_d1d43fcb
       type: ip
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.address != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_address_0d5a702a
+            tag: remove_qualys_gav_asset_address_3fd1a894
             field: qualys_gav.asset.address
         - append:
-            tag: append_error_message_549e6416
+            tag: append_error_message_9eee65b2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: host.ip
-      tag: append_qualys_gav_asset_address_into_host_ip
+      tag: append_qualys_gav_asset_address_into_host_ip_bf1ae64f
       value: '{{{qualys_gav.asset.address}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.address != null
   - append:
       field: related.ip
-      tag: append_asset_address_into_related_ip
+      tag: append_asset_address_into_related_ip_f9239949
       value: '{{{qualys_gav.asset.address}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.address != null
   - convert:
       field: qualys_gav.asset.agent.connected_from
-      tag: convert_agent_connected_from_to_ip
+      tag: convert_agent_connected_from_to_ip_1199a23a
       type: ip
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.agent?.connected_from != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_agent_connected_from_db5636ff
+            tag: remove_qualys_gav_asset_agent_connected_from_2681922e
             field: qualys_gav.asset.agent.connected_from
         - append:
-            tag: append_error_message_9aa308a0
+            tag: append_error_message_433fd5ea
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: related.ip
-      tag: append_asset_agent_connected_from_into_related_ip
+      tag: append_asset_agent_connected_from_into_related_ip_1f778f67
       value: '{{{qualys_gav.asset.agent.connected_from}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.agent?.connected_from != null
   - date:
       field: qualys_gav.asset.agent.last_activity
       target_field: qualys_gav.asset.agent.last_activity
-      tag: date_agent_last_activity
+      tag: date_agent_last_activity_ebb9b1a2
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.agent?.last_activity != null && ctx.qualys_gav.asset.agent.last_activity != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_agent_last_activity_eb3052f4
+            tag: remove_qualys_gav_asset_agent_last_activity_d2d83118
             field: qualys_gav.asset.agent.last_activity
         - append:
-            tag: append_error_message_f3dd5d7b
+            tag: append_error_message_5fa6a211
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.agent.last_checked_in
       target_field: qualys_gav.asset.agent.last_checked_in
-      tag: date_agent_last_checked_in
+      tag: date_agent_last_checked_in_6dd93541
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.agent?.last_checked_in != null && ctx.qualys_gav.asset.agent.last_checked_in != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_agent_last_checked_in_6c5fd0ec
+            tag: remove_qualys_gav_asset_agent_last_checked_in_5f504262
             field: qualys_gav.asset.agent.last_checked_in
         - append:
-            tag: append_error_message_f7b4d077
+            tag: append_error_message_7c069ed6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.agent.last_inventory
       target_field: qualys_gav.asset.agent.last_inventory
-      tag: date_agent_last_inventory
+      tag: date_agent_last_inventory_48fd6be7
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.agent?.last_inventory != null && ctx.qualys_gav.asset.agent.last_inventory != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_agent_last_inventory_13c41b13
+            tag: remove_qualys_gav_asset_agent_last_inventory_a10a0e11
             field: qualys_gav.asset.agent.last_inventory
         - append:
-            tag: append_error_message_6c5f5583
+            tag: append_error_message_5fa1c722
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.agent.udc_manifest_assigned
-      tag: convert_agent_udc_manifest_assigned_to_boolean
+      tag: convert_agent_udc_manifest_assigned_to_boolean_7d41636c
       type: boolean
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.agent?.udc_manifest_assigned != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_agent_udc_manifest_assigned_c69b65f0
+            tag: remove_qualys_gav_asset_agent_udc_manifest_assigned_386409f7
             field: qualys_gav.asset.agent.udc_manifest_assigned
         - append:
-            tag: append_error_message_cd44145c
+            tag: append_error_message_d02c73db
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.agent.error_status
-      tag: convert_agent_error_status_to_boolean
+      tag: convert_agent_error_status_to_boolean_c5eb0130
       type: boolean
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.agent?.error_status != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_agent_error_status_b1c7fde8
+            tag: remove_qualys_gav_asset_agent_error_status_61eb3431
             field: qualys_gav.asset.agent.error_status
         - append:
-            tag: append_error_message_3fc99ffa
+            tag: append_error_message_6803e037
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Remove fields having 0 value
   - script:
-      tag: script_to_drop_zero_values
+      tag: script_to_drop_zero_values_983a207d
       lang: painless
       description: This script processor iterates over the sensor object to remove fields with zero values.
       if: ctx.qualys_gav?.asset?.sensor instanceof Map
@@ -300,531 +300,531 @@ processors:
   - date:
       field: qualys_gav.asset.sensor.last_vmscan
       target_field: qualys_gav.asset.sensor.last_vmscan
-      tag: date_agent_last_vm_scan
+      tag: date_agent_last_vm_scan_fa6518e4
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_vmscan != null && ctx.qualys_gav.asset.sensor.last_vmscan != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_vmscan_808540e4
+            tag: remove_qualys_gav_asset_sensor_last_vmscan_4e14ab2c
             field: qualys_gav.asset.sensor.last_vmscan
         - append:
-            tag: append_error_message_cfb15aeb
+            tag: append_error_message_29bf52d6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_compliance_scan
       target_field: qualys_gav.asset.sensor.last_compliance_scan
-      tag: date_agent_last_compliance_scan
+      tag: date_agent_last_compliance_scan_bce238f9
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_compliance_scan != null && ctx.qualys_gav.asset.sensor.last_compliance_scan != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_compliance_scan_c14e34ae
+            tag: remove_qualys_gav_asset_sensor_last_compliance_scan_d793342d
             field: qualys_gav.asset.sensor.last_compliance_scan
         - append:
-            tag: append_error_message_15802628
+            tag: append_error_message_b2a07006
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_full_scan
       target_field: qualys_gav.asset.sensor.last_full_scan
-      tag: date_agent_last_full_scan
+      tag: date_agent_last_full_scan_a89be436
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_full_scan != null && ctx.qualys_gav.asset.sensor.last_full_scan != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_full_scan_b7013a00
+            tag: remove_qualys_gav_asset_sensor_last_full_scan_991a659a
             field: qualys_gav.asset.sensor.last_full_scan
         - append:
-            tag: append_error_message_6dc15e9c
+            tag: append_error_message_e6ceff15
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_vm_scan_date_scanner
       target_field: qualys_gav.asset.sensor.last_vm_scan_date_scanner
-      tag: date_agent_last_vm_scan_date_scanner
+      tag: date_agent_last_vm_scan_date_scanner_4d20be17
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_vm_scan_date_scanner != null && ctx.qualys_gav.asset.sensor.last_vm_scan_date_scanner != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_vm_scan_date_scanner_83b1afac
+            tag: remove_qualys_gav_asset_sensor_last_vm_scan_date_scanner_098dfdd7
             field: qualys_gav.asset.sensor.last_vm_scan_date_scanner
         - append:
-            tag: append_error_message_4b7cdc22
+            tag: append_error_message_a806b0dd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.first_easm_scan_date
       target_field: qualys_gav.asset.sensor.first_easm_scan_date
-      tag: date_agent_first_easm_scan_date
+      tag: date_agent_first_easm_scan_date_a348ee42
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.first_easm_scan_date != null && ctx.qualys_gav.asset.sensor.first_easm_scan_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_first_easm_scan_date_38825704
+            tag: remove_qualys_gav_asset_sensor_first_easm_scan_date_06955c12
             field: qualys_gav.asset.sensor.first_easm_scan_date
         - append:
-            tag: append_error_message_575d7e2c
+            tag: append_error_message_6d1a2de3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_vm_scan_date_agent
       target_field: qualys_gav.asset.sensor.last_vm_scan_date_agent
-      tag: date_agent_last_vm_scan_date_agent
+      tag: date_agent_last_vm_scan_date_agent_1cde43a5
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_vm_scan_date_agent != null && ctx.qualys_gav.asset.sensor.last_vm_scan_date_agent != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_vm_scan_date_agent_cfcc4641
+            tag: remove_qualys_gav_asset_sensor_last_vm_scan_date_agent_b8d47b9d
             field: qualys_gav.asset.sensor.last_vm_scan_date_agent
         - append:
-            tag: append_error_message_df5d0892
+            tag: append_error_message_031cca5e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_pc_scan_date_scanner
       target_field: qualys_gav.asset.sensor.last_pc_scan_date_scanner
-      tag: date_agent_last_pc_scan_date_scanner
+      tag: date_agent_last_pc_scan_date_scanner_aaed3c3f
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_pc_scan_date_scanner != null && ctx.qualys_gav.asset.sensor.last_pc_scan_date_scanner != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_pc_scan_date_scanner_2c1f4aec
+            tag: remove_qualys_gav_asset_sensor_last_pc_scan_date_scanner_853c1ce8
             field: qualys_gav.asset.sensor.last_pc_scan_date_scanner
         - append:
-            tag: append_error_message_43d142be
+            tag: append_error_message_29e185d3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_pc_scan_date_agent
       target_field: qualys_gav.asset.sensor.last_pc_scan_date_agent
-      tag: date_agent_last_pc_scan_date_agent
+      tag: date_agent_last_pc_scan_date_agent_12201bb1
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_pc_scan_date_agent != null && ctx.qualys_gav.asset.sensor.last_pc_scan_date_agent != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_pc_scan_date_agent_5153e27d
+            tag: remove_qualys_gav_asset_sensor_last_pc_scan_date_agent_6efd1368
             field: qualys_gav.asset.sensor.last_pc_scan_date_agent
         - append:
-            tag: append_error_message_01013632
+            tag: append_error_message_9ef2bf1c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.sensor.last_easm_scan_date
       target_field: qualys_gav.asset.sensor.last_easm_scan_date
-      tag: date_agent_last_easm_scan_date
+      tag: date_agent_last_easm_scan_date_054a385f
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.sensor?.last_easm_scan_date != null && ctx.qualys_gav.asset.sensor.last_easm_scan_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_easm_scan_date_800b1ff2
+            tag: remove_qualys_gav_asset_sensor_last_easm_scan_date_bcd055cf
             field: qualys_gav.asset.sensor.last_easm_scan_date
         - append:
-            tag: append_error_message_870aea82
+            tag: append_error_message_c693f834
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.asset_id
-      tag: convert_asset_id_to_string
+      tag: convert_asset_id_to_string_9f2d39b7
       type: string
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_asset_asset_id
+      tag: set_host_id_from_asset_asset_id_07a3c8b5
       copy_from: qualys_gav.asset.asset_id
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_asset_asset_id_into_related_hosts
+      tag: append_asset_asset_id_into_related_hosts_22943d40
       value: '{{{qualys_gav.asset.asset_id}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.asset_id != null
   - set:
       field: host.name
-      tag: set_host_name_from_asset_asset_name
+      tag: set_host_name_from_asset_asset_name_73de6552
       copy_from: qualys_gav.asset.asset_name
       ignore_empty_value: true
   - lowercase:
       field: host.name
-      tag: lowercase_host_name
+      tag: lowercase_host_name_676c5247
       ignore_missing: true
   - append:
       field: related.hosts
-      tag: append_asset_asset_name_into_related_hosts
+      tag: append_asset_asset_name_into_related_hosts_9e13a866
       value: '{{{qualys_gav.asset.asset_name}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.asset_name != null
   - set:
       field: host.type
-      tag: set_host_type_from_asset_asset_type
+      tag: set_host_type_from_asset_asset_type_cfcdfaca
       copy_from: qualys_gav.asset.asset_type
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_asset_asset_uuid_into_related_hosts
+      tag: append_asset_asset_uuid_into_related_hosts_f5bd4392
       value: '{{{qualys_gav.asset.asset_uuid}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.asset_uuid != null
   - convert:
       field: qualys_gav.asset.container.has_sensor
-      tag: convert_container_has_sensor_to_string
+      tag: convert_container_has_sensor_to_string_44616af2
       type: string
       ignore_missing: true
   - convert:
       field: qualys_gav.asset.container.no_of_containers
-      tag: convert_container_no_of_containers_to_long
+      tag: convert_container_no_of_containers_to_long_48cfa6f2
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.container?.no_of_containers != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_container_no_of_containers_d939893f
+            tag: remove_qualys_gav_asset_container_no_of_containers_ac100035
             field: qualys_gav.asset.container.no_of_containers
         - append:
-            tag: append_error_message_806d532c
+            tag: append_error_message_0c149769
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.container.no_of_images
-      tag: convert_container_no_of_images_to_long
+      tag: convert_container_no_of_images_to_long_c53cf40b
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.container?.no_of_images != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_container_no_of_images_063a2749
+            tag: remove_qualys_gav_asset_container_no_of_images_c4d7c7ac
             field: qualys_gav.asset.container.no_of_images
         - append:
-            tag: append_error_message_2e6f2388
+            tag: append_error_message_4ab2bff7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.cpu_count
-      tag: convert_cpu_count_to_long
+      tag: convert_cpu_count_to_long_3591cb22
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.cpu_count != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_cpu_count_aaa21c40
+            tag: remove_qualys_gav_asset_cpu_count_80189341
             field: qualys_gav.asset.cpu_count
         - append:
-            tag: append_error_message_c214ca06
+            tag: append_error_message_905bdb97
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.created_date
       target_field: qualys_gav.asset.created_date
-      tag: date_created_date
+      tag: date_created_date_89126040
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.created_date != null && ctx.qualys_gav.asset.created_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_created_date_705df3ae
+            tag: remove_qualys_gav_asset_created_date_1cdcf338
             field: qualys_gav.asset.created_date
         - append:
-            tag: append_error_message_95b697b7
+            tag: append_error_message_17219f56
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_asset_created_date
+      tag: set_event_created_from_asset_created_date_86a21dad
       copy_from: qualys_gav.asset.created_date
       ignore_empty_value: true
   - convert:
       field: qualys_gav.asset.criticality.is_default
-      tag: convert_criticality_is_default_to_boolean
+      tag: convert_criticality_is_default_to_boolean_86c69371
       type: boolean
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.criticality?.is_default != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_criticality_is_default_636ba50b
+            tag: remove_qualys_gav_asset_criticality_is_default_7df6fcec
             field: qualys_gav.asset.criticality.is_default
         - append:
-            tag: append_error_message_2e07343c
+            tag: append_error_message_cebf422a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.criticality.last_updated
       target_field: qualys_gav.asset.criticality.last_updated
-      tag: date_criticality_last_updated
+      tag: date_criticality_last_updated_dcf502fa
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.criticality?.last_updated != null && ctx.qualys_gav.asset.criticality.last_updated != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_criticality_last_updated_181d4b3e
+            tag: remove_qualys_gav_asset_criticality_last_updated_5af597f4
             field: qualys_gav.asset.criticality.last_updated
         - append:
-            tag: append_error_message_47c3d483
+            tag: append_error_message_825866da
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.criticality.score
-      tag: convert_criticality_score_to_long
+      tag: convert_criticality_score_to_long_8ff57787
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.criticality?.score != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_criticality_score_f0c6a845
+            tag: remove_qualys_gav_asset_criticality_score_6eb8840c
             field: qualys_gav.asset.criticality.score
         - append:
-            tag: append_error_message_a4fb47ea
+            tag: append_error_message_7a5f3e2e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: host.hostname
-      tag: set_host_hostname_from_asset_dns_name
+      tag: set_host_hostname_from_asset_dns_name_ae941a0c
       copy_from: qualys_gav.asset.dns_name
       ignore_empty_value: true
   - append:
       field: related.hosts
-      tag: append_asset_dns_name_into_related_hosts
+      tag: append_asset_dns_name_into_related_hosts_e0b09430
       value: '{{{qualys_gav.asset.dns_name}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.dns_name != null
   - foreach:
       field: qualys_gav.asset.domain
-      tag: foreach_asset_domain_to_set_host_domain
+      tag: foreach_asset_domain_to_set_host_domain_7c7de0dd
       if: ctx.qualys_gav?.asset?.domain instanceof List
       processor:
         append:
           field: host.domain
-          tag: append_asset_domain_into_host_domain
+          tag: append_asset_domain_into_host_domain_2439474e
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.domain
-      tag: foreach_asset_domain_to_set_related_hosts
+      tag: foreach_asset_domain_to_set_related_hosts_84a65113
       if: ctx.qualys_gav?.asset?.domain instanceof List
       processor:
         append:
           field: related.hosts
-          tag: append_asset_domain_into_related_hosts
+          tag: append_asset_domain_into_related_hosts_10d4a237
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.subdomain
-      tag: foreach_asset_subdomain
+      tag: foreach_asset_subdomain_4d3378fb
       if: ctx.qualys_gav?.asset?.subdomain instanceof List
       processor:
         append:
           field: related.hosts
-          tag: append_asset_subdomain_into_related_hosts
+          tag: append_asset_subdomain_into_related_hosts_71f3c226
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - date:
       field: qualys_gav.asset.hardware.lifecycle.eos_date
       target_field: qualys_gav.asset.hardware.lifecycle.eos_date
-      tag: date_qualys_gav_asset_hardware_lifecycle_eos_date
+      tag: date_qualys_gav_asset_hardware_lifecycle_eos_date_3931e96a
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.eos_date != null && ctx.qualys_gav.asset.hardware.lifecycle.eos_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_hardware_lifecycle_eos_date_5b63d3fd
+            tag: remove_qualys_gav_asset_hardware_lifecycle_eos_date_39c63924
             field: qualys_gav.asset.hardware.lifecycle.eos_date
         - append:
-            tag: append_error_message_bc086db7
+            tag: append_error_message_8a440b8b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.hardware.lifecycle.ga_date
       target_field: qualys_gav.asset.hardware.lifecycle.ga_date
-      tag: date_qualys_gav_asset_hardware_lifecycle_ga_date
+      tag: date_qualys_gav_asset_hardware_lifecycle_ga_date_8eb2d0a5
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.ga_date != null && ctx.qualys_gav.asset.hardware.lifecycle.ga_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_hardware_lifecycle_ga_date_c3032b5e
+            tag: remove_qualys_gav_asset_hardware_lifecycle_ga_date_d46459ce
             field: qualys_gav.asset.hardware.lifecycle.ga_date
         - append:
-            tag: append_error_message_26629491
+            tag: append_error_message_904a6591
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.hardware.lifecycle.intro_date
       target_field: qualys_gav.asset.hardware.lifecycle.intro_date
-      tag: date_qualys_gav_asset_hardware_lifecycle_intro_date
+      tag: date_qualys_gav_asset_hardware_lifecycle_intro_date_ff3f4301
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.intro_date != null && ctx.qualys_gav.asset.hardware.lifecycle.intro_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_hardware_lifecycle_intro_date_f47bf89c
+            tag: remove_qualys_gav_asset_hardware_lifecycle_intro_date_43ff370c
             field: qualys_gav.asset.hardware.lifecycle.intro_date
         - append:
-            tag: append_error_message_4e6e69df
+            tag: append_error_message_bf31e2bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.hardware.lifecycle.obsolete_date
       target_field: qualys_gav.asset.hardware.lifecycle.obsolete_date
-      tag: date_qualys_gav_asset_hardware_lifecycle_obsolete_date
+      tag: date_qualys_gav_asset_hardware_lifecycle_obsolete_date_7a629b28
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.hardware?.lifecycle?.obsolete_date != null && ctx.qualys_gav.asset.hardware.lifecycle.obsolete_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_hardware_lifecycle_obsolete_date_4c168eb9
+            tag: remove_qualys_gav_asset_hardware_lifecycle_obsolete_date_ee243581
             field: qualys_gav.asset.hardware.lifecycle.obsolete_date
         - append:
-            tag: append_error_message_3d56f317
+            tag: append_error_message_219d87c4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: device.manufacturer
-      tag: set_device_manufacturer_from_asset_hardware_manufacturer
+      tag: set_device_manufacturer_from_asset_hardware_manufacturer_47c4230c
       copy_from: qualys_gav.asset.hardware.manufacturer
       ignore_empty_value: true
   - set:
       field: device.model.name
-      tag: set_device_model_name_from_asset_hardware_model
+      tag: set_device_model_name_from_asset_hardware_model_ff8d27fa
       copy_from: qualys_gav.asset.hardware.model
       ignore_empty_value: true
   - convert:
       field: qualys_gav.asset.hardware.taxonomy.id
-      tag: convert_qualys_gav_asset_hardware_taxonomy_id_to_string
+      tag: convert_qualys_gav_asset_hardware_taxonomy_id_to_string_996d9edd
       type: string
       ignore_missing: true
   - convert:
       field: qualys_gav.asset.host_id
-      tag: convert_host_id_to_string
+      tag: convert_host_id_to_string_ff55be41
       type: string
       ignore_missing: true
   - append:
       field: related.hosts
-      tag: append_asset_host_id_into_related_hosts
+      tag: append_asset_host_id_into_related_hosts_0905f848
       value: '{{{qualys_gav.asset.host_id}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.host_id != null
   - date:
       field: qualys_gav.asset.inventory.created
       target_field: qualys_gav.asset.inventory.created
-      tag: date_qualys_gav_asset_inventory_created
+      tag: date_qualys_gav_asset_inventory_created_73f80a4d
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.inventory?.created != null && ctx.qualys_gav.asset.inventory.created != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_inventory_created_3621ec17
+            tag: remove_qualys_gav_asset_inventory_created_1a2ec5d6
             field: qualys_gav.asset.inventory.created
         - append:
-            tag: append_error_message_c79758e5
+            tag: append_error_message_c8599ca9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.inventory.last_updated
       target_field: qualys_gav.asset.inventory.last_updated
-      tag: date_qualys_gav_asset_inventory_last_updated
+      tag: date_qualys_gav_asset_inventory_last_updated_1d6688ad
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.inventory?.last_updated != null && ctx.qualys_gav.asset.inventory.last_updated != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_inventory_last_updated_76692d3f
+            tag: remove_qualys_gav_asset_inventory_last_updated_9807d99a
             field: qualys_gav.asset.inventory.last_updated
         - append:
-            tag: append_error_message_8b25398b
+            tag: append_error_message_dcf9419d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.inventory_list_data.inventory
-      tag: foreach_asset_inventory_list_data_inventory_to_date_created
+      tag: foreach_asset_inventory_list_data_inventory_to_date_created_61671ad1
       if: ctx.qualys_gav?.asset?.inventory_list_data?.inventory instanceof List
       processor:
         date:
           field: _ingest._value.created
           target_field: _ingest._value.created
-          tag: date_asset_inventory_list_data_inventory_created
+          tag: date_asset_inventory_list_data_inventory_created_370aff7f
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_created
+                tag: remove_ingest_value_created_c2830050
                 field: _ingest._value.created
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.inventory_list_data.inventory
-      tag: foreach_asset_inventory_list_data_inventory_to_date_last_updated
+      tag: foreach_asset_inventory_list_data_inventory_to_date_last_updated_62d86f55
       if: ctx.qualys_gav?.asset?.inventory_list_data?.inventory instanceof List
       processor:
         date:
           field: _ingest._value.last_updated
           target_field: _ingest._value.last_updated
-          tag: date_asset_inventory_list_data_inventory_last_updated
+          tag: date_asset_inventory_list_data_inventory_last_updated_eca5b6c9
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_last_updated
+                tag: remove_ingest_value_last_updated_d4efbd66
                 field: _ingest._value.last_updated
                 ignore_missing: true
   - date:
       field: qualys_gav.asset.activity.last_scanned_date
       target_field: qualys_gav.asset.activity.last_scanned_date
-      tag: date_qualys_gav_asset_activity_last_scanned_date
+      tag: date_qualys_gav_asset_activity_last_scanned_date_6de00f4b
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.activity?.last_scanned_date != null && ctx.qualys_gav.asset.activity.last_scanned_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_activity_last_scanned_date_83ecfaee
+            tag: remove_qualys_gav_asset_activity_last_scanned_date_f6c12efe
             field: qualys_gav.asset.activity.last_scanned_date
         - append:
-            tag: append_error_message_cf33fa95
+            tag: append_error_message_e658ad99
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.is_container_host
-      tag: convert_is_container_host_to_boolean
+      tag: convert_is_container_host_to_boolean_8f313971
       type: boolean
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.is_container_host != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_is_container_host_df8f9173
+            tag: remove_qualys_gav_asset_is_container_host_6cbaa43c
             field: qualys_gav.asset.is_container_host
         - append:
-            tag: append_error_message_0472b0ba
+            tag: append_error_message_567e7944
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.last_boot
-      tag: date_last_boot
+      tag: date_last_boot_bfb23966
       target_field: qualys_gav.asset.last_boot
       formats:
         - UNIX_MS
@@ -832,303 +832,303 @@ processors:
       if: ctx.qualys_gav?.asset?.last_boot != null && ctx.qualys_gav.asset.last_boot != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_last_boot_fb1aa69a
+            tag: remove_qualys_gav_asset_last_boot_69fa7502
             field: qualys_gav.asset.last_boot
         - append:
-            tag: append_error_message_295822fd
+            tag: append_error_message_ad56b01c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: host.geo.city_name
-      tag: set_host_geo_city_name_from_asset_last_location_city
+      tag: set_host_geo_city_name_from_asset_last_location_city_a1128296
       copy_from: qualys_gav.asset.last_location.city
       ignore_empty_value: true
   - set:
       field: host.geo.continent_name
-      tag: set_host_geo_continent_name_from_asset_last_location_continent
+      tag: set_host_geo_continent_name_from_asset_last_location_continent_db195fec
       copy_from: qualys_gav.asset.last_location.continent
       ignore_empty_value: true
   - set:
       field: host.geo.country_name
-      tag: set_host_geo_country_name_from_asset_last_location_name
+      tag: set_host_geo_country_name_from_asset_last_location_name_cf152e13
       copy_from: qualys_gav.asset.last_location.name
       ignore_empty_value: true
   - set:
       field: host.geo.postal_code
-      tag: set_host_geo_postal_code_from_asset_last_location_postal
+      tag: set_host_geo_postal_code_from_asset_last_location_postal_e45b6dc4
       copy_from: qualys_gav.asset.last_location.postal
       ignore_empty_value: true
   - set:
       field: user.name
-      tag: set_user_name_from_asset_last_logged_on_user
+      tag: set_user_name_from_asset_last_logged_on_user_22115cbe
       copy_from: qualys_gav.asset.last_logged_on_user
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_asset_last_logged_on_user_into_related_user
+      tag: append_asset_last_logged_on_user_into_related_user_79bef934
       value: '{{{qualys_gav.asset.last_logged_on_user}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.last_logged_on_user != null
   - append:
       field: related.hosts
-      tag: append_asset_netbios_name_into_related_hosts
+      tag: append_asset_netbios_name_into_related_hosts_41ab15fd
       value: '{{{qualys_gav.asset.netbios_name}}}'
       allow_duplicates: false
       if: ctx.qualys_gav?.asset?.netbios_name != null
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_split_address_ip_v4
+      tag: foreach_network_interface_list_data_network_interface_to_split_address_ip_v4_e3472b20
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         split:
           field: _ingest._value.address_ip_v4
           separator: ','
-          tag: split_asset_network_interface_list_data_network_interface_address_ip_v4
+          tag: split_asset_network_interface_list_data_network_interface_address_ip_v4_bdd915b6
           ignore_missing: true
           on_failure:
             - append:
-                tag: append_error_message
+                tag: append_error_message_305b518c
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_trim_address_ip_v4
+      tag: foreach_network_interface_list_data_network_interface_to_trim_address_ip_v4_3617315e
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         foreach:
           field: _ingest._value.address_ip_v4
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4_trim
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4_trim_2b93b6c3
           ignore_failure: true
           processor:
             trim:
               field: _ingest._value
-              tag: trim_asset_network_interface_list_data_network_interface_address_ip_v4
+              tag: trim_asset_network_interface_list_data_network_interface_address_ip_v4_42272592
               ignore_missing: true
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_asset_network_interface_list_data_network_interface_to_convert_address_ip_v4
+      tag: foreach_asset_network_interface_list_data_network_interface_to_convert_address_ip_v4_24c58762
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         foreach:
           field: _ingest._value.address_ip_v4
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4_9de440dc
           ignore_failure: true
           processor:
             convert:
               field: _ingest._value
-              tag: convert_asset_network_interface_list_data_network_interface_address_ip_v4
+              tag: convert_asset_network_interface_list_data_network_interface_address_ip_v4_79e2329c
               type: ip
               ignore_missing: true
               on_failure:
                 - remove:
-                    tag: remove_ingest_value
+                    tag: remove_ingest_value_ab28c5fe
                     field: _ingest._value
                     ignore_missing: true
                 - append:
-                    tag: append_error_message_4411f124
+                    tag: append_error_message_373f505b
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_set_related_ip_from_address_ip_v4
+      tag: foreach_network_interface_list_data_network_interface_to_set_related_ip_from_address_ip_v4_9cb0ecbc
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         foreach:
           field: _ingest._value.address_ip_v4
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4_43ff8a28
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v4_7fb83455
           ignore_failure: true
           processor:
             append:
               field: related.ip
-              tag: append_network_interface_list_data_network_interface_address_ip_v4_into_related_ip
+              tag: append_network_interface_list_data_network_interface_address_ip_v4_into_related_ip_5afc06d3
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_gsub_mac_address
+      tag: foreach_network_interface_list_data_network_interface_to_gsub_mac_address_ddd02c30
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         gsub:
           field: _ingest._value.mac_address
-          tag: gsub_network_interface_list_data_network_interface_mac_address
+          tag: gsub_network_interface_list_data_network_interface_mac_address_3bd7aa9e
           pattern: ':'
           replacement: '-'
           ignore_missing: true
           on_failure:
             - append:
-                tag: append_error_message_143963e5
+                tag: append_error_message_1e7075b7
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_uppercase_mac_address
+      tag: foreach_network_interface_list_data_network_interface_to_uppercase_mac_address_0f714dbe
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         uppercase:
           field: _ingest._value.mac_address
-          tag: uppercase_network_interface_list_data_network_interface_mac_address
+          tag: uppercase_network_interface_list_data_network_interface_mac_address_40887c9a
           ignore_missing: true
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_append_hostname
+      tag: foreach_network_interface_list_data_network_interface_to_append_hostname_d52c11c2
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         append:
           field: related.hosts
-          tag: append_network_interface_list_data_network_interface_hostname_into_related_hosts
+          tag: append_network_interface_list_data_network_interface_hostname_into_related_hosts_cbe4760d
           value: '{{{_ingest._value.hostname}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_network_interface_list_data_network_interface_to_split_address_ip_v6
+      tag: foreach_network_interface_list_data_network_interface_to_split_address_ip_v6_a0331d27
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         split:
           field: _ingest._value.address_ip_v6
           separator: ', '
-          tag: split_asset_network_interface_list_data_network_interface_address_ip_v6
+          tag: split_asset_network_interface_list_data_network_interface_address_ip_v6_c1b9e7d4
           ignore_missing: true
           on_failure:
             - append:
-                tag: append_error_message_7d48ee26
+                tag: append_error_message_bb32ce5f
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_asset_network_interface_list_data_network_interface_to_convert_address_ip_v6
+      tag: foreach_asset_network_interface_list_data_network_interface_to_convert_address_ip_v6_760fa039
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         foreach:
           field: _ingest._value.address_ip_v6
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v6
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v6_7a54d9f1
           ignore_failure: true
           processor:
             convert:
               field: _ingest._value
-              tag: convert_asset_network_interface_list_data_network_interface_address_ip_v6
+              tag: convert_asset_network_interface_list_data_network_interface_address_ip_v6_63d8abe7
               type: ip
               ignore_missing: true
               on_failure:
                 - remove:
-                    tag: remove_ingest_value_dfc3b655
+                    tag: remove_ingest_value_71285a21
                     field: _ingest._value
                     ignore_missing: true
                 - append:
-                    tag: append_error_message_e03cc8cb
+                    tag: append_error_message_35f0a99b
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_asset_network_interface_list_data_network_interface_to_set_related_ip_from_address_ip_v6
+      tag: foreach_asset_network_interface_list_data_network_interface_to_set_related_ip_from_address_ip_v6_d4db04bf
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         foreach:
           field: _ingest._value.address_ip_v6
-          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v6_dfc35121
+          tag: foreach_asset_network_interface_list_data_network_interface_address_ip_v6_e8786a53
           ignore_failure: true
           processor:
             append:
               field: related.ip
-              tag: append_asset_network_interface_list_data_network_interface_address_ip_v6_into_related_ip
+              tag: append_asset_network_interface_list_data_network_interface_address_ip_v6_into_related_ip_069e0eb0
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.network_interface_list_data.network_interface
-      tag: foreach_asset_network_interface_list_data_network_interface_to_date_mac_vendor_intro_date
+      tag: foreach_asset_network_interface_list_data_network_interface_to_date_mac_vendor_intro_date_aa30d78f
       if: ctx.qualys_gav?.asset?.network_interface_list_data?.network_interface instanceof List
       processor:
         date:
           field: _ingest._value.mac_vendor_intro_date
           target_field: _ingest._value.mac_vendor_intro_date
-          tag: date_asset_network_interface_list_data_network_interface_mac_vendor_intro_date
+          tag: date_asset_network_interface_list_data_network_interface_mac_vendor_intro_date_a4ed9d95
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_mac_vendor_intro_date
+                tag: remove_ingest_value_mac_vendor_intro_date_5fc68938
                 field: _ingest._value.mac_vendor_intro_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.open_port_list_data.open_port
-      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_convert_port_to_long
+      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_convert_port_to_long_24cc375d
       if: ctx.qualys_gav?.asset?.open_port_list_data?.open_port instanceof List
       processor:
         convert:
           field: _ingest._value.port
-          tag: convert_qualys_gav_asset_open_port_list_data_open_port_to_long
+          tag: convert_qualys_gav_asset_open_port_list_data_open_port_to_long_9948cb81
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_port
+                tag: remove_ingest_value_port_03caeeb4
                 field: _ingest._value.port
                 ignore_missing: true
             - append:
-                tag: append_error_message_d6899848
+                tag: append_error_message_a2e5e206
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.open_port_list_data.open_port
-      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_convert_detection_score_to_long
+      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_convert_detection_score_to_long_e012e311
       if: ctx.qualys_gav?.asset?.open_port_list_data?.open_port instanceof List
       processor:
         convert:
           field: _ingest._value.detection_score
-          tag: convert_qualys_gav_asset_open_port_list_data_open_port_detection_score_to_long
+          tag: convert_qualys_gav_asset_open_port_list_data_open_port_detection_score_to_long_d1eaf59a
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_detection_score
+                tag: remove_ingest_value_detection_score_ef35890e
                 field: _ingest._value.detection_score
                 ignore_missing: true
             - append:
-                tag: append_error_message_8da8184e
+                tag: append_error_message_6b05b3d2
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.open_port_list_data.open_port
-      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_date_first_found
+      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_date_first_found_f7054ca0
       if: ctx.qualys_gav?.asset?.open_port_list_data?.open_port instanceof List
       processor:
         date:
           field: _ingest._value.first_found
           target_field: _ingest._value.first_found
-          tag: date_open_port_list_data_open_port_first_found
+          tag: date_open_port_list_data_open_port_first_found_6d14a17f
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_first_found
+                tag: remove_ingest_value_first_found_69ef3fd7
                 field: _ingest._value.first_found
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.open_port_list_data.open_port
-      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_date_last_updated
+      tag: foreach_qualys_gav_asset_open_port_list_data_open_port_to_date_last_updated_33414d09
       if: ctx.qualys_gav?.asset?.open_port_list_data?.open_port instanceof List
       processor:
         date:
           field: _ingest._value.last_updated
           target_field: _ingest._value.last_updated
-          tag: date_open_port_list_data_open_port_last_updated
+          tag: date_open_port_list_data_open_port_last_updated_b7c289b7
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_last_updated_dcfad241
+                tag: remove_ingest_value_last_updated_0cddb16c
                 field: _ingest._value.last_updated
                 ignore_missing: true
   - set:
       field: host.architecture
-      tag: set_host_architecture_from_asset_operating_system_architecture
+      tag: set_host_architecture_from_asset_operating_system_architecture_0d70646c
       copy_from: qualys_gav.asset.operating_system.architecture
       ignore_empty_value: true
   - script:
       description: Dynamically set host.os.type values.
-      tag: script_map_host_os_type
+      tag: script_map_host_os_type_d6c71d44
       lang: painless
       if: ctx.qualys_gav?.asset?.operating_system?.category1 != null
       params:
@@ -1151,141 +1151,141 @@ processors:
         }
   - convert:
       field: qualys_gav.asset.operating_system.cpe_id
-      tag: convert_qualys_gav_asset_operating_system_cpe_id_to_string
+      tag: convert_qualys_gav_asset_operating_system_cpe_id_to_string_22fb1033
       type: string
       ignore_missing: true
   - set:
       field: host.os.full
-      tag: set_host_os_full_from_asset_operating_system_full_name
+      tag: set_host_os_full_from_asset_operating_system_full_name_c294a3ae
       copy_from: qualys_gav.asset.operating_system.full_name
       ignore_empty_value: true
   - date:
       field: qualys_gav.asset.operating_system.install_date
       target_field: qualys_gav.asset.operating_system.install_date
-      tag: date_qualys_gav_asset_operating_system_install_date
+      tag: date_qualys_gav_asset_operating_system_install_date_19d9d229
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.operating_system?.install_date != null && ctx.qualys_gav.asset.operating_system.install_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_operating_system_install_date_dd332c8a
+            tag: remove_qualys_gav_asset_operating_system_install_date_b2d27148
             field: qualys_gav.asset.operating_system.install_date
         - append:
-            tag: append_error_message_e86e0da1
+            tag: append_error_message_edaa5e7d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.operating_system.lifecycle.eol_date
       target_field: qualys_gav.asset.operating_system.lifecycle.eol_date
-      tag: date_qualys_gav_asset_operating_system_lifecycle_eol_date
+      tag: date_qualys_gav_asset_operating_system_lifecycle_eol_date_c87a81a8
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.eol_date != null && ctx.qualys_gav.asset.operating_system.lifecycle.eol_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_operating_system_lifecycle_eol_date_5ea340ed
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_eol_date_3da3b7b2
             field: qualys_gav.asset.operating_system.lifecycle.eol_date
         - append:
-            tag: append_error_message_b203b637
+            tag: append_error_message_61e0fc55
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.operating_system.lifecycle.eos_date
       target_field: qualys_gav.asset.operating_system.lifecycle.eos_date
-      tag: date_qualys_gav_asset_operating_system_lifecycle_eos_date
+      tag: date_qualys_gav_asset_operating_system_lifecycle_eos_date_cb248794
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.eos_date != null && ctx.qualys_gav.asset.operating_system.lifecycle.eos_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_operating_system_lifecycle_eos_date_29ce926e
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_eos_date_b7d31090
             field: qualys_gav.asset.operating_system.lifecycle.eos_date
         - append:
-            tag: append_error_message_8b8c416f
+            tag: append_error_message_ef3cbb2b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.operating_system.lifecycle.ga_date
       target_field: qualys_gav.asset.operating_system.lifecycle.ga_date
-      tag: date_qualys_gav_asset_operating_system_lifecycle_ga_date
+      tag: date_qualys_gav_asset_operating_system_lifecycle_ga_date_a52f0df3
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.ga_date != null && ctx.qualys_gav.asset.operating_system.lifecycle.ga_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_operating_system_lifecycle_ga_date_6efa9a05
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_ga_date_aea0bea5
             field: qualys_gav.asset.operating_system.lifecycle.ga_date
         - append:
-            tag: append_error_message_1ac03533
+            tag: append_error_message_a2c03cfd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.operating_system.lifecycle.detection_score
-      tag: convert_qualys_gav_asset_operating_system_lifecycle_detection_score_to_long
+      tag: convert_qualys_gav_asset_operating_system_lifecycle_detection_score_to_long_022dcda6
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.operating_system?.lifecycle?.detection_score != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_operating_system_lifecycle_detection_score_4b9ccf3d
+            tag: remove_qualys_gav_asset_operating_system_lifecycle_detection_score_d753c86c
             field: qualys_gav.asset.operating_system.lifecycle.detection_score
         - append:
-            tag: append_error_message_86dace88
+            tag: append_error_message_eb6c052f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: host.os.name
-      tag: set_host_os_name_from_asset_operating_system_os_name
+      tag: set_host_os_name_from_asset_operating_system_os_name_dbb44a4b
       copy_from: qualys_gav.asset.operating_system.os_name
       ignore_empty_value: true
   - set:
       field: host.os.family
-      tag: set_host_os_family_from_asset_operating_system_product_family
+      tag: set_host_os_family_from_asset_operating_system_product_family_869da589
       copy_from: qualys_gav.asset.operating_system.product_family
       ignore_empty_value: true
   - set:
       field: host.os.platform
-      tag: set_host_os_platform_from_asset_operating_system_product_name
+      tag: set_host_os_platform_from_asset_operating_system_product_name_e8097018
       copy_from: qualys_gav.asset.operating_system.product_name
       ignore_empty_value: true
   - convert:
       field: qualys_gav.asset.operating_system.taxonomy.id
-      tag: convert_qualys_gav_asset_operating_system_taxonomy_id_to_string
+      tag: convert_qualys_gav_asset_operating_system_taxonomy_id_to_string_1ba2a677
       type: string
       ignore_missing: true
   - set:
       field: host.os.version
-      tag: set_host_os_version_from_asset_operating_system_version
+      tag: set_host_os_version_from_asset_operating_system_version_4e1dc8e4
       copy_from: qualys_gav.asset.operating_system.version
       ignore_empty_value: true
   - lowercase:
       field: qualys_gav.asset.provider
       target_field: cloud.provider
-      tag: lowercase_cloud_provider_from_asset_provider
+      tag: lowercase_cloud_provider_from_asset_provider_6bf5e256
       ignore_missing: true
 
   # Convert AWS EC2 specific fields
   - convert:
       field: qualys_gav.asset.cloud_provider.aws.ec2.has_agent
-      tag: convert_qualys_gav_asset_cloud_provider_aws_ec2_has_agent_to_boolean
+      tag: convert_qualys_gav_asset_cloud_provider_aws_ec2_has_agent_to_boolean_6d53d690
       type: boolean
       ignore_missing: true
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_has_agent_0cdce69b
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_has_agent_3a794bf9
             field: qualys_gav.asset.cloud_provider.aws.ec2.has_agent
             ignore_missing: true
         - append:
-            tag: append_error_message_63a1c0be
+            tag: append_error_message_58dd58d3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: qualys_gav.asset.cloud_provider.aws.ec2.launchdate
-      tag: date_qualys_gav_asset_cloud_provider_aws_ec2_launchdate
+      tag: date_qualys_gav_asset_cloud_provider_aws_ec2_launchdate_448ac46a
       target_field: qualys_gav.asset.cloud_provider.aws.ec2.launchdate
       formats:
         - UNIX_MS
@@ -1293,253 +1293,253 @@ processors:
       if: ctx.qualys_gav?.asset?.cloud_provider?.aws?.ec2?.launchdate != null && ctx.qualys_gav.asset.cloud_provider.aws.ec2.launchdate != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_launchdate_8e78ea70
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_launchdate_e5cf1e79
             field: qualys_gav.asset.cloud_provider.aws.ec2.launchdate
             ignore_missing: true
         - append:
-            tag: append_error_message_3bfa46e8
+            tag: append_error_message_cc8e59d4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.cloud_provider.aws.ec2.qualys_scanner
-      tag: convert_qualys_gav_asset_cloud_provider_aws_ec2_qualys_scanner_to_boolean
+      tag: convert_qualys_gav_asset_cloud_provider_aws_ec2_qualys_scanner_to_boolean_660df783
       type: boolean
       ignore_missing: true
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_qualys_scanner_f49466f1
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_qualys_scanner_ea590b50
             field: qualys_gav.asset.cloud_provider.aws.ec2.qualys_scanner
             ignore_missing: true
         - append:
-            tag: append_error_message_5ae5e698
+            tag: append_error_message_7d265e70
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.cloud_provider.aws.ec2.spot_instance
-      tag: convert_qualys_gav_asset_cloud_provider_aws_ec2_spot_instance_to_boolean
+      tag: convert_qualys_gav_asset_cloud_provider_aws_ec2_spot_instance_to_boolean_84768335
       type: boolean
       ignore_missing: true
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_spot_instance_cdbd0f4b
+            tag: remove_qualys_gav_asset_cloud_provider_aws_ec2_spot_instance_7c65aeed
             field: qualys_gav.asset.cloud_provider.aws.ec2.spot_instance
             ignore_missing: true
         - append:
-            tag: append_error_message_ecb043c2
+            tag: append_error_message_72840dc3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   # Map/Convert AWS EC2 specific fields to ECS fields
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_asset_cloud_provider_aws_ec2_account_id
+      tag: set_cloud_account_id_from_asset_cloud_provider_aws_ec2_account_id_13d180e7
       copy_from: qualys_gav.asset.cloud_provider.aws.ec2.account_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.availability_zone
-      tag: set_cloud_availability_zone_from_asset_cloud_provider_aws_ec2_availability_zone
+      tag: set_cloud_availability_zone_from_asset_cloud_provider_aws_ec2_availability_zone_96cdc526
       copy_from: qualys_gav.asset.cloud_provider.aws.ec2.availability_zone
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.id
-      tag: set_cloud_instance_id_from_asset_cloud_provider_aws_ec2_instance_id
+      tag: set_cloud_instance_id_from_asset_cloud_provider_aws_ec2_instance_id_e2c3c5ab
       copy_from: qualys_gav.asset.cloud_provider.aws.ec2.instance_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.name
-      tag: set_cloud_instance_name_from_asset_cloud_provider_aws_ec2_hostname
+      tag: set_cloud_instance_name_from_asset_cloud_provider_aws_ec2_hostname_12a59c51
       copy_from: qualys_gav.asset.cloud_provider.aws.ec2.hostname
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.machine.type
-      tag: set_cloud_machine_type_from_asset_cloud_provider_aws_ec2_instance_type
+      tag: set_cloud_machine_type_from_asset_cloud_provider_aws_ec2_instance_type_deacabc8
       copy_from: qualys_gav.asset.cloud_provider.aws.ec2.instance_type
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.region
-      tag: set_cloud_region_from_asset_cloud_provider_aws_ec2_region_code
+      tag: set_cloud_region_from_asset_cloud_provider_aws_ec2_region_code_9e15e51c
       copy_from: qualys_gav.asset.cloud_provider.aws.ec2.region.code
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name
+      tag: set_cloud_service_name_4c2ee25e
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'aws' && ctx.qualys_gav?.asset?.cloud_provider?.aws?.ec2 != null
       value: ec2
 
   # Map/Convert Azure specific fields to ECS fields
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_asset_cloud_provider_azure_vm_subscription_id
+      tag: set_cloud_account_id_from_asset_cloud_provider_azure_vm_subscription_id_53826ba2
       copy_from: qualys_gav.asset.cloud_provider.azure.vm.subscription_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.id
-      tag: set_cloud_instance_id_from_asset_cloud_provider_azure_vm_vm_id
+      tag: set_cloud_instance_id_from_asset_cloud_provider_azure_vm_vm_id_92354705
       copy_from: qualys_gav.asset.cloud_provider.azure.vm.vm_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.name
-      tag: set_cloud_instance_name_from_asset_cloud_provider_azure_vm_name
+      tag: set_cloud_instance_name_from_asset_cloud_provider_azure_vm_name_305231d4
       copy_from: qualys_gav.asset.cloud_provider.azure.vm.name
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.machine.type
-      tag: set_cloud_machine_type_from_asset_cloud_provider_azure_vm_size
+      tag: set_cloud_machine_type_from_asset_cloud_provider_azure_vm_size_00c37cb7
       copy_from: qualys_gav.asset.cloud_provider.azure.vm.size
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.region
-      tag: set_cloud_region_from_asset_cloud_provider_azure_vm_location
+      tag: set_cloud_region_from_asset_cloud_provider_azure_vm_location_ad43723a
       copy_from: qualys_gav.asset.cloud_provider.azure.vm.location
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name_6f4b3b6c
+      tag: set_cloud_service_name_3c85a147
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'azure' && ctx.qualys_gav?.asset?.cloud_provider?.azure?.vm != null
       value: vm
 
   # Map/Convert GCP specific fields to ECS fields
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_asset_cloud_provider_gcp_compute_project_id
+      tag: set_cloud_account_id_from_asset_cloud_provider_gcp_compute_project_id_fdf4b031
       copy_from: qualys_gav.asset.cloud_provider.gcp.compute.project_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.availability_zone
-      tag: set_cloud_availability_zone_from_asset_cloud_provider_gcp_compute_zone
+      tag: set_cloud_availability_zone_from_asset_cloud_provider_gcp_compute_zone_e80d0b03
       copy_from: qualys_gav.asset.cloud_provider.gcp.compute.zone
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.id
-      tag: set_cloud_instance_id_from_asset_cloud_provider_gcp_compute_instance_id
+      tag: set_cloud_instance_id_from_asset_cloud_provider_gcp_compute_instance_id_aac60170
       copy_from: qualys_gav.asset.cloud_provider.gcp.compute.instance_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.name
-      tag: set_cloud_instance_name_from_asset_cloud_provider_gcp_compute_hostname
+      tag: set_cloud_instance_name_from_asset_cloud_provider_gcp_compute_hostname_b6e00122
       copy_from: qualys_gav.asset.cloud_provider.gcp.compute.hostname
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.machine.type
-      tag: set_cloud_machine_type_from_asset_cloud_provider_gcp_compute_machine_type
+      tag: set_cloud_machine_type_from_asset_cloud_provider_gcp_compute_machine_type_8fe360e1
       copy_from: qualys_gav.asset.cloud_provider.gcp.compute.machine_type
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.project.id
-      tag: set_cloud_project_id_from_asset_cloud_provider_gcp_compute_project_id
+      tag: set_cloud_project_id_from_asset_cloud_provider_gcp_compute_project_id_30aa39f7
       copy_from: qualys_gav.asset.cloud_provider.gcp.compute.project_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - grok:
       field: qualys_gav.asset.cloud_provider.gcp.compute.zone
-      tag: grok_cloud_region_from_asset_cloud_provider_gcp_compute_zone
+      tag: grok_cloud_region_from_asset_cloud_provider_gcp_compute_zone_f0d55a6c
       patterns:
         - '%{GREEDYDATA:cloud.region}-%{WORD}$'
       if: ctx._conf?.want_provider_cloud == true
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_e21b85a8
+            tag: append_error_message_f7c0d4cf
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name_dcdaf8c0
+      tag: set_cloud_service_name_7f3021b2
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'gcp' && ctx.qualys_gav?.asset?.cloud_provider?.gcp?.compute != null
       value: compute
 
   # Convert IBM specific fields
   - convert:
       field: qualys_gav.asset.cloud_provider.ibm.virtual_server.datacenter_id
-      tag: convert_qualys_gav_asset_cloud_provider_ibm_virtual_server_datacenter_id_to_string
+      tag: convert_qualys_gav_asset_cloud_provider_ibm_virtual_server_datacenter_id_to_string_d9d226f0
       type: string
       ignore_missing: true
   - convert:
       field: qualys_gav.asset.cloud_provider.ibm.virtual_server.ibm_id
-      tag: convert_qualys_gav_asset_cloud_provider_ibm_virtual_server_ibm_id_to_string
+      tag: convert_qualys_gav_asset_cloud_provider_ibm_virtual_server_ibm_id_to_string_a86b4449
       type: string
       ignore_missing: true
 
   # Map/Convert IBM specific fields to ECS fields
   - set:
       field: cloud.account.id
-      tag: set_cloud_account_id_from_asset_cloud_provider_ibm_virtual_server_datacenter_id
+      tag: set_cloud_account_id_from_asset_cloud_provider_ibm_virtual_server_datacenter_id_c5157c27
       copy_from: qualys_gav.asset.cloud_provider.ibm.virtual_server.datacenter_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.id
-      tag: set_cloud_instance_id_from_asset_cloud_provider_ibm_virtual_server_ibm_id
+      tag: set_cloud_instance_id_from_asset_cloud_provider_ibm_virtual_server_ibm_id_eb4eb59f
       copy_from: qualys_gav.asset.cloud_provider.ibm.virtual_server.ibm_id
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.instance.name
-      tag: set_cloud_instance_name_from_asset_cloud_provider_ibm_virtual_server_device_name
+      tag: set_cloud_instance_name_from_asset_cloud_provider_ibm_virtual_server_device_name_684c749d
       copy_from: qualys_gav.asset.cloud_provider.ibm.virtual_server.device_name
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.availability_zone
-      tag: set_cloud_availability_zone_from_asset_cloud_provider_ibm_virtual_server_location
+      tag: set_cloud_availability_zone_from_asset_cloud_provider_ibm_virtual_server_location_e153d6e6
       copy_from: qualys_gav.asset.cloud_provider.ibm.virtual_server.location
       if: ctx._conf?.want_provider_cloud == true
       ignore_empty_value: true
   - set:
       field: cloud.service.name
-      tag: set_cloud_service_name_93672477
+      tag: set_cloud_service_name_fb901813
       if: ctx._conf?.want_provider_cloud == true && ctx.cloud?.provider == 'azure' && ctx.qualys_gav?.asset?.cloud_provider?.ibm?.virtual_server != null
       value: virtual_server
 
   # Map risk scores
   - convert:
       field: qualys_gav.asset.risk_score
-      tag: convert_qualys_gav_asset_risk_score_to_float
+      tag: convert_qualys_gav_asset_risk_score_to_float_9da7aa85
       type: float
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.risk_score != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_risk_score_46898134
+            tag: remove_qualys_gav_asset_risk_score_bf125402
             field: qualys_gav.asset.risk_score
         - append:
-            tag: append_error_message_4bc086e0
+            tag: append_error_message_f8efa329
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.risk_score
-      tag: set_event_risk_score_from_asset_risk_score
+      tag: set_event_risk_score_from_asset_risk_score_fc2df9ed
       copy_from: qualys_gav.asset.risk_score
       ignore_empty_value: true
   - foreach:
       field: qualys_gav.asset.business_app_list_data.business_app
-      tag: foreach_business_app_list_data_software
+      tag: foreach_business_app_list_data_software_776d3011
       if: ctx.qualys_gav?.asset?.business_app_list_data?.business_app != null && ctx.qualys_gav.asset.business_app_list_data.business_app != ''
       processor:
         convert:
           field: _ingest._value.id
-          tag: convert_sofware_list_data_software_id_to_string
+          tag: convert_sofware_list_data_software_id_to_string_c90d159e
           type: string
           ignore_missing: true
   - date:
       field: qualys_gav.asset.sensor_last_updated_date
-      tag: date_sensor_last_updated_date
+      tag: date_sensor_last_updated_date_8dbb485e
       target_field: qualys_gav.asset.sensor_last_updated_date
       formats:
         - UNIX_MS
@@ -1547,642 +1547,642 @@ processors:
       if: ctx.qualys_gav?.asset?.sensor_last_updated_date != null && ctx.qualys_gav.asset.sensor_last_updated_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_sensor_last_updated_date_e7aa2ebb
+            tag: remove_qualys_gav_asset_sensor_last_updated_date_14dc9f26
             field: qualys_gav.asset.sensor_last_updated_date
         - append:
-            tag: append_error_message_18f0e285
+            tag: append_error_message_9be1c881
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_id_to_string
+      tag: foreach_sofware_list_data_software_to_convert_id_to_string_822ed7f8
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         convert:
           field: _ingest._value.id
-          tag: convert_sofware_list_data_software_id
+          tag: convert_sofware_list_data_software_id_571f4d28
           target_field: _ingest._value.id
           type: string
           ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_name_from_full_name
+      tag: foreach_sofware_list_data_software_to_append_package_name_from_full_name_1c28da11
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.name
-          tag: append_sofware_list_data_software_name_into_package_name
+          tag: append_sofware_list_data_software_name_into_package_name_8ce417ae
           value: '{{{_ingest._value.full_name}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_name_from_software_type
+      tag: foreach_sofware_list_data_software_to_append_package_name_from_software_type_832d8118
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.type
-          tag: append_sofware_list_data_software_name_into_package_name_f09d95a0
+          tag: append_sofware_list_data_software_name_into_package_name_fcdc66f5
           value: '{{{_ingest._value.software_type}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_is_ignored
+      tag: foreach_sofware_list_data_software_to_convert_is_ignored_2e02c5c0
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         convert:
           field: _ingest._value.is_ignored
-          tag: convert_sofware_list_data_software_is_ignored
+          tag: convert_sofware_list_data_software_is_ignored_d13e9160
           type: boolean
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_is_ignored
+                tag: remove_ingest_value_is_ignored_f1012280
                 field: _ingest._value.is_ignored
                 ignore_missing: true
             - append:
-                tag: append_error_message_5639bfa9
+                tag: append_error_message_c6120db2
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_version_from_version
+      tag: foreach_sofware_list_data_software_to_append_package_version_from_version_74c2b78f
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.version
-          tag: append_software_list_data_software_version_into_package_version
+          tag: append_software_list_data_software_version_into_package_version_6cb69e74
           value: '{{{_ingest._value.version}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_architecture_from_architecture
+      tag: foreach_sofware_list_data_software_to_append_package_architecture_from_architecture_57523a60
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.architecture
-          tag: append_software_list_data_software_architecture_into_package_architecture
+          tag: append_software_list_data_software_architecture_into_package_architecture_315e5f9e
           value: '{{{_ingest._value.architecture}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_date_installed_date
+      tag: foreach_sofware_list_data_software_to_date_installed_date_539c1466
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         date:
           field: _ingest._value.install_date
           target_field: _ingest._value.install_date
-          tag: date_software_list_data_software_installDate
+          tag: date_software_list_data_software_installDate_29df0a76
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_install_date
+                tag: remove_ingest_value_install_date_b2eb146d
                 field: _ingest._value.install_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_installed_from_install_date
+      tag: foreach_sofware_list_data_software_to_append_package_installed_from_install_date_81ad3ff2
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.installed
-          tag: append_software_list_data_software_installDate_into_package_installed
+          tag: append_software_list_data_software_installDate_into_package_installed_14864750
           value: '{{{_ingest._value.install_date}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_path_from_install_path
+      tag: foreach_sofware_list_data_software_to_append_package_path_from_install_path_1b4420ff
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.path
-          tag: append_software_list_data_software_install_path_into_package_path
+          tag: append_software_list_data_software_install_path_into_package_path_0dea6167
           value: '{{{_ingest._value.install_path}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_date_last_updated
+      tag: foreach_sofware_list_data_software_to_date_last_updated_3adb9a42
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         date:
           field: _ingest._value.last_updated
           target_field: _ingest._value.last_updated
-          tag: date_software_list_data_software_last_updated
+          tag: date_software_list_data_software_last_updated_ab5e077a
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_last_updated_48fae1a8
+                tag: remove_ingest_value_last_updated_67e6bda2
                 field: _ingest._value.last_updated
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_date_last_use
+      tag: foreach_sofware_list_data_software_to_date_last_use_4b4053ad
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         date:
           field: _ingest._value.last_use_date
           target_field: _ingest._value.last_use_date
-          tag: date_software_list_data_software_last_use_date
+          tag: date_software_list_data_software_last_use_date_a4128bab
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_last_use_date
+                tag: remove_ingest_value_last_use_date_5fa24a69
                 field: _ingest._value.last_use_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_is_package
+      tag: foreach_sofware_list_data_software_to_convert_is_package_7bc20da2
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         convert:
           field: _ingest._value.is_package
-          tag: convert_sofware_list_data_software_is_package
+          tag: convert_sofware_list_data_software_is_package_1c2243a1
           type: boolean
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_is_package
+                tag: remove_ingest_value_is_package_5afbdd35
                 field: _ingest._value.is_package
                 ignore_missing: true
             - append:
-                tag: append_error_message_e8e14e4a
+                tag: append_error_message_73af1cbd
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_is_package_component
+      tag: foreach_sofware_list_data_software_to_convert_is_package_component_adcb1ed9
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         convert:
           field: _ingest._value.is_package_component
-          tag: convert_sofware_list_data_software_is_package_component
+          tag: convert_sofware_list_data_software_is_package_component_bd7d3e93
           type: boolean
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_is_package_component
+                tag: remove_ingest_value_is_package_component_9dad3b2e
                 field: _ingest._value.is_package_component
                 ignore_missing: true
             - append:
-                tag: append_error_message_a4ddfd07
+                tag: append_error_message_42c1090a
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_path_from_product_url
+      tag: foreach_sofware_list_data_software_to_append_package_path_from_product_url_447e04dd
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.reference
-          tag: append_software_list_data_software_product_url_into_package_path
+          tag: append_software_list_data_software_product_url_into_package_path_c7610d05
           value: '{{{_ingest._value.product_url}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_ga_date
+      tag: foreach_sofware_list_data_software_to_convert_ga_date_e7d0c71e
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         date:
           field: _ingest._value.lifecycle.ga_date
           target_field: _ingest._value.lifecycle.ga_date
-          tag: date_software_list_data_software_ga_date
+          tag: date_software_list_data_software_ga_date_bfd56579
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_lifecycle_ga_date
+                tag: remove_ingest_value_lifecycle_ga_date_0cafbcfd
                 field: _ingest._value.lifecycle.ga_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_date_lifecycle_eol_date
+      tag: foreach_sofware_list_data_software_date_lifecycle_eol_date_1667e5f9
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         date:
           field: _ingest._value.lifecycle.eol_date
           target_field: _ingest._value.lifecycle.eol_date
-          tag: date_software_list_data_software_lifecycle_eol_date
+          tag: date_software_list_data_software_lifecycle_eol_date_6f5bc07c
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_lifecycle_eol_date
+                tag: remove_ingest_value_lifecycle_eol_date_768b22ff
                 field: _ingest._value.lifecycle.eol_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_date_lifecycle_eos_date
+      tag: foreach_sofware_list_data_software_date_lifecycle_eos_date_e75297c6
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         date:
           field: _ingest._value.lifecycle.eos_date
           target_field: _ingest._value.lifecycle.eos_date
-          tag: date_software_list_data_software_lifecycle_eos_date
+          tag: date_software_list_data_software_lifecycle_eos_date_d9032321
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_lifecycle_eos_date
+                tag: remove_ingest_value_lifecycle_eos_date_748cadfd
                 field: _ingest._value.lifecycle.eos_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_lifecycle_detection_score
+      tag: foreach_sofware_list_data_software_to_convert_lifecycle_detection_score_cdc53591
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         convert:
           field: _ingest._value.lifecycle.detection_score
-          tag: convert_software_list_data_software_lifecycle_detection_score
+          tag: convert_software_list_data_software_lifecycle_detection_score_717e66e4
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_lifecycle_detection_score
+                tag: remove_ingest_value_lifecycle_detection_score_aa28b02e
                 field: _ingest._value.lifecycle.detection_score
                 ignore_missing: true
             - append:
-                tag: append_error_message_f6de18a6
+                tag: append_error_message_a39bbaea
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_description_from_support_stage_desc
+      tag: foreach_sofware_list_data_software_to_append_package_description_from_support_stage_desc_028bca10
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.description
-          tag: append_software_list_data_software_support_stage_desc
+          tag: append_software_list_data_software_support_stage_desc_c364c5fd
           value: '{{{_ingest._value.support_stage_desc}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_append_package_license_from_support_stage_desc
+      tag: foreach_sofware_list_data_software_to_append_package_license_from_support_stage_desc_7d8269a5
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         append:
           field: package.license
-          tag: append_software_list_data_software_support_stage_desc_bbaeff2d
+          tag: append_software_list_data_software_support_stage_desc_acb1d2d9
           value: '{{{_ingest._value.license.category}}}'
           allow_duplicates: false
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_convert_authorization_detection_score
+      tag: foreach_sofware_list_data_software_to_convert_authorization_detection_score_e57c2dc2
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         convert:
           field: _ingest._value.authorization_detection_score
-          tag: convert_software_list_data_software_authorization_detection_score
+          tag: convert_software_list_data_software_authorization_detection_score_b3d41ac2
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_authorization_detection_score
+                tag: remove_ingest_value_authorization_detection_score_b86d2f0c
                 field: _ingest._value.authorization_detection_score
                 ignore_missing: true
             - append:
-                tag: append_error_message_f296c5ec
+                tag: append_error_message_7e88c160
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_date_software_instances_first_seen
+      tag: foreach_sofware_list_data_software_to_date_software_instances_first_seen_f0318b0e
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         foreach:
           field: _ingest._value.software_instances
-          tag: foreach_software_list_data_software_software_instances_first_seen
+          tag: foreach_software_list_data_software_software_instances_first_seen_ecf3861e
           ignore_failure: true
           processor:
             date:
               field: _ingest._value.first_seen
               target_field: _ingest._value.first_seen
-              tag: date_software_list_data_software_software_instances_firstSeen
+              tag: date_software_list_data_software_software_instances_firstSeen_7ba0d98b
               formats:
                 - UNIX_MS
                 - ISO8601
               on_failure:
                 - remove:
-                    tag: remove_ingest_value_first_seen
+                    tag: remove_ingest_value_first_seen_6525120d
                     field: _ingest._value.first_seen
                     ignore_missing: true
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_sofware_list_data_software_to_date_software_instances_last_seen
+      tag: foreach_sofware_list_data_software_to_date_software_instances_last_seen_bd5af510
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List
       processor:
         foreach:
           field: _ingest._value.software_instances
-          tag: foreach_software_list_data_software_software_instances_last_seen
+          tag: foreach_software_list_data_software_software_instances_last_seen_84615178
           ignore_failure: true
           processor:
             date:
               field: _ingest._value.last_seen
               target_field: _ingest._value.last_seen
-              tag: date_software_list_data_software_software_instances_last_seen
+              tag: date_software_list_data_software_software_instances_last_seen_bb92ebe5
               formats:
                 - UNIX_MS
                 - ISO8601
               on_failure:
                 - remove:
-                    tag: remove_ingest_value_last_seen
+                    tag: remove_ingest_value_last_seen_b5ee77e5
                     field: _ingest._value.last_seen
                     ignore_missing: true
   - foreach:
       field: qualys_gav.asset.tag_list.tag
-      tag: foreach_tagList_tag_to_convert_criticality_score
+      tag: foreach_tagList_tag_to_convert_criticality_score_18ccd4df
       if: ctx.qualys_gav?.asset?.tag_list?.tag instanceof List
       processor:
         convert:
           field: _ingest._value.criticality_score
-          tag: convert_tagList_tag_criticality_score
+          tag: convert_tagList_tag_criticality_score_42a8debf
           type: double
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_criticality_score
+                tag: remove_ingest_value_criticality_score_89a048af
                 field: _ingest._value.criticality_score
                 ignore_missing: true
             - append:
-                tag: append_error_message_dfdfe4bf
+                tag: append_error_message_c67ee697
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.tag_list.tag
-      tag: foreach_tagList_tag_to_convert_tag_id
+      tag: foreach_tagList_tag_to_convert_tag_id_48408904
       if: ctx.qualys_gav?.asset?.tag_list?.tag instanceof List
       processor:
         convert:
           field: _ingest._value.tag_id
-          tag: convert_tagList_tag_tag_id_to_string
+          tag: convert_tagList_tag_tag_id_to_string_7f7153c4
           type: string
           ignore_missing: true
   - foreach:
       field: qualys_gav.asset.tag_list.tag
-      tag: foreach_tagList_tag_to_convert_background_color
+      tag: foreach_tagList_tag_to_convert_background_color_b2d9d30a
       if: ctx.qualys_gav?.asset?.tag_list?.tag instanceof List
       processor:
         convert:
           field: _ingest._value.background_color
-          tag: convert_tagList_tag_background_color_to_string
+          tag: convert_tagList_tag_background_color_to_string_17b41ae2
           type: string
           ignore_missing: true
   - foreach:
       field: qualys_gav.asset.tag_list.tag
-      tag: foreach_tagList_tag_to_convert_foreground_color
+      tag: foreach_tagList_tag_to_convert_foreground_color_eef5126f
       if: ctx.qualys_gav?.asset?.tag_list?.tag instanceof List
       processor:
         convert:
           field: _ingest._value.foreground_color
-          tag: convert_tagList_tag_foreground_color_to_string
+          tag: convert_tagList_tag_foreground_color_to_string_0d5aa44e
           type: string
           ignore_missing: true
   - convert:
       field: qualys_gav.asset.threads_per_core
-      tag: convert_threads_per_core
+      tag: convert_threads_per_core_d2d319f2
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.threads_per_core != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_threads_per_core_2144e1fc
+            tag: remove_qualys_gav_asset_threads_per_core_a62a83c3
             field: qualys_gav.asset.threads_per_core
         - append:
-            tag: append_error_message_abc82d01
+            tag: append_error_message_f319ca57
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.timezone
-      tag: set_event_timezone_from_asset_time_zone
+      tag: set_event_timezone_from_asset_time_zone_4a06a43b
       copy_from: qualys_gav.asset.time_zone
       ignore_empty_value: true
   - convert:
       field: qualys_gav.asset.total_memory
-      tag: convert_total_memory_to_long
+      tag: convert_total_memory_to_long_27024366
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.total_memory != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_total_memory_d78e6fd6
+            tag: remove_qualys_gav_asset_total_memory_5b393921
             field: qualys_gav.asset.total_memory
         - append:
-            tag: append_error_message_730ab154
+            tag: append_error_message_93e233e9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.volume_list_data.volume
-      tag: foreach_volume_list_data_volume_to_convert_free
+      tag: foreach_volume_list_data_volume_to_convert_free_bbad66d2
       if: ctx.qualys_gav?.asset?.volume_list_data?.volume instanceof List
       processor:
         convert:
           field: _ingest._value.free
-          tag: convert_volume_list_data_volume_free_to_long
+          tag: convert_volume_list_data_volume_free_to_long_63409b2a
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_free
+                tag: remove_ingest_value_free_3c2fc818
                 field: _ingest._value.free
                 ignore_missing: true
             - append:
-                tag: append_error_message_8c49b7cd
+                tag: append_error_message_0281a330
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.volume_list_data.volume
-      tag: foreach_volume_list_data_volume_to_convert_size
+      tag: foreach_volume_list_data_volume_to_convert_size_5b700d8c
       if: ctx.qualys_gav?.asset?.volume_list_data?.volume instanceof List
       processor:
         convert:
           field: _ingest._value.size
-          tag: convert_volume_list_data_volume_size_to_long
+          tag: convert_volume_list_data_volume_size_to_long_9c7b5bf0
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_size
+                tag: remove_ingest_value_size_4b0fd9ca
                 field: _ingest._value.size
                 ignore_missing: true
             - append:
-                tag: append_error_message_47b2d786
+                tag: append_error_message_d3007a45
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: qualys_gav.asset.whois
-      tag: foreach_whois_to_date_created_date
+      tag: foreach_whois_to_date_created_date_3d150dfc
       if: ctx.qualys_gav?.asset?.whois instanceof List
       processor:
         date:
           field: _ingest._value.created_date
-          tag: date_whois_created_date
+          tag: date_whois_created_date_a6037c5d
           target_field: _ingest._value.created_date
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_created_date
+                tag: remove_ingest_value_created_date_19b8af96
                 field: _ingest._value.created_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.whois
-      tag: foreach_whois_to_date_expiration_date
+      tag: foreach_whois_to_date_expiration_date_ea92441b
       if: ctx.qualys_gav?.asset?.whois instanceof List
       processor:
         date:
           field: _ingest._value.expiration_date
-          tag: date_whois_expiration_date
+          tag: date_whois_expiration_date_3e1ac050
           target_field: _ingest._value.expiration_date
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_expiration_date
+                tag: remove_ingest_value_expiration_date_9704406f
                 field: _ingest._value.expiration_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.whois
-      tag: foreach_whois_to_date_updated_date
+      tag: foreach_whois_to_date_updated_date_1137c414
       if: ctx.qualys_gav?.asset?.whois instanceof List
       processor:
         date:
           field: _ingest._value.updated_date
-          tag: date_whois_updated_date
+          tag: date_whois_updated_date_37a941e7
           target_field: _ingest._value.updated_date
           formats:
             - UNIX_MS
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_updated_date
+                tag: remove_ingest_value_updated_date_bf67f445
                 field: _ingest._value.updated_date
                 ignore_missing: true
   - foreach:
       field: qualys_gav.asset.whois
-      tag: foreach_whois_to_append_domain_into_related_hosts
+      tag: foreach_whois_to_append_domain_into_related_hosts_4e0d0942
       if: ctx.qualys_gav?.asset?.whois instanceof List
       processor:
         append:
           field: related.hosts
-          tag: append_whois_domain_into_related_hosts
+          tag: append_whois_domain_into_related_hosts_8a564e07
           value: '{{{_ingest._value.domain}}}'
           allow_duplicates: false
   - date:
       field: qualys_gav.asset.last_modified_date
       target_field: qualys_gav.asset.last_modified_date
-      tag: date_last_modified_date
+      tag: date_last_modified_date_cd52caa3
       formats:
         - UNIX_MS
         - ISO8601
       if: ctx.qualys_gav?.asset?.last_modified_date != null && ctx.qualys_gav.asset.last_modified_date != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_last_modified_date_ca6e9e50
+            tag: remove_qualys_gav_asset_last_modified_date_0bbdcf13
             field: qualys_gav.asset.last_modified_date
         - append:
-            tag: append_error_message_52a15937
+            tag: append_error_message_243c0d23
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.processor.speed
-      tag: convert_processor_speed_to_long
+      tag: convert_processor_speed_to_long_977a1e8b
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.processor?.speed != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_processor_speed_36a66ad5
+            tag: remove_qualys_gav_asset_processor_speed_077b26fa
             field: qualys_gav.asset.processor.speed
         - append:
-            tag: append_error_message_c0a0bad4
+            tag: append_error_message_6bec619a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.processor.num_cpus
-      tag: convert_container_num_cpus_to_long
+      tag: convert_container_num_cpus_to_long_48e519a5
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.processor?.num_cpus != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_processor_num_cpus_ee19437d
+            tag: remove_qualys_gav_asset_processor_num_cpus_93302a4d
             field: qualys_gav.asset.processor.num_cpus
         - append:
-            tag: append_error_message_281bd05f
+            tag: append_error_message_3c3652a2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.processor.no_of_socket
-      tag: convert_container_no_of_socket_to_long
+      tag: convert_container_no_of_socket_to_long_73968f3b
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.processor?.no_of_socket != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_processor_no_of_socket_d60370fa
+            tag: remove_qualys_gav_asset_processor_no_of_socket_7c50cfab
             field: qualys_gav.asset.processor.no_of_socket
         - append:
-            tag: append_error_message_065b4e21
+            tag: append_error_message_0573ebda
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.processor.threads_per_core
-      tag: convert_container_threads_per_core_to_long
+      tag: convert_container_threads_per_core_to_long_d785cdee
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.processor?.threads_per_core != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_processor_threads_per_core_b07b85e8
+            tag: remove_qualys_gav_asset_processor_threads_per_core_91f902fe
             field: qualys_gav.asset.processor.threads_per_core
         - append:
-            tag: append_error_message_8ab88271
+            tag: append_error_message_2c1e5afe
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.processor.cores_per_socket
-      tag: convert_container_cores_per_socket_to_long
+      tag: convert_container_cores_per_socket_to_long_99ed9560
       type: long
       ignore_missing: true
       if: ctx.qualys_gav?.asset?.processor?.cores_per_socket != ''
       on_failure:
         - remove:
-            tag: remove_qualys_gav_asset_processor_cores_per_socket_13389faf
+            tag: remove_qualys_gav_asset_processor_cores_per_socket_bf28fa39
             field: qualys_gav.asset.processor.cores_per_socket
         - append:
-            tag: append_error_message_2c067477
+            tag: append_error_message_b106f4e3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: qualys_gav.asset.lpar_id
-      tag: convert_lpar_id_to_string
+      tag: convert_lpar_id_to_string_bf5a8788
       type: string
       ignore_missing: true
 
   # Mask Sensitive Data
   - foreach:
       field: qualys_gav.asset.whois
-      tag: foreach_whois_to_mask_registrant_contact
+      tag: foreach_whois_to_mask_registrant_contact_15cad3e1
       if: ctx.qualys_gav?.asset?.whois instanceof List && ctx.tags != null && ctx.tags.contains('hide_sensitive')
       processor:
         set:
           field: _ingest._value.registrant_contact
-          tag: set_whois_registrant_contact
+          tag: set_whois_registrant_contact_e057c1fe
           value: 'REDACTED'
 
   # Remove Duplicate Custom Field if preserve_duplicate_custom_fields are not enabled
   - foreach:
       field: qualys_gav.asset.software_list_data.software
-      tag: foreach_software_list_data_software_to_remove_duplicate_custom_fields
+      tag: foreach_software_list_data_software_to_remove_duplicate_custom_fields_574129ac
       if: ctx.qualys_gav?.asset?.software_list_data?.software instanceof List && (ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields'))
       processor:
         remove:
@@ -2196,7 +2196,7 @@ processors:
             - _ingest._value.product_url
             - _ingest._value.version
             - _ingest._value.support_stage_desc
-          tag: preserve_duplicate_custom_fields
+          tag: preserve_duplicate_custom_fields_a3265518
           ignore_missing: true
   - remove:
       field:
@@ -2224,18 +2224,18 @@ processors:
         - qualys_gav.asset.cloud_provider
         - qualys_gav.asset.risk_score
         - qualys_gav.asset.time_zone
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_e11998d1
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field:
         - _conf
-      tag: remove_temporary_fields
+      tag: remove_temporary_fields_1277a50c
       ignore_missing: true
 
   # Cleanup
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_93302de8
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -2262,18 +2262,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_30479dff
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -2281,10 +2281,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/qualys_gav/manifest.yml
+++ b/packages/qualys_gav/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: qualys_gav
 title: Qualys Global AssetView
-version: 0.9.3
+version: 0.10.0
 description: Collect logs from Qualys Global AssetView with Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_gav/manifest.yml
+++ b/packages/qualys_gav/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: qualys_gav
 title: Qualys Global AssetView
-version: 0.9.2
+version: 0.9.3
 description: Collect logs from Qualys Global AssetView with Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_was/changelog.yml
+++ b/packages/qualys_was/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/qualys_was/changelog.yml
+++ b/packages/qualys_was/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.5.2"
+- version: "0.6.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/qualys_was/changelog.yml
+++ b/packages/qualys_was/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -251,7 +251,7 @@ processors:
       ignore_missing: true
   - rename:
       field: json.detection.webApp.id
-      tag: rename_webApp_url_d9470b51
+      tag: rename_webApp_id_d9470b51
       target_field: qualys_was.vulnerability.web_app.id
       ignore_missing: true
   - script:
@@ -423,7 +423,7 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: script_6501d9f9
+      tag: script_create_list_owasp_references_6501d9f9
       description: 'Create list of owasp references'
       if: ctx.json?.detection?.owasp?.list != null && ctx.json?.detection?.owasp?.list.size() > 0
       lang: painless

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -5,31 +5,37 @@ processors:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
+      tag: rename_message_to_event_original_c35a9364
       field: message
       target_field: event.original
       if: ctx.event?.original == null
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message.'
       on_failure:
         - append:
+            tag: append_error_message_9219f8a2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
+      tag: set_event_created_3b69f632
       if: ctx['@timestamp'] != null
       field: event.created
       copy_from: '@timestamp'
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_ecs_version_135371bc
       field: ecs.version
       value: '8.16.0'
   - terminate:
-      tag: data_collection_error
+      tag: terminate_3c149bdd
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - set:
@@ -37,28 +43,36 @@ processors:
       tag: set_event_kind_1
       value: event
   - set:
+      tag: set_event_category_13b30ef2
       field: event.category
       value: [vulnerability]
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - set:
+      tag: set_vulnerability_classification_8b34b171
       field: vulnerability.classification
       value: CVSS
   - set:
+      tag: set_vulnerability_enumeration_c3d6bae0
       field: vulnerability.enumeration
       value: CWE
   - set:
+      tag: set_vulnerability_category_8b0e7a6a
       field: vulnerability.category
       value: [Web Application]
   - set:
+      tag: set_vulnerability_scanner_vendor_54e04563
       field: vulnerability.scanner.vendor
       value: Qualys
   - json:
+      tag: json_event_original_to_json_2ab742de
       field: event.original
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_c9525988
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -94,11 +108,12 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_df4a45fa
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       if: ctx.qualys_was?.vulnerability?.qid != null
-      tag: vul_id_is_long
+      tag: script_d94403e4
       lang: painless
       source: >
         if (ctx.qualys_was.vulnerability.qid instanceof String) {
@@ -108,6 +123,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_24297e4e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -124,6 +140,7 @@ processors:
       if: ctx.json?.detection?.lastDetectedDate != null && ctx.json.detection.lastDetectedDate != ''
       on_failure:
         - append:
+            tag: append_error_message_d75914ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -135,6 +152,7 @@ processors:
       if: ctx.json?.detection?.firstDetectedDate != null && ctx.json.detection.firstDetectedDate != ''
       on_failure:
         - append:
+            tag: append_error_message_5e842a89
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -145,6 +163,7 @@ processors:
       target_field: qualys_was.vulnerability.last_test_datetime
       on_failure:
         - append:
+            tag: append_error_message_e779d17f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -156,6 +175,7 @@ processors:
       if: ctx.json?.detection?.updatedDate != null && ctx.json.detection.updatedDate != ''
       on_failure:
         - append:
+            tag: append_error_message_97a7e165
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -167,6 +187,7 @@ processors:
       if: ctx.json?.detection?.fixedDate != null && ctx.json.detection.fixedDate != ''
       on_failure:
         - append:
+            tag: append_error_message_c140f81e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -181,14 +202,15 @@ processors:
   - rename:
       field: json.detection.potential
       tag: rename_potential
-      target_field:  qualys_was.vulnerability.potential
+      target_field: qualys_was.vulnerability.potential
       ignore_missing: true
   - rename:
       field: json.detection.param
       tag: rename_param
-      target_field:  qualys_was.vulnerability.param
+      target_field: qualys_was.vulnerability.param
       ignore_missing: true
   - script:
+      tag: script_0c1121dd
       if: ctx.json?.detection?.detectionScore != null
       lang: painless
       source: >
@@ -199,9 +221,11 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_a62cb073
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
+      tag: script_9af9e5ad
       if: ctx.json?.detection?.timesDetected != null
       lang: painless
       source: >
@@ -212,24 +236,26 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_00b5fe93
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.detection.webApp.name
       tag: rename_webApp_name
-      target_field:  qualys_was.vulnerability.web_app.name
+      target_field: qualys_was.vulnerability.web_app.name
       ignore_missing: true
   - rename:
       field: json.detection.webApp.url
       tag: rename_webApp_url
-      target_field:  qualys_was.vulnerability.web_app.url
+      target_field: qualys_was.vulnerability.web_app.url
       ignore_missing: true
   - rename:
       field: json.detection.webApp.id
-      tag: rename_webApp_url
-      target_field:  qualys_was.vulnerability.web_app.id
+      tag: rename_json_detection_webApp_id_to_qualys_was_vulnerability_web_app_id_de71119f
+      target_field: qualys_was.vulnerability.web_app.id
       ignore_missing: true
   - script:
+      tag: script_9ac6595e
       if: ctx.qualys_was?.vulnerability?.web_app?.id != null
       lang: painless
       source: >
@@ -240,6 +266,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_34fe91bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -262,12 +289,13 @@ processors:
         ctx.qualys_was.vulnerability.web_app.tags = tagsList;
       on_failure:
         - append:
+            tag: append_error_message_b0076e78
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.detection.type
       tag: rename_type
-      target_field:  qualys_was.vulnerability.type
+      target_field: qualys_was.vulnerability.type
   - rename:
       field: json.detection.status
       tag: rename_status
@@ -298,6 +326,7 @@ processors:
       target_field: qualys_was.vulnerability.ignoredBy.id
       ignore_missing: true
   - script:
+      tag: script_78116e44
       if: ctx.qualys_was?.vulnerability?.ignoredBy?.id != null && ctx.qualys_was.vulnerability.ignoredBy.id != ""
       lang: painless
       source: >
@@ -308,6 +337,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_62d80e16
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -335,6 +365,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8e3259c9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -365,6 +396,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_1ff4112d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -387,9 +419,11 @@ processors:
         ctx.qualys_was.vulnerability.wasc_references = wascList;
       on_failure:
         - append:
+            tag: append_error_message_a0fee976
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
+      tag: script_65779699
       description: 'Create list of owasp references'
       if: ctx.json?.detection?.owasp?.list != null && ctx.json?.detection?.owasp?.list.size() > 0
       lang: painless
@@ -408,6 +442,7 @@ processors:
         ctx.qualys_was.vulnerability.owasp_references = owaspList;
       on_failure:
         - append:
+            tag: append_error_message_0ba1f82b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -417,6 +452,7 @@ processors:
 
   # Handle knowledge_base
   - append:
+      tag: append_error_message_22b416f3
       field: error.message
       if: ctx.json?.Finding.knowledge_base == null || ctx.json.Finding.knowledge_base.size() == 0
       value: 'Qualys QID not found in the Knowledge Base'
@@ -426,6 +462,7 @@ processors:
       tag: pipeline_knowledge_base
       ignore_missing_pipeline: true
   - rename:
+      tag: rename_message_to_event_original_35631c5d
       field: message
       target_field: event.original
       ignore_missing: true
@@ -433,7 +470,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_knowledge_base" }}'
       if: ctx.Finding != null && ctx.Finding.knowledge_base != null && ctx.Finding.knowledge_base.size() > 0
-      tag: pipeline_knowledge_base
+      tag: pipeline_693c5eae
       ignore_missing_pipeline: true
   - append:
       field: event.kind
@@ -443,6 +480,7 @@ processors:
       if: ctx.error?.message != null
       allow_duplicates: false
   - append:
+      tag: append_tags_0f0a9140
       field: tags
       value: preserve_original_event
       allow_duplicates: false
@@ -451,8 +489,8 @@ processors:
 on_failure:
   - append:
       field: error.message
-      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}}
-        in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+
   - set:
       field: event.kind
       value: pipeline_error

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -2,103 +2,103 @@
 description: Pipeline for processing Tenable Vulnerability Management vulnerability logs.
 processors:
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
-      tag: rename_message_to_event_original_c35a9364
+      tag: rename_message_to_event_original_b645dbbc
       field: message
       target_field: event.original
       if: ctx.event?.original == null
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message.'
       on_failure:
         - append:
-            tag: append_error_message_9219f8a2
+            tag: append_error_message_553620f2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
-      tag: remove_message_2ee3a7d4
+      tag: remove_message_facc4822
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
-      tag: set_event_created_3b69f632
+      tag: set_event_created_eeecb9ec
       if: ctx['@timestamp'] != null
       field: event.created
       copy_from: '@timestamp'
   - json:
-      tag: json_event_original_to_json_5e54dc16
+      tag: json_event_original_to_json_74d23cc2
       field: event.original
       target_field: json
   - set:
-      tag: set_ecs_version_135371bc
+      tag: set_ecs_version_d69d3fcf
       field: ecs.version
       value: '8.16.0'
   - terminate:
-      tag: data_collection_error_3c149bdd
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - set:
       field: event.kind
-      tag: set_event_kind_1
+      tag: set_event_kind_1_d452ef2c
       value: event
   - set:
-      tag: set_event_category_13b30ef2
+      tag: set_event_category_f174b464
       field: event.category
       value: [vulnerability]
   - set:
-      tag: set_event_type_ec95f7f2
+      tag: set_event_type_8bf4a5be
       field: event.type
       value: [info]
   - set:
-      tag: set_vulnerability_classification_8b34b171
+      tag: set_vulnerability_classification_91e7ba7a
       field: vulnerability.classification
       value: CVSS
   - set:
-      tag: set_vulnerability_enumeration_c3d6bae0
+      tag: set_vulnerability_enumeration_12cf400d
       field: vulnerability.enumeration
       value: CWE
   - set:
-      tag: set_vulnerability_category_8b0e7a6a
+      tag: set_vulnerability_category_28f41e3e
       field: vulnerability.category
       value: [Web Application]
   - set:
-      tag: set_vulnerability_scanner_vendor_54e04563
+      tag: set_vulnerability_scanner_vendor_54795747
       field: vulnerability.scanner.vendor
       value: Qualys
   - json:
-      tag: json_event_original_to_json_2ab742de
+      tag: json_event_original_to_json_a68ecd77
       field: event.original
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_c9525988
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.Finding.detection
-      tag: rename_detection
+      tag: rename_detection_07658d10
       target_field: json.detection
   - rename:
       field: json.detection.url
-      tag: rename_full_url
+      tag: rename_full_url_aea5406f
       target_field: url.full
       ignore_missing: true
   - rename:
       field: json.detection.name
-      tag: rename_vul_name
+      tag: rename_vul_name_e6a10cea
       target_field: qualys_was.vulnerability.name
   - rename:
       field: json.detection.id
-      tag: rename_vul_id
+      tag: rename_vul_id_16232955
       target_field: qualys_was.vulnerability.id
   - rename:
       field: json.detection.qid
-      tag: rename_vul_qid
+      tag: rename_vul_qid_05185043
       target_field: qualys_was.vulnerability.qid
   - script:
       if: ctx.qualys_was?.vulnerability?.id != null
-      tag: vul_id_is_long
+      tag: vul_id_is_long_b339976f
       lang: painless
       source: >
         if (ctx.qualys_was.vulnerability.id instanceof String) {
@@ -108,12 +108,12 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_df4a45fa
+            tag: append_error_message_132cf9fc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       if: ctx.qualys_was?.vulnerability?.qid != null
-      tag: vul_id_is_long_d94403e4
+      tag: vul_qid_is_long_3b587f31
       lang: painless
       source: >
         if (ctx.qualys_was.vulnerability.qid instanceof String) {
@@ -123,94 +123,94 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_24297e4e
+            tag: append_error_message_70d9d8ce
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.detection.severity
-      tag: rename_severity
+      tag: rename_severity_9088c5bb
       target_field: vulnerability.severity
       ignore_missing: true
   - date:
       field: json.detection.lastDetectedDate
-      tag: rename_lastDetectedDate
+      tag: rename_lastDetectedDate_a26dca73
       formats:
         - ISO8601
       target_field: qualys_was.vulnerability.last_found_datetime
       if: ctx.json?.detection?.lastDetectedDate != null && ctx.json.detection.lastDetectedDate != ''
       on_failure:
         - append:
-            tag: append_error_message_d75914ef
+            tag: append_error_message_8fe27a34
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.detection.firstDetectedDate
-      tag: rename_firstDetectedDate
+      tag: rename_firstDetectedDate_3d692cb0
       formats:
         - ISO8601
       target_field: qualys_was.vulnerability.first_found_datetime
       if: ctx.json?.detection?.firstDetectedDate != null && ctx.json.detection.firstDetectedDate != ''
       on_failure:
         - append:
-            tag: append_error_message_5e842a89
+            tag: append_error_message_af222939
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.detection.lastTestedDate
-      tag: rename_lastTestedDate
+      tag: rename_lastTestedDate_1f0ad1f0
       formats:
         - ISO8601
       target_field: qualys_was.vulnerability.last_test_datetime
       on_failure:
         - append:
-            tag: append_error_message_e779d17f
+            tag: append_error_message_06c7696b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.detection.updatedDate
-      tag: rename_updatedDate
+      tag: rename_updatedDate_5965efd5
       formats:
         - ISO8601
       target_field: qualys_was.vulnerability.updated_datetime
       if: ctx.json?.detection?.updatedDate != null && ctx.json.detection.updatedDate != ''
       on_failure:
         - append:
-            tag: append_error_message_97a7e165
+            tag: append_error_message_1a7f4b1f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.detection.fixedDate
-      tag: rename_fixedDate
+      tag: rename_fixedDate_5ece4e5b
       formats:
         - ISO8601
       target_field: qualys_was.vulnerability.fixed_datetime
       if: ctx.json?.detection?.fixedDate != null && ctx.json.detection.fixedDate != ''
       on_failure:
         - append:
-            tag: append_error_message_c140f81e
+            tag: append_error_message_cd57362f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: '@timestamp'
-      tag: set_event_ingest_to_timestamp
+      tag: set_event_ingest_to_timestamp_937f3012
       target_field: event.ingested
       ignore_missing: true
   - set:
       field: '@timestamp'
-      tag: set_timestamp_last_test_datetime
+      tag: set_timestamp_last_test_datetime_789c94da
       copy_from: qualys_was.vulnerability.last_test_datetime
   - rename:
       field: json.detection.potential
-      tag: rename_potential
+      tag: rename_potential_13a1081b
       target_field: qualys_was.vulnerability.potential
       ignore_missing: true
   - rename:
       field: json.detection.param
-      tag: rename_param
+      tag: rename_param_447f49a2
       target_field: qualys_was.vulnerability.param
       ignore_missing: true
   - script:
-      tag: script_0c1121dd
+      tag: script_7572984d
       if: ctx.json?.detection?.detectionScore != null
       lang: painless
       source: >
@@ -221,11 +221,11 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_a62cb073
+            tag: append_error_message_76173af1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: script_9af9e5ad
+      tag: script_7289528b
       if: ctx.json?.detection?.timesDetected != null
       lang: painless
       source: >
@@ -236,26 +236,26 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_00b5fe93
+            tag: append_error_message_9b7b3818
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.detection.webApp.name
-      tag: rename_webApp_name
+      tag: rename_webApp_name_279262c3
       target_field: qualys_was.vulnerability.web_app.name
       ignore_missing: true
   - rename:
       field: json.detection.webApp.url
-      tag: rename_webApp_url
+      tag: rename_webApp_url_3ffca8dd
       target_field: qualys_was.vulnerability.web_app.url
       ignore_missing: true
   - rename:
       field: json.detection.webApp.id
-      tag: rename_webApp_url_de71119f
+      tag: rename_webApp_url_d9470b51
       target_field: qualys_was.vulnerability.web_app.id
       ignore_missing: true
   - script:
-      tag: script_9ac6595e
+      tag: script_9b0fb9f8
       if: ctx.qualys_was?.vulnerability?.web_app?.id != null
       lang: painless
       source: >
@@ -266,11 +266,11 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_34fe91bc
+            tag: append_error_message_275c9ac5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: add_web_app_tags
+      tag: add_web_app_tags_f759a51f
       description: 'Add web app tags'
       if: ctx.json?.detection?.webApp?.tags?.list != null && ctx.json.detection.webApp.tags.list.size() > 0
       lang: painless
@@ -289,44 +289,44 @@ processors:
         ctx.qualys_was.vulnerability.web_app.tags = tagsList;
       on_failure:
         - append:
-            tag: append_error_message_b0076e78
+            tag: append_error_message_ee798ae7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.detection.type
-      tag: rename_type
+      tag: rename_type_f4b697bd
       target_field: qualys_was.vulnerability.type
   - rename:
       field: json.detection.status
-      tag: rename_status
+      tag: rename_status_767bdb97
       target_field: qualys_was.vulnerability.status
       ignore_missing: true
   - rename:
       field: json.detection.uniqueId
-      tag: rename_uniqueID
+      tag: rename_uniqueID_af767f5b
       target_field: qualys_was.vulnerability.unique_vuln_id
   - rename:
       field: json.detection.isIgnored
-      tag: rename_isIgnored
+      tag: rename_isIgnored_166a5d0d
       target_field: qualys_was.vulnerability.is_ignored
       ignore_missing: true
   - rename:
       field: json.detection.ignoredBy.name
-      tag: rename_ignoredBy_name
+      tag: rename_ignoredBy_name_4d16be68
       target_field: qualys_was.vulnerability.ignoredBy.name
       ignore_missing: true
   - rename:
       field: json.detection.ignoredBy.username
-      tag: rename_ignoredBy_username
+      tag: rename_ignoredBy_username_85bb5342
       target_field: qualys_was.vulnerability.ignoredBy.username
       ignore_missing: true
   - rename:
       field: json.detection.ignoredBy.id
-      tag: rename_ignoredBy_id
+      tag: rename_ignoredBy_id_966e4baf
       target_field: qualys_was.vulnerability.ignoredBy.id
       ignore_missing: true
   - script:
-      tag: script_78116e44
+      tag: script_b862a2a7
       if: ctx.qualys_was?.vulnerability?.ignoredBy?.id != null && ctx.qualys_was.vulnerability.ignoredBy.id != ""
       lang: painless
       source: >
@@ -337,50 +337,50 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_62d80e16
+            tag: append_error_message_c0b45b4e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.detection.ignoredComment
-      tag: rename_ignoredComment
+      tag: rename_ignoredComment_ad54153d
       target_field: qualys_was.vulnerability.ignoredBy.comment
       ignore_missing: true
   - rename:
       field: json.detection.ignoredReason
-      tag: rename_ignoredReason
+      tag: rename_ignoredReason_fd45e682
       target_field: qualys_was.vulnerability.ignoredBy.reason
       ignore_missing: true
   - date:
       field: json.detection.ignoredDate
-      tag: rename_lignoredDate
+      tag: rename_lignoredDate_35e892cd
       formats:
         - ISO8601
       target_field: qualys_was.vulnerability.ignoredBy.date
       ignore_failure: true
   - convert:
       field: json.detection.resultList.list
-      tag: convert_result_list_to_string
+      tag: convert_result_list_to_string_ef4aebf3
       target_field: qualys_was.vulnerability.result_list_text
       type: string
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8e3259c9
+            tag: append_error_message_f21091ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   - rename:
       field: json.detection.cvss3.base
-      tag: rename_cvss3_base
+      tag: rename_cvss3_base_7e145a8c
       target_field: vulnerability.score.base
       ignore_missing: true
   - rename:
       field: json.detection.cvss3.temporal
-      tag: rename_cvss3_temporal
+      tag: rename_cvss3_temporal_f85f088f
       target_field: vulnerability.score.temporal
       ignore_missing: true
   - script:
-      tag: append_cwe_ids
+      tag: append_cwe_ids_c275d240
       description: 'Append cwe ids to vulnerability.id'
       if: ctx.json?.detection?.cwe?.list != null && ctx.json.detection.cwe.list.size() > 0
       lang: painless
@@ -396,11 +396,11 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_1ff4112d
+            tag: append_error_message_5509a700
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: create_wasc_references
+      tag: create_wasc_references_077a86eb
       description: 'Create list of wasc references'
       if: ctx.json?.detection?.wasc?.list != null && ctx.json.detection.wasc.list.size() > 0
       lang: painless
@@ -419,11 +419,11 @@ processors:
         ctx.qualys_was.vulnerability.wasc_references = wascList;
       on_failure:
         - append:
-            tag: append_error_message_a0fee976
+            tag: append_error_message_4d51d407
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
-      tag: script_65779699
+      tag: script_6501d9f9
       description: 'Create list of owasp references'
       if: ctx.json?.detection?.owasp?.list != null && ctx.json?.detection?.owasp?.list.size() > 0
       lang: painless
@@ -442,27 +442,27 @@ processors:
         ctx.qualys_was.vulnerability.owasp_references = owaspList;
       on_failure:
         - append:
-            tag: append_error_message_0ba1f82b
+            tag: append_error_message_8851bcd9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
       field: json.detection
-      tag: remove_unused_fields
+      tag: remove_unused_fields_e53e0927
       ignore_missing: true
 
   # Handle knowledge_base
   - append:
-      tag: append_error_message_22b416f3
+      tag: append_error_message_59f01f46
       field: error.message
       if: ctx.json?.Finding.knowledge_base == null || ctx.json.Finding.knowledge_base.size() == 0
       value: 'Qualys QID not found in the Knowledge Base'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_knowledge_base" }}'
       if: ctx.json?.Finding?.knowledge_base != null && ctx.json.Finding.knowledge_base.size() > 0
-      tag: pipeline_knowledge_base
+      tag: pipeline_knowledge_base_385b1f6d
       ignore_missing_pipeline: true
   - rename:
-      tag: rename_message_to_event_original_35631c5d
+      tag: rename_message_to_event_original_b0723971
       field: message
       target_field: event.original
       ignore_missing: true
@@ -470,17 +470,17 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_knowledge_base" }}'
       if: ctx.Finding != null && ctx.Finding.knowledge_base != null && ctx.Finding.knowledge_base.size() > 0
-      tag: pipeline_knowledge_base_693c5eae
+      tag: pipeline_knowledge_base_0fefdaca
       ignore_missing_pipeline: true
   - append:
       field: event.kind
       value: pipeline_error
-      tag: append_pipeline_error_to_event_kind
+      tag: append_pipeline_error_to_event_kind_eab632c5
       description: Append pipeline_error for non-terminal errors
       if: ctx.error?.message != null
       allow_duplicates: false
   - append:
-      tag: append_tags_0f0a9140
+      tag: append_tags_c8d9872a
       field: tags
       value: preserve_original_event
       allow_duplicates: false
@@ -488,18 +488,18 @@ processors:
       description: 'Keep copy of original event if there are errors'
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   - set:
       field: event.kind
       value: pipeline_error
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_784dfb8c
       description: 'Overwrite event.kind with pipeline_error for terminal failure'
       if: ctx.error?.message != null
   - append:
-      tag: append_tags
+      tag: append_tags_88ed28c7
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -35,7 +35,7 @@ processors:
       field: ecs.version
       value: '8.16.0'
   - terminate:
-      tag: terminate_3c149bdd
+      tag: data_collection_error_3c149bdd
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - set:
@@ -113,7 +113,7 @@ processors:
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       if: ctx.qualys_was?.vulnerability?.qid != null
-      tag: script_d94403e4
+      tag: vul_id_is_long_d94403e4
       lang: painless
       source: >
         if (ctx.qualys_was.vulnerability.qid instanceof String) {
@@ -251,7 +251,7 @@ processors:
       ignore_missing: true
   - rename:
       field: json.detection.webApp.id
-      tag: rename_json_detection_webApp_id_to_qualys_was_vulnerability_web_app_id_de71119f
+      tag: rename_webApp_url_de71119f
       target_field: qualys_was.vulnerability.web_app.id
       ignore_missing: true
   - script:
@@ -470,7 +470,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_knowledge_base" }}'
       if: ctx.Finding != null && ctx.Finding.knowledge_base != null && ctx.Finding.knowledge_base.size() > 0
-      tag: pipeline_693c5eae
+      tag: pipeline_knowledge_base_693c5eae
       ignore_missing_pipeline: true
   - append:
       field: event.kind
@@ -488,6 +488,7 @@ processors:
       description: 'Keep copy of original event if there are errors'
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -498,6 +499,7 @@ on_failure:
       description: 'Overwrite event.kind with pipeline_error for terminal failure'
       if: ctx.error?.message != null
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/pipeline_knowledge_base.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/pipeline_knowledge_base.yml
@@ -37,7 +37,7 @@ processors:
       tag: rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION
       target_field: qualys_was.vulnerability.knowledge_base.compliance_list.description
       ignore_missing: true
-# Handle case when COMPLIANCE_LIST.COMPLIANCE is an array
+  # Handle case when COMPLIANCE_LIST.COMPLIANCE is an array
   - foreach:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE
       if: ctx.qualys_was?.vulnerability?.knowledge_base?.COMPLIANCE_LIST?.COMPLIANCE instanceof List
@@ -107,7 +107,7 @@ processors:
       ignore_missing: true
   - rename:
       field: json.knowledge_base.QID
-      tag: rename_QID
+      tag: rename_json_knowledge_base_QID_to_qualys_was_vulnerability_knowledge_base_qid_35560f2c
       target_field: qualys_was.vulnerability.knowledge_base.qid
       ignore_missing: true
   - rename:
@@ -130,7 +130,7 @@ processors:
       tag: rename_TITLE
       target_field: qualys_was.vulnerability.knowledge_base.title
       ignore_missing: true
-# Handle case when BUGTRAQ_LIST.BUGTRAQ is an object
+  # Handle case when BUGTRAQ_LIST.BUGTRAQ is an object
   - rename:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ.ID
       tag: rename_BUGTRAQ_LIST_BUGTRAQ_ID
@@ -141,7 +141,7 @@ processors:
       tag: rename_BUGTRAQ_LIST_BUGTRAQ_URL
       target_field: qualys_was.vulnerability.knowledge_base.bugtraq_list.url
       ignore_missing: true
-# Handle case when BUGTRAQ_LIST.BUGTRAQ is an array
+  # Handle case when BUGTRAQ_LIST.BUGTRAQ is an array
   - foreach:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ
       if: ctx.json?.knowledge_base?.BUGTRAQ_LIST?.BUGTRAQ instanceof List
@@ -186,7 +186,7 @@ processors:
       if: ctx.json?.knowledge_base?.CVSS?.BASE instanceof String
   - rename:
       field: json.knowledge_base.CVSS.BASE
-      tag: rename_CVSS_BASE
+      tag: rename_json_knowledge_base_CVSS_BASE_to_qualys_was_vulnerability_knowledge_base_cvss_base_obj_06e1b687
       target_field: qualys_was.vulnerability.knowledge_base.cvss.base_obj
       ignore_missing: true
       if: ctx.json?.knowledge_base?.CVSS?.BASE instanceof Object
@@ -347,6 +347,7 @@ processors:
       if: ctx.vulnerability?.reference != null && !(ctx.vulnerability.reference instanceof List)
       on_failure:
         - append:
+            tag: append_error_message_ccfa865f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when EXPLT_SRC and EXPLT_LIST.EXPLT is an object
@@ -496,6 +497,7 @@ processors:
       if: ctx.json?.knowledge_base?.DISCOVERY?.REMOTE != ''
       on_failure:
         - append:
+            tag: append_error_message_d25f745d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when SOFTWARE_LIST.SOFTWARE is an object
@@ -583,6 +585,7 @@ processors:
       if: ctx.json?.knowledge_base?.LAST_SERVICE_MODIFICATION_DATETIME != null && ctx.qualys_was.vulnerability.knowledge_base.LAST_SERVICE_MODIFICATION_DATETIME != ''
       on_failure:
         - append:
+            tag: append_error_message_8c705c64
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -594,6 +597,7 @@ processors:
       if: ctx.json?.knowledge_base?.LAST_CUSTOMIZATION?.DATETIME != null && ctx.qualys_was.vulnerability.knowledge_base.LAST_CUSTOMIZATION.DATETIME != ''
       on_failure:
         - append:
+            tag: append_error_message_c0ac2860
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -610,6 +614,7 @@ processors:
       if: ctx.json?.knowledge_base?.PUBLISHED_DATETIME != null && ctx.qualys_was.vulnerability.knowledge_base.PUBLISHED_DATETIME != ''
       on_failure:
         - append:
+            tag: append_error_message_0fd6a546
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when CHANGE_LOG_LIST.CHANGE_LOG_INFO is an object
@@ -632,6 +637,7 @@ processors:
       - ISO8601
       on_failure:
         - append:
+            tag: append_error_message_9f1a2e73
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when CHANGE_LOG_LIST.CHANGE_LOG_INFO is an array
@@ -696,6 +702,7 @@ processors:
       if: ctx.json?.knowledge_base?.IS_DISABLED != ''
       on_failure:
         - append:
+            tag: append_error_message_599d4103
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -707,7 +714,7 @@ processors:
       field: json.knowledge_base.PATCHABLE
       tag: set_PATCHABLE_false
       value: false
-      if:  ctx.json?.knowledge_base?.PATCHABLE == '0'
+      if: ctx.json?.knowledge_base?.PATCHABLE == '0'
   - convert:
       field: json.knowledge_base.PATCHABLE
       tag: convert_PATCHABLE_to_boolean
@@ -717,6 +724,7 @@ processors:
       if: ctx.json?.knowledge_base?.PATCHABLE != ''
       on_failure:
         - append:
+            tag: append_error_message_ab46bb45
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -738,6 +746,7 @@ processors:
       if: ctx.json?.knowledge_base?.PCI_FLAG != ''
       on_failure:
         - append:
+            tag: append_error_message_6253e86b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -760,6 +769,7 @@ processors:
         ctx.vulnerability.severity = params.vuln_level.getOrDefault(level, params.vuln_level["0"]);
       on_failure:
         - append:
+            tag: append_error_message_e8a952ee
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -791,6 +801,7 @@ processors:
         drop(ctx);
       on_failure:
         - append:
+            tag: append_error_message_2dc525b4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/pipeline_knowledge_base.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/pipeline_knowledge_base.yml
@@ -107,7 +107,7 @@ processors:
       ignore_missing: true
   - rename:
       field: json.knowledge_base.QID
-      tag: rename_json_knowledge_base_QID_to_qualys_was_vulnerability_knowledge_base_qid_35560f2c
+      tag: rename_QID_35560f2c
       target_field: qualys_was.vulnerability.knowledge_base.qid
       ignore_missing: true
   - rename:
@@ -186,7 +186,7 @@ processors:
       if: ctx.json?.knowledge_base?.CVSS?.BASE instanceof String
   - rename:
       field: json.knowledge_base.CVSS.BASE
-      tag: rename_json_knowledge_base_CVSS_BASE_to_qualys_was_vulnerability_knowledge_base_cvss_base_obj_06e1b687
+      tag: rename_CVSS_BASE_06e1b687
       target_field: qualys_was.vulnerability.knowledge_base.cvss.base_obj
       ignore_missing: true
       if: ctx.json?.knowledge_base?.CVSS?.BASE instanceof Object
@@ -379,7 +379,7 @@ processors:
       processor:
         rename:
           field: _ingest._value.SRC_NAME
-          tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME
+          tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME_8678befe
           target_field: _ingest._value.name
           ignore_missing: true
   - foreach:
@@ -394,7 +394,7 @@ processors:
           processor:
             rename:
               field: _ingest._value.DESC
-              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC
+              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC_e877f799
               target_field: _ingest._value.desc
               ignore_missing: true
   - foreach:
@@ -409,7 +409,7 @@ processors:
           processor:
             rename:
               field: _ingest._value.LINK
-              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK
+              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK_c7f77dd5
               target_field: _ingest._value.link
               ignore_missing: true
   - foreach:
@@ -424,7 +424,7 @@ processors:
           processor:
             rename:
               field: _ingest._value.REF
-              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF
+              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF_1cec4812
               target_field: _ingest._value.ref
               ignore_missing: true
   - foreach:
@@ -817,8 +817,10 @@ on_failure:
       value: preserve_original_event
       allow_duplicates: false
   - append:
+      tag: append_error_message
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_event_kind
       field: event.kind
       value: pipeline_error

--- a/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/pipeline_knowledge_base.yml
+++ b/packages/qualys_was/data_stream/vulnerability/elasticsearch/ingest_pipeline/pipeline_knowledge_base.yml
@@ -3,755 +3,755 @@ description: Pipeline for processing Knowledge Base data.
 processors:
   - rename:
       field: json.Finding.knowledge_base
-      tag: rename_json_knowledge_base
+      tag: rename_json_knowledge_base_f516f166
       target_field: json.knowledge_base
       ignore_missing: true
   - rename:
       field: json.knowledge_base.QID
-      tag: rename_QID
+      tag: rename_QID_b03b221b
       target_field: qualys_was.vulnerability.knowledge_base.qid
       ignore_missing: false
   - rename:
       field: json.knowledge_base.CONSEQUENCE
-      tag: rename_CONSEQUENCE
+      tag: rename_CONSEQUENCE_b0f0a452
       target_field: qualys_was.vulnerability.knowledge_base.consequence.value
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CONSEQUENCE_COMMENT
-      tag: rename_CONSEQUENCE_COMMENT
+      tag: rename_CONSEQUENCE_COMMENT_e96b0d6b
       target_field: qualys_was.vulnerability.knowledge_base.consequence.comment
       ignore_missing: true
   # Handle case when COMPLIANCE_LIST.COMPLIANCE is an object
   - rename:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE.TYPE
-      tag: rename_COMPLIANCE_LIST_COMPLIANCE_TYPE
+      tag: rename_COMPLIANCE_LIST_COMPLIANCE_TYPE_2666f372
       target_field: qualys_was.vulnerability.knowledge_base.compliance_list.type
       ignore_missing: true
   - rename:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE.SECTION
-      tag: rename_COMPLIANCE_LIST_COMPLIANCE_SECTION
+      tag: rename_COMPLIANCE_LIST_COMPLIANCE_SECTION_49baf80e
       target_field: qualys_was.vulnerability.knowledge_base.compliance_list.section
       ignore_missing: true
   - rename:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE.DESCRIPTION
-      tag: rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION
+      tag: rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION_9f76dca9
       target_field: qualys_was.vulnerability.knowledge_base.compliance_list.description
       ignore_missing: true
   # Handle case when COMPLIANCE_LIST.COMPLIANCE is an array
   - foreach:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE
       if: ctx.qualys_was?.vulnerability?.knowledge_base?.COMPLIANCE_LIST?.COMPLIANCE instanceof List
-      tag: foreach_rename_COMPLIANCE_LIST_COMPLIANCE_TYPE
+      tag: foreach_rename_COMPLIANCE_LIST_COMPLIANCE_TYPE_b25ab278
       processor:
         rename:
           field: _ingest._value.TYPE
-          tag: rename_COMPLIANCE_LIST_COMPLIANCE_TYPE_1
+          tag: rename_COMPLIANCE_LIST_COMPLIANCE_TYPE_1_662f531b
           target_field: _ingest._value.type
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE
       if: ctx.qualys_was?.vulnerability?.knowledge_base?.COMPLIANCE_LIST?.COMPLIANCE instanceof List
-      tag: foreach_rename_COMPLIANCE_LIST_COMPLIANCE_SECTION
+      tag: foreach_rename_COMPLIANCE_LIST_COMPLIANCE_SECTION_25c7c150
       processor:
         rename:
           field: _ingest._value.SECTION
-          tag: rename_COMPLIANCE_LIST_COMPLIANCE_SECTION_1
+          tag: rename_COMPLIANCE_LIST_COMPLIANCE_SECTION_1_51a2eb01
           target_field: _ingest._value.section
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE
       if: ctx.qualys_was?.vulnerability?.knowledge_base?.COMPLIANCE_LIST?.COMPLIANCE instanceof List
-      tag: foreach_rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION
+      tag: foreach_rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION_95ffd362
       processor:
         rename:
           field: _ingest._value.DESCRIPTION
-          tag: rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION_1
+          tag: rename_COMPLIANCE_LIST_COMPLIANCE_DESCRIPTION_1_74b3771c
           target_field: _ingest._value.description
           ignore_missing: true
   - rename:
       field: json.knowledge_base.COMPLIANCE_LIST.COMPLIANCE
       if: ctx.qualys_was?.vulnerability?.knowledge_base?.COMPLIANCE_LIST?.COMPLIANCE instanceof List
-      tag: rename_COMPLIANCE_LIST_COMPLIANCE
+      tag: rename_COMPLIANCE_LIST_COMPLIANCE_abdf5792
       target_field: qualys_was.vulnerability.knowledge_base.compliance_list
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CATEGORY
-      tag: rename_CATEGORY
+      tag: rename_CATEGORY_bb900589
       target_field: qualys_was.vulnerability.knowledge_base.category
       ignore_missing: true
   - append:
       field: vulnerability.category
-      tag: append_vulnerability_category
+      tag: append_vulnerability_category_55a5d49c
       value: '{{{qualys_was.vulnerability.knowledge_base.category}}}'
       allow_duplicates: false
       if: ctx.json?.knowledge_base?.category != null
   - rename:
       field: json.knowledge_base.DIAGNOSIS
-      tag: rename_DIAGNOSIS
+      tag: rename_DIAGNOSIS_930aa718
       target_field: qualys_was.vulnerability.knowledge_base.diagnosis.value
       ignore_missing: true
   - set:
       field: vulnerability.description
-      tag: set_vulnerability_description
+      tag: set_vulnerability_description_90536945
       copy_from: qualys_was.vulnerability.knowledge_base.diagnosis.value
       ignore_empty_value: true
   - rename:
       field: json.knowledge_base.DIAGNOSIS_COMMENT
-      tag: rename_DIAGNOSIS_COMMENT
+      tag: rename_DIAGNOSIS_COMMENT_435b0abb
       target_field: qualys_was.vulnerability.knowledge_base.diagnosis.comment
       ignore_missing: true
   - rename:
       field: json.knowledge_base.PCI_REASONS.PCI_REASON
-      tag: rename_PCI_REASONS_PCI_REASON
+      tag: rename_PCI_REASONS_PCI_REASON_cc88597f
       target_field: qualys_was.vulnerability.knowledge_base.pci_reasons.value
       ignore_missing: true
   - rename:
       field: json.knowledge_base.QID
-      tag: rename_QID_35560f2c
+      tag: rename_QID_5e8fd326
       target_field: qualys_was.vulnerability.knowledge_base.qid
       ignore_missing: true
   - rename:
       field: json.knowledge_base.SOLUTION
-      tag: rename_SOLUTION
+      tag: rename_SOLUTION_ed8508ab
       target_field: qualys_was.vulnerability.knowledge_base.solution.value
       ignore_missing: true
   - rename:
       field: json.knowledge_base.SOLUTION_COMMENT
-      tag: rename_SOLUTION_COMMENT
+      tag: rename_SOLUTION_COMMENT_e889a17b
       target_field: qualys_was.vulnerability.knowledge_base.solution.comment
       ignore_missing: true
   - rename:
       field: json.knowledge_base.SUPPORTED_MODULES
-      tag: rename_SUPPORTED_MODULES
+      tag: rename_SUPPORTED_MODULES_06364715
       target_field: qualys_was.vulnerability.knowledge_base.supported_modules
       ignore_missing: true
   - rename:
       field: json.knowledge_base.TITLE
-      tag: rename_TITLE
+      tag: rename_TITLE_3f0ced70
       target_field: qualys_was.vulnerability.knowledge_base.title
       ignore_missing: true
   # Handle case when BUGTRAQ_LIST.BUGTRAQ is an object
   - rename:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ.ID
-      tag: rename_BUGTRAQ_LIST_BUGTRAQ_ID
+      tag: rename_BUGTRAQ_LIST_BUGTRAQ_ID_dd446cdd
       target_field: qualys_was.vulnerability.knowledge_base.bugtraq_list.id
       ignore_missing: true
   - rename:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ.URL
-      tag: rename_BUGTRAQ_LIST_BUGTRAQ_URL
+      tag: rename_BUGTRAQ_LIST_BUGTRAQ_URL_9fbeb13c
       target_field: qualys_was.vulnerability.knowledge_base.bugtraq_list.url
       ignore_missing: true
   # Handle case when BUGTRAQ_LIST.BUGTRAQ is an array
   - foreach:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ
       if: ctx.json?.knowledge_base?.BUGTRAQ_LIST?.BUGTRAQ instanceof List
-      tag: foreach_rename_BUGTRAQ_LIST_BUGTRAQ_ID
+      tag: foreach_rename_BUGTRAQ_LIST_BUGTRAQ_ID_3a3009a8
       processor:
         rename:
           field: _ingest._value.ID
-          tag: rename_BUGTRAQ_LIST_BUGTRAQ_ID_1
+          tag: rename_BUGTRAQ_LIST_BUGTRAQ_ID_1_d4e7987d
           target_field: _ingest._value.id
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ
       if: ctx.json?.knowledge_base?.BUGTRAQ_LIST?.BUGTRAQ instanceof List
-      tag: foreach_rename_BUGTRAQ_LIST_BUGTRAQ_URL
+      tag: foreach_rename_BUGTRAQ_LIST_BUGTRAQ_URL_e03be7bb
       processor:
         rename:
           field: _ingest._value.URL
-          tag: rename_BUGTRAQ_LIST_BUGTRAQ_URL_1
+          tag: rename_BUGTRAQ_LIST_BUGTRAQ_URL_1_6c70b0a6
           target_field: _ingest._value.url
           ignore_missing: true
   - rename:
       field: json.knowledge_base.BUGTRAQ_LIST.BUGTRAQ
       if: ctx.json?.knowledge_base?.BUGTRAQ_LIST?.BUGTRAQ instanceof List
-      tag: rename_BUGTRAQ_LIST_BUGTRAQ
+      tag: rename_BUGTRAQ_LIST_BUGTRAQ_6aaf6f79
       target_field: qualys_was.vulnerability.knowledge_base.bugtraq_list
       ignore_missing: true
   - rename:
       field: json.knowledge_base.VULN_TYPE
-      tag: rename_VULN_TYPE
+      tag: rename_VULN_TYPE_8220dbb1
       target_field: qualys_was.vulnerability.knowledge_base.vuln_type
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVE_LIST
-      tag: rename_CVE_LIST
+      tag: rename_CVE_LIST_5e86e879
       target_field: qualys_was.vulnerability.knowledge_base.cve_list
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.BASE
-      tag: rename_CVSS_BASE
+      tag: rename_CVSS_BASE_103e3de4
       target_field: qualys_was.vulnerability.knowledge_base.cvss.base
       ignore_missing: true
       if: ctx.json?.knowledge_base?.CVSS?.BASE instanceof String
   - rename:
       field: json.knowledge_base.CVSS.BASE
-      tag: rename_CVSS_BASE_06e1b687
+      tag: rename_CVSS_BASE_d256ab33
       target_field: qualys_was.vulnerability.knowledge_base.cvss.base_obj
       ignore_missing: true
       if: ctx.json?.knowledge_base?.CVSS?.BASE instanceof Object
   - rename:
       field: json.knowledge_base.CVSS.TEMPORAL
-      tag: rename_CVSS_TEMPORAL
+      tag: rename_CVSS_TEMPORAL_a80e14a0
       target_field: qualys_was.vulnerability.knowledge_base.cvss.temporal
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.VECTOR_STRING
-      tag: rename_CVSS_VECTOR_STRING
+      tag: rename_CVSS_VECTOR_STRING_0a193c12
       target_field: qualys_was.vulnerability.knowledge_base.cvss.vector_string
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.ACCESS.VECTOR
-      tag: rename_CVSS_ACCESS_VECTOR
+      tag: rename_CVSS_ACCESS_VECTOR_b0bd2247
       target_field: qualys_was.vulnerability.knowledge_base.cvss.access.vector
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.ACCESS.COMPLEXITY
-      tag: rename_CVSS_ACCESS_COMPLEXITY
+      tag: rename_CVSS_ACCESS_COMPLEXITY_909c80a5
       target_field: qualys_was.vulnerability.knowledge_base.cvss.access.complexity
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.IMPACT.CONFIDENTIALITY
-      tag: rename_CVSS_IMPACT_CONFIDENTIALITY
+      tag: rename_CVSS_IMPACT_CONFIDENTIALITY_e668f403
       target_field: qualys_was.vulnerability.knowledge_base.cvss.impact.confidentiality
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.IMPACT.INTEGRITY
-      tag: rename_CVSS_IMPACT_INTEGRITY
+      tag: rename_CVSS_IMPACT_INTEGRITY_998dd2dc
       target_field: qualys_was.vulnerability.knowledge_base.cvss.impact.integrity
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.IMPACT.AVAILABILITY
-      tag: rename_CVSS_IMPACT_AVAILABILITY
+      tag: rename_CVSS_IMPACT_AVAILABILITY_3be99681
       target_field: qualys_was.vulnerability.knowledge_base.cvss.impact.availability
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.AUTHENTICATION
-      tag: rename_CVSS_AUTHENTICATION
+      tag: rename_CVSS_AUTHENTICATION_3def6e91
       target_field: qualys_was.vulnerability.knowledge_base.cvss.authentication
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.EXPLOITABILITY
-      tag: rename_CVSS_EXPLOITABILITY
+      tag: rename_CVSS_EXPLOITABILITY_b2dc1d2a
       target_field: qualys_was.vulnerability.knowledge_base.cvss.exploitability
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.REMEDIATION_LEVEL
-      tag: rename_CVSS_REMEDIATION_LEVEL
+      tag: rename_CVSS_REMEDIATION_LEVEL_fa23e1cf
       target_field: qualys_was.vulnerability.knowledge_base.cvss.remediation_level
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS.REPORT_CONFIDENCE
-      tag: rename_CVSS_REPORT_CONFIDENCE
+      tag: rename_CVSS_REPORT_CONFIDENCE_ecabf4c1
       target_field: qualys_was.vulnerability.knowledge_base.cvss.report_confidence
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.BASE
-      tag: rename_CVSS_V3.BASE
+      tag: rename_CVSS_V3.BASE_db6fde04
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.base
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.TEMPORAL
-      tag: rename_CVSS_V3_TEMPORAL
+      tag: rename_CVSS_V3_TEMPORAL_6b41e602
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.temporal
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.VECTOR_STRING
-      tag: rename_CVSS_V3_VECTOR_STRING
+      tag: rename_CVSS_V3_VECTOR_STRING_b5b93cee
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.vector_string
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.CVSS3_VERSION
-      tag: rename_CVSS_V3_CVSS3_VERSION
+      tag: rename_CVSS_V3_CVSS3_VERSION_73bdd66b
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.version
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.ATTACK.VECTOR
-      tag: rename_CVSS_V3_ATTACK_VECTOR
+      tag: rename_CVSS_V3_ATTACK_VECTOR_95c1d1ea
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.attack.vector
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.ATTACK.COMPLEXITY
-      tag: rename_CVSS_V3_ATTACK_COMPLEXITY
+      tag: rename_CVSS_V3_ATTACK_COMPLEXITY_822d5e2a
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.attack.complexity
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.IMPACT.CONFIDENTIALITY
-      tag: rename_CVSS_V3_IMPACT_CONFIDENTIALITY
+      tag: rename_CVSS_V3_IMPACT_CONFIDENTIALITY_dcf2d236
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.impact.confidentiality
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.IMPACT.INTEGRITY
-      tag: rename_CVSS_V3_IMPACT_INTEGRITY
+      tag: rename_CVSS_V3_IMPACT_INTEGRITY_567459e4
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.impact.integrity
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.IMPACT.AVAILABILITY
-      tag: rename_CVSS_V3_IMPACT_AVAILABILITY
+      tag: rename_CVSS_V3_IMPACT_AVAILABILITY_a066edcb
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.impact.availability
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.PRIVILEGES_REQUIRED
-      tag: rename_CVSS_V3_PRIVILEGES_REQUIRED
+      tag: rename_CVSS_V3_PRIVILEGES_REQUIRED_dadacd4a
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.privileges_required
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.USER_INTERACTION
-      tag: rename_CVSS_V3_USER_INTERACTION
+      tag: rename_CVSS_V3_USER_INTERACTION_f16aa821
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.user_interaction
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.SCOPE
-      tag: rename_CVSS_V3_SCOPE
+      tag: rename_CVSS_V3_SCOPE_a070f3de
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.scope
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.EXPLOIT_CODE_MATURITY
-      tag: rename_CVSS_V3_EXPLOIT_CODE_MATURITY
+      tag: rename_CVSS_V3_EXPLOIT_CODE_MATURITY_be1396ef
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.exploit_code_maturity
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.REMEDIATION_LEVEL
-      tag: rename_CVSS_V3_REMEDIATION_LEVEL
+      tag: rename_CVSS_V3_REMEDIATION_LEVEL_7e4cc8b7
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.remediation_level
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CVSS_V3.REPORT_CONFIDENCE
-      tag: rename_CVSS_V3_REPORT_CONFIDENCE
+      tag: rename_CVSS_V3_REPORT_CONFIDENCE_88c7cb43
       target_field: qualys_was.vulnerability.knowledge_base.cvss_v3.report_confidence
       ignore_missing: true
   - rename:
       field: json.knowledge_base.AUTOMATIC_PCI_FAIL
-      tag: rename_AUTOMATIC_PCI_FAIL
+      tag: rename_AUTOMATIC_PCI_FAIL_4ddcd87e
       target_field: qualys_was.vulnerability.knowledge_base.automatic_pci_fail
       ignore_missing: true
   - set:
       field: vulnerability.reference
-      tag: set_vulnerability_reference
+      tag: set_vulnerability_reference_2d1fb49a
       if: ctx.vulnerability?.id != null && !(ctx.vulnerability.id instanceof List)
       value: 'https://cwe.mitre.org/data/definitions/{{ vulnerability.id }}}.html'
       ignore_empty_value: true
   - foreach:
       field: vulnerability.id
       if: ctx.vulnerability?.id instanceof List
-      tag: foreach_vulnerability_id_if_list
+      tag: foreach_vulnerability_id_if_list_403d95a3
       processor:
         append:
           field: vulnerability.reference
-          tag: append_vulnerability_reference
+          tag: append_vulnerability_reference_ed4af01e
           value: 'https://cwe.mitre.org/data/definitions/{{{ _ingest._value }}}.html'
           allow_duplicates: false
   - uri_parts:
       field: vulnerability.reference
-      tag: 'uri_parts_to_split_vulnerability_reference'
+      tag: uri_parts_to_split_vulnerability_reference_743e96da
       if: ctx.vulnerability?.reference != null && !(ctx.vulnerability.reference instanceof List)
       on_failure:
         - append:
-            tag: append_error_message_ccfa865f
+            tag: append_error_message_df383327
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when EXPLT_SRC and EXPLT_LIST.EXPLT is an object
   - rename:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC.EXPLT_LIST.EXPLT.DESC
-      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC
+      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC_c873125c
       target_field: qualys_was.vulnerability.knowledge_base.correlation.exploits.explt_src.list.explt.desc
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC.EXPLT_LIST.EXPLT.LINK
-      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK
+      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK_d2060ae0
       target_field: qualys_was.vulnerability.knowledge_base.correlation.exploits.explt_src.list.explt.link
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC.EXPLT_LIST.EXPLT.REF
-      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF
+      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF_6c1ad42e
       target_field: qualys_was.vulnerability.knowledge_base.correlation.exploits.explt_src.list.explt.ref
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC.SRC_NAME
-      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME
+      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME_7848f34c
       target_field: qualys_was.vulnerability.knowledge_base.correlation.exploits.explt_src.name
       ignore_missing: true
     # Handle case when EXPLT_SRC and EXPLT_LIST.EXPLT is an array
   - foreach:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC
       if: ctx.json?.knowledge_base?.CORRELATION?.EXPLOITS?.EXPLT_SRC instanceof List
-      tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME
+      tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME_e1997d30
       processor:
         rename:
           field: _ingest._value.SRC_NAME
-          tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME_8678befe
+          tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_SRC_NAME_56c11d71
           target_field: _ingest._value.name
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC
       if: ctx.json?.knowledge_base?.CORRELATION?.EXPLOITS?.EXPLT_SRC instanceof List
-      tag: foreach_foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC
+      tag: foreach_foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC_b680aadc
       processor:
         foreach:
           field: _ingest._value.EXPLT_LIST.EXPLT
-          tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC
+          tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC_8969ebd4
           ignore_failure: true
           processor:
             rename:
               field: _ingest._value.DESC
-              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC_e877f799
+              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_DESC_c40631c4
               target_field: _ingest._value.desc
               ignore_missing: true
   - foreach:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC
       if: ctx.json?.knowledge_base?.CORRELATION?.EXPLOITS?.EXPLT_SRC instanceof List
-      tag: foreach_foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK
+      tag: foreach_foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK_e71baadb
       processor:
         foreach:
           field: _ingest._value.EXPLT_LIST.EXPLT
-          tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK
+          tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK_f5589a36
           ignore_failure: true
           processor:
             rename:
               field: _ingest._value.LINK
-              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK_c7f77dd5
+              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_LINK_35cda0f5
               target_field: _ingest._value.link
               ignore_missing: true
   - foreach:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC
       if: ctx.json?.knowledge_base?.CORRELATION?.EXPLOITS?.EXPLT_SRC instanceof List
-      tag: foreach_foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF
+      tag: foreach_foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF_d02049a1
       processor:
         foreach:
           field: _ingest._value.EXPLT_LIST.EXPLT
-          tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF
+          tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF_fe5bef2a
           ignore_failure: true
           processor:
             rename:
               field: _ingest._value.REF
-              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF_1cec4812
+              tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_REF_cabe289b
               target_field: _ingest._value.ref
               ignore_missing: true
   - foreach:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC
       if: ctx.json?.knowledge_base?.CORRELATION?.EXPLOITS?.EXPLT_SRC instanceof List
-      tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT
+      tag: foreach_rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_11f5642c
       processor:
         rename:
           field: _ingest._value.EXPLT_LIST.EXPLT
-          tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT
+          tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_EXPLT_LIST_EXPLT_ed719bce
           target_field: _ingest._value.list.explt
           ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.EXPLOITS.EXPLT_SRC
       if: ctx.json?.knowledge_base?.CORRELATION?.EXPLOITS?.EXPLT_SRC instanceof List
-      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC
+      tag: rename_CORRELATION_EXPLOITS_EXPLT_SRC_67b938a1
       target_field: qualys_was.vulnerability.knowledge_base.correlation.exploits.explt_src
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.MW_LIST.MW_INFO.MW_ID
-      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_ID
+      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_ID_9286a35f
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.list.info.id
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.SRC_NAME
-      tag: rename_CORRELATION_MALWARE_MW_SRC_SRC_NAME
+      tag: rename_CORRELATION_MALWARE_MW_SRC_SRC_NAME_ce1077ab
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.name
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.MW_LIST.MW_INFO.MW_TYPE
-      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_TYPE
+      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_TYPE_1b58679f
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.list.info.type
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.MW_LIST.MW_INFO.MW_PLATFORM
-      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_PLATFORM
+      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_PLATFORM_7d15db17
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.list.info.platform
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.MW_LIST.MW_INFO.MW_ALIAS
-      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_ALIAS
+      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_ALIAS_950577f8
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.list.info.alias
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.MW_LIST.MW_INFO.MW_RATING
-      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_RATING
+      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_RATING_84851e58
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.list.info.rating
       ignore_missing: true
   - rename:
       field: json.knowledge_base.CORRELATION.MALWARE.MW_SRC.MW_LIST.MW_INFO.MW_LINK
-      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_LINK
+      tag: rename_CORRELATION_MALWARE_MW_SRC_MW_LIST_MW_INFO_MW_LINK_5fd9e239
       target_field: qualys_was.vulnerability.knowledge_base.correlation.malware.src.list.info.link
       ignore_missing: true
   - rename:
       field: json.knowledge_base.DISCOVERY.ADDITIONAL_INFO
-      tag: rename_DISCOVERY_ADDITIONAL_INFO
+      tag: rename_DISCOVERY_ADDITIONAL_INFO_a79300aa
       target_field: qualys_was.vulnerability.knowledge_base.discovery.additional_info
       ignore_missing: true
   - rename:
       field: json.knowledge_base.DISCOVERY.AUTH_TYPE_LIST.AUTH_TYPE
-      tag: rename_DISCOVERY_AUTH_TYPE_LIST_AUTH_TYPE
+      tag: rename_DISCOVERY_AUTH_TYPE_LIST_AUTH_TYPE_587b7358
       target_field: qualys_was.vulnerability.knowledge_base.discovery.auth_type_list.value
       ignore_missing: true
   - convert:
       field: json.knowledge_base.DISCOVERY.REMOTE
-      tag: convert_DISCOVERY_REMOTE_to_long
+      tag: convert_DISCOVERY_REMOTE_to_long_6969d443
       target_field: qualys_was.vulnerability.knowledge_base.discovery.remote
       type: long
       ignore_missing: true
       if: ctx.json?.knowledge_base?.DISCOVERY?.REMOTE != ''
       on_failure:
         - append:
-            tag: append_error_message_d25f745d
+            tag: append_error_message_c56c637c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when SOFTWARE_LIST.SOFTWARE is an object
   - rename:
       field: json.knowledge_base.SOFTWARE_LIST.SOFTWARE.PRODUCT
-      tag: rename_SOFTWARE_LIST_SOFTWARE_PRODUCT
+      tag: rename_SOFTWARE_LIST_SOFTWARE_PRODUCT_9a705ee6
       target_field: qualys_was.vulnerability.knowledge_base.software_list.product
       ignore_missing: true
   - rename:
       field: json.knowledge_base.SOFTWARE_LIST.SOFTWARE.VENDOR
-      tag: rename_SOFTWARE_LIST_SOFTWARE_VENDOR
+      tag: rename_SOFTWARE_LIST_SOFTWARE_VENDOR_5397aa8f
       target_field: qualys_was.vulnerability.knowledge_base.software_list.vendor
       ignore_missing: true
   # Handle case when SOFTWARE_LIST.SOFTWARE is an array
   - foreach:
       field: json.knowledge_base.SOFTWARE_LIST.SOFTWARE
       if: ctx.json?.knowledge_base?.SOFTWARE_LIST?.SOFTWARE instanceof List
-      tag: foreach_rename_SOFTWARE_LIST_SOFTWARE_PRODUCT
+      tag: foreach_rename_SOFTWARE_LIST_SOFTWARE_PRODUCT_fd82336f
       processor:
         rename:
           field: _ingest._value.PRODUCT
-          tag: rename_SOFTWARE_LIST_SOFTWARE_PRODUCT_1
+          tag: rename_SOFTWARE_LIST_SOFTWARE_PRODUCT_1_af4fe0db
           target_field: _ingest._value.product
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.SOFTWARE_LIST.SOFTWARE
       if: ctx.json?.knowledge_base?.SOFTWARE_LIST?.SOFTWARE instanceof List
-      tag: foreach_rename_SOFTWARE_LIST_SOFTWARE_VENDOR
+      tag: foreach_rename_SOFTWARE_LIST_SOFTWARE_VENDOR_ddb48622
       processor:
         rename:
           field: _ingest._value.VENDOR
-          tag: rename_SOFTWARE_LIST_SOFTWARE_VENDOR_1
+          tag: rename_SOFTWARE_LIST_SOFTWARE_VENDOR_1_9e264f56
           target_field: _ingest._value.vendor
           ignore_missing: true
   - rename:
       field: json.knowledge_base.SOFTWARE_LIST.SOFTWARE
       if: ctx.json?.knowledge_base?.SOFTWARE_LIST?.SOFTWARE instanceof List
-      tag: rename_SOFTWARE_LIST_SOFTWARE
+      tag: rename_SOFTWARE_LIST_SOFTWARE_3082a0f2
       target_field: qualys_was.vulnerability.knowledge_base.software_list
       ignore_missing: true
   # Handle case when VENDOR_REFERENCE_LIST.VENDOR_REFERENCE is an object
   - rename:
       field: json.knowledge_base.VENDOR_REFERENCE_LIST.VENDOR_REFERENCE.ID
-      tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_ID
+      tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_ID_36fc4c81
       target_field: qualys_was.vulnerability.knowledge_base.vendor_reference_list.id
       ignore_missing: true
   - rename:
       field: json.knowledge_base.VENDOR_REFERENCE_LIST.VENDOR_REFERENCE.URL
-      tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_URL
+      tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_URL_16beba71
       target_field: qualys_was.vulnerability.knowledge_base.vendor_reference_list.url
       ignore_missing: true
   # Handle case when VENDOR_REFERENCE_LIST.VENDOR_REFERENCE is an array
   - foreach:
       field: json.knowledge_base.VENDOR_REFERENCE_LIST.VENDOR_REFERENCE
       if: ctx.json?.knowledge_base?.VENDOR_REFERENCE_LIST?.VENDOR_REFERENCE instanceof List
-      tag: foreach_rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_ID
+      tag: foreach_rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_ID_bd72753b
       processor:
         rename:
           field: _ingest._value.ID
-          tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_ID_1
+          tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_ID_1_6b511451
           target_field: _ingest._value.id
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.VENDOR_REFERENCE_LIST.VENDOR_REFERENCE
       if: ctx.json?.knowledge_base?.VENDOR_REFERENCE_LIST?.VENDOR_REFERENCE instanceof List
-      tag: foreach_rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_URL
+      tag: foreach_rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_URL_f36bc2b8
       processor:
         rename:
           field: _ingest._value.URL
-          tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_URL_1
+          tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_URL_1_acbb3dbc
           target_field: _ingest._value.url
           ignore_missing: true
   - rename:
       field: json.knowledge_base.VENDOR_REFERENCE_LIST.VENDOR_REFERENCE
       if: ctx.json?.knowledge_base?.VENDOR_REFERENCE_LIST?.VENDOR_REFERENCE instanceof List
-      tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE
+      tag: rename_VENDOR_REFERENCE_LIST_VENDOR_REFERENCE_65ec3cbc
       target_field: qualys_was.vulnerability.knowledge_base.vendor_reference_list
       ignore_missing: true
   - date:
       field: json.knowledge_base.LAST_SERVICE_MODIFICATION_DATETIME
-      tag: date_LAST_SERVICE_MODIFICATION_DATETIME
+      tag: date_LAST_SERVICE_MODIFICATION_DATETIME_352c16ba
       target_field: qualys_was.vulnerability.knowledge_base.last.service_modification_datetime
       formats:
         - ISO8601
       if: ctx.json?.knowledge_base?.LAST_SERVICE_MODIFICATION_DATETIME != null && ctx.qualys_was.vulnerability.knowledge_base.LAST_SERVICE_MODIFICATION_DATETIME != ''
       on_failure:
         - append:
-            tag: append_error_message_8c705c64
+            tag: append_error_message_1158f967
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.knowledge_base.LAST_CUSTOMIZATION.DATETIME
-      tag: date_LAST_CUSTOMIZATION_DATETIME
+      tag: date_LAST_CUSTOMIZATION_DATETIME_fd18d39e
       target_field: qualys_was.vulnerability.knowledge_base.last.customization.datetime
       formats:
         - ISO8601
       if: ctx.json?.knowledge_base?.LAST_CUSTOMIZATION?.DATETIME != null && ctx.qualys_was.vulnerability.knowledge_base.LAST_CUSTOMIZATION.DATETIME != ''
       on_failure:
         - append:
-            tag: append_error_message_c0ac2860
+            tag: append_error_message_9b551f7b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.knowledge_base.LAST_CUSTOMIZATION.USER_LOGIN
-      tag: rename_LAST_CUSTOMIZATION_USER_LOGIN
+      tag: rename_LAST_CUSTOMIZATION_USER_LOGIN_4a54c9ec
       target_field: qualys_was.vulnerability.knowledge_base.last.customization.user_login
       ignore_missing: true
   - date:
       field: json.knowledge_base.PUBLISHED_DATETIME
-      tag: date_PUBLISHED_DATETIME
+      tag: date_PUBLISHED_DATETIME_3486ca5b
       target_field: qualys_was.vulnerability.knowledge_base.published_datetime
       formats:
         - ISO8601
       if: ctx.json?.knowledge_base?.PUBLISHED_DATETIME != null && ctx.qualys_was.vulnerability.knowledge_base.PUBLISHED_DATETIME != ''
       on_failure:
         - append:
-            tag: append_error_message_0fd6a546
+            tag: append_error_message_4b61318f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when CHANGE_LOG_LIST.CHANGE_LOG_INFO is an object
   - rename:
       field: json.knowledge_base.CHANGE_LOG_LIST.CHANGE_LOG_INFO
-      tag: rename_CHANGE_LOG_LIST_CHANGE_LOG_INFO
+      tag: rename_CHANGE_LOG_LIST_CHANGE_LOG_INFO_aa78c6c6
       target_field: qualys_was.vulnerability.knowledge_base.changelog_list.info
       ignore_missing: true
   - rename:
       field: json.knowledge_base.changelog_list.info.COMMENTS
-      tag: rename_qualys_was_vulnerability_knowledge_base_changelog_list_info_COMMENTS_1
+      tag: rename_qualys_was_vulnerability_knowledge_base_changelog_list_info_COMMENTS_1_d70e2ee5
       target_field: qualys_was.vulnerability.knowledge_base.changelog_list.info.comments
       ignore_missing: true
   - date:
       field: json.knowledge_base.changelog_list.info.CHANGE_DATE
-      tag: date_qualys_was_vulnerability_knowledge_base_changelog_list_info_CHANGE_DATE_1
+      tag: date_qualys_was_vulnerability_knowledge_base_changelog_list_info_CHANGE_DATE_1_f0f773b5
       if: (!(ctx.json?.knowledge_base?.changelog_list?.info instanceof List)) && ctx.json?.knowledge_base?.changelog_list?.info?.CHANGE_DATE != null && ctx.json?.knowledge_base?.changelog_list?.info?.CHANGE_DATE != ''
       target_field: qualys_was.vulnerability.knowledge_base.changelog_list.info.change_date
       formats:
       - ISO8601
       on_failure:
         - append:
-            tag: append_error_message_9f1a2e73
+            tag: append_error_message_8a93a42e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   # Handle case when CHANGE_LOG_LIST.CHANGE_LOG_INFO is an array
   - foreach:
       field: json.knowledge_base.changelog_list.info
       if: ctx.json?.knowledge_base?.changelog_list?.info instanceof List
-      tag: foreach_rename_COMMENTS
+      tag: foreach_rename_COMMENTS_8cc0cba6
       processor:
         rename:
           field: _ingest._value.COMMENTS
-          tag: rename_qualys_was_vulnerability_knowledge_base_changelog_list_info_COMMENTS_2
+          tag: rename_qualys_was_vulnerability_knowledge_base_changelog_list_info_COMMENTS_2_2aa98bf3
           target_field: _ingest._value.comments
           ignore_missing: true
   - foreach:
       field: json.knowledge_base.changelog_list.info
       if: ctx.json?.knowledge_base?.changelog_list?.info instanceof List
-      tag: foreach_date_CHANGE_DATE
+      tag: foreach_date_CHANGE_DATE_c89e5102
       processor:
         date:
           field: _ingest._value.CHANGE_DATE
-          tag: date_qualys_was_vulnerability_knowledge_base_changelog_list_info_CHANGE_DATE_2
+          tag: date_qualys_was_vulnerability_knowledge_base_changelog_list_info_CHANGE_DATE_2_d724371c
           target_field: _ingest._value.change_date
           formats:
             - ISO8601
           ignore_failure: true
   - rename:
       field: json.knowledge_base.THREAT_INTELLIGENCE.THREAT_INTEL
-      tag: rename_THREAT_INTELLIGENCE_THREAT_INTEL
+      tag: rename_THREAT_INTELLIGENCE_THREAT_INTEL_8c93e991
       target_field: qualys_was.vulnerability.knowledge_base.threat_intelligence.intel
       ignore_missing: true
   - foreach:
       field: qualys_was.vulnerability.knowledge_base.threat_intelligence.intel
       if: ctx.qualys_was?.vulnerability?.knowledge_base?.threat_intelligence?.intel instanceof List
-      tag: foreach_rename_#text
+      tag: foreach_rename_#text_a7cf6c85
       processor:
         rename:
           field: _ingest._value.#text
-          tag: rename_qualys_was_vulnerability_knowledge_base_threat_intelligence_intel_#text_1
+          tag: rename_qualys_was_vulnerability_knowledge_base_threat_intelligence_intel_#text_1_824f32be
           target_field: _ingest._value.text
           ignore_missing: true
   - rename:
       field: qualys_was.vulnerability.knowledge_base.threat_intelligence.intel.#text
-      tag: rename_qualys_vmdr_knowledge_base_threat_intelligence_intel_#text_2
+      tag: rename_qualys_vmdr_knowledge_base_threat_intelligence_intel_#text_2_255345a1
       target_field: qualys_was.vulnerability.knowledge_base.threat_intelligence.intel.text
       ignore_missing: true
   - set:
       field: json.knowledge_base.IS_DISABLED
-      tag: set_IS_DISABLED_true
+      tag: set_IS_DISABLED_true_6b9c6a9b
       value: true
       if: ctx.json?.knowledge_base?.IS_DISABLED == '1'
   - set:
       field: json.knowledge_base.IS_DISABLED
-      tag: set_IS_DISABLED_false
+      tag: set_IS_DISABLED_false_3ead7f9b
       value: false
       if: ctx.json?.knowledge_base?.IS_DISABLED == '0'
   - convert:
       field: json.knowledge_base.IS_DISABLED
-      tag: convert_IS_DISABLED_to_boolean
+      tag: convert_IS_DISABLED_to_boolean_42f28087
       target_field: qualys_was.vulnerability.knowledge_base.is_disabled
       type: boolean
       ignore_missing: true
       if: ctx.json?.knowledge_base?.IS_DISABLED != ''
       on_failure:
         - append:
-            tag: append_error_message_599d4103
+            tag: append_error_message_b9af8f85
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: json.knowledge_base.PATCHABLE
-      tag: set_PATCHABLE_true
+      tag: set_PATCHABLE_true_670ea8d4
       value: true
       if: ctx.json?.knowledge_base?.PATCHABLE == '1'
   - set:
       field: json.knowledge_base.PATCHABLE
-      tag: set_PATCHABLE_false
+      tag: set_PATCHABLE_false_fe7633e9
       value: false
       if: ctx.json?.knowledge_base?.PATCHABLE == '0'
   - convert:
       field: json.knowledge_base.PATCHABLE
-      tag: convert_PATCHABLE_to_boolean
+      tag: convert_PATCHABLE_to_boolean_a252d995
       target_field: qualys_was.vulnerability.knowledge_base.patchable
       type: boolean
       ignore_missing: true
       if: ctx.json?.knowledge_base?.PATCHABLE != ''
       on_failure:
         - append:
-            tag: append_error_message_ab46bb45
+            tag: append_error_message_35d76b81
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: json.knowledge_base.PCI_FLAG
-      tag: set_PCI_FLAG_true
+      tag: set_PCI_FLAG_true_b1a97709
       value: true
       if: ctx.json?.knowledge_base?.PCI_FLAG == '1'
   - set:
       field: json.knowledge_base.PCI_FLAG
-      tag: set_PCI_FLAG_false
+      tag: set_PCI_FLAG_false_8ddf7361
       value: false
       if: ctx.json?.knowledge_base?.PCI_FLAG == '0'
   - convert:
       field: json.knowledge_base.PCI_FLAG
-      tag: convert_PCI_FLAG_to_boolean
+      tag: convert_PCI_FLAG_to_boolean_1c9fb8b4
       target_field: qualys_was.vulnerability.knowledge_base.pci_flag
       type: boolean
       ignore_missing: true
       if: ctx.json?.knowledge_base?.PCI_FLAG != ''
       on_failure:
         - append:
-            tag: append_error_message_6253e86b
+            tag: append_error_message_5fe64f44
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       lang: painless
-      tag: script_to_set_SEVERITY_LEVEL
+      tag: script_to_set_SEVERITY_LEVEL_4cc1b434
       description: Script to set SEVERITY_LEVEL for different ranges.
       params:
         vuln_level:
@@ -769,21 +769,21 @@ processors:
         ctx.vulnerability.severity = params.vuln_level.getOrDefault(level, params.vuln_level["0"]);
       on_failure:
         - append:
-            tag: append_error_message_e8a952ee
+            tag: append_error_message_1d04af74
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.knowledge_base.SEVERITY_LEVEL
-      tag: set_qualys_was_vulnerability_knowledge_base_SEVERITY_LEVEL
+      tag: set_qualys_was_vulnerability_knowledge_base_SEVERITY_LEVEL_47564e49
       target_field: qualys_was.vulnerability.knowledge_base.severity_level
       ignore_missing: true
   - remove:
-      tag: remove_unmapped_fields
+      tag: remove_unmapped_fields_20264aee
       field: json.
       ignore_missing: false
   - script:
       lang: painless
-      tag: script_to_remove_null_values
+      tag: script_to_remove_null_values_0f064478
       description: Drops null/empty values recursively.
       source: |-
         boolean drop(Object object) {
@@ -801,26 +801,26 @@ processors:
         drop(ctx);
       on_failure:
         - append:
-            tag: append_error_message_2dc525b4
+            tag: append_error_message_cef05db2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
       field: tags
-      tag: append_tags_preserve_original_event_3
+      tag: append_tags_preserve_original_event_3_b6c08950
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
       field: tags
-      tag: append_tags_preserve_original_event_4
+      tag: append_tags_preserve_original_event_4_279d5a5c
       value: preserve_original_event
       allow_duplicates: false
   - append:
-      tag: append_error_message
+      tag: append_error_message_0841b325
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
-      tag: set_event_kind
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error

--- a/packages/qualys_was/manifest.yml
+++ b/packages/qualys_was/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_was
 title: Qualys Web Application Scanning (WAS)
-version: "0.5.2"
+version: "0.6.0"
 description: Collect data from Qualys Web Application Scanning platform with Elastic Agent or Agentless
 type: integration
 categories:

--- a/packages/qualys_was/manifest.yml
+++ b/packages/qualys_was/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_was
 title: Qualys Web Application Scanning (WAS)
-version: "0.5.1"
+version: "0.5.2"
 description: Collect data from Qualys Web Application Scanning platform with Elastic Agent or Agentless
 type: integration
 categories:

--- a/packages/swimlane/changelog.yml
+++ b/packages/swimlane/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/swimlane/changelog.yml
+++ b/packages/swimlane/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.5.2"
+- version: "0.6.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/swimlane/changelog.yml
+++ b/packages/swimlane/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/swimlane/changelog.yml
+++ b/packages/swimlane/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20575
+    - description: Remove a redundant no-op `rename` processor for `swimlane.audit_log.category` in the `audit_logs` data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
@@ -137,7 +137,7 @@ processors:
       ignore_missing: true
   - script:
       lang: painless
-      tag: Add ECS categorization
+      tag: add_ecs_categorization_5da2a2f7
       params:
         Create:
           type:
@@ -168,11 +168,6 @@ processors:
         }
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
-  - rename:
-      tag: rename_swimlane_audit_log_category_to_log_category_fa1d4a96
-      field: swimlane.audit_log.category
-      target_field: log.category
-      ignore_missing: true
   - grok:
       tag: grok_swimlane_audit_log_endpoint_2bf2105a
       field: swimlane.audit_log.endpoint
@@ -226,13 +221,16 @@ processors:
       ignore_missing: false
 on_failure:
   - set:
+      tag: set_event_kind
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
@@ -70,7 +70,7 @@ processors:
       target_field: url.path
       ignore_missing: true
   - script:
-      tag: script_db8ff8d6
+      tag: script_normalize_sourceip_to_single_value_db8ff8d6
       lang: painless
       description: Normalize SourceIp to a single value
       source: >-
@@ -175,11 +175,11 @@ processors:
         - '%{GREEDYDATA:url.path}'
       ignore_missing: true
   - drop:
-      tag: drop_064ef718
+      tag: drop_events_related_to_hubs_record_endpoint_064ef718
       description: Drop events related to the hubs/record endpoint
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().contains('hubs/record')
   - drop:
-      tag: drop_d39d6301
+      tag: drop_events_related_to_record_updates_d39d6301
       description: Drop events related to any record updates
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().endsWith('/values')
   - rename:

--- a/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,25 +2,31 @@
 description: Pipeline for Swimlane Audit Logs
 processors:
   - set:
+      tag: set_event_original_b9758751
       field: event.original
       copy_from: message
   - json:
+      tag: json_message_to_json_576c813b
       field: message
       target_field: json
       ignore_failure: true
   - drop:
+      tag: drop_631a5346
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      field: 
+      tag: remove_974dbe77
+      field:
         - message
         - input
         - log
       ignore_missing: true
   - rename:
+      tag: rename_json_to_swimlane_audit_log_d2655548
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
+      tag: drop_5063c354
       if: >-
         ctx.swimlane?.audit_log?.description != null &&
         (
@@ -28,35 +34,43 @@ processors:
           ctx.swimlane.audit_log.description.toLowerCase().contains('created a new record')
         )
   - json:
+      tag: json_swimlane_audit_log_newValue_561e4375
       field: swimlane.audit_log.newValue
       if: ctx.swimlane?.audit_log?.newValue != null
       ignore_failure: true
   - rename:
+      tag: rename_swimlane_audit_log_user_to_user_name_dbbc9be1
       field: swimlane.audit_log.user
       target_field: user.name
       ignore_missing: true
   - append:
+      tag: append_related_user_837e080f
       field: related.user
       value: '{{{user.name}}}'
       allow_duplicates: false
       if: ctx.user?.name != null
   - rename:
+      tag: rename_swimlane_audit_log_accountId_to_cloud_origin_account_id_f309b8fd
       field: swimlane.audit_log.accountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_tenantId_to_cloud_origin_project_id_a841958a
       field: swimlane.audit_log.tenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_logLevel_to_log_level_519425d8
       field: swimlane.audit_log.logLevel
       target_field: log.level
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_path_to_url_path_0515a08d
       field: swimlane.audit_log.path
       target_field: url.path
       ignore_missing: true
   - script:
+      tag: script_0fb4f610
       lang: painless
       description: Normalize SourceIp to a single value
       source: >-
@@ -69,45 +83,55 @@ processors:
             }
         }
   - grok:
+      tag: grok_swimlane_audit_log_sourceIp_30e91ffc
       field: swimlane.audit_log.sourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
         - '%{IPV4:source.ip}'
-        - '%{IPV6:source.ip}' 
+        - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_tenant_to_cloud_origin_tenant_id_4e46bff8
       field: swimlane.audit_log.tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_category_to_log_category_fa1d4a96
       field: swimlane.audit_log.category
       target_field: log.category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_logFeatureCategory_to_log_feature_category_e1839923
       field: swimlane.audit_log.logFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_logSource_to_log_source_type_d85318e8
       field: swimlane.audit_log.logSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_logType_to_log_type_f49fe23a
       field: swimlane.audit_log.logType
       target_field: log.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_description_to_message_7e7bb22b
       field: swimlane.audit_log.description
       target_field: message
       ignore_missing: true
   - set:
+      tag: set_message_da12ebac
       field: message
       value: '{{{message}}}'
       if: ctx.message != null && ctx.message != ''
   - rename:
+      tag: rename_swimlane_audit_log_userId_to_user_id_aab25936
       field: swimlane.audit_log.userId
       target_field: user.id
       ignore_missing: true
@@ -145,47 +169,59 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
+      tag: rename_swimlane_audit_log_category_to_log_category_fa1d4a96
       field: swimlane.audit_log.category
       target_field: log.category
       ignore_missing: true
   - grok:
+      tag: grok_swimlane_audit_log_endpoint_2bf2105a
       field: swimlane.audit_log.endpoint
       patterns:
         - '%{GREEDYDATA:url.path}'
       ignore_missing: true
   - drop:
+      tag: drop_df5a2f3e
       description: Drop events related to the hubs/record endpoint
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().contains('hubs/record')
   - drop:
+      tag: drop_1abc01dd
       description: Drop events related to any record updates
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().endsWith('/values')
   - rename:
+      tag: rename_swimlane_audit_log_eventOutcome_to_event_outcome_b878d118
       field: swimlane.audit_log.eventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
+      tag: lowercase_event_outcome_eb9dfc47
       field: event.outcome
       ignore_missing: true
   - set:
+      tag: set_user_roles_558b689e
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
+      tag: rename_swimlane_audit_log_authenticationType_to_user_authentication_type_b4a5d0bb
       field: swimlane.audit_log.authenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
+      tag: lowercase_user_authentication_type_f3146340
       field: user.authentication.type
       ignore_missing: true
   - user_agent:
+      tag: user_agent_swimlane_audit_log_userAgent_30bda3c1
       field: swimlane.audit_log.userAgent
       ignore_missing: true
   - date:
+      tag: date_swimlane_audit_log_eventTime_to_timestamp_a7ebb4c6
       field: swimlane.audit_log.eventTime
       target_field: '@timestamp'
-      formats: 
+      formats:
         - ISO8601
   - remove:
+      tag: remove_swimlane_96409c73
       field: swimlane
       ignore_missing: false
 on_failure:

--- a/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,31 +2,31 @@
 description: Pipeline for Swimlane Audit Logs
 processors:
   - set:
-      tag: set_event_original_b9758751
+      tag: set_event_original_990fc2f3
       field: event.original
       copy_from: message
   - json:
-      tag: json_message_to_json_576c813b
+      tag: json_message_to_json_649b2289
       field: message
       target_field: json
       ignore_failure: true
   - drop:
-      tag: drop_631a5346
+      tag: drop_acb5b6f4
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      tag: remove_974dbe77
+      tag: remove_2cf04eba
       field:
         - message
         - input
         - log
       ignore_missing: true
   - rename:
-      tag: rename_json_to_swimlane_audit_log_d2655548
+      tag: rename_json_to_swimlane_audit_log_abd84bef
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
-      tag: drop_5063c354
+      tag: drop_1e0aa322
       if: >-
         ctx.swimlane?.audit_log?.description != null &&
         (
@@ -34,43 +34,43 @@ processors:
           ctx.swimlane.audit_log.description.toLowerCase().contains('created a new record')
         )
   - json:
-      tag: json_swimlane_audit_log_newValue_561e4375
+      tag: json_swimlane_audit_log_newValue_3c186eb2
       field: swimlane.audit_log.newValue
       if: ctx.swimlane?.audit_log?.newValue != null
       ignore_failure: true
   - rename:
-      tag: rename_swimlane_audit_log_user_to_user_name_dbbc9be1
+      tag: rename_swimlane_audit_log_user_to_user_name_d834976b
       field: swimlane.audit_log.user
       target_field: user.name
       ignore_missing: true
   - append:
-      tag: append_related_user_837e080f
+      tag: append_related_user_325195a6
       field: related.user
       value: '{{{user.name}}}'
       allow_duplicates: false
       if: ctx.user?.name != null
   - rename:
-      tag: rename_swimlane_audit_log_accountId_to_cloud_origin_account_id_f309b8fd
+      tag: rename_swimlane_audit_log_accountId_to_cloud_origin_account_id_2a854e81
       field: swimlane.audit_log.accountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_tenantId_to_cloud_origin_project_id_a841958a
+      tag: rename_swimlane_audit_log_tenantId_to_cloud_origin_project_id_cbd32487
       field: swimlane.audit_log.tenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_logLevel_to_log_level_519425d8
+      tag: rename_swimlane_audit_log_logLevel_to_log_level_3ee0906b
       field: swimlane.audit_log.logLevel
       target_field: log.level
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_path_to_url_path_0515a08d
+      tag: rename_swimlane_audit_log_path_to_url_path_04f39696
       field: swimlane.audit_log.path
       target_field: url.path
       ignore_missing: true
   - script:
-      tag: script_0fb4f610
+      tag: script_db8ff8d6
       lang: painless
       description: Normalize SourceIp to a single value
       source: >-
@@ -83,7 +83,7 @@ processors:
             }
         }
   - grok:
-      tag: grok_swimlane_audit_log_sourceIp_30e91ffc
+      tag: grok_swimlane_audit_log_sourceIp_6ac73999
       field: swimlane.audit_log.sourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
@@ -91,53 +91,53 @@ processors:
         - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_tenant_to_cloud_origin_tenant_id_4e46bff8
+      tag: rename_swimlane_audit_log_tenant_to_cloud_origin_tenant_id_3094457b
       field: swimlane.audit_log.tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_category_to_log_category_fa1d4a96
+      tag: rename_swimlane_audit_log_category_to_log_category_10749655
       field: swimlane.audit_log.category
       target_field: log.category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_logFeatureCategory_to_log_feature_category_e1839923
+      tag: rename_swimlane_audit_log_logFeatureCategory_to_log_feature_category_537607be
       field: swimlane.audit_log.logFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_logSource_to_log_source_type_d85318e8
+      tag: rename_swimlane_audit_log_logSource_to_log_source_type_c80e4851
       field: swimlane.audit_log.logSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_logType_to_log_type_f49fe23a
+      tag: rename_swimlane_audit_log_logType_to_log_type_1a9d70da
       field: swimlane.audit_log.logType
       target_field: log.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_description_to_message_7e7bb22b
+      tag: rename_swimlane_audit_log_description_to_message_f44e3632
       field: swimlane.audit_log.description
       target_field: message
       ignore_missing: true
   - set:
-      tag: set_message_da12ebac
+      tag: set_message_3e28ea47
       field: message
       value: '{{{message}}}'
       if: ctx.message != null && ctx.message != ''
   - rename:
-      tag: rename_swimlane_audit_log_userId_to_user_id_aab25936
+      tag: rename_swimlane_audit_log_userId_to_user_id_ddfbf50d
       field: swimlane.audit_log.userId
       target_field: user.id
       ignore_missing: true
   - script:
       lang: painless
-      tag: add_ecs_categorization_5da2a2f7
+      tag: add_ecs_categorization_907dba2d
       params:
         Create:
           type:
@@ -169,68 +169,68 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - grok:
-      tag: grok_swimlane_audit_log_endpoint_2bf2105a
+      tag: grok_swimlane_audit_log_endpoint_27df0c58
       field: swimlane.audit_log.endpoint
       patterns:
         - '%{GREEDYDATA:url.path}'
       ignore_missing: true
   - drop:
-      tag: drop_df5a2f3e
+      tag: drop_064ef718
       description: Drop events related to the hubs/record endpoint
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().contains('hubs/record')
   - drop:
-      tag: drop_1abc01dd
+      tag: drop_d39d6301
       description: Drop events related to any record updates
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().endsWith('/values')
   - rename:
-      tag: rename_swimlane_audit_log_eventOutcome_to_event_outcome_b878d118
+      tag: rename_swimlane_audit_log_eventOutcome_to_event_outcome_79410360
       field: swimlane.audit_log.eventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
-      tag: lowercase_event_outcome_eb9dfc47
+      tag: lowercase_event_outcome_cfcf3a0f
       field: event.outcome
       ignore_missing: true
   - set:
-      tag: set_user_roles_558b689e
+      tag: set_user_roles_be8afef5
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
-      tag: rename_swimlane_audit_log_authenticationType_to_user_authentication_type_b4a5d0bb
+      tag: rename_swimlane_audit_log_authenticationType_to_user_authentication_type_c401d607
       field: swimlane.audit_log.authenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
-      tag: lowercase_user_authentication_type_f3146340
+      tag: lowercase_user_authentication_type_41c30272
       field: user.authentication.type
       ignore_missing: true
   - user_agent:
-      tag: user_agent_swimlane_audit_log_userAgent_30bda3c1
+      tag: user_agent_swimlane_audit_log_userAgent_3d632f44
       field: swimlane.audit_log.userAgent
       ignore_missing: true
   - date:
-      tag: date_swimlane_audit_log_eventTime_to_timestamp_a7ebb4c6
+      tag: date_swimlane_audit_log_eventTime_to_timestamp_9e2f0013
       field: swimlane.audit_log.eventTime
       target_field: '@timestamp'
       formats:
         - ISO8601
   - remove:
-      tag: remove_swimlane_96409c73
+      tag: remove_swimlane_1b248413
       field: swimlane
       ignore_missing: false
 on_failure:
   - set:
-      tag: set_event_kind
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
@@ -152,7 +152,7 @@ processors:
       ignore_missing: true
   - script:
       lang: painless
-      tag: Add ECS categorization
+      tag: add_ecs_categorization_bd0e2ba1
       params:
         Create:
           type:
@@ -240,13 +240,16 @@ processors:
       ignore_missing: false
 on_failure:
   - set:
+      tag: set_event_kind
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
@@ -6,34 +6,43 @@ processors:
       tag: set_ecs_version
       value: 8.17.0
   - set:
+      tag: set_event_original_b9758751
       field: event.original
       copy_from: message
   - json:
+      tag: json_message_to_json_576c813b
       field: message
       target_field: json
       ignore_failure: true
   - drop:
+      tag: drop_631a5346
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      field: 
+      tag: remove_d1205855
+      field:
         - message
         - input
         - stream
         - log
       ignore_missing: true
   - rename:
+      tag: rename_json_to_swimlane_audit_log_d2655548
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
+      tag: drop_83b3b0cb
       if: ctx.swimlane?.audit_log?.LogType != 'Audit'
   - drop:
+      tag: drop_4f7f469b
       if: ctx.swimlane?.audit_log?.Description instanceof String && ctx.swimlane.audit_log.Description.toLowerCase().contains('read')
   - json:
+      tag: json_swimlane_audit_log_NewValue_7826aa37
       field: swimlane.audit_log.NewValue
       if: ctx.swimlane.audit_log.NewValue != null
       ignore_failure: true
   - rename:
+      tag: rename_swimlane_audit_log_User_to_user_name_1343b4c1
       field: swimlane.audit_log.User
       target_field: user.name
       ignore_missing: true
@@ -50,77 +59,94 @@ processors:
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
+      tag: append_related_user_3b423052
       field: related.user
       value: "{{{user.name}}}"
       if: ctx.user?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_user_36d4b55a
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
+      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_ad8c599d
       field: swimlane.audit_log.AccountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_8ac9beaa
       field: swimlane.audit_log.TenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogLevel_to_log_level_62b87df8
       field: swimlane.audit_log.LogLevel
       target_field: log.level
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Message_to_message_f6c0c7aa
       field: swimlane.audit_log.Message
       target_field: message
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Path_to_url_path_b51e086d
       field: swimlane.audit_log.Path
       target_field: url.path
       ignore_missing: true
   - grok:
+      tag: grok_swimlane_audit_log_SourceIp_b92053dc
       field: swimlane.audit_log.SourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
         - '%{IPV4:source.ip}'
-        - '%{IPV6:source.ip}' 
+        - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_7161a5d8
       field: swimlane.audit_log.Tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogCategory_to_log_category_d3f06aa6
       field: swimlane.audit_log.LogCategory
       target_field: log.category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_ea354a43
       field: swimlane.audit_log.LogFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_0bbc5288
       field: swimlane.audit_log.LogSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogType_to_log_type_186b70da
       field: swimlane.audit_log.LogType
       target_field: log.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Description_to_message_3225068b
       field: swimlane.audit_log.Description
       target_field: message
       ignore_missing: true
   - set:
+      tag: set_message_79c51558
       field: message
       value: '{{{message}}}: {{{swimlane.audit_log.NewValue.Name}}} with Id: {{{swimlane.audit_log.NewValue.Id}}}'
       if: ctx.message != null && ctx.message != '' && ctx.swimlane?.audit_log?.NewValue?.Name != null && ctx.swimlane.audit_log.NewValue.Id != null
   - rename:
+      tag: rename_swimlane_audit_log_UserId_to_user_id_d33a52d6
       field: swimlane.audit_log.UserId
       target_field: user.id
       ignore_missing: true
@@ -145,7 +171,7 @@ processors:
             - start
         Logout:
           type:
-            - end   
+            - end
       source: >-
         ctx.event.kind = 'event';
         ctx.event.type = ['info'];
@@ -158,46 +184,58 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
+      tag: rename_swimlane_audit_log_Category_to_log_category_2687cc76
       field: swimlane.audit_log.Category
       target_field: log.category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Endpoint_to_url_path_d34b6cc7
       field: swimlane.audit_log.Endpoint
       target_field: url.path
       ignore_missing: true
   - drop:
+      tag: drop_df5a2f3e
       description: Drop events related to the hubs/record endpoint
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().contains('hubs/record')
   - drop:
+      tag: drop_1abc01dd
       description: Drop events related to any record updates
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().endsWith('/values')
   - rename:
+      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_e0920fb8
       field: swimlane.audit_log.EventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
+      tag: lowercase_event_outcome_eb9dfc47
       field: event.outcome
       ignore_missing: true
   - set:
+      tag: set_user_roles_558b689e
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
+      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_df8c1c5b
       field: swimlane.audit_log.AuthenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
+      tag: lowercase_user_authentication_type_f3146340
       field: user.authentication.type
       ignore_missing: true
   - user_agent:
+      tag: user_agent_swimlane_audit_log_UserAgent_29d1ee21
       field: swimlane.audit_log.UserAgent
       ignore_missing: true
   - date:
+      tag: date_swimlane_audit_log_EventTime_to_timestamp_f88048e6
       field: swimlane.audit_log.EventTime
       target_field: '@timestamp'
-      formats: 
+      formats:
         - ISO8601
   - remove:
+      tag: remove_swimlane_96409c73
       field: swimlane
       ignore_missing: false
 on_failure:

--- a/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
@@ -3,22 +3,22 @@ description: Pipeline for Swimlane API Logs
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - set:
-      tag: set_event_original_b9758751
+      tag: set_event_original_990fc2f3
       field: event.original
       copy_from: message
   - json:
-      tag: json_message_to_json_576c813b
+      tag: json_message_to_json_649b2289
       field: message
       target_field: json
       ignore_failure: true
   - drop:
-      tag: drop_631a5346
+      tag: drop_acb5b6f4
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      tag: remove_d1205855
+      tag: remove_8031fbf0
       field:
         - message
         - input
@@ -26,79 +26,79 @@ processors:
         - log
       ignore_missing: true
   - rename:
-      tag: rename_json_to_swimlane_audit_log_d2655548
+      tag: rename_json_to_swimlane_audit_log_abd84bef
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
-      tag: drop_83b3b0cb
+      tag: drop_50cd0bd8
       if: ctx.swimlane?.audit_log?.LogType != 'Audit'
   - drop:
-      tag: drop_4f7f469b
+      tag: drop_27259341
       if: ctx.swimlane?.audit_log?.Description instanceof String && ctx.swimlane.audit_log.Description.toLowerCase().contains('read')
   - json:
-      tag: json_swimlane_audit_log_NewValue_7826aa37
+      tag: json_swimlane_audit_log_NewValue_cc257128
       field: swimlane.audit_log.NewValue
       if: ctx.swimlane.audit_log.NewValue != null
       ignore_failure: true
   - rename:
-      tag: rename_swimlane_audit_log_User_to_user_name_1343b4c1
+      tag: rename_swimlane_audit_log_User_to_user_name_5724881c
       field: swimlane.audit_log.User
       target_field: user.name
       ignore_missing: true
   - rename:
       field: user.name
       target_field: user.email
-      tag: rename_user_email
+      tag: rename_user_email_455f691a
       if: ctx.user?.name != null && ctx.user.name.indexOf("@") > 0
   - dissect:
       field: user.email
       pattern: '%{user.name}@%{user.domain}'
-      tag: dissect_user_email
+      tag: dissect_user_email_d5fb5c7e
       ignore_missing: true
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
-      tag: append_related_user_3b423052
+      tag: append_related_user_736bc21b
       field: related.user
       value: "{{{user.name}}}"
       if: ctx.user?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
-      tag: append_related_user_36d4b55a
+      tag: append_related_user_5d0d8db5
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
-      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_ad8c599d
+      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_89b17af8
       field: swimlane.audit_log.AccountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_8ac9beaa
+      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_273294ba
       field: swimlane.audit_log.TenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogLevel_to_log_level_62b87df8
+      tag: rename_swimlane_audit_log_LogLevel_to_log_level_ec8c483e
       field: swimlane.audit_log.LogLevel
       target_field: log.level
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Message_to_message_f6c0c7aa
+      tag: rename_swimlane_audit_log_Message_to_message_2ac4ab5f
       field: swimlane.audit_log.Message
       target_field: message
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Path_to_url_path_b51e086d
+      tag: rename_swimlane_audit_log_Path_to_url_path_305b6caf
       field: swimlane.audit_log.Path
       target_field: url.path
       ignore_missing: true
   - grok:
-      tag: grok_swimlane_audit_log_SourceIp_b92053dc
+      tag: grok_swimlane_audit_log_SourceIp_246e42fc
       field: swimlane.audit_log.SourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
@@ -106,53 +106,53 @@ processors:
         - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_7161a5d8
+      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_4ca9e047
       field: swimlane.audit_log.Tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogCategory_to_log_category_d3f06aa6
+      tag: rename_swimlane_audit_log_LogCategory_to_log_category_1dbfa126
       field: swimlane.audit_log.LogCategory
       target_field: log.category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_ea354a43
+      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_807b9aa6
       field: swimlane.audit_log.LogFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_0bbc5288
+      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_e2e7a1da
       field: swimlane.audit_log.LogSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogType_to_log_type_186b70da
+      tag: rename_swimlane_audit_log_LogType_to_log_type_c574940d
       field: swimlane.audit_log.LogType
       target_field: log.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Description_to_message_3225068b
+      tag: rename_swimlane_audit_log_Description_to_message_339dc08c
       field: swimlane.audit_log.Description
       target_field: message
       ignore_missing: true
   - set:
-      tag: set_message_79c51558
+      tag: set_message_57f677c4
       field: message
       value: '{{{message}}}: {{{swimlane.audit_log.NewValue.Name}}} with Id: {{{swimlane.audit_log.NewValue.Id}}}'
       if: ctx.message != null && ctx.message != '' && ctx.swimlane?.audit_log?.NewValue?.Name != null && ctx.swimlane.audit_log.NewValue.Id != null
   - rename:
-      tag: rename_swimlane_audit_log_UserId_to_user_id_d33a52d6
+      tag: rename_swimlane_audit_log_UserId_to_user_id_8c6cf0b4
       field: swimlane.audit_log.UserId
       target_field: user.id
       ignore_missing: true
   - script:
       lang: painless
-      tag: add_ecs_categorization_bd0e2ba1
+      tag: add_ecs_categorization_907dba2d
       params:
         Create:
           type:
@@ -184,72 +184,72 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
-      tag: rename_swimlane_audit_log_Category_to_log_category_2687cc76
+      tag: rename_swimlane_audit_log_Category_to_log_category_4d401cac
       field: swimlane.audit_log.Category
       target_field: log.category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Endpoint_to_url_path_d34b6cc7
+      tag: rename_swimlane_audit_log_Endpoint_to_url_path_b947e6ce
       field: swimlane.audit_log.Endpoint
       target_field: url.path
       ignore_missing: true
   - drop:
-      tag: drop_df5a2f3e
+      tag: drop_064ef718
       description: Drop events related to the hubs/record endpoint
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().contains('hubs/record')
   - drop:
-      tag: drop_1abc01dd
+      tag: drop_d39d6301
       description: Drop events related to any record updates
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().endsWith('/values')
   - rename:
-      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_e0920fb8
+      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_68c68456
       field: swimlane.audit_log.EventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
-      tag: lowercase_event_outcome_eb9dfc47
+      tag: lowercase_event_outcome_cfcf3a0f
       field: event.outcome
       ignore_missing: true
   - set:
-      tag: set_user_roles_558b689e
+      tag: set_user_roles_be8afef5
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
-      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_df8c1c5b
+      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_b3502c96
       field: swimlane.audit_log.AuthenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
-      tag: lowercase_user_authentication_type_f3146340
+      tag: lowercase_user_authentication_type_41c30272
       field: user.authentication.type
       ignore_missing: true
   - user_agent:
-      tag: user_agent_swimlane_audit_log_UserAgent_29d1ee21
+      tag: user_agent_swimlane_audit_log_UserAgent_da6b3e9f
       field: swimlane.audit_log.UserAgent
       ignore_missing: true
   - date:
-      tag: date_swimlane_audit_log_EventTime_to_timestamp_f88048e6
+      tag: date_swimlane_audit_log_EventTime_to_timestamp_8aa71c56
       field: swimlane.audit_log.EventTime
       target_field: '@timestamp'
       formats:
         - ISO8601
   - remove:
-      tag: remove_swimlane_96409c73
+      tag: remove_swimlane_1b248413
       field: swimlane
       ignore_missing: false
 on_failure:
   - set:
-      tag: set_event_kind
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/swimlane_api/elasticsearch/ingest_pipeline/default.yml
@@ -194,11 +194,11 @@ processors:
       target_field: url.path
       ignore_missing: true
   - drop:
-      tag: drop_064ef718
+      tag: drop_events_related_to_hubs_record_endpoint_064ef718
       description: Drop events related to the hubs/record endpoint
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().contains('hubs/record')
   - drop:
-      tag: drop_d39d6301
+      tag: drop_events_related_to_record_updates_d39d6301
       description: Drop events related to any record updates
       if: ctx.url?.path instanceof String && ctx.url.path.toLowerCase().endsWith('/values')
   - rename:

--- a/packages/swimlane/data_stream/tenant_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/tenant_api/elasticsearch/ingest_pipeline/default.yml
@@ -139,7 +139,7 @@ processors:
       ignore_missing: true
   - script:
       lang: painless
-      tag: Add ECS categorization
+      tag: add_ecs_categorization_c47f10e9
       params:
         Create:
           type:
@@ -234,13 +234,16 @@ processors:
       ignore_missing: false
 on_failure:
   - set:
+      tag: set_event_kind
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/tenant_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/tenant_api/elasticsearch/ingest_pipeline/default.yml
@@ -6,28 +6,35 @@ processors:
       tag: set_ecs_version
       value: 8.17.0
   - set:
+      tag: set_event_original_b9758751
       field: event.original
       copy_from: message
   - json:
+      tag: json_message_to_json_576c813b
       field: message
       target_field: json
       ignore_failure: true
   - drop:
+      tag: drop_631a5346
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      field: 
+      tag: remove_d1205855
+      field:
         - message
         - input
         - stream
         - log
       ignore_missing: true
   - rename:
+      tag: rename_json_to_swimlane_audit_log_d2655548
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
+      tag: drop_83b3b0cb
       if: ctx.swimlane?.audit_log?.LogType != 'Audit'
   - rename:
+      tag: rename_swimlane_audit_log_User_to_user_name_1343b4c1
       field: swimlane.audit_log.User
       target_field: user.name
       ignore_missing: true
@@ -44,73 +51,89 @@ processors:
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
+      tag: append_related_user_3b423052
       field: related.user
       value: "{{{user.name}}}"
       if: ctx.user?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_user_36d4b55a
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
+      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_ad8c599d
       field: swimlane.audit_log.AccountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_8ac9beaa
       field: swimlane.audit_log.TenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogLevel_to_log_level_62b87df8
       field: swimlane.audit_log.LogLevel
       target_field: log.level
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Message_to_message_f6c0c7aa
       field: swimlane.audit_log.Message
       target_field: message
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Path_to_url_path_b51e086d
       field: swimlane.audit_log.Path
       target_field: url.path
       ignore_missing: true
   - grok:
+      tag: grok_swimlane_audit_log_SourceIp_b92053dc
       field: swimlane.audit_log.SourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
         - '%{IPV4:source.ip}'
-        - '%{IPV6:source.ip}' 
+        - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_7161a5d8
       field: swimlane.audit_log.Tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogCategory_to_log_category_d3f06aa6
       field: swimlane.audit_log.LogCategory
       target_field: log.category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_ea354a43
       field: swimlane.audit_log.LogFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_0bbc5288
       field: swimlane.audit_log.LogSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogType_to_log_type_186b70da
       field: swimlane.audit_log.LogType
       target_field: log.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Description_to_message_3225068b
       field: swimlane.audit_log.Description
       target_field: message
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_UserId_to_user_id_d33a52d6
       field: swimlane.audit_log.UserId
       target_field: user.id
       ignore_missing: true
@@ -135,7 +158,7 @@ processors:
             - start
         Logout:
           type:
-            - end   
+            - end
       source: >-
         ctx.event.kind = 'event';
         ctx.event.type = ['info'];
@@ -148,52 +171,65 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
+      tag: rename_swimlane_audit_log_Category_to_log_category_2687cc76
       field: swimlane.audit_log.Category
       target_field: log.category
       ignore_missing: true
   - grok:
+      tag: grok_swimlane_audit_log_EndPoint_b612c867
       field: swimlane.audit_log.EndPoint
       patterns:
         - '%{HOSTNAME:url.domain}/%{GREEDYDATA:url.path}'
   - rename:
+      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_e0920fb8
       field: swimlane.audit_log.EventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
+      tag: lowercase_event_outcome_eb9dfc47
       field: event.outcome
       ignore_missing: true
   - set:
+      tag: set_user_roles_558b689e
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
+      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_df8c1c5b
       field: swimlane.audit_log.AuthenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
+      tag: lowercase_user_authentication_type_f3146340
       field: user.authentication.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_NewValue_Id_to_destination_user_changes_id_34eaa959
       field: swimlane.audit_log.NewValue.Id
       target_field: destination.user.changes.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_NewValue_Name_to_destination_user_changes_name_802b39c1
       field: swimlane.audit_log.NewValue.Name
       target_field: destination.user.changes.name
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_NewValue_ModifiedByUser_to_source_user_changes_id_242f1226
       field: swimlane.audit_log.NewValue.ModifiedByUser
       target_field: source.user.changes.id
-      ignore_missing: true         
+      ignore_missing: true
   - user_agent:
+      tag: user_agent_swimlane_audit_log_UserAgent_29d1ee21
       field: swimlane.audit_log.UserAgent
       ignore_missing: true
   - date:
+      tag: date_swimlane_audit_log_EventTime_to_timestamp_f88048e6
       field: swimlane.audit_log.EventTime
       target_field: '@timestamp'
-      formats: 
+      formats:
         - ISO8601
   - remove:
+      tag: remove_swimlane_96409c73
       field: swimlane
       ignore_missing: false
 on_failure:

--- a/packages/swimlane/data_stream/tenant_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/tenant_api/elasticsearch/ingest_pipeline/default.yml
@@ -3,22 +3,22 @@ description: Pipeline for Swimlane Tenant Logs
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - set:
-      tag: set_event_original_b9758751
+      tag: set_event_original_990fc2f3
       field: event.original
       copy_from: message
   - json:
-      tag: json_message_to_json_576c813b
+      tag: json_message_to_json_649b2289
       field: message
       target_field: json
       ignore_failure: true
   - drop:
-      tag: drop_631a5346
+      tag: drop_acb5b6f4
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      tag: remove_d1205855
+      tag: remove_8031fbf0
       field:
         - message
         - input
@@ -26,71 +26,71 @@ processors:
         - log
       ignore_missing: true
   - rename:
-      tag: rename_json_to_swimlane_audit_log_d2655548
+      tag: rename_json_to_swimlane_audit_log_abd84bef
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
-      tag: drop_83b3b0cb
+      tag: drop_50cd0bd8
       if: ctx.swimlane?.audit_log?.LogType != 'Audit'
   - rename:
-      tag: rename_swimlane_audit_log_User_to_user_name_1343b4c1
+      tag: rename_swimlane_audit_log_User_to_user_name_5724881c
       field: swimlane.audit_log.User
       target_field: user.name
       ignore_missing: true
   - rename:
       field: user.name
       target_field: user.email
-      tag: rename_user_email
+      tag: rename_user_email_455f691a
       if: ctx.user?.name != null && ctx.user.name.indexOf("@") > 0
   - dissect:
       field: user.email
       pattern: '%{user.name}@%{user.domain}'
-      tag: dissect_user_email
+      tag: dissect_user_email_d5fb5c7e
       ignore_missing: true
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
-      tag: append_related_user_3b423052
+      tag: append_related_user_736bc21b
       field: related.user
       value: "{{{user.name}}}"
       if: ctx.user?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
-      tag: append_related_user_36d4b55a
+      tag: append_related_user_5d0d8db5
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
-      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_ad8c599d
+      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_89b17af8
       field: swimlane.audit_log.AccountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_8ac9beaa
+      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_273294ba
       field: swimlane.audit_log.TenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogLevel_to_log_level_62b87df8
+      tag: rename_swimlane_audit_log_LogLevel_to_log_level_ec8c483e
       field: swimlane.audit_log.LogLevel
       target_field: log.level
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Message_to_message_f6c0c7aa
+      tag: rename_swimlane_audit_log_Message_to_message_2ac4ab5f
       field: swimlane.audit_log.Message
       target_field: message
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Path_to_url_path_b51e086d
+      tag: rename_swimlane_audit_log_Path_to_url_path_305b6caf
       field: swimlane.audit_log.Path
       target_field: url.path
       ignore_missing: true
   - grok:
-      tag: grok_swimlane_audit_log_SourceIp_b92053dc
+      tag: grok_swimlane_audit_log_SourceIp_246e42fc
       field: swimlane.audit_log.SourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
@@ -98,48 +98,48 @@ processors:
         - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_7161a5d8
+      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_4ca9e047
       field: swimlane.audit_log.Tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogCategory_to_log_category_d3f06aa6
+      tag: rename_swimlane_audit_log_LogCategory_to_log_category_1dbfa126
       field: swimlane.audit_log.LogCategory
       target_field: log.category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_ea354a43
+      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_807b9aa6
       field: swimlane.audit_log.LogFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_0bbc5288
+      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_e2e7a1da
       field: swimlane.audit_log.LogSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogType_to_log_type_186b70da
+      tag: rename_swimlane_audit_log_LogType_to_log_type_c574940d
       field: swimlane.audit_log.LogType
       target_field: log.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Description_to_message_3225068b
+      tag: rename_swimlane_audit_log_Description_to_message_339dc08c
       field: swimlane.audit_log.Description
       target_field: message
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_UserId_to_user_id_d33a52d6
+      tag: rename_swimlane_audit_log_UserId_to_user_id_8c6cf0b4
       field: swimlane.audit_log.UserId
       target_field: user.id
       ignore_missing: true
   - script:
       lang: painless
-      tag: add_ecs_categorization_c47f10e9
+      tag: add_ecs_categorization_3050da03
       params:
         Create:
           type:
@@ -171,79 +171,79 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
-      tag: rename_swimlane_audit_log_Category_to_log_category_2687cc76
+      tag: rename_swimlane_audit_log_Category_to_log_category_4d401cac
       field: swimlane.audit_log.Category
       target_field: log.category
       ignore_missing: true
   - grok:
-      tag: grok_swimlane_audit_log_EndPoint_b612c867
+      tag: grok_swimlane_audit_log_EndPoint_1afe902e
       field: swimlane.audit_log.EndPoint
       patterns:
         - '%{HOSTNAME:url.domain}/%{GREEDYDATA:url.path}'
   - rename:
-      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_e0920fb8
+      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_68c68456
       field: swimlane.audit_log.EventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
-      tag: lowercase_event_outcome_eb9dfc47
+      tag: lowercase_event_outcome_cfcf3a0f
       field: event.outcome
       ignore_missing: true
   - set:
-      tag: set_user_roles_558b689e
+      tag: set_user_roles_be8afef5
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
-      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_df8c1c5b
+      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_b3502c96
       field: swimlane.audit_log.AuthenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
-      tag: lowercase_user_authentication_type_f3146340
+      tag: lowercase_user_authentication_type_41c30272
       field: user.authentication.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_NewValue_Id_to_destination_user_changes_id_34eaa959
+      tag: rename_swimlane_audit_log_NewValue_Id_to_destination_user_changes_id_7334a51b
       field: swimlane.audit_log.NewValue.Id
       target_field: destination.user.changes.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_NewValue_Name_to_destination_user_changes_name_802b39c1
+      tag: rename_swimlane_audit_log_NewValue_Name_to_destination_user_changes_name_48b0e835
       field: swimlane.audit_log.NewValue.Name
       target_field: destination.user.changes.name
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_NewValue_ModifiedByUser_to_source_user_changes_id_242f1226
+      tag: rename_swimlane_audit_log_NewValue_ModifiedByUser_to_source_user_changes_id_a9229938
       field: swimlane.audit_log.NewValue.ModifiedByUser
       target_field: source.user.changes.id
       ignore_missing: true
   - user_agent:
-      tag: user_agent_swimlane_audit_log_UserAgent_29d1ee21
+      tag: user_agent_swimlane_audit_log_UserAgent_da6b3e9f
       field: swimlane.audit_log.UserAgent
       ignore_missing: true
   - date:
-      tag: date_swimlane_audit_log_EventTime_to_timestamp_f88048e6
+      tag: date_swimlane_audit_log_EventTime_to_timestamp_8aa71c56
       field: swimlane.audit_log.EventTime
       target_field: '@timestamp'
       formats:
         - ISO8601
   - remove:
-      tag: remove_swimlane_96409c73
+      tag: remove_swimlane_1b248413
       field: swimlane
       ignore_missing: false
 on_failure:
   - set:
-      tag: set_event_kind
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
@@ -6,33 +6,41 @@ processors:
       tag: set_ecs_version
       value: 8.17.0
   - set:
+      tag: set_event_original_b9758751
       field: event.original
       copy_from: message
   - json:
+      tag: json_message_to_json_576c813b
       field: message
       target_field: json
       ignore_failure: true
   - drop:
+      tag: drop_631a5346
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      field: 
+      tag: remove_d1205855
+      field:
         - message
         - input
         - stream
         - log
       ignore_missing: true
   - rename:
+      tag: rename_json_to_swimlane_audit_log_d2655548
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
+      tag: drop_83b3b0cb
       if: ctx.swimlane?.audit_log?.LogType != 'Audit'
   - json:
+      tag: json_swimlane_audit_log_NewValue_to_swimlane_audit_log_NewValue_9b3c2f0e
       field: swimlane.audit_log.NewValue
       target_field: swimlane.audit_log.NewValue
       if: ctx.swimlane?.audit_log?.NewValue != null
       ignore_failure: true
   - rename:
+      tag: rename_swimlane_audit_log_User_to_user_name_1343b4c1
       field: swimlane.audit_log.User
       target_field: user.name
       ignore_missing: true
@@ -49,34 +57,41 @@ processors:
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
+      tag: append_related_user_3b423052
       field: related.user
       value: "{{{user.name}}}"
       if: ctx.user?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_user_36d4b55a
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
+      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_ad8c599d
       field: swimlane.audit_log.AccountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_8ac9beaa
       field: swimlane.audit_log.TenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogLevel_to_log_level_62b87df8
       field: swimlane.audit_log.LogLevel
       target_field: log.level
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Message_to_message_f6c0c7aa
       field: swimlane.audit_log.Message
       target_field: message
       ignore_missing: true
   - script:
+      tag: script_eb7a89f0
       lang: painless
       description: Normalize SourceIp to a single value
       source: >-
@@ -89,45 +104,55 @@ processors:
             }
         }
   - grok:
+      tag: grok_swimlane_audit_log_SourceIp_b92053dc
       field: swimlane.audit_log.SourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
         - '%{IPV4:source.ip}'
-        - '%{IPV6:source.ip}' 
+        - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_7161a5d8
       field: swimlane.audit_log.Tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogCategory_to_log_category_d3f06aa6
       field: swimlane.audit_log.LogCategory
       target_field: log.category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_ea354a43
       field: swimlane.audit_log.LogFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_0bbc5288
       field: swimlane.audit_log.LogSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_LogType_to_log_type_186b70da
       field: swimlane.audit_log.LogType
       target_field: log.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Description_to_message_3225068b
       field: swimlane.audit_log.Description
       target_field: message
       ignore_missing: true
   - set:
+      tag: set_message_481c9e18
       field: message
       value: '{{{message}}}: {{{swimlane.audit_log.NewValue.name}}} with Id: {{{swimlane.audit_log.NewValue.id}}}'
       if: ctx.message != null && ctx.message != '' && ctx.swimlane?.audit_log?.NewValue?.name != null && ctx.swimlane.audit_log.NewValue.id != null
   - rename:
+      tag: rename_swimlane_audit_log_UserId_to_user_id_d33a52d6
       field: swimlane.audit_log.UserId
       target_field: user.id
       ignore_missing: true
@@ -152,7 +177,7 @@ processors:
             - start
         Logout:
           type:
-            - end   
+            - end
       source: >-
         ctx.event.kind = 'event';
         ctx.event.type = ['info'];
@@ -165,52 +190,65 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
+      tag: rename_swimlane_audit_log_Category_to_log_category_2687cc76
       field: swimlane.audit_log.Category
       target_field: log.category
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_Endpoint_to_url_path_d34b6cc7
       field: swimlane.audit_log.Endpoint
       target_field: url.path
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_e0920fb8
       field: swimlane.audit_log.EventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
+      tag: lowercase_event_outcome_eb9dfc47
       field: event.outcome
       ignore_missing: true
   - set:
+      tag: set_user_roles_558b689e
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
+      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_df8c1c5b
       field: swimlane.audit_log.AuthenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
+      tag: lowercase_user_authentication_type_f3146340
       field: user.authentication.type
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_NewValue_Id_to_destination_user_changes_id_34eaa959
       field: swimlane.audit_log.NewValue.Id
       target_field: destination.user.changes.id
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_NewValue_Name_to_destination_user_changes_name_802b39c1
       field: swimlane.audit_log.NewValue.Name
       target_field: destination.user.changes.name
       ignore_missing: true
   - rename:
+      tag: rename_swimlane_audit_log_NewValue_ModifiedByUser_to_source_user_changes_id_242f1226
       field: swimlane.audit_log.NewValue.ModifiedByUser
       target_field: source.user.changes.id
-      ignore_missing: true         
+      ignore_missing: true
   - user_agent:
+      tag: user_agent_swimlane_audit_log_UserAgent_29d1ee21
       field: swimlane.audit_log.UserAgent
       ignore_missing: true
   - date:
+      tag: date_swimlane_audit_log_EventTime_to_timestamp_f88048e6
       field: swimlane.audit_log.EventTime
       target_field: '@timestamp'
-      formats: 
+      formats:
         - ISO8601
   - remove:
+      tag: remove_swimlane_96409c73
       field: swimlane
       ignore_missing: false
 on_failure:

--- a/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
@@ -91,7 +91,7 @@ processors:
       target_field: message
       ignore_missing: true
   - script:
-      tag: script_3b9772fd
+      tag: script_normalize_sourceip_to_single_value_3b9772fd
       lang: painless
       description: Normalize SourceIp to a single value
       source: >-

--- a/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
@@ -158,7 +158,7 @@ processors:
       ignore_missing: true
   - script:
       lang: painless
-      tag: Add ECS categorization
+      tag: add_ecs_categorization_3e8b0d64
       params:
         Create:
           type:
@@ -253,13 +253,16 @@ processors:
       ignore_missing: false
 on_failure:
   - set:
+      tag: set_event_kind
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/swimlane/data_stream/turbine_api/elasticsearch/ingest_pipeline/default.yml
@@ -3,22 +3,22 @@ description: Pipeline for Swimlane Turbine API Logs
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - set:
-      tag: set_event_original_b9758751
+      tag: set_event_original_990fc2f3
       field: event.original
       copy_from: message
   - json:
-      tag: json_message_to_json_576c813b
+      tag: json_message_to_json_649b2289
       field: message
       target_field: json
       ignore_failure: true
   - drop:
-      tag: drop_631a5346
+      tag: drop_acb5b6f4
       if: ctx.json == null || !(ctx.json instanceof Map)
   - remove:
-      tag: remove_d1205855
+      tag: remove_8031fbf0
       field:
         - message
         - input
@@ -26,72 +26,72 @@ processors:
         - log
       ignore_missing: true
   - rename:
-      tag: rename_json_to_swimlane_audit_log_d2655548
+      tag: rename_json_to_swimlane_audit_log_abd84bef
       field: json
       target_field: swimlane.audit_log
       ignore_missing: true
   - drop:
-      tag: drop_83b3b0cb
+      tag: drop_50cd0bd8
       if: ctx.swimlane?.audit_log?.LogType != 'Audit'
   - json:
-      tag: json_swimlane_audit_log_NewValue_to_swimlane_audit_log_NewValue_9b3c2f0e
+      tag: json_swimlane_audit_log_NewValue_to_swimlane_audit_log_NewValue_d5936e06
       field: swimlane.audit_log.NewValue
       target_field: swimlane.audit_log.NewValue
       if: ctx.swimlane?.audit_log?.NewValue != null
       ignore_failure: true
   - rename:
-      tag: rename_swimlane_audit_log_User_to_user_name_1343b4c1
+      tag: rename_swimlane_audit_log_User_to_user_name_5724881c
       field: swimlane.audit_log.User
       target_field: user.name
       ignore_missing: true
   - rename:
       field: user.name
       target_field: user.email
-      tag: rename_user_email
+      tag: rename_user_email_455f691a
       if: ctx.user?.name != null && ctx.user.name.indexOf("@") > 0
   - dissect:
       field: user.email
       pattern: '%{user.name}@%{user.domain}'
-      tag: dissect_user_email
+      tag: dissect_user_email_d5fb5c7e
       ignore_missing: true
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
-      tag: append_related_user_3b423052
+      tag: append_related_user_736bc21b
       field: related.user
       value: "{{{user.name}}}"
       if: ctx.user?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
-      tag: append_related_user_36d4b55a
+      tag: append_related_user_5d0d8db5
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
-      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_ad8c599d
+      tag: rename_swimlane_audit_log_AccountId_to_cloud_origin_account_id_89b17af8
       field: swimlane.audit_log.AccountId
       target_field: cloud.origin.account.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_8ac9beaa
+      tag: rename_swimlane_audit_log_TenantId_to_cloud_origin_project_id_273294ba
       field: swimlane.audit_log.TenantId
       target_field: cloud.origin.project.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogLevel_to_log_level_62b87df8
+      tag: rename_swimlane_audit_log_LogLevel_to_log_level_ec8c483e
       field: swimlane.audit_log.LogLevel
       target_field: log.level
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Message_to_message_f6c0c7aa
+      tag: rename_swimlane_audit_log_Message_to_message_2ac4ab5f
       field: swimlane.audit_log.Message
       target_field: message
       ignore_missing: true
   - script:
-      tag: script_eb7a89f0
+      tag: script_3b9772fd
       lang: painless
       description: Normalize SourceIp to a single value
       source: >-
@@ -104,7 +104,7 @@ processors:
             }
         }
   - grok:
-      tag: grok_swimlane_audit_log_SourceIp_b92053dc
+      tag: grok_swimlane_audit_log_SourceIp_246e42fc
       field: swimlane.audit_log.SourceIp
       patterns:
         - '::ffff:%{IPV4:source.ip}'
@@ -112,53 +112,53 @@ processors:
         - '%{IPV6:source.ip}'
       ignore_failure: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_7161a5d8
+      tag: rename_swimlane_audit_log_Tenant_to_cloud_origin_tenant_id_4ca9e047
       field: swimlane.audit_log.Tenant
       target_field: cloud.origin.tenant.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogCategory_to_log_category_d3f06aa6
+      tag: rename_swimlane_audit_log_LogCategory_to_log_category_1dbfa126
       field: swimlane.audit_log.LogCategory
       target_field: log.category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_ea354a43
+      tag: rename_swimlane_audit_log_LogFeatureCategory_to_log_feature_category_807b9aa6
       field: swimlane.audit_log.LogFeatureCategory
       target_field: log.feature_category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_0bbc5288
+      tag: rename_swimlane_audit_log_LogSource_to_log_source_type_e2e7a1da
       field: swimlane.audit_log.LogSource
       target_field: log.source.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_LogType_to_log_type_186b70da
+      tag: rename_swimlane_audit_log_LogType_to_log_type_c574940d
       field: swimlane.audit_log.LogType
       target_field: log.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Description_to_message_3225068b
+      tag: rename_swimlane_audit_log_Description_to_message_339dc08c
       field: swimlane.audit_log.Description
       target_field: message
       ignore_missing: true
   - set:
-      tag: set_message_481c9e18
+      tag: set_message_b23cfbcc
       field: message
       value: '{{{message}}}: {{{swimlane.audit_log.NewValue.name}}} with Id: {{{swimlane.audit_log.NewValue.id}}}'
       if: ctx.message != null && ctx.message != '' && ctx.swimlane?.audit_log?.NewValue?.name != null && ctx.swimlane.audit_log.NewValue.id != null
   - rename:
-      tag: rename_swimlane_audit_log_UserId_to_user_id_d33a52d6
+      tag: rename_swimlane_audit_log_UserId_to_user_id_8c6cf0b4
       field: swimlane.audit_log.UserId
       target_field: user.id
       ignore_missing: true
   - script:
       lang: painless
-      tag: add_ecs_categorization_3e8b0d64
+      tag: add_ecs_categorization_907dba2d
       params:
         Create:
           type:
@@ -190,79 +190,79 @@ processors:
         def hm = new HashMap(params.get(ctx.swimlane?.audit_log?.ActionType));
         hm.forEach((k, v) -> ctx.event[k] = v);
   - rename:
-      tag: rename_swimlane_audit_log_Category_to_log_category_2687cc76
+      tag: rename_swimlane_audit_log_Category_to_log_category_4d401cac
       field: swimlane.audit_log.Category
       target_field: log.category
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_Endpoint_to_url_path_d34b6cc7
+      tag: rename_swimlane_audit_log_Endpoint_to_url_path_b947e6ce
       field: swimlane.audit_log.Endpoint
       target_field: url.path
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_e0920fb8
+      tag: rename_swimlane_audit_log_EventOutcome_to_event_outcome_68c68456
       field: swimlane.audit_log.EventOutcome
       target_field: event.outcome
       ignore_missing: true
   - lowercase:
-      tag: lowercase_event_outcome_eb9dfc47
+      tag: lowercase_event_outcome_cfcf3a0f
       field: event.outcome
       ignore_missing: true
   - set:
-      tag: set_user_roles_558b689e
+      tag: set_user_roles_be8afef5
       field: user.roles
       value: ['administrator']
       if: ctx.swimlane?.audit_log?.isAdmin == 'True'
   - rename:
-      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_df8c1c5b
+      tag: rename_swimlane_audit_log_AuthenticationType_to_user_authentication_type_b3502c96
       field: swimlane.audit_log.AuthenticationType
       target_field: user.authentication.type
       ignore_missing: true
   - lowercase:
-      tag: lowercase_user_authentication_type_f3146340
+      tag: lowercase_user_authentication_type_41c30272
       field: user.authentication.type
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_NewValue_Id_to_destination_user_changes_id_34eaa959
+      tag: rename_swimlane_audit_log_NewValue_Id_to_destination_user_changes_id_7334a51b
       field: swimlane.audit_log.NewValue.Id
       target_field: destination.user.changes.id
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_NewValue_Name_to_destination_user_changes_name_802b39c1
+      tag: rename_swimlane_audit_log_NewValue_Name_to_destination_user_changes_name_48b0e835
       field: swimlane.audit_log.NewValue.Name
       target_field: destination.user.changes.name
       ignore_missing: true
   - rename:
-      tag: rename_swimlane_audit_log_NewValue_ModifiedByUser_to_source_user_changes_id_242f1226
+      tag: rename_swimlane_audit_log_NewValue_ModifiedByUser_to_source_user_changes_id_a9229938
       field: swimlane.audit_log.NewValue.ModifiedByUser
       target_field: source.user.changes.id
       ignore_missing: true
   - user_agent:
-      tag: user_agent_swimlane_audit_log_UserAgent_29d1ee21
+      tag: user_agent_swimlane_audit_log_UserAgent_da6b3e9f
       field: swimlane.audit_log.UserAgent
       ignore_missing: true
   - date:
-      tag: date_swimlane_audit_log_EventTime_to_timestamp_f88048e6
+      tag: date_swimlane_audit_log_EventTime_to_timestamp_8aa71c56
       field: swimlane.audit_log.EventTime
       target_field: '@timestamp'
       formats:
         - ISO8601
   - remove:
-      tag: remove_swimlane_96409c73
+      tag: remove_swimlane_1b248413
       field: swimlane
       ignore_missing: false
 on_failure:
   - set:
-      tag: set_event_kind
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'

--- a/packages/swimlane/manifest.yml
+++ b/packages/swimlane/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: swimlane
 title: "Swimlane Turbine"
-version: 0.5.2
+version: 0.6.0
 description: "Collect Swimlane Turbine Audit logs with Elastic Agent"
 type: integration
 categories:

--- a/packages/swimlane/manifest.yml
+++ b/packages/swimlane/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: swimlane
 title: "Swimlane Turbine"
-version: 0.5.1
+version: 0.5.2
 description: "Collect Swimlane Turbine Audit logs with Elastic Agent"
 type: integration
 categories:

--- a/packages/ti_cyware_intel_exchange/changelog.yml
+++ b/packages/ti_cyware_intel_exchange/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.4.3"
+- version: "0.5.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/ti_cyware_intel_exchange/changelog.yml
+++ b/packages/ti_cyware_intel_exchange/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.4.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/ti_cyware_intel_exchange/changelog.yml
+++ b/packages/ti_cyware_intel_exchange/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.3"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.4.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/ti_cyware_intel_exchange/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cyware_intel_exchange/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -38,6 +38,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -79,6 +80,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f7751d3a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -105,6 +107,7 @@ processors:
       if: ctx.json?.created != null && ctx.json.created != ''
       on_failure:
         - append:
+            tag: append_error_message_6834a02a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -116,6 +119,7 @@ processors:
       if: ctx.json?.ctix_created != null && ctx.json.ctix_created != ''
       on_failure:
         - append:
+            tag: append_error_message_b5013287
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -132,6 +136,7 @@ processors:
       if: ctx.json?.ctix_modified != null && ctx.json.ctix_modified != ''
       on_failure:
         - append:
+            tag: append_error_message_b7af3172
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -147,6 +152,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d0710820
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -224,6 +230,7 @@ processors:
       if: ctx.json?.name != ''
       on_failure:
         - rename:
+            tag: rename_json_name_to_ti_cyware_intel_exchange_indicator_name_1eb51e7a
             field: json.name
             target_field: ti_cyware_intel_exchange.indicator.name
             ignore_missing: true
@@ -241,6 +248,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b42f62cb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -251,6 +259,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f06af911
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -261,6 +270,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_754615eb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -271,6 +281,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_061b5045
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -281,6 +292,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2ec4abd6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -291,6 +303,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_42249443
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -302,6 +315,7 @@ processors:
       if: ctx.json?.modified != null && ctx.json.modified != ''
       on_failure:
         - append:
+            tag: append_error_message_afda5729
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -323,6 +337,7 @@ processors:
       if: ctx.json?.sdo_name != ''
       on_failure:
         - rename:
+            tag: rename_json_sdo_name_to_ti_cyware_intel_exchange_indicator_sdo_name_5bd349d8
             field: json.sdo_name
             target_field: ti_cyware_intel_exchange.indicator.sdo_name
             ignore_missing: true
@@ -381,7 +396,7 @@ processors:
                 ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_sources_first_seen
+      tag: foreach_json_sources_bb6d4acb
       if: ctx.json?.sources instanceof List
       processor:
         append:
@@ -406,7 +421,7 @@ processors:
                 ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_sources_last_seen
+      tag: foreach_json_sources_055df765
       if: ctx.json?.sources instanceof List
       processor:
         append:
@@ -492,6 +507,7 @@ processors:
       if: ctx.json?.valid_from != null && ctx.json.valid_from != ''
       on_failure:
         - append:
+            tag: append_error_message_8136d0b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -503,6 +519,7 @@ processors:
       if: ctx.json?.valid_until != null && ctx.json.valid_until != ''
       on_failure:
         - append:
+            tag: append_error_message_dd7cdcef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   ######################
@@ -539,6 +556,7 @@ processors:
         ctx.ti_cyware_intel_exchange.indicator.deleted_at = _tmp_deleted_at;
       on_failure:
         - append:
+            tag: append_error_message_1ae85c69
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -615,6 +633,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_cyware_intel_exchange/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cyware_intel_exchange/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -8,157 +8,157 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_d5c66e22
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_20c33993
       value: Cyware
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_d7b0bc08
       value: Threat Intelligence Management
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_3410a97a
       value: enrichment
   - append:
       field: event.category
-      tag: append_threat_into_event_category
+      tag: append_threat_into_event_category_4039b90d
       value: threat
   - append:
       field: event.type
-      tag: append_indicator_into_event_type
+      tag: append_indicator_into_event_type_d4da06cc
       value: indicator
   - fingerprint:
       fields:
         - json.id
         - json.ctix_modified
-      tag: fingerprint_indicator
+      tag: fingerprint_indicator_6d3b66ea
       target_field: _id
   - rename:
       field: json.analyst_description
-      tag: rename_analyst_description
+      tag: rename_analyst_description_6a73269a
       target_field: ti_cyware_intel_exchange.indicator.analyst_description
       ignore_missing: true
   - convert:
       field: json.analyst_score
-      tag: convert_analyst_score_to_long
+      tag: convert_analyst_score_to_long_e9aa38cc
       target_field: ti_cyware_intel_exchange.indicator.analyst_score
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f7751d3a
+            tag: append_error_message_0c4c128b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.analyst_tlp
-      tag: rename_analyst_tlp
+      tag: rename_analyst_tlp_e4a9bf16
       target_field: ti_cyware_intel_exchange.indicator.analyst_tlp
       ignore_missing: true
   - rename:
       field: json.country
-      tag: rename_country
+      tag: rename_country_f4c5e835
       target_field: ti_cyware_intel_exchange.indicator.country
       ignore_missing: true
   - set:
       field: threat.indicator.geo.country_name
-      tag: set_threat_indicator_geo_country_name_from_indicator_country
+      tag: set_threat_indicator_geo_country_name_from_indicator_country_6cf53ba5
       copy_from: ti_cyware_intel_exchange.indicator.country
       ignore_empty_value: true
   - date:
       field: json.created
-      tag: date_created
+      tag: date_created_679219c2
       target_field: ti_cyware_intel_exchange.indicator.created
       formats:
         - UNIX
       if: ctx.json?.created != null && ctx.json.created != ''
       on_failure:
         - append:
-            tag: append_error_message_6834a02a
+            tag: append_error_message_52776794
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.ctix_created
-      tag: date_ctix_created
+      tag: date_ctix_created_01a119bf
       target_field: ti_cyware_intel_exchange.indicator.ctix_created
       formats:
         - UNIX
       if: ctx.json?.ctix_created != null && ctx.json.ctix_created != ''
       on_failure:
         - append:
-            tag: append_error_message_b5013287
+            tag: append_error_message_03feeac2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.created
-      tag: set_event_created_from_indicator_ctix_created
+      tag: set_event_created_from_indicator_ctix_created_d923a187
       copy_from: ti_cyware_intel_exchange.indicator.ctix_created
       ignore_empty_value: true
   - date:
       field: json.ctix_modified
-      tag: date_ctix_modified
+      tag: date_ctix_modified_244ad198
       target_field: ti_cyware_intel_exchange.indicator.ctix_modified
       formats:
         - UNIX
       if: ctx.json?.ctix_modified != null && ctx.json.ctix_modified != ''
       on_failure:
         - append:
-            tag: append_error_message_b7af3172
+            tag: append_error_message_536dae4e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_indicator_ctix_modified
+      tag: set_@timestamp_from_indicator_ctix_modified_14dc9d1a
       copy_from: ti_cyware_intel_exchange.indicator.ctix_modified
       ignore_empty_value: true
   - convert:
       field: json.ctix_score
-      tag: convert_ctix_score_to_long
+      tag: convert_ctix_score_to_long_b95abdfa
       target_field: ti_cyware_intel_exchange.indicator.ctix_score
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d0710820
+            tag: append_error_message_e6e85842
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
       lang: painless
       description: Script to set event_severity.
-      tag: set_event_severity
+      tag: set_event_severity_ec4c1083
       if: ctx.ti_cyware_intel_exchange?.indicator?.ctix_score != null
       source: |-
         ctx.event = ctx.event ?: [:];
@@ -173,357 +173,357 @@ processors:
         }
   - rename:
       field: json.ctix_tlp
-      tag: rename_ctix_tlp
+      tag: rename_ctix_tlp_4219e064
       target_field: ti_cyware_intel_exchange.indicator.ctix_tlp
       ignore_missing: true
   - rename:
       field: json.custom_attributes
-      tag: rename_custom_attributes
+      tag: rename_custom_attributes_8ff6ff58
       target_field: ti_cyware_intel_exchange.indicator.custom_attributes
       ignore_missing: true
   - rename:
       field: json.custom_scores
-      tag: rename_custom_scores
+      tag: rename_custom_scores_12d11923
       target_field: ti_cyware_intel_exchange.indicator.custom_scores
       ignore_missing: true
   - rename:
       field: json.external_references
-      tag: rename_external_references
+      tag: rename_external_references_e92122ad
       target_field: ti_cyware_intel_exchange.indicator.external_references
       ignore_missing: true
   - rename:
       field: json.id
-      tag: rename_id
+      tag: rename_id_337282cf
       target_field: ti_cyware_intel_exchange.indicator.id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_indicator_id
+      tag: set_event_id_from_indicator_id_d5f1eabd
       copy_from: ti_cyware_intel_exchange.indicator.id
       ignore_empty_value: true
   - rename:
       field: json.indicator_type.attribute_field
-      tag: rename_indicator_type_attribute_field
+      tag: rename_indicator_type_attribute_field_5cfe3e43
       target_field: ti_cyware_intel_exchange.indicator.indicator_type.attribute_field
       ignore_missing: true
   - rename:
       field: json.indicator_type.type
-      tag: rename_indicator_type_type
+      tag: rename_indicator_type_type_5b9f3183
       target_field: ti_cyware_intel_exchange.indicator.indicator_type.type
       ignore_missing: true
   - rename:
       field: json.ioc_type
-      tag: rename_ioc_type
+      tag: rename_ioc_type_c91fc20f
       target_field: ti_cyware_intel_exchange.indicator.ioc_type
       ignore_missing: true
   - set:
       field: threat.indicator.type
-      tag: set_threat_indicator_type_from_indicator_ioc_type
+      tag: set_threat_indicator_type_from_indicator_ioc_type_d9a1995e
       copy_from: ti_cyware_intel_exchange.indicator.ioc_type
       ignore_empty_value: true
   - convert:
       field: json.name
-      tag: convert_name_to_ip
+      tag: convert_name_to_ip_8769d0e7
       target_field: ti_cyware_intel_exchange.indicator.ip
       type: ip
       ignore_missing: true
       if: ctx.json?.name != ''
       on_failure:
         - rename:
-            tag: rename_json_name_to_ti_cyware_intel_exchange_indicator_name_1eb51e7a
+            tag: rename_json_name_to_ti_cyware_intel_exchange_indicator_name_e32c8b77
             field: json.name
             target_field: ti_cyware_intel_exchange.indicator.name
             ignore_missing: true
   - append:
       field: related.ip
-      tag: append_indicator_ip_into_related_ip
+      tag: append_indicator_ip_into_related_ip_572d3d3c
       value: '{{{ti_cyware_intel_exchange.indicator.ip}}}'
       allow_duplicates: false
       if: ctx.ti_cyware_intel_exchange?.indicator?.ip != null
   - convert:
       field: json.is_actioned
-      tag: convert_is_actioned_to_boolean
+      tag: convert_is_actioned_to_boolean_51e2709a
       target_field: ti_cyware_intel_exchange.indicator.is_actioned
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b42f62cb
+            tag: append_error_message_309218df
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_deprecated
-      tag: convert_is_deprecated_to_boolean
+      tag: convert_is_deprecated_to_boolean_c88389de
       target_field: ti_cyware_intel_exchange.indicator.is_deprecated
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f06af911
+            tag: append_error_message_050ebe74
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_false_positive
-      tag: convert_is_false_positive_to_boolean
+      tag: convert_is_false_positive_to_boolean_b9fcd534
       target_field: ti_cyware_intel_exchange.indicator.is_false_positive
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_754615eb
+            tag: append_error_message_7cce5ea5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_reviewed
-      tag: convert_is_reviewed_to_boolean
+      tag: convert_is_reviewed_to_boolean_82de3bc3
       target_field: ti_cyware_intel_exchange.indicator.is_reviewed
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_061b5045
+            tag: append_error_message_484e5393
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_revoked
-      tag: convert_is_revoked_to_boolean
+      tag: convert_is_revoked_to_boolean_92b2a6ec
       target_field: ti_cyware_intel_exchange.indicator.is_revoked
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_2ec4abd6
+            tag: append_error_message_1e96b549
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_whitelist
-      tag: convert_is_whitelist_to_boolean
+      tag: convert_is_whitelist_to_boolean_086400c9
       target_field: ti_cyware_intel_exchange.indicator.is_whitelist
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_42249443
+            tag: append_error_message_0b9da631
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.modified
-      tag: date_modified
+      tag: date_modified_ce2fd96b
       target_field: ti_cyware_intel_exchange.indicator.modified
       formats:
         - UNIX
       if: ctx.json?.modified != null && ctx.json.modified != ''
       on_failure:
         - append:
-            tag: append_error_message_afda5729
+            tag: append_error_message_0829ab16
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: threat.indicator.modified_at
-      tag: set_threat_indicator_modified_at_from_indicator_modified
+      tag: set_threat_indicator_modified_at_from_indicator_modified_95f03c56
       copy_from: ti_cyware_intel_exchange.indicator.modified
       ignore_empty_value: true
   - rename:
       field: json.report_types
-      tag: rename_report_types
+      tag: rename_report_types_cc6d7095
       target_field: ti_cyware_intel_exchange.indicator.report_types
       ignore_missing: true
   - convert:
       field: json.sdo_name
-      tag: convert_sdo_name_to_ip
+      tag: convert_sdo_name_to_ip_3469d5a7
       target_field: ti_cyware_intel_exchange.indicator.sdo_ip
       type: ip
       ignore_missing: true
       if: ctx.json?.sdo_name != ''
       on_failure:
         - rename:
-            tag: rename_json_sdo_name_to_ti_cyware_intel_exchange_indicator_sdo_name_5bd349d8
+            tag: rename_json_sdo_name_to_ti_cyware_intel_exchange_indicator_sdo_name_5a5bf6a7
             field: json.sdo_name
             target_field: ti_cyware_intel_exchange.indicator.sdo_name
             ignore_missing: true
   - append:
       field: threat.indicator.name
-      tag: append_ti_cyware_intel_exchange_indicator_sdo_name_into_threat_indicator_name
+      tag: append_ti_cyware_intel_exchange_indicator_sdo_name_into_threat_indicator_name_0f0a1023
       value: '{{{ti_cyware_intel_exchange.indicator.sdo_name}}}'
       allow_duplicates: false
       if: ctx.ti_cyware_intel_exchange?.indicator?.sdo_name != null
   - append:
       field: threat.indicator.ip
-      tag: append_ti_cyware_intel_exchange_indicator_sdo_ip_into_threat_indicator_ip
+      tag: append_ti_cyware_intel_exchange_indicator_sdo_ip_into_threat_indicator_ip_b369268c
       value: '{{{ti_cyware_intel_exchange.indicator.sdo_ip}}}'
       allow_duplicates: false
       if: ctx.ti_cyware_intel_exchange?.indicator?.sdo_ip != null
   - append:
       field: related.ip
-      tag: append_indicator_sdo_ip_into_related_ip
+      tag: append_indicator_sdo_ip_into_related_ip_23019865
       value: '{{{ti_cyware_intel_exchange.indicator.sdo_ip}}}'
       allow_duplicates: false
       if: ctx.ti_cyware_intel_exchange?.indicator?.sdo_ip != null
   - rename:
       field: json.sdo_type
-      tag: rename_sdo_type
+      tag: rename_sdo_type_4f1b9028
       target_field: ti_cyware_intel_exchange.indicator.sdo_type
       ignore_missing: true
   - rename:
       field: json.source_description
-      tag: rename_source_description
+      tag: rename_source_description_848249ee
       target_field: ti_cyware_intel_exchange.indicator.source_description
       ignore_missing: true
   - set:
       field: threat.indicator.description
-      tag: set_threat_indicator_description_from_indicator_source_description
+      tag: set_threat_indicator_description_from_indicator_source_description_70126eec
       copy_from: ti_cyware_intel_exchange.indicator.source_description
       ignore_empty_value: true
   - rename:
       field: json.source_tlp
-      tag: rename_source_tlp
+      tag: rename_source_tlp_9e425888
       target_field: ti_cyware_intel_exchange.indicator.source_tlp
       ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_sources_first_seen
+      tag: foreach_sources_first_seen_836c0bb6
       if: ctx.json?.sources instanceof List
       processor:
         date:
           field: _ingest._value.first_seen
-          tag: date_sources_first_seen
+          tag: date_sources_first_seen_5fcbc5b4
           target_field: _ingest._value.first_seen
           formats:
             - UNIX
           on_failure:
             - remove:
-                tag: remove_ingest_value_first_seen
+                tag: remove_ingest_value_first_seen_153c4810
                 field: _ingest._value.first_seen
                 ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_sources_first_seen_bb6d4acb
+      tag: foreach_sources_first_seen_a3e8ef92
       if: ctx.json?.sources instanceof List
       processor:
         append:
           field: threat.indicator.first_seen
-          tag: append_sources_first_seen_into_threat_indicator_first_seen
+          tag: append_sources_first_seen_into_threat_indicator_first_seen_3e3963a4
           value: '{{{_ingest._value.first_seen}}}'
           allow_duplicates: false
   - foreach:
       field: json.sources
-      tag: foreach_sources_last_seen
+      tag: foreach_sources_last_seen_6144690e
       if: ctx.json?.sources instanceof List
       processor:
         date:
           field: _ingest._value.last_seen
-          tag: date_sources_last_seen
+          tag: date_sources_last_seen_93cf02e3
           target_field: _ingest._value.last_seen
           formats:
             - UNIX
           on_failure:
             - remove:
-                tag: remove_ingest_value_last_seen
+                tag: remove_ingest_value_last_seen_f53d0f81
                 field: _ingest._value.last_seen
                 ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_sources_last_seen_055df765
+      tag: foreach_sources_last_seen_45a0a7e8
       if: ctx.json?.sources instanceof List
       processor:
         append:
           field: threat.indicator.last_seen
-          tag: append_sources_last_seen_into_threat_indicator_last_seen
+          tag: append_sources_last_seen_into_threat_indicator_last_seen_8136cd48
           value: '{{{_ingest._value.last_seen}}}'
           allow_duplicates: false
   - foreach:
       field: json.sources
-      tag: foreach_sources_name
+      tag: foreach_sources_name_0c7b66b5
       if: ctx.json?.sources instanceof List
       processor:
         append:
           field: threat.indicator.provider
-          tag: append_sources_name_into_threat_indicator_provider
+          tag: append_sources_name_into_threat_indicator_provider_565f1cc4
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
       field: json.sources
-      tag: foreach_sources_score
+      tag: foreach_sources_score_27a4c3e9
       if: ctx.json?.sources instanceof List
       processor:
         convert:
           field: _ingest._value.score
-          tag: convert_sources_score_to_long
+          tag: convert_sources_score_to_long_2c06d231
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_score
+                tag: remove_ingest_value_score_58395f2a
                 field: _ingest._value.score
                 ignore_missing: true
             - append:
-                tag: append_error_message
+                tag: append_error_message_94785693
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
       field: json.sources
-      tag: foreach_sources_tlp
+      tag: foreach_sources_tlp_56989ab3
       if: ctx.json?.sources instanceof List
       processor:
         append:
           field: threat.indicator.marking.tlp
-          tag: append_sources_tlp_into_threat_indicator_marking_tlp
+          tag: append_sources_tlp_into_threat_indicator_marking_tlp_7a544453
           value: '{{{_ingest._value.tlp}}}'
           allow_duplicates: false
   - rename:
       field: json.sources
-      tag: rename_sources
+      tag: rename_sources_7dc7d0c6
       target_field: ti_cyware_intel_exchange.indicator.sources
       ignore_missing: true
   - rename:
       field: json.tags
-      tag: rename_tags_to_tags_list
+      tag: rename_tags_to_tags_list_7da0f4bf
       target_field: ti_cyware_intel_exchange.indicator.tags_list
       if: ctx.json?.tags instanceof List
       ignore_missing: true
   - rename:
       field: json.tags
-      tag: rename_tags_to_tags_object
+      tag: rename_tags_to_tags_object_c32cbb51
       target_field: ti_cyware_intel_exchange.indicator.tags_object
       ignore_missing: true
       if: ctx.json?.tags instanceof Map
   - foreach:
       field: ti_cyware_intel_exchange.indicator.tags_list
-      tag: foreach_ti_cyware_intel_exchange_indicator_tags_list
+      tag: foreach_ti_cyware_intel_exchange_indicator_tags_list_4d815a13
       if: ctx.ti_cyware_intel_exchange?.indicator?.tags_list instanceof List
       processor:
         append:
           field: tags
-          tag: append_tags_list_into_tags
+          tag: append_tags_list_into_tags_eb376ce5
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.tlp_value
-      tag: rename_tlp_value
+      tag: rename_tlp_value_58479713
       target_field: ti_cyware_intel_exchange.indicator.tlp_value
       ignore_missing: true
   - date:
       field: json.valid_from
-      tag: date_valid_from
+      tag: date_valid_from_9ffdc926
       target_field: ti_cyware_intel_exchange.indicator.valid_from
       formats:
         - UNIX
       if: ctx.json?.valid_from != null && ctx.json.valid_from != ''
       on_failure:
         - append:
-            tag: append_error_message_8136d0b1
+            tag: append_error_message_5199d9f2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.valid_until
-      tag: date_valid_until
+      tag: date_valid_until_485e93c6
       target_field: ti_cyware_intel_exchange.indicator.valid_until
       formats:
         - UNIX
       if: ctx.json?.valid_until != null && ctx.json.valid_until != ''
       on_failure:
         - append:
-            tag: append_error_message_dd7cdcef
+            tag: append_error_message_8724f801
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   ######################
@@ -531,7 +531,7 @@ processors:
   ######################
   - script:
       lang: painless
-      tag: script-default-deleted_at
+      tag: script-default-deleted_at_96594798
       if: ctx.ti_cyware_intel_exchange?.indicator?.deleted_at == null && ctx._conf?.ioc_expiration_duration != null && (ctx._conf.ioc_expiration_duration instanceof String) && ctx._conf.ioc_expiration_duration != ''
       description: Indicator Expiration is done after `_conf.ioc_expiration_duration` (default 90d) since the indicator's ctix_modified time. This script adds a default `ti_cyware_intel_exchange.indicator.deleted_at` field to allow indicator expiration.
       source: >
@@ -560,24 +560,24 @@ processors:
         ctx.ti_cyware_intel_exchange.indicator.deleted_at = _tmp_deleted_at;
       on_failure:
         - append:
-            tag: append_error_message_1ae85c69
+            tag: append_error_message_fcdc0040
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: ti_cyware_intel_exchange.indicator.deleted_at
-      tag: date_deleted_at
+      tag: date_deleted_at_3eba8bfc
       target_field: ti_cyware_intel_exchange.indicator.deleted_at
       formats:
         - ISO8601
         - UNIX
   - rename:
       field: _conf.ioc_expiration_duration
-      tag: rename_conf_ioc_expiration_duration
+      tag: rename_conf_ioc_expiration_duration_35e757a6
       target_field: ti_cyware_intel_exchange.indicator.ioc_expiration_duration
       ignore_missing: true
   - foreach:
       field: ti_cyware_intel_exchange.indicator.sources
-      tag: foreach_ti_cyware_intel_exchange_indicator_sources
+      tag: foreach_ti_cyware_intel_exchange_indicator_sources_76c4fbb8
       if: ctx.ti_cyware_intel_exchange?.indicator?.sources instanceof List
       processor:
         remove:
@@ -586,7 +586,7 @@ processors:
             - _ingest._value.name
             - _ingest._value.last_seen
             - _ingest._value.first_seen
-          tag: remove_custom_duplicate_fields_from_ti_cyware_intel_exchange_indicator_sources
+          tag: remove_custom_duplicate_fields_from_ti_cyware_intel_exchange_indicator_sources_1bb49624
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
@@ -598,15 +598,15 @@ processors:
         - ti_cyware_intel_exchange.indicator.ioc_type
         - ti_cyware_intel_exchange.indicator.modified
         - ti_cyware_intel_exchange.indicator.source_description
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_b9147d91
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_7559f019
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |-
@@ -633,18 +633,18 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_7d89407f
+      tag: append_error_message_417e65c9
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -652,10 +652,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_cyware_intel_exchange/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cyware_intel_exchange/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -392,11 +392,12 @@ processors:
             - UNIX
           on_failure:
             - remove:
+                tag: remove_ingest_value_first_seen
                 field: _ingest._value.first_seen
                 ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_json_sources_bb6d4acb
+      tag: foreach_sources_first_seen_bb6d4acb
       if: ctx.json?.sources instanceof List
       processor:
         append:
@@ -417,11 +418,12 @@ processors:
             - UNIX
           on_failure:
             - remove:
+                tag: remove_ingest_value_last_seen
                 field: _ingest._value.last_seen
                 ignore_missing: true
   - foreach:
       field: json.sources
-      tag: foreach_json_sources_055df765
+      tag: foreach_sources_last_seen_055df765
       if: ctx.json?.sources instanceof List
       processor:
         append:
@@ -451,9 +453,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_score
                 field: _ingest._value.score
                 ignore_missing: true
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -640,6 +644,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_7d89407f
       field: error.message
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -650,6 +655,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_cyware_intel_exchange/manifest.yml
+++ b/packages/ti_cyware_intel_exchange/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_cyware_intel_exchange
 title: Cyware Intel Exchange
-version: 0.4.3
+version: 0.5.0
 description: Collect logs from Cyware Intel Exchange with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]

--- a/packages/ti_cyware_intel_exchange/manifest.yml
+++ b/packages/ti_cyware_intel_exchange/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_cyware_intel_exchange
 title: Cyware Intel Exchange
-version: 0.4.2
+version: 0.4.3
 description: Collect logs from Cyware Intel Exchange with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]

--- a/packages/ti_greynoise/changelog.yml
+++ b/packages/ti_greynoise/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.9.4"
+- version: "0.10.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/ti_greynoise/changelog.yml
+++ b/packages/ti_greynoise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.4"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.9.3"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/ti_greynoise/changelog.yml
+++ b/packages/ti_greynoise/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.9.3"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
@@ -3,15 +3,15 @@ description: Pipeline for processing ip logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - drop:
       if: ctx.message == 'retry'
-      tag: drop_retry_events
+      tag: drop_retry_events_1f05010a
   - remove:
       field:
         - organization
@@ -19,184 +19,184 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
       fields:
         - json.ip
         - json.internet_scanner_intelligence.last_seen_timestamp
-      tag: fingerprint_ip
+      tag: fingerprint_ip_1651e2e5
       target_field: _id
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_event_kind_to_enrichment
+      tag: set_event_kind_to_enrichment_3410a97a
       value: enrichment
   - append:
       field: event.category
-      tag: append_event_category
+      tag: append_event_category_4039b90d
       value: threat
   - append:
       field: event.type
-      tag: append_event_type
+      tag: append_event_type_d4da06cc
       value: indicator
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_1b3fbbe2
       value: Threat Intelligence
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_f5e077d1
       value: GreyNoise
   - rename:
       field: json.ip
-      tag: rename_ip
+      tag: rename_ip_268915d2
       target_field: threat.indicator.ip
       ignore_missing: true
   - set:
       field: greynoise.ip.indicator.ip
-      tag: set_indicator_ip
+      tag: set_indicator_ip_5729433b
       copy_from: threat.indicator.ip
       ignore_empty_value: true
   - set:
       field: threat.indicator.name
-      tag: set_threat_indicator_name
+      tag: set_threat_indicator_name_754c9cb2
       copy_from: threat.indicator.ip
       ignore_empty_value: true
   - convert:
       field: json.business_service_intelligence.found
-      tag: convert_business_service_intelligence_found_to_boolean
+      tag: convert_business_service_intelligence_found_to_boolean_e08b8a3a
       target_field: greynoise.ip.business_service_intelligence.found
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_a8154e27
+            tag: append_error_message_e6fbccb1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.business_service_intelligence.category
-      tag: rename_business_service_intelligence_category
+      tag: rename_business_service_intelligence_category_84fc3f1d
       target_field: greynoise.ip.business_service_intelligence.category
       ignore_missing: true
   - rename:
       field: json.business_service_intelligence.description
-      tag: rename_business_service_intelligence_description
+      tag: rename_business_service_intelligence_description_1ce665d6
       target_field: greynoise.ip.business_service_intelligence.description
       ignore_missing: true
   - rename:
       field: json.business_service_intelligence.explanation
-      tag: rename_business_service_intelligence_explanation
+      tag: rename_business_service_intelligence_explanation_223603f9
       target_field: greynoise.ip.business_service_intelligence.explanation
       ignore_missing: true
   - date:
       field: json.business_service_intelligence.last_updated
-      tag: date_business_service_intelligence_last_updated
+      tag: date_business_service_intelligence_last_updated_9b8bb192
       target_field: greynoise.ip.business_service_intelligence.last_updated
       formats:
         - yyyy-MM-dd'T'HH:mm:ss'Z'
       if: ctx.json?.business_service_intelligence?.last_updated != null && ctx.json.business_service_intelligence.last_updated != ''
       on_failure:
         - append:
-            tag: append_error_message_34b0379d
+            tag: append_error_message_d6cfc13e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.business_service_intelligence.name
-      tag: rename_business_service_intelligence_name
+      tag: rename_business_service_intelligence_name_377d066c
       target_field: greynoise.ip.business_service_intelligence.name
       ignore_missing: true
   - rename:
       field: json.business_service_intelligence.reference
-      tag: rename_business_service_intelligence_reference
+      tag: rename_business_service_intelligence_reference_5ac5a3d2
       target_field: greynoise.ip.business_service_intelligence.reference
       ignore_missing: true
   - set:
       field: threat.indicator.url.full
-      tag: set_threat_indicator_url_full
+      tag: set_threat_indicator_url_full_daa8d84d
       copy_from: greynoise.ip.business_service_intelligence.reference
       ignore_empty_value: true
   - rename:
       field: json.business_service_intelligence.trust_level
-      tag: rename_business_service_intelligence_trust_level
+      tag: rename_business_service_intelligence_trust_level_85a6ddcb
       target_field: greynoise.ip.business_service_intelligence.trust_level
       ignore_missing: true
   - rename:
       field: json.internet_scanner_intelligence.actor
-      tag: rename_internet_scanner_intelligence_actor
+      tag: rename_internet_scanner_intelligence_actor_5503a8df
       target_field: greynoise.ip.internet_scanner_intelligence.actor
       ignore_missing: true
   - set:
       field: organization.name
-      tag: set_organization_name_from_ip_internet_scanner_intelligence_actor
+      tag: set_organization_name_from_ip_internet_scanner_intelligence_actor_ff62ec1d
       copy_from: greynoise.ip.internet_scanner_intelligence.actor
       ignore_empty_value: true
   - convert:
       field: json.internet_scanner_intelligence.bot
-      tag: convert_internet_scanner_intelligence_bot_to_boolean
+      tag: convert_internet_scanner_intelligence_bot_to_boolean_ed563d75
       target_field: greynoise.ip.internet_scanner_intelligence.bot
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_609e00a8
+            tag: append_error_message_ffe3c3dd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.internet_scanner_intelligence.classification
-      tag: rename_internet_scanner_intelligence_classification
+      tag: rename_internet_scanner_intelligence_classification_cf4b3256
       target_field: greynoise.ip.internet_scanner_intelligence.classification
       ignore_missing: true
   - convert:
       field: json.internet_scanner_intelligence.found
-      tag: convert_internet_scanner_intelligence_found_to_boolean
+      tag: convert_internet_scanner_intelligence_found_to_boolean_bacbc3ce
       target_field: greynoise.ip.internet_scanner_intelligence.found
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_e634be79
+            tag: append_error_message_cb8a3bd3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.internet_scanner_intelligence.last_seen
-      tag: date_internet_scanner_intelligence_last_seen
+      tag: date_internet_scanner_intelligence_last_seen_aa6a3d49
       target_field: greynoise.ip.internet_scanner_intelligence.last_seen
       formats:
         - yyyy-MM-dd
       if: ctx.json?.internet_scanner_intelligence?.last_seen != null && ctx.json.internet_scanner_intelligence.last_seen != ''
       on_failure:
         - append:
-            tag: append_error_message_4d5bfd01
+            tag: append_error_message_ee7fb58f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.internet_scanner_intelligence.last_seen_timestamp
-      tag: date_internet_scanner_intelligence_last_seen_timestamp
+      tag: date_internet_scanner_intelligence_last_seen_timestamp_9da4028c
       target_field: greynoise.ip.internet_scanner_intelligence.last_seen_timestamp
       formats:
         - yyyy-MM-dd HH:mm:ss
@@ -204,26 +204,26 @@ processors:
       if: ctx.json?.internet_scanner_intelligence?.last_seen_timestamp != null && ctx.json.internet_scanner_intelligence.last_seen_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_22202546
+            tag: append_error_message_06da2ffb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_ip_internet_scanner_intelligence_last_seen_timestamp
+      tag: set_@timestamp_from_ip_internet_scanner_intelligence_last_seen_timestamp_9a61dee4
       copy_from: greynoise.ip.internet_scanner_intelligence.last_seen_timestamp
       ignore_empty_value: true
   - set:
       field: threat.indicator.last_seen
-      tag: set_threat_indicator_last_seen_from_ip_internet_scanner_intelligence_last_seen_timestamp
+      tag: set_threat_indicator_last_seen_from_ip_internet_scanner_intelligence_last_seen_timestamp_a130ae4f
       copy_from: greynoise.ip.internet_scanner_intelligence.last_seen_timestamp
       ignore_empty_value: true
   - rename:
       field: json.internet_scanner_intelligence.metadata.asn
-      tag: rename_internet_scanner_intelligence_metadata_asn
+      tag: rename_internet_scanner_intelligence_metadata_asn_d294ba7e
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.asn
       ignore_missing: true
   - gsub:
-      tag: gsub_greynoise_ip_internet_scanner_intelligence_metadata_asn_to_threat_indicator_as_number_a8b7373b
+      tag: gsub_greynoise_ip_internet_scanner_intelligence_metadata_asn_to_threat_indicator_as_number_d60dc398
       field: greynoise.ip.internet_scanner_intelligence.metadata.asn
       target_field: threat.indicator.as.number
       pattern: 'AS'
@@ -231,158 +231,158 @@ processors:
       if: ctx.greynoise?.ip?.internet_scanner_intelligence?.metadata?.asn != null && ctx.greynoise.ip.internet_scanner_intelligence.metadata.asn != ''
   - convert:
       field: threat.indicator.as.number
-      tag: convert_threat_indicator_as_number
+      tag: convert_threat_indicator_as_number_69f78850
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_98a16d98
+            tag: append_error_message_6ad17b67
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
         - remove:
-            tag: remove_threat_indicator_as_number_80cd56a8
+            tag: remove_threat_indicator_as_number_860ff97d
             field: threat.indicator.as.number
   - rename:
       field: json.internet_scanner_intelligence.metadata.category
-      tag: rename_internet_scanner_intelligence_metadata_category
+      tag: rename_internet_scanner_intelligence_metadata_category_d522cbcf
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.category
       ignore_missing: true
   - convert:
       field: json.internet_scanner_intelligence.metadata.mobile
-      tag: convert_internet_scanner_intelligence_metadata_mobile_to_boolean
+      tag: convert_internet_scanner_intelligence_metadata_mobile_to_boolean_b2444528
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.mobile
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_58bd188f
+            tag: append_error_message_cd394212
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.internet_scanner_intelligence.metadata.organization
-      tag: rename_internet_scanner_intelligence_metadata_organization
+      tag: rename_internet_scanner_intelligence_metadata_organization_536963fe
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.organization
       ignore_missing: true
   - set:
       field: threat.indicator.as.organization.name
-      tag: set_threat_indicator_as_organization_name_from_ip_internet_scanner_intelligence_metadata_organization
+      tag: set_threat_indicator_as_organization_name_from_ip_internet_scanner_intelligence_metadata_organization_a97613ff
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.organization
       ignore_empty_value: true
   - rename:
       field: json.internet_scanner_intelligence.metadata.rdns
-      tag: rename_internet_scanner_intelligence_metadata_rdns
+      tag: rename_internet_scanner_intelligence_metadata_rdns_74e0a334
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.rdns
       ignore_missing: true
   - rename:
       field: json.internet_scanner_intelligence.metadata.region
-      tag: rename_internet_scanner_intelligence_metadata_region
+      tag: rename_internet_scanner_intelligence_metadata_region_4ed45673
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.region
       ignore_missing: true
   - set:
       field: threat.indicator.geo.region_name
-      tag: set_threat_indicator_geo_region_name_from_ip_internet_scanner_intelligence_metadata_region
+      tag: set_threat_indicator_geo_region_name_from_ip_internet_scanner_intelligence_metadata_region_8ac003e5
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.region
       ignore_empty_value: true
   - rename:
       field: json.internet_scanner_intelligence.metadata.source_city
-      tag: rename_internet_scanner_intelligence_metadata_source_city
+      tag: rename_internet_scanner_intelligence_metadata_source_city_e38a89d7
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.source_city
       ignore_missing: true
   - set:
       field: threat.indicator.geo.city_name
-      tag: set_threat_indicator_geo_city_name_from_ip_internet_scanner_intelligence_metadata_source_city
+      tag: set_threat_indicator_geo_city_name_from_ip_internet_scanner_intelligence_metadata_source_city_d7196cf2
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.source_city
       ignore_empty_value: true
   - rename:
       field: json.internet_scanner_intelligence.metadata.source_country
-      tag: rename_internet_scanner_intelligence_metadata_source_country
+      tag: rename_internet_scanner_intelligence_metadata_source_country_a8cd6b5b
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.source_country
       ignore_missing: true
   - set:
       field: threat.indicator.geo.country_name
-      tag: set_threat_indicator_geo_country_name_from_ip_internet_scanner_intelligence_metadata_source_country
+      tag: set_threat_indicator_geo_country_name_from_ip_internet_scanner_intelligence_metadata_source_country_b2bc01ef
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.source_country
       ignore_empty_value: true
   - rename:
       field: json.internet_scanner_intelligence.metadata.source_country_code
-      tag: rename_internet_scanner_intelligence_metadata_source_country_code
+      tag: rename_internet_scanner_intelligence_metadata_source_country_code_6b562b7e
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.source_country_code
       ignore_missing: true
   - set:
       field: threat.indicator.geo.country_iso_code
-      tag: set_threat_indicator_geo_country_iso_code_from_ip_internet_scanner_intelligence_metadata_source_country_code
+      tag: set_threat_indicator_geo_country_iso_code_from_ip_internet_scanner_intelligence_metadata_source_country_code_95cc2fc5
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.source_country_code
       ignore_empty_value: true
   - convert:
       field: json.internet_scanner_intelligence.spoofable
-      tag: convert_internet_scanner_intelligence_spoofable_to_boolean
+      tag: convert_internet_scanner_intelligence_spoofable_to_boolean_44fd2792
       target_field: greynoise.ip.internet_scanner_intelligence.spoofable
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_ee717e58
+            tag: append_error_message_5b31a761
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_internet_scanner_intelligence_tags_efbc068a
+      tag: foreach_json_internet_scanner_intelligence_tags_d0109995
       field: json.internet_scanner_intelligence.tags
       if: ctx.json?.internet_scanner_intelligence?.tags instanceof List
       processor:
         append:
           field: greynoise.ip.internet_scanner_intelligence.tag.names
-          tag: append_internet_scanner_intelligence_tag_names
+          tag: append_internet_scanner_intelligence_tag_names_78b5d65f
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_greynoise_ip_internet_scanner_intelligence_tag_names_5fd52255
+      tag: foreach_greynoise_ip_internet_scanner_intelligence_tag_names_d99a3557
       field: greynoise.ip.internet_scanner_intelligence.tag.names
       if: ctx.greynoise?.ip?.internet_scanner_intelligence?.tag?.names instanceof List
       processor:
         append:
           field: tags
-          tag: append_tags
+          tag: append_tags_0a6c2d9a
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - convert:
       field: json.internet_scanner_intelligence.tor
-      tag: convert_internet_scanner_intelligence_tor_to_boolean
+      tag: convert_internet_scanner_intelligence_tor_to_boolean_7f76a778
       target_field: greynoise.ip.internet_scanner_intelligence.tor
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_414373e4
+            tag: append_error_message_e2220f90
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.internet_scanner_intelligence.vpn
-      tag: convert_internet_scanner_intelligence_vpn_to_boolean
+      tag: convert_internet_scanner_intelligence_vpn_to_boolean_2d9e6184
       target_field: greynoise.ip.internet_scanner_intelligence.vpn
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_223c1b15
+            tag: append_error_message_e93832fb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.internet_scanner_intelligence.vpn_service
-      tag: rename_internet_scanner_intelligence_vpn_service
+      tag: rename_internet_scanner_intelligence_vpn_service_ae32873b
       target_field: greynoise.ip.internet_scanner_intelligence.vpn_service
       ignore_missing: true
   - set:
       field: threat.indicator.reference
-      tag: set_threat_indicator_reference_from_ip_internet_scanner_intelligence_ip
+      tag: set_threat_indicator_reference_from_ip_internet_scanner_intelligence_ip_d5c7a4f7
       value: 'https://www.greynoise.io/ip/{{{threat.indicator.ip}}}'
       if: ctx.threat?.indicator?.ip != null && ctx.threat.indicator.ip != ''
   - set:
       field: threat.indicator.provider
-      tag: set_threat_indicator_provider
+      tag: set_threat_indicator_provider_594f8887
       value: GreyNoise
   - set:
       field: threat.indicator.description
-      tag: set_threat_indicator_description
+      tag: set_threat_indicator_description_32aca49b
       value: '{{{threat.indicator.ip}}} IP has been observed mass scanning the internet by GreyNoise with a classification of {{{greynoise.ip.internet_scanner_intelligence.classification}}}'
       if: >-
         ctx.threat?.indicator?.ip != null &&
@@ -391,32 +391,32 @@ processors:
         ctx.greynoise.ip.internet_scanner_intelligence.classification != ''
   - set:
       field: threat.indicator.type
-      tag: set_threat_indicator_type
+      tag: set_threat_indicator_type_08395b94
       value: ipv4-addr
   - set:
       field: threat.feed.description
-      tag: set_threat_feed_description
+      tag: set_threat_feed_description_c96789f2
       value: 'Threat feed from the GreyNoise cybersecurity platform'
   - set:
       field: threat.feed.name
-      tag: set_threat_feed_name
+      tag: set_threat_feed_name_2cf27abf
       value: 'GreyNoise IP'
   - set:
       field: threat.feed.reference
-      tag: set_threat_feed_provider
+      tag: set_threat_feed_provider_7f77d1af
       value: 'https://docs.greynoise.io/docs/using-greynoise-as-an-indicator-feed'
   - append:
       field: related.ip
-      tag: append_threat_indicator_ip_into_related_ip
+      tag: append_threat_indicator_ip_into_related_ip_d57eade3
       value: '{{{threat.indicator.ip}}}'
       allow_duplicates: false
       if: ctx.threat?.indicator?.ip != null && ctx.threat.indicator.ip != ''
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_f6a89620
       lang: painless
       description: Drops null/empty values recursively.
       source: |-
@@ -435,18 +435,18 @@ processors:
         drop(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -454,10 +454,10 @@ on_failure:
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags_fbf50489
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
@@ -446,6 +446,7 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -456,6 +457,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags_fbf50489
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_greynoise/data_stream/ip/elasticsearch/ingest_pipeline/default.yml
@@ -42,6 +42,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -94,6 +95,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a8154e27
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -120,6 +122,7 @@ processors:
       if: ctx.json?.business_service_intelligence?.last_updated != null && ctx.json.business_service_intelligence.last_updated != ''
       on_failure:
         - append:
+            tag: append_error_message_34b0379d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -160,6 +163,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_609e00a8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -175,6 +179,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e634be79
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -186,6 +191,7 @@ processors:
       if: ctx.json?.internet_scanner_intelligence?.last_seen != null && ctx.json.internet_scanner_intelligence.last_seen != ''
       on_failure:
         - append:
+            tag: append_error_message_4d5bfd01
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -198,6 +204,7 @@ processors:
       if: ctx.json?.internet_scanner_intelligence?.last_seen_timestamp != null && ctx.json.internet_scanner_intelligence.last_seen_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_22202546
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -216,6 +223,7 @@ processors:
       target_field: greynoise.ip.internet_scanner_intelligence.metadata.asn
       ignore_missing: true
   - gsub:
+      tag: gsub_greynoise_ip_internet_scanner_intelligence_metadata_asn_to_threat_indicator_as_number_a8b7373b
       field: greynoise.ip.internet_scanner_intelligence.metadata.asn
       target_field: threat.indicator.as.number
       pattern: 'AS'
@@ -228,9 +236,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_98a16d98
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
         - remove:
+            tag: remove_threat_indicator_as_number_80cd56a8
             field: threat.indicator.as.number
   - rename:
       field: json.internet_scanner_intelligence.metadata.category
@@ -245,6 +255,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_58bd188f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -310,9 +321,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ee717e58
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_internet_scanner_intelligence_tags_efbc068a
       field: json.internet_scanner_intelligence.tags
       if: ctx.json?.internet_scanner_intelligence?.tags instanceof List
       processor:
@@ -322,6 +335,7 @@ processors:
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_greynoise_ip_internet_scanner_intelligence_tag_names_5fd52255
       field: greynoise.ip.internet_scanner_intelligence.tag.names
       if: ctx.greynoise?.ip?.internet_scanner_intelligence?.tag?.names instanceof List
       processor:
@@ -338,6 +352,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_414373e4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -348,6 +363,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_223c1b15
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -423,6 +439,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_greynoise/elasticsearch/ingest_pipeline/ti_greynoise-correlation_detection_rule-pipeline.yml
+++ b/packages/ti_greynoise/elasticsearch/ingest_pipeline/ti_greynoise-correlation_detection_rule-pipeline.yml
@@ -2,7 +2,7 @@
 description: Pipeline for processing detected IOC events from the user's environment.
 processors:
   - script:
-      tag: script_9114740c
+      tag: script_store_first_matched_indicator_object_from_alert_comes_9114740c
       lang: painless
       if: ctx.threat?.enrichments != null;
       description: Store the first 'matched' and 'indicator' object from the alert, as it comes from GreyNoise API.
@@ -202,7 +202,7 @@ processors:
       ignore_missing: true
   - convert:
       field: threat.indicator.as.number
-      tag: convert_internet_scanner_intelligence_metadata_mobile_to_boolean_05e467e1
+      tag: convert_threat_indicator_as_number_to_long_05e467e1
       type: long
       ignore_missing: true
       on_failure:

--- a/packages/ti_greynoise/elasticsearch/ingest_pipeline/ti_greynoise-correlation_detection_rule-pipeline.yml
+++ b/packages/ti_greynoise/elasticsearch/ingest_pipeline/ti_greynoise-correlation_detection_rule-pipeline.yml
@@ -2,7 +2,7 @@
 description: Pipeline for processing detected IOC events from the user's environment.
 processors:
   - script:
-      tag: script
+      tag: script_9114740c
       lang: painless
       if: ctx.threat?.enrichments != null;
       description: Store the first 'matched' and 'indicator' object from the alert, as it comes from GreyNoise API.
@@ -15,7 +15,7 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message
+            tag: append_error_message_170c20a2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 # Retain event.dataset and event.module from the matched source index in temp_fields,
@@ -23,17 +23,17 @@ processors:
 # and are essential for navigating to the corresponding document.
   - rename:
       field: event.dataset
-      tag: keep_event_dataset_from_alert
+      tag: keep_event_dataset_from_alert_c6c0ad3d
       target_field: temp_fields.dataset
       ignore_missing: true
   - rename:
       field: event.module
-      tag: keep_event_module_from_alert
+      tag: keep_event_module_from_alert_0b3ed9f0
       target_field: temp_fields.module
       ignore_missing: true
   - script:
       lang: painless
-      tag: remove_unwanted_fields
+      tag: remove_unwanted_fields_cc8a8a78
       source: |-
         // Define the list of fields to retain
         def fieldsToKeep = ["@timestamp"];
@@ -50,151 +50,151 @@ processors:
         }
       on_failure:
         - append:
-            tag: append_error_message_c8631e7c
+            tag: append_error_message_d139d48f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 # Define hardcoded values required for processing.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - set:
       field: event.kind
-      tag: set_event_kind_to_event
+      tag: set_event_kind_to_event_d452ef2c
       value: event
   - append:
       field: event.category
-      tag: append_event_category
+      tag: append_event_category_4039b90d
       value: threat
   - append:
       field: event.type
-      tag: append_event_type
+      tag: append_event_type_d4da06cc
       value: indicator
   - set:
       field: observer.vendor
-      tag: set_observer_vendor
+      tag: set_observer_vendor_f5e077d1
       value: GreyNoise
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_1b3fbbe2
       value: Threat Intelligence
   - set:
       field: data_stream.dataset
-      tag: set_data_stream_dataset
+      tag: set_data_stream_dataset_25d0eb96
       value: ti_greynoise.enriched_ioc
   - set:
       field: event.dataset
-      tag: set_event_dataset
+      tag: set_event_dataset_772c8ad6
       value: ti_greynoise.enriched_ioc
 # Extract relevant fields from temp_fields and map them to threat.indicator.
   - rename:
       field: temp_fields.indicator
-      tag: rename_temp_fields_to_indicator
+      tag: rename_temp_fields_to_indicator_5d947779
       target_field: greynoise.ip
       ignore_missing: true
   - set:
       field: threat.indicator.ip
-      tag: set_indicator_ip
+      tag: set_indicator_ip_f1f281c4
       copy_from: greynoise.ip.indicator.ip
       ignore_empty_value: true
   - set:
       field: threat.indicator.name
-      tag: set_threat_indicator_name
+      tag: set_threat_indicator_name_754c9cb2
       copy_from: threat.indicator.ip
       ignore_empty_value: true
   - set:
       field: threat.indicator.url.full
-      tag: set_threat_indicator_url_full
+      tag: set_threat_indicator_url_full_daa8d84d
       copy_from: greynoise.ip.business_service_intelligence.reference
       ignore_empty_value: true
   - set:
       field: threat.indicator.as.organization.name
-      tag: set_threat_indicator_as_organization_name_from_ip_internet_scanner_intelligence_metadata_organization
+      tag: set_threat_indicator_as_organization_name_from_ip_internet_scanner_intelligence_metadata_organization_a97613ff
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.organization
       ignore_empty_value: true
   - set:
       field: organization.name
-      tag: set_organization_name_from_ip_internet_scanner_intelligence_actor
+      tag: set_organization_name_from_ip_internet_scanner_intelligence_actor_ff62ec1d
       copy_from: greynoise.ip.internet_scanner_intelligence.actor
       ignore_empty_value: true
   - set:
       field: threat.indicator.geo.region_name
-      tag: set_threat_indicator_geo_region_name_from_ip_internet_scanner_intelligence_metadata_region
+      tag: set_threat_indicator_geo_region_name_from_ip_internet_scanner_intelligence_metadata_region_8ac003e5
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.region
       ignore_empty_value: true
   - set:
       field: threat.indicator.geo.city_name
-      tag: set_threat_indicator_geo_city_name_from_ip_internet_scanner_intelligence_metadata_source_city
+      tag: set_threat_indicator_geo_city_name_from_ip_internet_scanner_intelligence_metadata_source_city_d7196cf2
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.source_city
       ignore_empty_value: true
   - set:
       field: threat.indicator.geo.country_name
-      tag: set_threat_indicator_geo_country_name_from_ip_internet_scanner_intelligence_metadata_source_country
+      tag: set_threat_indicator_geo_country_name_from_ip_internet_scanner_intelligence_metadata_source_country_b2bc01ef
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.source_country
       ignore_empty_value: true
   - set:
       field: threat.indicator.geo.country_iso_code
-      tag: set_threat_indicator_geo_country_iso_code_from_ip_internet_scanner_intelligence_metadata_source_country_code
+      tag: set_threat_indicator_geo_country_iso_code_from_ip_internet_scanner_intelligence_metadata_source_country_code_95cc2fc5
       copy_from: greynoise.ip.internet_scanner_intelligence.metadata.source_country_code
       ignore_empty_value: true
   - set:
       field: threat.indicator.reference
-      tag: set_threat_indicator_reference_from_ip_internet_scanner_intelligence_ip
+      tag: set_threat_indicator_reference_from_ip_internet_scanner_intelligence_ip_28b197e9
       value: 'https://www.greynoise.io/ip/{{{threat.indicator.ip}}}'
       if: ctx.threat?.indicator?.ip != null && ctx.threat?.indicator?.ip != ''
   - set:
       field: threat.indicator.provider
-      tag: set_threat_indicator_provider
+      tag: set_threat_indicator_provider_594f8887
       value: GreyNoise
   - set:
       field: threat.indicator.description
-      tag: set_threat_indicator_description
+      tag: set_threat_indicator_description_519d03e8
       value: '{{{threat.indicator.ip}}} IP has been observed mass scanning the internet by GreyNoise with a classification of {{{greynoise.ip.internet_scanner_intelligence.classification}}}'
       if: ctx.threat?.indicator?.ip != null && ctx.threat?.indicator?.ip != '' && ctx.greynoise?.ip?.internet_scanner_intelligence?.classification != null && ctx.greynoise?.ip?.internet_scanner_intelligence?.classification != ''
   - set:
       field: threat.indicator.type
-      tag: set_threat_indicator_type
+      tag: set_threat_indicator_type_08395b94
       value: ipv4-addr
   - set:
       field: threat.feed.description
-      tag: set_threat_feed_description
+      tag: set_threat_feed_description_c96789f2
       value: 'Threat feed from the GreyNoise cybersecurity platform'
   - set:
       field: threat.feed.name
-      tag: set_threat_feed_name
+      tag: set_threat_feed_name_2cf27abf
       value: 'GreyNoise IP'
   - set:
       field: threat.feed.reference
-      tag: set_threat_feed_provider
+      tag: set_threat_feed_provider_7f77d1af
       value: 'https://docs.greynoise.io/docs/using-greynoise-as-an-indicator-feed'
   - append:
       field: related.ip
-      tag: append_threat_indicator_ip_into_related_ip
+      tag: append_threat_indicator_ip_into_related_ip_bd39017a
       value: '{{{threat.indicator.ip}}}'
       allow_duplicates: false
       if: ctx.threat?.indicator?.ip != null && ctx.threat?.indicator?.ip != ''
   - rename:
       field: temp_fields.matched.atomic
-      tag: rename_temp_fields_to_matched_value
+      tag: rename_temp_fields_to_matched_value_6e3f5654
       target_field: threat.indicator.matched.value
       ignore_missing: true
   - rename:
       field: temp_fields.matched.field
-      tag: rename_temp_fields_to_matched_field
+      tag: rename_temp_fields_to_matched_field_fb4be5e5
       target_field: threat.indicator.matched.field
       ignore_missing: true
   - rename:
       field: temp_fields.dataset
-      tag: rename_temp_fields_to_matched_field_b298d715
+      tag: rename_temp_fields_to_matched_field_036d5f5c
       target_field: threat.indicator.matched.dataset
       ignore_missing: true
   - rename:
       field: temp_fields.module
-      tag: rename_temp_fields_to_matched_field_d974fcd0
+      tag: rename_temp_fields_to_matched_field_4eaa91cf
       target_field: threat.indicator.matched.module
       ignore_missing: true
   - gsub:
-      tag: gsub_greynoise_ip_internet_scanner_intelligence_metadata_asn_to_threat_indicator_as_number
+      tag: gsub_greynoise_ip_internet_scanner_intelligence_metadata_asn_to_threat_indicator_as_number_6545f8a8
       field: greynoise.ip.internet_scanner_intelligence.metadata.asn
       target_field: threat.indicator.as.number
       pattern: 'AS'
@@ -202,67 +202,67 @@ processors:
       ignore_missing: true
   - convert:
       field: threat.indicator.as.number
-      tag: convert_internet_scanner_intelligence_metadata_mobile_to_boolean
+      tag: convert_internet_scanner_intelligence_metadata_mobile_to_boolean_05e467e1
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_210030f4
+            tag: append_error_message_638fb0d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_greynoise_ip_internet_scanner_intelligence_tag_names
+      tag: foreach_greynoise_ip_internet_scanner_intelligence_tag_names_d99a3557
       field: greynoise.ip.internet_scanner_intelligence.tag.names
       if: ctx.greynoise?.ip?.internet_scanner_intelligence?.tag?.names instanceof List
       processor:
         append:
           field: tags
-          tag: append_tags
+          tag: append_tags_0a6c2d9a
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
 # Create ECS-compliant mappings for threat.indicator fields.
   - append:
       field: related.ip
-      tag: append_ip_into_related_ip
+      tag: append_ip_into_related_ip_f6bb2e5f
       value: '{{{threat.indicator.ip}}}'
       allow_duplicates: false
       if: ctx.threat?.indicator?.ip != null
   - set:
       field: event.created
-      tag: set_greynoise_enriched_ioc_event_created
+      tag: set_greynoise_enriched_ioc_event_created_a33d4249
       copy_from: threat.indicator.created
       ignore_empty_value: true
   - set:
       field: event.ingested
-      tag: set_event_ingested_as_timestamp
+      tag: set_event_ingested_as_timestamp_6108544a
       copy_from: '@timestamp'
       ignore_empty_value: true
   - remove:
       field: temp_fields
-      tag: remove_temp_fields
+      tag: remove_temp_fields_82ce2669
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_3e20ead6
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_48b0633f
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags_a71abfd4
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_greynoise/elasticsearch/ingest_pipeline/ti_greynoise-correlation_detection_rule-pipeline.yml
+++ b/packages/ti_greynoise/elasticsearch/ingest_pipeline/ti_greynoise-correlation_detection_rule-pipeline.yml
@@ -2,6 +2,7 @@
 description: Pipeline for processing detected IOC events from the user's environment.
 processors:
   - script:
+      tag: script
       lang: painless
       if: ctx.threat?.enrichments != null;
       description: Store the first 'matched' and 'indicator' object from the alert, as it comes from GreyNoise API.
@@ -14,6 +15,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 # Retain event.dataset and event.module from the matched source index in temp_fields,
@@ -21,12 +23,12 @@ processors:
 # and are essential for navigating to the corresponding document.
   - rename:
       field: event.dataset
-      tag : keep_event_dataset_from_alert
+      tag: keep_event_dataset_from_alert
       target_field: temp_fields.dataset
       ignore_missing: true
   - rename:
       field: event.module
-      tag : keep_event_module_from_alert
+      tag: keep_event_module_from_alert
       target_field: temp_fields.module
       ignore_missing: true
   - script:
@@ -48,6 +50,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_c8631e7c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 # Define hardcoded values required for processing.
@@ -86,7 +89,7 @@ processors:
 # Extract relevant fields from temp_fields and map them to threat.indicator.
   - rename:
       field: temp_fields.indicator
-      tag : rename_temp_fields_to_indicator
+      tag: rename_temp_fields_to_indicator
       target_field: greynoise.ip
       ignore_missing: true
   - set:
@@ -172,25 +175,26 @@ processors:
       if: ctx.threat?.indicator?.ip != null && ctx.threat?.indicator?.ip != ''
   - rename:
       field: temp_fields.matched.atomic
-      tag : rename_temp_fields_to_matched_value
+      tag: rename_temp_fields_to_matched_value
       target_field: threat.indicator.matched.value
       ignore_missing: true
   - rename:
       field: temp_fields.matched.field
-      tag : rename_temp_fields_to_matched_field
+      tag: rename_temp_fields_to_matched_field
       target_field: threat.indicator.matched.field
       ignore_missing: true
   - rename:
       field: temp_fields.dataset
-      tag : rename_temp_fields_to_matched_field
+      tag: rename_temp_fields_to_matched_field_b298d715
       target_field: threat.indicator.matched.dataset
       ignore_missing: true
   - rename:
       field: temp_fields.module
-      tag : rename_temp_fields_to_matched_field
+      tag: rename_temp_fields_to_matched_field_d974fcd0
       target_field: threat.indicator.matched.module
       ignore_missing: true
   - gsub:
+      tag: gsub_greynoise_ip_internet_scanner_intelligence_metadata_asn_to_threat_indicator_as_number
       field: greynoise.ip.internet_scanner_intelligence.metadata.asn
       target_field: threat.indicator.as.number
       pattern: 'AS'
@@ -203,9 +207,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_210030f4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_greynoise_ip_internet_scanner_intelligence_tag_names
       field: greynoise.ip.internet_scanner_intelligence.tag.names
       if: ctx.greynoise?.ip?.internet_scanner_intelligence?.tag?.names instanceof List
       processor:
@@ -241,12 +247,14 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_3e20ead6
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_48b0633f
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -254,6 +262,7 @@ on_failure:
       tag: set_pipeline_error_to_event_kind
       value: pipeline_error
   - append:
+      tag: append_tags_a71abfd4
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/ti_greynoise/manifest.yml
+++ b/packages/ti_greynoise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_greynoise
 title: GreyNoise
-version: "0.9.3"
+version: "0.9.4"
 description: Collect Threat Intelligence Indicators from GreyNoise using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/ti_greynoise/manifest.yml
+++ b/packages/ti_greynoise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_greynoise
 title: GreyNoise
-version: "0.9.4"
+version: "0.10.0"
 description: Collect Threat Intelligence Indicators from GreyNoise using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/vectra_rux/changelog.yml
+++ b/packages/vectra_rux/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/vectra_rux/changelog.yml
+++ b/packages/vectra_rux/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.5.2"
+- version: "0.6.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement

--- a/packages/vectra_rux/changelog.yml
+++ b/packages/vectra_rux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -405,13 +405,15 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_7292f93b
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -130,6 +131,7 @@ processors:
       if: ctx.event?.action != ''
       on_failure:
         - append:
+            tag: append_error_message_ce1e3af4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - join:
@@ -139,6 +141,7 @@ processors:
       if: ctx.event?.action != null
       on_failure:
         - append:
+            tag: append_error_message_f136491d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -160,6 +163,7 @@ processors:
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_64a7d6af
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -202,6 +206,7 @@ processors:
       if: ctx.json?.source_ip != ''
       on_failure:
         - append:
+            tag: append_error_message_31245381
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -210,10 +215,12 @@ processors:
       copy_from: vectra_rux.audit.source_ip
       ignore_empty_value: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -391,6 +398,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -3,17 +3,17 @@ description: Pipeline for processing audit logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -23,48 +23,48 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_3f675d2b
       value: Vectra RUX
   - append:
       field: event.category
-      tag: append_category_session
+      tag: append_category_session_7accd1f3
       value: session
       allow_duplicates: false
       if: ctx.json?.event_action?.contains('logout') == true
   - append:
       field: event.category
-      tag: append_category_authentication
+      tag: append_category_authentication_32ea3d8d
       value: authentication
       allow_duplicates: false
       if: ctx.json?.event_action?.contains('login') == true
   - append:
       field: event.category
-      tag: append_category_configuration
+      tag: append_category_configuration_53d58dcc
       value: configuration
       allow_duplicates: false
       if: >-
@@ -77,7 +77,7 @@ processors:
         ctx.json?.event_action?.contains('unmarked_as_fixed') == true
   - append:
       field: event.category
-      tag: append_category_access
+      tag: append_category_access_800b9df7
       value: access
       allow_duplicates: false
       if: >-
@@ -85,7 +85,7 @@ processors:
         ctx.json?.event_action?.contains('unlock') == true
   - append:
       field: event.type
-      tag: append_type_change
+      tag: append_type_change_de24274c
       value: change
       allow_duplicates: false
       if: >-
@@ -94,133 +94,133 @@ processors:
         ctx.json?.event_action?.contains('unmarked_as_fixed') == true
   - append:
       field: event.type
-      tag: append_type_creation
+      tag: append_type_creation_b86bf63c
       value: creation
       allow_duplicates: false
       if: ctx.json?.event_action?.contains('created') == true
   - append:
       field: event.type
-      tag: append_type_deletion
+      tag: append_type_deletion_8b187210
       value: deletion
       allow_duplicates: false
       if: ctx.json?.event_action?.contains('deleted') == true
   - rename:
       field: json.api_client_id
-      tag: rename_api_client_id
+      tag: rename_api_client_id_3ae5ae6a
       target_field: vectra_rux.audit.api_client_id
       ignore_missing: true
   - rename:
       field: json.event_action
-      tag: rename_event_action
+      tag: rename_event_action_bdc7bb82
       target_field: vectra_rux.audit.event.action
       ignore_missing: true
   - set:
       field: event.action
-      tag: set_event_action_from_audit_event_action
+      tag: set_event_action_from_audit_event_action_80733d23
       copy_from: vectra_rux.audit.event.action
       ignore_empty_value: true
   - lowercase:
       field: event.action
-      tag: lowercase_event_action
+      tag: lowercase_event_action_945f0fcf
       ignore_missing: true
   - split:
       field: event.action
-      tag: split_event_action
+      tag: split_event_action_ee0a3f8a
       separator: \s+
       ignore_missing: true
       if: ctx.event?.action != ''
       on_failure:
         - append:
-            tag: append_error_message_ce1e3af4
+            tag: append_error_message_40560a09
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - join:
       field: event.action
-      tag: join_event_action
+      tag: join_event_action_1b3a653e
       separator: '-'
       if: ctx.event?.action != null
       on_failure:
         - append:
-            tag: append_error_message_f136491d
+            tag: append_error_message_a9668992
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.event_data
-      tag: rename_event_data
+      tag: rename_event_data_2e203d24
       target_field: vectra_rux.audit.event.data
       ignore_missing: true
   - rename:
       field: json.event_object
-      tag: rename_event_object
+      tag: rename_event_object_3f62a264
       target_field: vectra_rux.audit.event.object
       ignore_missing: true
   - date:
       field: json.event_timestamp
-      tag: date_event_timestamp
+      tag: date_event_timestamp_67af833d
       target_field: vectra_rux.audit.event.timestamp
       formats:
         - ISO8601
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_64a7d6af
+            tag: append_error_message_a55a95da
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_audit_event_timestamp
+      tag: set_@timestamp_from_audit_event_timestamp_6ae51d4c
       copy_from: vectra_rux.audit.event.timestamp
       ignore_empty_value: true
   - convert:
       field: json.id
-      tag: convert_id
+      tag: convert_id_1735e987
       type: string
       target_field: vectra_rux.audit.id
       ignore_missing: true
   - rename:
       field: json.message
-      tag: rename_message
+      tag: rename_message_cb197194
       target_field: vectra_rux.audit.message
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_audit_message
+      tag: set_message_from_audit_message_216f565d
       copy_from: vectra_rux.audit.message
       ignore_empty_value: true
   - rename:
       field: json.result_status
-      tag: rename_result_status
+      tag: rename_result_status_82b1617b
       target_field: vectra_rux.audit.result_status
       ignore_missing: true
   - set:
       field: event.outcome
-      tag: set_event_outcome_from_audit_result_status
+      tag: set_event_outcome_from_audit_result_status_7c874525
       copy_from: vectra_rux.audit.result_status
       ignore_empty_value: true
   - convert:
       field: json.source_ip
-      tag: convert_source_ip_to_ip
+      tag: convert_source_ip_to_ip_9f448c50
       target_field: vectra_rux.audit.source_ip
       type: ip
       ignore_missing: true
       if: ctx.json?.source_ip != ''
       on_failure:
         - append:
-            tag: append_error_message_31245381
+            tag: append_error_message_964646cd
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
-      tag: set_source_ip_from_audit_source_ip
+      tag: set_source_ip_from_audit_source_ip_602a20f1
       copy_from: vectra_rux.audit.source_ip
       ignore_empty_value: true
   - geoip:
-      tag: geoip_source_ip_to_source_geo_da2e41b2
+      tag: geoip_source_ip_to_source_geo_9a2d4d31
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
-      tag: geoip_source_ip_to_source_as_28d69883
+      tag: geoip_source_ip_to_source_as_58199963
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -230,100 +230,100 @@ processors:
       ignore_missing: true
   - rename:
       field: source.as.asn
-      tag: rename_source_as_asn
+      tag: rename_source_as_asn_168bbbaf
       target_field: source.as.number
       ignore_missing: true
   - rename:
       field: source.as.organization_name
-      tag: rename_source_as_organization_name
+      tag: rename_source_as_organization_name_aa06a00b
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
       field: related.ip
-      tag: append_vectra_rux_audit_source_ip_into_related_ip
+      tag: append_vectra_rux_audit_source_ip_into_related_ip_b3412dbc
       value: '{{{vectra_rux.audit.source_ip}}}'
       allow_duplicates: false
       if: ctx.vectra_rux?.audit?.source_ip != null
   - convert:
       field: json.user_id
-      tag: convert_user_id_to_string
+      tag: convert_user_id_to_string_7034ac03
       type: string
       target_field: vectra_rux.audit.user.id
       ignore_missing: true
   - set:
       field: user.id
-      tag: set_user_id_from_audit_user_id
+      tag: set_user_id_from_audit_user_id_5c9efa2b
       copy_from: vectra_rux.audit.user.id
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_vectra_rux_audit_user_id_into_related_user
+      tag: append_vectra_rux_audit_user_id_into_related_user_469ff66a
       value: '{{{vectra_rux.audit.user.id}}}'
       allow_duplicates: false
       if: ctx.vectra_rux?.audit?.user?.id != null
   - rename:
       field: json.username
-      tag: rename_username
+      tag: rename_username_d8f4c499
       target_field: vectra_rux.audit.user.name
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_audit_user_name
+      tag: set_user_name_from_audit_user_name_3d15396e
       copy_from: vectra_rux.audit.user.name
       ignore_empty_value: true
   - rename:
       field: user.name
       target_field: user.email
-      tag: rename_user_email
+      tag: rename_user_email_455f691a
       if: ctx.user?.name != null && ctx.user.name.indexOf("@") > 0
   - dissect:
       field: user.email
       pattern: '%{user.name}@%{user.domain}'
-      tag: dissect_user_email
+      tag: dissect_user_email_d5fb5c7e
       ignore_missing: true
       ignore_failure: true
       if: ctx.user?.name == null
   - append:
       field: related.user
-      tag: append_vectra_rux_audit_user_name_into_related_user
+      tag: append_vectra_rux_audit_user_name_into_related_user_325195a6
       value: '{{{user.name}}}'
       allow_duplicates: false
       if: ctx.user?.name != null
   - append:
       field: related.user
-      tag: append_vectra_rux_audit_user_email_into_related_user
+      tag: append_vectra_rux_audit_user_email_into_related_user_b9ac313b
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
   - rename:
       field: json.user_role
-      tag: rename_user_role
+      tag: rename_user_role_649c6388
       target_field: vectra_rux.audit.user.role
       ignore_missing: true
   - append:
       field: user.roles
-      tag: append_vectra_rux_audit_user_role_into_user_roles
+      tag: append_vectra_rux_audit_user_role_into_user_roles_c1a91ed7
       value: '{{{vectra_rux.audit.user.role}}}'
       allow_duplicates: false
       if: ctx.vectra_rux?.audit?.user?.role != null
   - rename:
       field: json.role
-      tag: rename_role
+      tag: rename_role_28e79d95
       target_field: vectra_rux.audit.role
       ignore_missing: true
   - rename:
       field: json.user_type
-      tag: rename_user_type
+      tag: rename_user_type_3a86f259
       target_field: vectra_rux.audit.user.type
       ignore_missing: true
   - rename:
       field: json.version
-      tag: rename_version
+      tag: rename_version_8f0ce548
       target_field: vectra_rux.audit.version
       ignore_missing: true
   - set:
       field: observer.version
-      tag: set_observer_version_from_audit_version
+      tag: set_observer_version_from_audit_version_2f91aefb
       copy_from: vectra_rux.audit.version
       ignore_empty_value: true
   - remove:
@@ -336,15 +336,15 @@ processors:
         - vectra_rux.audit.user.name
         - vectra_rux.audit.user.role
         - vectra_rux.audit.version
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_f5fc0fc6
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   - script:
-       tag: script_to_truncate_long_fields
+       tag: script_to_truncate_long_fields_68a9333e
        lang: painless
        description: Truncate fields that are over length.
        source: |-
@@ -368,7 +368,7 @@ processors:
   # Cleanup
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -394,26 +394,26 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind_7292f93b
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/detection_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/detection_event/elasticsearch/ingest_pipeline/default.yml
@@ -8,204 +8,204 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_ab1166ce
       value: alert
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_3f675d2b
       value: Vectra RUX
   - append:
       field: event.category
-      tag: set_event_category_host
+      tag: set_event_category_host_91eb2116
       value: host
       if: ctx.json?.type == 'host'
   - append:
       field: event.type
-      tag: set_event_type_info
+      tag: set_event_type_info_ea9c2a21
       value: info
       if: ctx.json?.type == 'host'
   - append:
       field: event.category
-      tag: set_event_category_threat
+      tag: set_event_category_threat_4039b90d
       value: threat
   - append:
       field: event.type
-      tag: set_event_type_indicator
+      tag: set_event_type_indicator_d4da06cc
       value: indicator
   - rename:
       field: json.category
-      tag: rename_category
+      tag: rename_category_a0fef8ff
       target_field: vectra_rux.detection_event.category
       ignore_missing: true
   - append:
       field: threat.tactic.name
-      tag: append_detection_event_category_into_threat_tactic_name
+      tag: append_detection_event_category_into_threat_tactic_name_607b90df
       value: '{{{vectra_rux.detection_event.category}}}'
       allow_duplicates: false
       if: ctx.vectra_rux?.detection_event?.category != null
   - convert:
       field: json.certainty
-      tag: convert_certainty_to_long
+      tag: convert_certainty_to_long_e716ae77
       target_field: vectra_rux.detection_event.certainty
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_c31ebc50
+            tag: append_error_message_2e4ef44c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.d_type_vname
-      tag: rename_d_type_vname
+      tag: rename_d_type_vname_d7aac0a4
       target_field: vectra_rux.detection_event.d_type_vname
       ignore_missing: true
   - set:
       field: rule.name
-      tag: set_rule_name_from_detection_event_d_type_vname
+      tag: set_rule_name_from_detection_event_d_type_vname_4ce0e493
       copy_from: vectra_rux.detection_event.d_type_vname
       ignore_empty_value: true
   - rename:
       field: json.detail
-      tag: rename_detail
+      tag: rename_detail_76e3818e
       target_field: vectra_rux.detection_event.detail
       ignore_missing: true
   - rename:
       field: json.detection_href
-      tag: rename_detection_href
+      tag: rename_detection_href_d8532ce6
       target_field: vectra_rux.detection_event.detection.href
       ignore_missing: true
   - set:
       field: event.reference
-      tag: set_event_reference_from_detection_event_detection_href
+      tag: set_event_reference_from_detection_event_detection_href_c609e2a6
       copy_from: vectra_rux.detection_event.detection.href
       ignore_empty_value: true
   - set:
       field: threat.indicator.reference
-      tag: set_threat_indicator_reference_from_detection_event_detection_href
+      tag: set_threat_indicator_reference_from_detection_event_detection_href_558bdafe
       copy_from: vectra_rux.detection_event.detection.href
       ignore_empty_value: true
   - uri_parts:
       field: event.reference
-      tag: uri_parts_event_reference
+      tag: uri_parts_event_reference_4536448f
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_067fe3ec
+            tag: append_error_message_8d0abaac
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.detection_id
-      tag: convert_detection_id_to_string
+      tag: convert_detection_id_to_string_2de4d528
       target_field: vectra_rux.detection_event.detection.id
       type: string
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_detection_event_detection_id
+      tag: set_event_id_from_detection_event_detection_id_6b21ef1d
       copy_from: vectra_rux.detection_event.detection.id
       ignore_empty_value: true
   - rename:
       field: json.detection_type
-      tag: rename_detection_type
+      tag: rename_detection_type_905916d5
       target_field: vectra_rux.detection_event.detection.type
       ignore_missing: true
   - convert:
       field: json.entity_id
-      tag: convert_entity_id_to_string
+      tag: convert_entity_id_to_string_299ebc49
       target_field: vectra_rux.detection_event.entity.id
       type: string
       ignore_missing: true
   - set:
       field: user.id
-      tag: set_user_id_from_detection_event_entity_id
+      tag: set_user_id_from_detection_event_entity_id_e1ac6cdb
       copy_from: vectra_rux.detection_event.entity.id
       ignore_empty_value: true
       if: ctx.json?.type == 'account'
   - append:
       field: related.user
-      tag: append_user_id_into_related_user
+      tag: append_user_id_into_related_user_23cff8dc
       value: '{{{user.id}}}'
       allow_duplicates: false
       if: ctx.user?.id != null
   - set:
       field: host.id
-      tag: set_host_id_from_detection_event_entity_id
+      tag: set_host_id_from_detection_event_entity_id_c3b41f36
       copy_from: vectra_rux.detection_event.entity.id
       ignore_empty_value: true
       if: ctx.json?.type == 'host'
   - append:
       field: related.hosts
-      tag: append_host_id_into_related_hosts
+      tag: append_host_id_into_related_hosts_bd1f7443
       value: '{{{host.id}}}'
       allow_duplicates: false
       if: ctx.host?.id != null
   - rename:
       field: json.entity_uid
-      tag: rename_entity_uid
+      tag: rename_entity_uid_33821082
       target_field: vectra_rux.detection_event.entity.uid
       ignore_missing: true
   - date:
       field: json.event_timestamp
-      tag: date_event_timestamp
+      tag: date_event_timestamp_6438d075
       target_field: vectra_rux.detection_event.event_timestamp
       formats:
         - ISO8601
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_ef18c781
+            tag: append_error_message_6bc888ba
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_detection_event_event_timestamp
+      tag: set_@timestamp_from_detection_event_event_timestamp_aa0cf5ab
       copy_from: vectra_rux.detection_event.event_timestamp
       ignore_empty_value: true
   - convert:
       field: json.id
-      tag: convert_id_to_string
+      tag: convert_id_to_string_1c3754c3
       target_field: vectra_rux.detection_event.id
       type: string
       ignore_missing: true
   - rename:
       field: json.mitre
-      tag: rename_mitre
+      tag: rename_mitre_adeaf252
       target_field: vectra_rux.detection_event.mitre
       ignore_missing: true
   - foreach:
-      tag: foreach_vectra_rux_detection_event_mitre_7a055e72
+      tag: foreach_vectra_rux_detection_event_mitre_46d92e37
       field: vectra_rux.detection_event.mitre
       if: ctx.vectra_rux?.detection_event?.mitre instanceof List
       ignore_failure: true
@@ -213,76 +213,76 @@ processors:
         append:
           field: threat.technique.id
           value: '{{{_ingest._value}}}'
-          tag: append_vectra_rux_detection_event_mitre_into_threat_technique_id
+          tag: append_vectra_rux_detection_event_mitre_into_threat_technique_id_87bcd04c
           allow_duplicates: false
   - convert:
       field: json.severity
-      tag: convert_severity_to_long
+      tag: convert_severity_to_long_4bbfdbda
       target_field: vectra_rux.detection_event.severity
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_34e5fa7c
+            tag: append_error_message_e80557ec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.severity
-      tag: set_event_severity_from_detection_event_severity
+      tag: set_event_severity_from_detection_event_severity_92bca05a
       copy_from: vectra_rux.detection_event.severity
       ignore_empty_value: true
   - rename:
       field: json.src_entity
-      tag: rename_src_entity
+      tag: rename_src_entity_a655a846
       target_field: vectra_rux.detection_event.src_entity
       ignore_missing: true
   - convert:
       field: json.threat
-      tag: convert_threat_to_long
+      tag: convert_threat_to_long_ba1cde08
       target_field: vectra_rux.detection_event.threat
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_0186344f
+            tag: append_error_message_73c8b671
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: user.risk.calculated_score
-      tag: set_user_risk_calculated_score_from_detection_event_threat
+      tag: set_user_risk_calculated_score_from_detection_event_threat_04d7c0f8
       copy_from: vectra_rux.detection_event.threat
       ignore_empty_value: true
       if: ctx.json?.type == 'account'
   - set:
       field: host.risk.calculated_score
-      tag: set_host_risk_calculated_score_from_detection_event_threat
+      tag: set_host_risk_calculated_score_from_detection_event_threat_f6ff0265
       copy_from: vectra_rux.detection_event.threat
       ignore_empty_value: true
       if: ctx.json?.type == 'host'
   - convert:
       field: json.triaged
-      tag: convert_triaged_to_boolean
+      tag: convert_triaged_to_boolean_c5bd82d9
       target_field: vectra_rux.detection_event.triaged
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_53395579
+            tag: append_error_message_2b61345a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_2f5dae51
       target_field: vectra_rux.detection_event.type
       ignore_missing: true
   - rename:
       field: json.url
-      tag: rename_url
+      tag: rename_url_6d3d330d
       target_field: vectra_rux.detection_event.url
       ignore_missing: true
   - set:
       field: event.url
-      tag: set_event_url_from_detection_event_url
+      tag: set_event_url_from_detection_event_url_42df9871
       copy_from: vectra_rux.detection_event.url
       ignore_empty_value: true
   - remove:
@@ -296,17 +296,17 @@ processors:
         - vectra_rux.detection_event.category
         - vectra_rux.detection_event.d_type_vname
         - vectra_rux.detection_event.entity.id
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_d5867a39
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   # Cleanup
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -332,26 +332,26 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind_e666f0e3
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/detection_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/detection_event/elasticsearch/ingest_pipeline/default.yml
@@ -343,13 +343,15 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_e666f0e3
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/detection_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/detection_event/elasticsearch/ingest_pipeline/default.yml
@@ -35,6 +35,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -82,6 +83,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c31ebc50
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -120,6 +122,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_067fe3ec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -167,7 +170,7 @@ processors:
       tag: append_host_id_into_related_hosts
       value: '{{{host.id}}}'
       allow_duplicates: false
-      if: ctx.host?.id != null  
+      if: ctx.host?.id != null
   - rename:
       field: json.entity_uid
       tag: rename_entity_uid
@@ -182,6 +185,7 @@ processors:
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_ef18c781
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -201,6 +205,7 @@ processors:
       target_field: vectra_rux.detection_event.mitre
       ignore_missing: true
   - foreach:
+      tag: foreach_vectra_rux_detection_event_mitre_7a055e72
       field: vectra_rux.detection_event.mitre
       if: ctx.vectra_rux?.detection_event?.mitre instanceof List
       ignore_failure: true
@@ -218,6 +223,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_34e5fa7c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -238,6 +244,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0186344f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -260,6 +267,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_53395579
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -328,6 +336,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/entity_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/entity_event/elasticsearch/ingest_pipeline/default.yml
@@ -364,13 +364,15 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_162fd445
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/entity_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/entity_event/elasticsearch/ingest_pipeline/default.yml
@@ -8,251 +8,251 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_3f675d2b
       value: Vectra RUX
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_91eb2116
       value: host
       if: ctx.json?.type == 'host'
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_ea9c2a21
       value: info
       if: ctx.json?.type == 'host'
   - append:
       field: tags
-      tag: append_host_tag
+      tag: append_host_tag_663c2843
       value: vectra_rux-entity_event-host
       allow_duplicates: false
       if: ctx.json?.type == 'host'
   - append:
       field: tags
-      tag: append_account_tag
+      tag: append_account_tag_40e5d7d6
       value: vectra_rux-entity_event-account
       allow_duplicates: false
       if: ctx.json?.type == 'account'
   - rename:
       field: json.active_detection_types
-      tag: rename_active_detection_types
+      tag: rename_active_detection_types_47a1aa04
       target_field: vectra_rux.entity_event.active_detection_types
       ignore_missing: true
   - convert:
       field: json.attack_rating
-      tag: convert_attack_rating_to_long
+      tag: convert_attack_rating_to_long_ecf8a63a
       target_field: vectra_rux.entity_event.attack_rating
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d1fdfb15
+            tag: append_error_message_b2731d47
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.breadth_contrib
-      tag: convert_breadth_contrib_to_long
+      tag: convert_breadth_contrib_to_long_f9032fad
       target_field: vectra_rux.entity_event.breadth_contrib
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_fa02e0d5
+            tag: append_error_message_7d145c65
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.category
-      tag: rename_category
+      tag: rename_category_981bd3df
       target_field: vectra_rux.entity_event.category
       ignore_missing: true
   - convert:
       field: json.entity_id
-      tag: convert_entity_id
+      tag: convert_entity_id_20235f3d
       type: string
       target_field: vectra_rux.entity_event.entity_id
       ignore_missing: true
   - set:
       field: event.id
-      tag: set_event_id_from_entity_event_entity_id
+      tag: set_event_id_from_entity_event_entity_id_33ceb2de
       copy_from: vectra_rux.entity_event.entity_id
       ignore_empty_value: true
   - set:
       field: user.id
-      tag: set_user_id_from_entity_event_entity_id
+      tag: set_user_id_from_entity_event_entity_id_2ff256b3
       copy_from: vectra_rux.entity_event.entity_id
       ignore_empty_value: true
       if: ctx.json?.type == 'account'
   - append:
       field: related.user
-      tag: append_user_id_into_related_user
+      tag: append_user_id_into_related_user_23cff8dc
       value: '{{{user.id}}}'
       allow_duplicates: false
       if: ctx.user?.id != null
   - set:
       field: host.id
-      tag: set_host_id_from_entity_event_entity_id
+      tag: set_host_id_from_entity_event_entity_id_10849338
       copy_from: vectra_rux.entity_event.entity_id
       ignore_empty_value: true
       if: ctx.json?.type == 'host'
   - append:
       field: related.hosts
-      tag: append_host_id_into_related_hosts
+      tag: append_host_id_into_related_hosts_bd1f7443
       value: '{{{host.id}}}'
       allow_duplicates: false
       if: ctx.host?.id != null
   - date:
       field: json.event_timestamp
-      tag: date_event_timestamp
+      tag: date_event_timestamp_9f8276fd
       target_field: vectra_rux.entity_event.event_timestamp
       formats:
         - ISO8601
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_a57ad9ed
+            tag: append_error_message_a96695b0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_entity_event_event_timestamp
+      tag: set_@timestamp_from_entity_event_event_timestamp_f8f2d458
       copy_from: vectra_rux.entity_event.event_timestamp
       ignore_empty_value: true
   - convert:
       field: json.id
-      tag: convert_id
+      tag: convert_id_9824612d
       type: string
       target_field: vectra_rux.entity_event.id
       ignore_missing: true
   - convert:
       field: json.importance
-      tag: convert_importance_to_long
+      tag: convert_importance_to_long_32d86f30
       target_field: vectra_rux.entity_event.importance
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8705a74b
+            tag: append_error_message_16b36eb0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.is_prioritized
-      tag: convert_is_prioritized_to_boolean
+      tag: convert_is_prioritized_to_boolean_775ca1b0
       target_field: vectra_rux.entity_event.is_prioritized
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_1848ee77
+            tag: append_error_message_134de6fe
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.last_detection.id
-      tag: convert_last_detection_id
+      tag: convert_last_detection_id_b87a265b
       type: string
       target_field: vectra_rux.entity_event.last_detection.id
       ignore_missing: true
   - rename:
       field: json.last_detection.type
-      tag: rename_last_detection_type
+      tag: rename_last_detection_type_7297c984
       target_field: vectra_rux.entity_event.last_detection.type
       ignore_missing: true
   - rename:
       field: json.last_detection.url
-      tag: rename_last_detection_url
+      tag: rename_last_detection_url_a3d7ea4b
       target_field: vectra_rux.entity_event.last_detection.url
       ignore_missing: true
   - set:
       field: event.reference
-      tag: set_event_reference_from_last_detection_url
+      tag: set_event_reference_from_last_detection_url_cb8427b1
       copy_from: vectra_rux.entity_event.last_detection.url
       ignore_empty_value: true
   - set:
       field: threat.indicator.reference
-      tag: set_threat_indicator_reference_from_entity_event_last_detection_url
+      tag: set_threat_indicator_reference_from_entity_event_last_detection_url_f132e11b
       copy_from: vectra_rux.entity_event.last_detection.url
       ignore_empty_value: true
   - uri_parts:
       field: event.reference
-      tag: uri_parts_event_reference
+      tag: uri_parts_event_reference_4536448f
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_067fe3ec
+            tag: append_error_message_8d0abaac
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.name
-      tag: rename_name
+      tag: rename_name_fad10abf
       target_field: vectra_rux.entity_event.name
       ignore_missing: true
   - set:
       field: user.email
-      tag: set_user_email_from_entity_event_name
+      tag: set_user_email_from_entity_event_name_e351b987
       copy_from: vectra_rux.entity_event.name
       ignore_empty_value: true
       if: ctx.json?.type == 'account' && ctx.vectra_rux?.entity_event?.name.contains("@")
   - append:
       field: related.user
-      tag: append_user_email_into_related_user
+      tag: append_user_email_into_related_user_b9ac313b
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
   - set:
       field: host.name
-      tag: set_user_name_from_entity_event_name
+      tag: set_user_name_from_entity_event_name_5d6f35e8
       copy_from: vectra_rux.entity_event.name
       ignore_empty_value: true
       if: ctx.json?.type == 'host'
   - append:
       field: related.hosts
-      tag: append_host_name_into_related_hosts
+      tag: append_host_name_into_related_hosts_82ac1e98
       value: '{{{host.name}}}'
       allow_duplicates: false
       if: ctx.host?.name != null
   - rename:
       field: json.severity
-      tag: rename_severity
+      tag: rename_severity_c83678fe
       target_field: vectra_rux.entity_event.severity
       ignore_missing: true
   - script:
       lang: painless
       description: Script to set event.severity.
-      tag: set_event_severity
+      tag: set_event_severity_0a5484ad
       if: ctx.vectra_rux?.entity_event?.severity instanceof String
       source: |-
         def severity = ctx.vectra_rux.entity_event.severity.toLowerCase();
@@ -265,49 +265,49 @@ processors:
           }
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_1cae1fd4
       target_field: vectra_rux.entity_event.type
       ignore_missing: true
   - rename:
       field: json.urgency_reason
-      tag: rename_urgency_reason
+      tag: rename_urgency_reason_69b88ef6
       target_field: vectra_rux.entity_event.urgency.reason
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_entity_event_urgency_reason
+      tag: set_message_from_entity_event_urgency_reason_04ff3f37
       copy_from: vectra_rux.entity_event.urgency.reason
       ignore_empty_value: true
   - convert:
       field: json.urgency_score
-      tag: convert_urgency_score_to_long
+      tag: convert_urgency_score_to_long_28abf440
       target_field: vectra_rux.entity_event.urgency.score
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_bbe378dc
+            tag: append_error_message_6d31c7f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.url
-      tag: rename_url
+      tag: rename_url_8ccbf52a
       target_field: vectra_rux.entity_event.url
       ignore_missing: true
   - set:
       field: event.url
-      tag: set_event_url_from_entity_event_url
+      tag: set_event_url_from_entity_event_url_329f2ded
       copy_from: vectra_rux.entity_event.url
       ignore_empty_value: true
   - convert:
       field: json.velocity_contrib
-      tag: convert_velocity_contrib_to_long
+      tag: convert_velocity_contrib_to_long_7b74b008
       target_field: vectra_rux.entity_event.velocity_contrib
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_639b6b30
+            tag: append_error_message_f65a98a6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -317,17 +317,17 @@ processors:
         - vectra_rux.entity_event.urgency.reason
         - vectra_rux.entity_event.url
         - vectra_rux.entity_event.last_detection.url
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_b3cf84eb
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   # Cleanup
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -353,26 +353,26 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind_162fd445
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/entity_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/entity_event/elasticsearch/ingest_pipeline/default.yml
@@ -35,6 +35,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -80,6 +81,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d1fdfb15
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -90,6 +92,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fa02e0d5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -131,7 +134,7 @@ processors:
       tag: append_host_id_into_related_hosts
       value: '{{{host.id}}}'
       allow_duplicates: false
-      if: ctx.host?.id != null 
+      if: ctx.host?.id != null
   - date:
       field: json.event_timestamp
       tag: date_event_timestamp
@@ -141,6 +144,7 @@ processors:
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_a57ad9ed
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -162,6 +166,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8705a74b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -172,6 +177,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1848ee77
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -206,6 +212,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_067fe3ec
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -279,6 +286,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bbe378dc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -299,6 +307,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_639b6b30
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -348,6 +357,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -3,25 +3,25 @@ description: Pipeline for processing health logs.
 processors:
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_3f675d2b
       value: Vectra RUX
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - terminate:
-      tag: data_collection_error
+      tag: data_collection_error_4bdbb3d0
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
       description: error message set and no data to process.
   - remove:
@@ -31,100 +31,100 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.network.interfaces
-      tag: rename_network_interfaces
+      tag: rename_network_interfaces_9c1d1917
       target_field: vectra_rux.health.network.interfaces
       ignore_missing: true
   - foreach:
-      tag: foreach_json_connectivity_sensors_bb60514d
+      tag: foreach_json_connectivity_sensors_0f5e734a
       field: json.connectivity.sensors
       if: ctx.json?.connectivity?.sensors instanceof List
       processor:
         convert:
           field: _ingest._value.ip_address
-          tag: convert_connectivity_sensors_ip_address_to_ip
+          tag: convert_connectivity_sensors_ip_address_to_ip_1e294ffb
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_ip_address
+                tag: remove_ingest_value_ip_address_84882d9c
                 field: _ingest._value.ip_address
                 ignore_missing: true
             - append:
-                tag: append_error_message
+                tag: append_error_message_c892c26c
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_connectivity_sensors_885beff1
+      tag: foreach_json_connectivity_sensors_0833e0d2
       field: json.connectivity.sensors
       if: ctx.json?.connectivity?.sensors instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_connectivity_sensors_ip_address
+          tag: append_connectivity_sensors_ip_address_a15dc0e5
           value: '{{{_ingest._value.ip_address}}}'
           allow_duplicates: false
   - rename:
       field: json.connectivity.sensors
-      tag: rename_connectivity_sensors
+      tag: rename_connectivity_sensors_6fdacae7
       target_field: vectra_rux.health.connectivity.sensors
       ignore_missing: true
   - convert:
       field: json.cpu.idle_percent
-      tag: convert_cpu_idle_percent_to_double
+      tag: convert_cpu_idle_percent_to_double_06016a54
       target_field: vectra_rux.health.cpu.idle_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_8e22c31a
+            tag: append_error_message_05c3ae0c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.cpu.nice_percent
-      tag: convert_cpu_nice_percent_to_double
+      tag: convert_cpu_nice_percent_to_double_11a05e06
       target_field: vectra_rux.health.cpu.nice_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_43453a8d
+            tag: append_error_message_1f3b19f1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.cpu.system_percent
-      tag: convert_cpu_system_percent_to_double
+      tag: convert_cpu_system_percent_to_double_b52e1054
       target_field: vectra_rux.health.cpu.system_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_6d950525
+            tag: append_error_message_b557fcd4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.cpu.updated_at
-      tag: date_cpu_updated_at
+      tag: date_cpu_updated_at_cdaa3064
       target_field: vectra_rux.health.cpu.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -134,68 +134,68 @@ processors:
       if: ctx.json?.cpu?.updated_at != null && ctx.json.cpu.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_9c1d5e39
+            tag: append_error_message_003c30e0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.cpu.user_percent
-      tag: convert_cpu_user_percent_to_double
+      tag: convert_cpu_user_percent_to_double_4eaaea14
       target_field: vectra_rux.health.cpu.user_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_b1eda2c3
+            tag: append_error_message_de7f2a38
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: host.cpu.usage
-      tag: set_host_cpu_usage_from_health_cpu_user_percent
+      tag: set_host_cpu_usage_from_health_cpu_user_percent_85cbb15c
       copy_from: vectra_rux.health.cpu.user_percent
       ignore_empty_value: true
   - rename:
       field: json.detection.check_results
-      tag: rename_detection_check_results
+      tag: rename_detection_check_results_f5d8f7a6
       target_field: vectra_rux.health.detection.check_results
       ignore_missing: true
   - rename:
       field: json.detection.detection_type
-      tag: rename_detection_detection_type
+      tag: rename_detection_detection_type_b9ced65a
       target_field: vectra_rux.health.detection.detection_type
       ignore_missing: true
   - rename:
       field: json.detection.message
-      tag: rename_detection_message
+      tag: rename_detection_message_5800f3cd
       target_field: vectra_rux.health.detection.message
       ignore_missing: true
   - set:
       field: message
-      tag: set_message_from_health_detection_message
+      tag: set_message_from_health_detection_message_e39e0961
       copy_from: vectra_rux.health.detection.message
       ignore_empty_value: true
   - set:
       field: threat.indicator.description
-      tag: set_threat_indicator_description_from_health_detection_message
+      tag: set_threat_indicator_description_from_health_detection_message_e456b51e
       copy_from: vectra_rux.health.detection.message
       ignore_empty_value: true
   - rename:
       field: json.detection.name
-      tag: rename_detection_name
+      tag: rename_detection_name_3062ef9a
       target_field: vectra_rux.health.detection.name
       ignore_missing: true
   - set:
       field: rule.name
-      tag: set_rule_name_from_health_detection_name
+      tag: set_rule_name_from_health_detection_name_fb4720e0
       copy_from: vectra_rux.health.detection.name
       ignore_empty_value: true
   - rename:
       field: json.detection.status
-      tag: rename_detection_status
+      tag: rename_detection_status_5c4aa583
       target_field: vectra_rux.health.detection.status
       ignore_missing: true
   - date:
       field: json.detection.updated_at
-      tag: date_detection_updated_at
+      tag: date_detection_updated_at_7c99ea02
       target_field: vectra_rux.health.detection.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -205,101 +205,101 @@ processors:
       if: ctx.json?.detection?.updated_at != null && ctx.json.detection.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_b71d3574
+            tag: append_error_message_bbe5c5d8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.disk.degraded_raid_volume.error
-      tag: rename_disk_degraded_raid_volume_error
+      tag: rename_disk_degraded_raid_volume_error_8bd85072
       target_field: vectra_rux.health.disk.degraded_raid_volume.error
       ignore_missing: true
   - rename:
       field: json.disk.degraded_raid_volume.output
-      tag: rename_disk_degraded_raid_volume_output
+      tag: rename_disk_degraded_raid_volume_output_1b454d27
       target_field: vectra_rux.health.disk.degraded_raid_volume.output
       ignore_missing: true
   - rename:
       field: json.disk.degraded_raid_volume.status
-      tag: rename_disk_degraded_raid_volume_status
+      tag: rename_disk_degraded_raid_volume_status_22a1a40e
       target_field: vectra_rux.health.disk.degraded_raid_volume.status
       ignore_missing: true
   - rename:
       field: json.disk.disk_raid.error
-      tag: rename_disk_disk_raid_error
+      tag: rename_disk_disk_raid_error_9b7df429
       target_field: vectra_rux.health.disk.disk_raid.error
       ignore_missing: true
   - rename:
       field: json.disk.disk_raid.output
-      tag: rename_disk_disk_raid_output
+      tag: rename_disk_disk_raid_output_b83e6f9c
       target_field: vectra_rux.health.disk.disk_raid.output
       ignore_missing: true
   - rename:
       field: json.disk.disk_raid.status
-      tag: rename_disk_disk_raid_status
+      tag: rename_disk_disk_raid_status_f2b0f358
       target_field: vectra_rux.health.disk.disk_raid.status
       ignore_missing: true
   - convert:
       field: json.disk.disk_utilization.free_bytes
-      tag: convert_disk_disk_utilization_free_bytes_to_long
+      tag: convert_disk_disk_utilization_free_bytes_to_long_456befc8
       target_field: vectra_rux.health.disk.disk_utilization.free_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_66249cd8
+            tag: append_error_message_98482439
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.disk.disk_utilization.total_bytes
-      tag: convert_disk_disk_utilization_total_bytes_to_long
+      tag: convert_disk_disk_utilization_total_bytes_to_long_b26931d8
       target_field: vectra_rux.health.disk.disk_utilization.total_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_bc337510
+            tag: append_error_message_97bf44c1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.disk.disk_utilization.usage_percent
-      tag: convert_disk_disk_utilization_usage_percent_to_double
+      tag: convert_disk_disk_utilization_usage_percent_to_double_37f1e93a
       target_field: vectra_rux.health.disk.disk_utilization.usage_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_286e9087
+            tag: append_error_message_2f6ffdb6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.disk.disk_utilization.used_bytes
-      tag: convert_disk_disk_utilization_used_bytes_to_long
+      tag: convert_disk_disk_utilization_used_bytes_to_long_70360935
       target_field: vectra_rux.health.disk.disk_utilization.used_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_97b7bb5f
+            tag: append_error_message_08d14fee
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.disk.raid_disks_missing.error
-      tag: rename_disk_raid_disks_missing_error
+      tag: rename_disk_raid_disks_missing_error_739543bf
       target_field: vectra_rux.health.disk.raid_disks_missing.error
       ignore_missing: true
   - rename:
       field: json.disk.raid_disks_missing.output
-      tag: rename_disk_raid_disks_missing_output
+      tag: rename_disk_raid_disks_missing_output_db65ec79
       target_field: vectra_rux.health.disk.raid_disks_missing.output
       ignore_missing: true
   - rename:
       field: json.disk.raid_disks_missing.status
-      tag: rename_disk_raid_disks_missing_status
+      tag: rename_disk_raid_disks_missing_status_cdc4c171
       target_field: vectra_rux.health.disk.raid_disks_missing.status
       ignore_missing: true
   - date:
       field: json.disk.updated_at
-      tag: date_disk_updated_at
+      tag: date_disk_updated_at_e75b1290
       target_field: vectra_rux.health.disk.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -309,67 +309,67 @@ processors:
       if: ctx.json?.disk?.updated_at != null && ctx.json.disk.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_41e4a47a
+            tag: append_error_message_d97e4265
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.event_timestamp
-      tag: date_event_timestamp
+      tag: date_event_timestamp_b42f1a29
       target_field: vectra_rux.health.event_timestamp
       formats:
         - ISO8601
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_a94eb2f3
+            tag: append_error_message_f92308ad
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_health_event_timestamp
+      tag: set_@timestamp_from_health_event_timestamp_090cf6a0
       copy_from: vectra_rux.health.event_timestamp
       ignore_empty_value: true
   - rename:
       field: json.hostid.artifact_counts
-      tag: rename_hostid_artifact_counts
+      tag: rename_hostid_artifact_counts_25662f2d
       target_field: vectra_rux.health.hostid.artifact_counts
       ignore_missing: true
   - convert:
       field: json.hostid.ip_always_percent
-      tag: convert_hostid_ip_always_percent_to_double
+      tag: convert_hostid_ip_always_percent_to_double_f8fa4b1b
       target_field: vectra_rux.health.hostid.ip_always_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_f3aecd30
+            tag: append_error_message_4cdf71db
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.hostid.ip_sometimes_percent
-      tag: convert_hostid_ip_sometimes_percent_to_double
+      tag: convert_hostid_ip_sometimes_percent_to_double_4d00ed6e
       target_field: vectra_rux.health.hostid.ip_never_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_36479aed
+            tag: append_error_message_a8efdb4f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.hostid.ip_never_percent
-      tag: convert_hostid_ip_never_percent_to_double
+      tag: convert_hostid_ip_never_percent_to_double_d328827e
       target_field: vectra_rux.health.hostid.ip_sometimes_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_be67519d
+            tag: append_error_message_7fd27010
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.hostid.updated_at
-      tag: date_hostid_updated_at
+      tag: date_hostid_updated_at_b51fcd2c
       target_field: vectra_rux.health.hostid.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -379,34 +379,34 @@ processors:
       if: ctx.json?.hostid?.updated_at != null && ctx.json.hostid.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_841133ac
+            tag: append_error_message_ddd991f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.memory.free_bytes
-      tag: convert_memory_free_bytes_to_long
+      tag: convert_memory_free_bytes_to_long_fa4f7793
       target_field: vectra_rux.health.memory.free_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_9d505463
+            tag: append_error_message_85c82fe5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.memory.total_bytes
-      tag: convert_memory_total_bytes_to_long
+      tag: convert_memory_total_bytes_to_long_70f8f36f
       target_field: vectra_rux.health.memory.total_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_d5a09987
+            tag: append_error_message_b8beb38f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.memory.updated_at
-      tag: date_memory_updated_at
+      tag: date_memory_updated_at_53ca0ea6
       target_field: vectra_rux.health.memory.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -416,39 +416,39 @@ processors:
       if: ctx.json?.memory?.updated_at != null && ctx.json.memory.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_bc94db90
+            tag: append_error_message_cdd69ef4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.memory.usage_percent
-      tag: convert_memory_usage_percent_to_double
+      tag: convert_memory_usage_percent_to_double_ee206bdd
       target_field: vectra_rux.health.memory.usage_percent
       type: double
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_995b2880
+            tag: append_error_message_40a0007a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.memory.used_bytes
-      tag: convert_memory_used_bytes_to_long
+      tag: convert_memory_used_bytes_to_long_838cde73
       target_field: vectra_rux.health.memory.used_bytes
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_1b3bbdd6
+            tag: append_error_message_25865588
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.network.traffic
-      tag: rename_network_traffic
+      tag: rename_network_traffic_713d89d0
       target_field: vectra_rux.health.network.traffic
       ignore_missing: true
   - date:
       field: json.network.updated_at
-      tag: date_network_updated_at
+      tag: date_network_updated_at_c1530ecb
       target_field: vectra_rux.health.network.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -458,53 +458,53 @@ processors:
       if: ctx.json?.network?.updated_at != null && ctx.json.network.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_878ce00d
+            tag: append_error_message_f1baf716
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.network.vlans.count
-      tag: convert_network_vlans_count_to_long
+      tag: convert_network_vlans_count_to_long_a7f3e2a6
       target_field: vectra_rux.health.network.vlans.count
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_efb5f6b6
+            tag: append_error_message_9338e0bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_network_vlans_vlan_ids_d37b9a1c
+      tag: foreach_json_network_vlans_vlan_ids_992f1a72
       field: json.network.vlans.vlan_ids
       if: ctx.json?.network?.vlans?.vlan_ids instanceof List
       processor:
         append:
           field: network.vlan.id
-          tag: append_network_vlans_vlan_ids_into_network_vlan_id
+          tag: append_network_vlans_vlan_ids_into_network_vlan_id_85bcb79e
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
       field: json.network.vlans.vlan_ids
-      tag: rename_network_vlans_vlan_ids
+      tag: rename_network_vlans_vlan_ids_33105367
       target_field: vectra_rux.health.network.vlans.vlan_ids
       ignore_missing: true
   - rename:
       field: json.power.error
-      tag: rename_power_error
+      tag: rename_power_error_9ed5332f
       target_field: vectra_rux.health.power.error
       ignore_missing: true
   - rename:
       field: json.power.power_supplies
-      tag: rename_power_power_supplies
+      tag: rename_power_power_supplies_29b812f1
       target_field: vectra_rux.health.power.power_supplies
       ignore_missing: true
   - rename:
       field: json.power.status
-      tag: rename_power_status
+      tag: rename_power_status_a45eec01
       target_field: vectra_rux.health.power.status
       ignore_missing: true
   - date:
       field: json.power.updated_at
-      tag: date_power_updated_at
+      tag: date_power_updated_at_ddcf77ea
       target_field: vectra_rux.health.power.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -514,131 +514,131 @@ processors:
       if: ctx.json?.power?.updated_at != null && ctx.json.power.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_dcefbc5a
+            tag: append_error_message_7b83f73d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_sensors_cc2adddd
+      tag: foreach_json_sensors_4bf4875f
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         convert:
           field: _ingest._value.headend_uri
-          tag: convert_sensors_headend_uri_to_ip
+          tag: convert_sensors_headend_uri_to_ip_cb4078c2
           target_field: _ingest._value.headend_ip
           type: ip
           ignore_missing: true
           on_failure:
             - set:
                 field: _ingest._value.headend_url
-                tag: set_sensors_headend_uri
+                tag: set_sensors_headend_uri_6890e749
                 value: '{{{_ingest._value.headend_uri}}}'
   - foreach:
-      tag: foreach_json_sensors_8007c8b4
+      tag: foreach_json_sensors_6dbf9027
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         convert:
           field: _ingest._value.ip_address
-          tag: convert_sensors_ip_address_to_ip
+          tag: convert_sensors_ip_address_to_ip_323f5706
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_ip_address_ac3230f5
+                tag: remove_ingest_value_ip_address_001f391a
                 field: _ingest._value.ip_address
                 ignore_missing: true
             - append:
-                tag: append_error_message_263fb6e9
+                tag: append_error_message_5b36f65d
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_sensors_59fe3c47
+      tag: foreach_json_sensors_567e7216
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         append:
           field: observer.ip
-          tag: append_sensors_ip_address_into_observer_ip
+          tag: append_sensors_ip_address_into_observer_ip_a4dc8f4d
           value: '{{{_ingest._value.ip_address}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_json_sensors_ea469ea7
+      tag: foreach_json_sensors_717af6de
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_sensors_ip_address_into_related_ip
+          tag: append_sensors_ip_address_into_related_ip_25008ec1
           value: '{{{_ingest._value.ip_address}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_json_sensors_7846c061
+      tag: foreach_json_sensors_c267b75a
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         date:
           field: _ingest._value.last_seen
-          tag: date_sensors_last_seen
+          tag: date_sensors_last_seen_c61ab04d
           target_field: _ingest._value.last_seen
           formats:
             - ISO8601
           on_failure:
             - remove:
-                tag: remove_ingest_value_last_seen
+                tag: remove_ingest_value_last_seen_7253fe1a
                 field: _ingest._value.last_seen
                 ignore_missing: true
   - foreach:
-      tag: foreach_json_sensors_abe59fe3
+      tag: foreach_json_sensors_0092d4d0
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         append:
           field: observer.name
-          tag: append_sensors_name_into_observer_name
+          tag: append_sensors_name_into_observer_name_b84fc087
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_json_sensors_62a04cad
+      tag: foreach_json_sensors_ea38d3e6
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         append:
           field: observer.serial_number
-          tag: append_sensors_serial_number_into_observer_serial_number
+          tag: append_sensors_serial_number_into_observer_serial_number_81db2072
           value: '{{{_ingest._value.serial_number}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_json_sensors_394710ab
+      tag: foreach_json_sensors_b9257835
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         convert:
           field: _ingest._value.update_count
-          tag: convert_sensors_update_count_to_long
+          tag: convert_sensors_update_count_to_long_4ade8fdd
           type: long
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_update_count
+                tag: remove_ingest_value_update_count_ec0eee4e
                 field: _ingest._value.update_count
                 ignore_missing: true
             - append:
-                tag: append_error_message_def17ce7
+                tag: append_error_message_1a39438b
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_sensors_399086f9
+      tag: foreach_json_sensors_bf947e86
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
         append:
           field: observer.version
-          tag: append_sensors_version_into_observer_version
+          tag: append_sensors_version_into_observer_version_9f59c8d0
           value: '{{{_ingest._value.version}}}'
           allow_duplicates: false
   - foreach:
-      tag: foreach_json_sensors_be14c680
+      tag: foreach_json_sensors_86a72a17
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -647,46 +647,46 @@ processors:
             - _ingest._value.ip_address
             - _ingest._value.last_seen
             - _ingest._value.headend_uri
-          tag: remove_sensors
+          tag: remove_sensors_218d8b94
           ignore_missing: true
   - rename:
       field: json.sensors
-      tag: rename_sensors
+      tag: rename_sensors_885824c8
       target_field: vectra_rux.health.sensors
       ignore_missing: true
   - foreach:
       field: vectra_rux.health.sensors
-      tag: foreach_vectra_rux_health_sensors_id
+      tag: foreach_vectra_rux_health_sensors_id_ae83b9c5
       if: ctx.vectra_rux?.health?.sensors instanceof List
       processor:
         convert:
           field: _ingest._value.id
-          tag: convert_vectra_rux_health_sensors_id_to_string
+          tag: convert_vectra_rux_health_sensors_id_to_string_75f814eb
           type: string
           ignore_missing: true
   - foreach:
       field: vectra_rux.health.sensors
-      tag: foreach_vectra_rux_health_sensors_headend_ip
+      tag: foreach_vectra_rux_health_sensors_headend_ip_b2e09e15
       if: ctx.vectra_rux?.health?.sensors instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_vectra_rux_health_sensors_headend_ip_into_related_ip
+          tag: append_vectra_rux_health_sensors_headend_ip_into_related_ip_cf95f6a9
           value: '{{{_ingest._value.headend_ip}}}'
           allow_duplicates: false
   - rename:
       field: json.system.serial_number
-      tag: rename_system_serial_number
+      tag: rename_system_serial_number_eace8b0c
       target_field: vectra_rux.health.system.serial_number
       ignore_missing: true
   - set:
       field: host.id
-      tag: set_host_id_from_health_system_serial_number
+      tag: set_host_id_from_health_system_serial_number_0d39e386
       copy_from: vectra_rux.health.system.serial_number
       ignore_empty_value: true
   - date:
       field: json.system.updated_at
-      tag: date_system_updated_at
+      tag: date_system_updated_at_936c333f
       target_field: vectra_rux.health.system.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -696,40 +696,40 @@ processors:
       if: ctx.json?.system?.updated_at != null && ctx.json.system.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_663b07f6
+            tag: append_error_message_e55714e1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.system.uptime
-      tag: rename_system_uptime
+      tag: rename_system_uptime_a575ef45
       target_field: vectra_rux.health.system.uptime
       ignore_missing: true
   - convert:
       field: json.system.version.cloud_bridge
-      tag: convert_system_version_cloud_bridge_to_boolean
+      tag: convert_system_version_cloud_bridge_to_boolean_b69b3b18
       target_field: vectra_rux.health.system.version.cloud_bridge
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_23701d3d
+            tag: append_error_message_5d50b2da
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.system.version.gmt
-      tag: date_system_version_gmt
+      tag: date_system_version_gmt_1f331a55
       target_field: vectra_rux.health.system.version.gmt
       formats:
         - ISO8601
       if: ctx.json?.system?.version?.gmt != null && ctx.json.system.version.gmt != ''
       on_failure:
         - append:
-            tag: append_error_message_d39962ff
+            tag: append_error_message_e567ae10
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.system.version.last_update
-      tag: date_system_version_last_update
+      tag: date_system_version_last_update_6777dfd6
       target_field: vectra_rux.health.system.version.last_update
       formats:
         - 'EEE MMM dd HH:mm:ss yyyy'
@@ -739,88 +739,88 @@ processors:
       if: ctx.json?.system?.version?.last_update != null && ctx.json.system.version.last_update != ''
       on_failure:
         - append:
-            tag: append_error_message_7c4732f7
+            tag: append_error_message_038765cc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       field: json.system.version.last_update_utc
-      tag: date_system_version_last_update_utc
+      tag: date_system_version_last_update_utc_d83833f1
       target_field: vectra_rux.health.system.version.last_update_utc
       formats:
         - ISO8601
       if: ctx.json?.system?.version?.last_update_utc != null && ctx.json.system.version.last_update_utc != ''
       on_failure:
         - append:
-            tag: append_error_message_5dcf4c28
+            tag: append_error_message_25d03756
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.system.version.mode
-      tag: rename_system_version_mode
+      tag: rename_system_version_mode_39c97d53
       target_field: vectra_rux.health.system.version.mode
       ignore_missing: true
   - rename:
       field: json.system.version.model
-      tag: rename_system_version_model
+      tag: rename_system_version_model_d3d630f4
       target_field: vectra_rux.health.system.version.model
       ignore_missing: true
   - rename:
       field: json.system.version.vectra_instance_type
-      tag: rename_system_version_vectra_instance_type
+      tag: rename_system_version_vectra_instance_type_bd1723d0
       target_field: vectra_rux.health.system.version.vectra_instance_type
       ignore_missing: true
   - rename:
       field: json.system.version.vectra_version
-      tag: rename_system_version_vectra_version
+      tag: rename_system_version_vectra_version_2ff9370d
       target_field: vectra_rux.health.system.version.vectra_version
       ignore_missing: true
   - rename:
       field: json.system.version.vm_type
-      tag: rename_system_version_vm_type
+      tag: rename_system_version_vm_type_b97c0e68
       target_field: vectra_rux.health.system.version.vm_type
       ignore_missing: true
   - set:
       field: host.type
-      tag: set_host_type_from_health_system_version_vm_type
+      tag: set_host_type_from_health_system_version_vm_type_ea890167
       copy_from: vectra_rux.health.system.version.vm_type
       ignore_empty_value: true
   - foreach:
-      tag: foreach_json_trafficdrop_sensors_bcf04b56
+      tag: foreach_json_trafficdrop_sensors_4d0479c2
       field: json.trafficdrop.sensors
       if: ctx.json?.trafficdrop?.sensors instanceof List
       processor:
         convert:
           field: _ingest._value.ip_address
-          tag: convert_trafficdrop_sensors_ip_address_to_ip
+          tag: convert_trafficdrop_sensors_ip_address_to_ip_d3be2bb9
           type: ip
           ignore_missing: true
           on_failure:
             - remove:
-                tag: remove_ingest_value_ip_address_f675b353
+                tag: remove_ingest_value_ip_address_3dad040e
                 field: _ingest._value.ip_address
                 ignore_missing: true
             - append:
-                tag: append_error_message_138b9be5
+                tag: append_error_message_da106a8b
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_json_trafficdrop_sensors_19e83dbc
+      tag: foreach_json_trafficdrop_sensors_71e94189
       field: json.trafficdrop.sensors
       if: ctx.json?.trafficdrop?.sensors instanceof List
       processor:
         append:
           field: related.ip
-          tag: append_trafficdrop_sensors_ip_address
+          tag: append_trafficdrop_sensors_ip_address_13781e44
           value: '{{{_ingest._value.ip_address}}}'
           allow_duplicates: false
   - rename:
       field: json.trafficdrop.sensors
-      tag: rename_trafficdrop_sensors
+      tag: rename_trafficdrop_sensors_7b8238ce
       target_field: vectra_rux.health.trafficdrop.sensors
       ignore_missing: true
   - date:
       field: json.trafficdrop.updated_at
-      tag: date_trafficdrop_updated_at
+      tag: date_trafficdrop_updated_at_84ee99ea
       target_field: vectra_rux.health.trafficdrop.updated_at
       formats:
         - yyyy-MM-dd HH:mm:ssXXXXX
@@ -830,11 +830,11 @@ processors:
       if: ctx.json?.trafficdrop?.updated_at != null && ctx.json.trafficdrop.updated_at != ''
       on_failure:
         - append:
-            tag: append_error_message_06f98d37
+            tag: append_error_message_fd26aae7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
-      tag: foreach_vectra_rux_health_sensors_9b375788
+      tag: foreach_vectra_rux_health_sensors_f73472a5
       field: vectra_rux.health.sensors
       if: ctx.vectra_rux?.health?.sensors instanceof List
       processor:
@@ -844,7 +844,7 @@ processors:
             - _ingest._value.version
             - _ingest._value.ip_address
             - _ingest._value.name
-          tag: remove_custom_duplicate_fields_from_vectra_rux_health_sensors
+          tag: remove_custom_duplicate_fields_from_vectra_rux_health_sensors_24c7a92f
           ignore_missing: true
           if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
@@ -860,17 +860,17 @@ processors:
         - vectra_rux.health.sensors.ip_address
         - vectra_rux.health.sensors.name
         - vectra_rux.health.cpu.user_percent
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_9caf8434
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   # Cleanup
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -896,26 +896,26 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message_7c7a2933
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind_68926a8f
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -47,6 +47,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -55,6 +56,7 @@ processors:
       target_field: vectra_rux.health.network.interfaces
       ignore_missing: true
   - foreach:
+      tag: foreach_json_connectivity_sensors_bb60514d
       field: json.connectivity.sensors
       if: ctx.json?.connectivity?.sensors instanceof List
       processor:
@@ -71,6 +73,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_connectivity_sensors_885beff1
       field: json.connectivity.sensors
       if: ctx.json?.connectivity?.sensors instanceof List
       processor:
@@ -92,6 +95,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8e22c31a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -102,6 +106,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_43453a8d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -112,6 +117,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6d950525
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -126,6 +132,7 @@ processors:
       if: ctx.json?.cpu?.updated_at != null && ctx.json.cpu.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_9c1d5e39
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -136,6 +143,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b1eda2c3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -195,6 +203,7 @@ processors:
       if: ctx.json?.detection?.updated_at != null && ctx.json.detection.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_b71d3574
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -235,6 +244,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_66249cd8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -245,6 +255,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bc337510
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -255,6 +266,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_286e9087
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -265,6 +277,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_97b7bb5f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -294,6 +307,7 @@ processors:
       if: ctx.json?.disk?.updated_at != null && ctx.json.disk.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_41e4a47a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -305,6 +319,7 @@ processors:
       if: ctx.json?.event_timestamp != null && ctx.json.event_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_a94eb2f3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -325,6 +340,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f3aecd30
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -335,6 +351,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_36479aed
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -345,6 +362,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_be67519d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -359,6 +377,7 @@ processors:
       if: ctx.json?.hostid?.updated_at != null && ctx.json.hostid.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_841133ac
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -369,6 +388,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9d505463
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -379,6 +399,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d5a09987
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -393,6 +414,7 @@ processors:
       if: ctx.json?.memory?.updated_at != null && ctx.json.memory.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_bc94db90
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -403,6 +425,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_995b2880
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -413,6 +436,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1b3bbdd6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -432,6 +456,7 @@ processors:
       if: ctx.json?.network?.updated_at != null && ctx.json.network.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_878ce00d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -442,9 +467,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_efb5f6b6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_network_vlans_vlan_ids_d37b9a1c
       field: json.network.vlans.vlan_ids
       if: ctx.json?.network?.vlans?.vlan_ids instanceof List
       processor:
@@ -485,9 +512,11 @@ processors:
       if: ctx.json?.power?.updated_at != null && ctx.json.power.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_dcefbc5a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_sensors_cc2adddd
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -503,6 +532,7 @@ processors:
                 tag: set_sensors_headend_uri
                 value: '{{{_ingest._value.headend_uri}}}'
   - foreach:
+      tag: foreach_json_sensors_8007c8b4
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -519,6 +549,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_sensors_59fe3c47
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -528,6 +559,7 @@ processors:
           value: '{{{_ingest._value.ip_address}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_sensors_ea469ea7
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -537,6 +569,7 @@ processors:
           value: '{{{_ingest._value.ip_address}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_sensors_7846c061
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -551,6 +584,7 @@ processors:
                 field: _ingest._value.last_seen
                 ignore_missing: true
   - foreach:
+      tag: foreach_json_sensors_abe59fe3
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -560,6 +594,7 @@ processors:
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_sensors_62a04cad
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -569,6 +604,7 @@ processors:
           value: '{{{_ingest._value.serial_number}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_sensors_394710ab
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -585,6 +621,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_sensors_399086f9
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -594,6 +631,7 @@ processors:
           value: '{{{_ingest._value.version}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_sensors_be14c680
       field: json.sensors
       if: ctx.json?.sensors instanceof List
       processor:
@@ -651,6 +689,7 @@ processors:
       if: ctx.json?.system?.updated_at != null && ctx.json.system.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_663b07f6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -666,6 +705,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_23701d3d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -677,6 +717,7 @@ processors:
       if: ctx.json?.system?.version?.gmt != null && ctx.json.system.version.gmt != ''
       on_failure:
         - append:
+            tag: append_error_message_d39962ff
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -691,6 +732,7 @@ processors:
       if: ctx.json?.system?.version?.last_update != null && ctx.json.system.version.last_update != ''
       on_failure:
         - append:
+            tag: append_error_message_7c4732f7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -702,6 +744,7 @@ processors:
       if: ctx.json?.system?.version?.last_update_utc != null && ctx.json.system.version.last_update_utc != ''
       on_failure:
         - append:
+            tag: append_error_message_5dcf4c28
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -735,6 +778,7 @@ processors:
       copy_from: vectra_rux.health.system.version.vm_type
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_trafficdrop_sensors_bcf04b56
       field: json.trafficdrop.sensors
       if: ctx.json?.trafficdrop?.sensors instanceof List
       processor:
@@ -751,6 +795,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_trafficdrop_sensors_19e83dbc
       field: json.trafficdrop.sensors
       if: ctx.json?.trafficdrop?.sensors instanceof List
       processor:
@@ -776,9 +821,11 @@ processors:
       if: ctx.json?.trafficdrop?.updated_at != null && ctx.json.trafficdrop.updated_at != ''
       on_failure:
         - append:
+            tag: append_error_message_06f98d37
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_vectra_rux_health_sensors_9b375788
       field: vectra_rux.health.sensors
       if: ctx.vectra_rux?.health?.sensors instanceof List
       processor:
@@ -844,6 +891,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/health/elasticsearch/ingest_pipeline/default.yml
@@ -67,9 +67,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_ip_address
                 field: _ingest._value.ip_address
                 ignore_missing: true
             - append:
+                tag: append_error_message
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -543,9 +545,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_ip_address_ac3230f5
                 field: _ingest._value.ip_address
                 ignore_missing: true
             - append:
+                tag: append_error_message_263fb6e9
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -581,6 +585,7 @@ processors:
             - ISO8601
           on_failure:
             - remove:
+                tag: remove_ingest_value_last_seen
                 field: _ingest._value.last_seen
                 ignore_missing: true
   - foreach:
@@ -615,9 +620,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_update_count
                 field: _ingest._value.update_count
                 ignore_missing: true
             - append:
+                tag: append_error_message_def17ce7
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -789,9 +796,11 @@ processors:
           ignore_missing: true
           on_failure:
             - remove:
+                tag: remove_ingest_value_ip_address_f675b353
                 field: _ingest._value.ip_address
                 ignore_missing: true
             - append:
+                tag: append_error_message_138b9be5
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -898,13 +907,15 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message_7c7a2933
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_68926a8f
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/lockdown/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/lockdown/elasticsearch/ingest_pipeline/default.yml
@@ -8,34 +8,34 @@ processors:
         - team
       ignore_missing: true
       if: ctx.organization instanceof String && ctx.division instanceof String && ctx.team instanceof String
-      tag: remove_agentless_tags
+      tag: remove_agentless_tags_e6856012
       description: >-
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
       field: ecs.version
-      tag: set_ecs_version
+      tag: set_ecs_version_dbf680ba
       value: 8.17.0
   - rename:
       field: message
-      tag: rename_message_to_event_original
+      tag: rename_message_to_event_original_176375fd
       target_field: event.original
       ignore_missing: true
       description: Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.
       if: ctx.event?.original == null
   - remove:
       field: message
-      tag: remove_message
+      tag: remove_message_9ecc8509
       ignore_missing: true
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
       field: event.original
-      tag: json_event_original
+      tag: json_event_original_a68ecd77
       target_field: json
       on_failure:
         - append:
-            tag: append_error_message_cea45f41
+            tag: append_error_message_b006b7b1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -44,161 +44,161 @@ processors:
         - json.entity_id
         - json.lock_event_timestamp
         - json.unlock_event_timestamp
-      tag: fingerprint_lockdown
+      tag: fingerprint_lockdown_2d60d88e
       target_field: _id
       ignore_missing: true
   - set:
       field: event.kind
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
       value: event
   - set:
       field: observer.product
-      tag: set_observer_product
+      tag: set_observer_product_3f675d2b
       value: Vectra RUX
   - append:
       field: event.category
-      tag: set_event_category
+      tag: set_event_category_91eb2116
       value: host
       if: ctx.json?.type == 'host'
   - append:
       field: event.type
-      tag: set_event_type
+      tag: set_event_type_ea9c2a21
       value: info
       if: ctx.json?.type == 'host'
   - convert:
       field: json.certainty
-      tag: convert_certainty_to_long
+      tag: convert_certainty_to_long_5b6de2e7
       target_field: vectra_rux.lockdown.certainty
       type: long
       ignore_missing: true
       on_failure:
         - append:
-            tag: append_error_message_37a48ed7
+            tag: append_error_message_68d7f913
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.entity_id
-      tag: convert_entity_id_to_string
+      tag: convert_entity_id_to_string_cc8b1dd0
       target_field: vectra_rux.lockdown.entity_id
       type: string
       ignore_missing: true
   - set:
       field: user.id
-      tag: set_user_id_from_lockdown_entity_id
+      tag: set_user_id_from_lockdown_entity_id_15c1b9bd
       copy_from: vectra_rux.lockdown.entity_id
       ignore_empty_value: true
       if: ctx.json?.type == 'account'
   - append:
       field: related.user
-      tag: append_user_id_into_related_user
+      tag: append_user_id_into_related_user_23cff8dc
       value: '{{{user.id}}}'
       allow_duplicates: false
       if: ctx.user?.id != null
   - set:
       field: host.id
-      tag: set_host_id_from_lockdown_entity_id
+      tag: set_host_id_from_lockdown_entity_id_3ef49a53
       copy_from: vectra_rux.lockdown.entity_id
       ignore_empty_value: true
       if: ctx.json?.type == 'host'
   - append:
       field: related.hosts
-      tag: append_host_id_into_related_hosts
+      tag: append_host_id_into_related_hosts_bd1f7443
       value: '{{{host.id}}}'
       allow_duplicates: false
       if: ctx.host?.id != null
   - rename:
       field: json.entity_name
-      tag: rename_entity_name
+      tag: rename_entity_name_a34ea93b
       target_field: vectra_rux.lockdown.entity_name
       ignore_missing: true
   - set:
       field: user.email
-      tag: set_user_email_from_lockdown_entity_name
+      tag: set_user_email_from_lockdown_entity_name_bda4266c
       copy_from: vectra_rux.lockdown.entity_name
       ignore_empty_value: true
       if: ctx.json?.type == 'account' && ctx.vectra_rux?.lockdown?.entity_name.contains("@")
   - append:
       field: related.user
-      tag: append_user_email_into_related_user
+      tag: append_user_email_into_related_user_b9ac313b
       value: '{{{user.email}}}'
       allow_duplicates: false
       if: ctx.user?.email != null
   - set:
       field: host.name
-      tag: set_user_name_from_lockdown_entity_name
+      tag: set_user_name_from_lockdown_entity_name_7a5b6469
       copy_from: vectra_rux.lockdown.entity_name
       ignore_empty_value: true
       if: ctx.json?.type == 'host'
   - append:
       field: related.hosts
-      tag: append_host_name_into_related_hosts
+      tag: append_host_name_into_related_hosts_82ac1e98
       value: '{{{host.name}}}'
       allow_duplicates: false
       if: ctx.host?.name != null
   - convert:
       field: json.id
-      tag: convert_id_to_string
+      tag: convert_id_to_string_db4ac93b
       target_field: vectra_rux.lockdown.id
       type: string
       ignore_missing: true
   - date:
       field: json.lock_event_timestamp
-      tag: date_lock_event_timestamp
+      tag: date_lock_event_timestamp_153e2628
       target_field: vectra_rux.lockdown.lock_event_timestamp
       formats:
         - ISO8601
       if: ctx.json?.lock_event_timestamp != null && ctx.json.lock_event_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_3824055e
+            tag: append_error_message_7aca9b03
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: '@timestamp'
-      tag: set_@timestamp_from_lockdown_lock_event_timestamp
+      tag: set_@timestamp_from_lockdown_lock_event_timestamp_aaaf28fa
       copy_from: vectra_rux.lockdown.lock_event_timestamp
       ignore_empty_value: true
   - set:
       field: event.start
-      tag: set_event_start_from_lockdown_lock_event_timestamp
+      tag: set_event_start_from_lockdown_lock_event_timestamp_891c531b
       copy_from: vectra_rux.lockdown.lock_event_timestamp
       ignore_empty_value: true
   - rename:
       field: json.locked_by
-      tag: rename_locked_by
+      tag: rename_locked_by_7bcd8f72
       target_field: vectra_rux.lockdown.locked_by
       ignore_missing: true
   - set:
       field: user.name
-      tag: set_user_name_from_lockdown_locked_by
+      tag: set_user_name_from_lockdown_locked_by_12df62ba
       copy_from: vectra_rux.lockdown.locked_by
       ignore_empty_value: true
   - append:
       field: related.user
-      tag: append_user_name_into_related_user
+      tag: append_user_name_into_related_user_325195a6
       value: '{{{user.name}}}'
       allow_duplicates: false
       if: ctx.user?.name != null
   - rename:
       field: json.type
-      tag: rename_type
+      tag: rename_type_b9c813c6
       target_field: vectra_rux.lockdown.type
       ignore_missing: true
   - date:
       field: json.unlock_event_timestamp
-      tag: date_unlock_event_timestamp
+      tag: date_unlock_event_timestamp_4d6aafbe
       target_field: vectra_rux.lockdown.unlock_event_timestamp
       formats:
         - ISO8601
       if: ctx.json?.unlock_event_timestamp != null && ctx.json.unlock_event_timestamp != ''
       on_failure:
         - append:
-            tag: append_error_message_c1d15d2b
+            tag: append_error_message_d2deec56
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.end
-      tag: set_event_end_from_lockdown_unlock_event_timestamp
+      tag: set_event_end_from_lockdown_unlock_event_timestamp_dd28f8c8
       copy_from: vectra_rux.lockdown.unlock_event_timestamp
       ignore_empty_value: true
   - remove:
@@ -207,17 +207,17 @@ processors:
         - vectra_rux.lockdown.lock_event_timestamp
         - vectra_rux.lockdown.locked_by
         - vectra_rux.lockdown.unlock_event_timestamp
-      tag: remove_custom_duplicate_fields
+      tag: remove_custom_duplicate_fields_bc5050b0
       ignore_missing: true
       if: ctx.tags == null || !ctx.tags.contains('preserve_duplicate_custom_fields')
   - remove:
       field: json
-      tag: remove_json
+      tag: remove_json_94dc55cd
       ignore_missing: true
   # Cleanup
   - script:
       description: This script processor iterates over the whole document to remove fields with null values.
-      tag: script_to_drop_null_values
+      tag: script_to_drop_null_values_47584e1d
       lang: painless
       source: |
         void handleMap(Map map) {
@@ -243,26 +243,26 @@ processors:
         handleMap(ctx);
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_4fd8ffa8
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
   - append:
-      tag: append_error_message
+      tag: append_error_message_6906b116
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind_147ffe6a
+      tag: set_pipeline_error_to_event_kind_72b1902f
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/lockdown/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/lockdown/elasticsearch/ingest_pipeline/default.yml
@@ -254,13 +254,15 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - append:
+      tag: append_error_message
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: event.kind
-      tag: set_pipeline_error_to_event_kind
+      tag: set_pipeline_error_to_event_kind_147ffe6a
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/data_stream/lockdown/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vectra_rux/data_stream/lockdown/elasticsearch/ingest_pipeline/default.yml
@@ -35,6 +35,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -72,6 +73,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_37a48ed7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -103,7 +105,7 @@ processors:
       tag: append_host_id_into_related_hosts
       value: '{{{host.id}}}'
       allow_duplicates: false
-      if: ctx.host?.id != null  
+      if: ctx.host?.id != null
   - rename:
       field: json.entity_name
       tag: rename_entity_name
@@ -148,6 +150,7 @@ processors:
       if: ctx.json?.lock_event_timestamp != null && ctx.json.lock_event_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_3824055e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -190,6 +193,7 @@ processors:
       if: ctx.json?.unlock_event_timestamp != null && ctx.json.unlock_event_timestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_c1d15d2b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -243,6 +247,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/vectra_rux/manifest.yml
+++ b/packages/vectra_rux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: vectra_rux
 title: "Vectra RUX"
-version: 0.5.1
+version: 0.5.2
 description: "Collect logs from Vectra RUX with Elastic Agent."
 type: integration
 categories:

--- a/packages/vectra_rux/manifest.yml
+++ b/packages/vectra_rux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: vectra_rux
 title: "Vectra RUX"
-version: 0.5.2
+version: 0.6.0
 description: "Collect logs from Vectra RUX with Elastic Agent."
 type: integration
 categories:

--- a/packages/withsecure_elements/changelog.yml
+++ b/packages/withsecure_elements/changelog.yml
@@ -1,7 +1,10 @@
-- version: "0.3.2"
+- version: "0.4.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/20575
+    - description: Append to `error.message` in the pipeline-level `on_failure` handlers instead of overwriting messages recorded by processor-level handlers.
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/20575
 - version: "0.3.1"
   changes:

--- a/packages/withsecure_elements/changelog.yml
+++ b/packages/withsecure_elements/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/20558
+      link: https://github.com/elastic/integrations/pull/20575
 - version: "0.3.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/withsecure_elements/changelog.yml
+++ b/packages/withsecure_elements/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.2"
+  changes:
+    - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20558
 - version: "0.3.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/withsecure_elements/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/withsecure_elements/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,7 @@ processors:
       if: ctx.event?.original != null && ctx.event.original instanceof String
       on_failure:
         - set:
+            tag: set_error_message_cebe6eaa
             field: error.message
             value: 'Failed to parse JSON from event.original'
       tag: json_decode
@@ -72,7 +73,7 @@ processors:
       target_field: _id
       ignore_missing: true
       tag: generate_document_id
-  
+
   # Map to ECS fields using copy_from
   - set:
       field: event.id
@@ -107,7 +108,6 @@ processors:
         } else if (normalized == 'severe') {
           ctx.event.severity = 99;
         }
-
   # Set timestamps
   - date:
       field: withsecure_elements.incidents.createdTimestamp
@@ -119,6 +119,7 @@ processors:
       tag: set_timestamp
       on_failure:
         - append:
+            tag: append_error_message_54574230
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -143,6 +144,7 @@ processors:
       tag: set_event_end
       on_failure:
         - append:
+            tag: append_error_message_52da5d7b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -152,6 +154,7 @@ processors:
       tag: set_pipeline_error_into_event_kind
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/withsecure_elements/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/withsecure_elements/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
@@ -161,15 +161,18 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - set:
+      tag: set_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
+      tag: set_event_kind_9da4dce5
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/withsecure_elements/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/withsecure_elements/data_stream/incidents/elasticsearch/ingest_pipeline/default.yml
@@ -7,12 +7,12 @@ processors:
       copy_from: message
       if: ctx.event?.original == null && ctx.message != null
       ignore_failure: true
-      tag: set_event_original
+      tag: set_event_original_9fef8b10
   - remove:
       field: message
       if: ctx.event?.original != null && ctx.message != null && ctx.message == ctx.event.original
       ignore_missing: true
-      tag: remove_message
+      tag: remove_message_edcbffed
 
   # Parse JSON directly into custom namespace
   - json:
@@ -21,49 +21,49 @@ processors:
       if: ctx.event?.original != null && ctx.event.original instanceof String
       on_failure:
         - set:
-            tag: set_error_message_cebe6eaa
+            tag: set_error_message_2eb15271
             field: error.message
             value: 'Failed to parse JSON from event.original'
-      tag: json_decode
+      tag: json_decode_b5ae2280
       description: Decode JSON from event.original into withsecure_elements.incidents
 
   # Set ECS version and basic fields
   - set:
       field: ecs.version
       value: '8.11.0'
-      tag: set_ecs_version
+      tag: set_ecs_version_6b2cef5e
   - set:
       field: event.dataset
       value: withsecure_elements.incidents
-      tag: set_event_dataset
+      tag: set_event_dataset_cde44aa2
   - set:
       field: event.module
       value: withsecure_elements
-      tag: set_event_module
+      tag: set_event_module_614d9fa0
   - set:
       field: event.category
       value: [threat]
-      tag: set_event_category
+      tag: set_event_category_4675e36d
   - set:
       field: event.type
       value: [incident]
-      tag: set_event_type
+      tag: set_event_type_222a3759
   - set:
       field: event.kind
       value: alert
-      tag: set_event_kind
+      tag: set_event_kind_ab1166ce
   - set:
       field: event.provider
       value: withsecure_elements
-      tag: set_event_provider
+      tag: set_event_provider_9379fd36
   - set:
       field: event.action
       value: detected
-      tag: set_event_action
+      tag: set_event_action_014ef516
   - set:
       field: event.outcome
       value: success
-      tag: set_event_outcome
+      tag: set_event_outcome_5592503e
 
   # Generate unique _id for automatic deduplication
   - fingerprint:
@@ -72,7 +72,7 @@ processors:
         - withsecure_elements.incidents.updatedTimestamp
       target_field: _id
       ignore_missing: true
-      tag: generate_document_id
+      tag: generate_document_id_db261dbc
 
   # Map to ECS fields using copy_from
   - set:
@@ -80,16 +80,16 @@ processors:
       copy_from: withsecure_elements.incidents.incidentId
       if: ctx.withsecure_elements?.incidents?.incidentId != null
       ignore_failure: true
-      tag: set_event_id
+      tag: set_event_id_a50183e8
   - set:
       field: event.risk_score
       copy_from: withsecure_elements.incidents.riskScore
       if: ctx.withsecure_elements?.incidents?.riskScore != null
       ignore_failure: true
-      tag: set_event_risk_score
+      tag: set_event_risk_score_6ede324d
   - script:
       lang: painless
-      tag: normalize_incident_severity
+      tag: normalize_incident_severity_9cb39bbe
       if: ctx.withsecure_elements?.incidents?.riskLevel != null
       source: >
         def riskLevelValue = ctx.withsecure_elements.incidents.riskLevel;
@@ -116,10 +116,10 @@ processors:
         - ISO8601
         - UNIX_MS
       if: ctx.withsecure_elements?.incidents?.createdTimestamp != null
-      tag: set_timestamp
+      tag: set_timestamp_0480b0bb
       on_failure:
         - append:
-            tag: append_error_message_54574230
+            tag: append_error_message_8375ebd9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -127,13 +127,13 @@ processors:
       copy_from: "@timestamp"
       if: ctx['@timestamp'] != null
       ignore_failure: true
-      tag: set_event_created
+      tag: set_event_created_0e43076c
   - set:
       field: event.start
       copy_from: "@timestamp"
       if: ctx['@timestamp'] != null
       ignore_failure: true
-      tag: set_event_start
+      tag: set_event_start_3a95004e
   - date:
       field: withsecure_elements.incidents.updatedTimestamp
       target_field: event.end
@@ -141,38 +141,38 @@ processors:
         - ISO8601
         - UNIX_MS
       if: ctx.withsecure_elements?.incidents?.updatedTimestamp != null
-      tag: set_event_end
+      tag: set_event_end_f6368345
       on_failure:
         - append:
-            tag: append_error_message_52da5d7b
+            tag: append_error_message_20cf2916
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
   - set:
       field: event.kind
       value: pipeline_error
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
-  - set:
-      tag: set_error_message
+  - append:
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
-      tag: set_event_kind_9da4dce5
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/withsecure_elements/data_stream/security_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/withsecure_elements/data_stream/security_events/elasticsearch/ingest_pipeline/default.yml
@@ -7,12 +7,12 @@ processors:
       copy_from: message
       if: ctx.event?.original == null && ctx.message != null
       ignore_failure: true
-      tag: set_event_original
+      tag: set_event_original_9fef8b10
   - remove:
       field: message
       if: ctx.event?.original != null && ctx.message != null && ctx.message == ctx.event.original
       ignore_missing: true
-      tag: remove_message
+      tag: remove_message_edcbffed
 
   # Parse JSON directly into custom namespace
   - json:
@@ -21,41 +21,41 @@ processors:
       if: ctx.event?.original != null && ctx.event.original instanceof String
       on_failure:
         - set:
-            tag: set_error_message_ed130b04
+            tag: set_error_message_8b43f7cf
             field: error.message
             value: 'Failed to parse JSON from event.original'
-      tag: json_decode
+      tag: json_decode_4c694c9f
       description: Decode JSON from event.original into withsecure_elements.security_events
 
   # Set ECS version and basic fields
   - set:
       field: ecs.version
       value: '8.11.0'
-      tag: set_ecs_version
+      tag: set_ecs_version_6b2cef5e
   - set:
       field: event.dataset
       value: withsecure_elements.security_events
-      tag: set_event_dataset
+      tag: set_event_dataset_622541f0
   - set:
       field: event.module
       value: withsecure_elements
-      tag: set_event_module
+      tag: set_event_module_614d9fa0
   - set:
       field: event.category
       value: [threat]
-      tag: set_event_category
+      tag: set_event_category_4675e36d
   - set:
       field: event.type
       value: [info]
-      tag: set_event_type
+      tag: set_event_type_8bf4a5be
   - set:
       field: event.kind
       value: event
-      tag: set_event_kind
+      tag: set_event_kind_d452ef2c
   - set:
       field: event.provider
       value: withsecure_elements
-      tag: set_event_provider
+      tag: set_event_provider_9379fd36
 
   # Generate unique _id for automatic deduplication
   - fingerprint:
@@ -64,7 +64,7 @@ processors:
         - withsecure_elements.security_events.persistenceTimestamp
       target_field: _id
       ignore_missing: true
-      tag: generate_document_id
+      tag: generate_document_id_f51c916c
 
   # Map to ECS fields using copy_from
   - set:
@@ -72,16 +72,16 @@ processors:
       copy_from: withsecure_elements.security_events.id
       if: ctx.withsecure_elements?.security_events?.id != null
       ignore_failure: true
-      tag: set_event_id
+      tag: set_event_id_0cff88d9
   - set:
       field: event.action
       copy_from: withsecure_elements.security_events.action
       if: ctx.withsecure_elements?.security_events?.action != null
       ignore_failure: true
-      tag: set_event_action
+      tag: set_event_action_b53546aa
   - script:
       lang: painless
-      tag: normalize_security_event_severity
+      tag: normalize_security_event_severity_f7523b29
       if: ctx.withsecure_elements?.security_events?.severity != null
       source: >
         def severityValue = ctx.withsecure_elements.security_events.severity;
@@ -106,10 +106,10 @@ processors:
         - UNIX_MS
         - ISO8601
       if: ctx.withsecure_elements?.security_events?.serverTimestamp != null
-      tag: set_timestamp
+      tag: set_timestamp_90203686
       on_failure:
         - append:
-            tag: append_error_message_4512bd14
+            tag: append_error_message_075d3d98
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -119,10 +119,10 @@ processors:
         - UNIX_MS
         - ISO8601
       if: ctx.withsecure_elements?.security_events?.persistenceTimestamp != null
-      tag: convert_persistence_timestamp
+      tag: convert_persistence_timestamp_65ee3cc4
       on_failure:
         - append:
-            tag: append_error_message_62c01212
+            tag: append_error_message_d968284a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -132,10 +132,10 @@ processors:
         - UNIX_MS
         - ISO8601
       if: ctx.withsecure_elements?.security_events?.clientTimestamp != null
-      tag: convert_client_timestamp
+      tag: convert_client_timestamp_27248e4f
       on_failure:
         - append:
-            tag: append_error_message_ff605dc2
+            tag: append_error_message_ddda4a03
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -146,33 +146,33 @@ processors:
         - withsecure_elements.security_events.persistenceTimestamp
         - withsecure_elements.security_events.clientTimestamp
       ignore_missing: true
-      tag: remove_raw_timestamps
+      tag: remove_raw_timestamps_31d9fc23
 
   - set:
       field: event.kind
       value: pipeline_error
-      tag: set_pipeline_error_into_event_kind
+      tag: set_pipeline_error_into_event_kind_4fd8ffa8
       if: ctx.error?.message != null
   - append:
-      tag: append_tags_9fe66b2c
+      tag: append_tags_b6c08950
       field: tags
       value: preserve_original_event
       allow_duplicates: false
       if: ctx.error?.message != null
 on_failure:
-  - set:
-      tag: set_error_message
+  - append:
+      tag: append_error_message_d916120d
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
-      tag: set_event_kind_0dea3c49
+      tag: set_event_kind_72b1902f
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_tags
+      tag: append_tags_279d5a5c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/withsecure_elements/data_stream/security_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/withsecure_elements/data_stream/security_events/elasticsearch/ingest_pipeline/default.yml
@@ -161,15 +161,18 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - set:
+      tag: set_error_message
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
         {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
+      tag: set_event_kind_0dea3c49
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/withsecure_elements/data_stream/security_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/withsecure_elements/data_stream/security_events/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,7 @@ processors:
       if: ctx.event?.original != null && ctx.event.original instanceof String
       on_failure:
         - set:
+            tag: set_error_message_ed130b04
             field: error.message
             value: 'Failed to parse JSON from event.original'
       tag: json_decode
@@ -64,7 +65,7 @@ processors:
       target_field: _id
       ignore_missing: true
       tag: generate_document_id
-  
+
   # Map to ECS fields using copy_from
   - set:
       field: event.id
@@ -97,7 +98,6 @@ processors:
         } else if (normalized == 'critical') {
           ctx.event.severity = 99;
         }
-
   # Set timestamps
   - date:
       field: withsecure_elements.security_events.serverTimestamp
@@ -109,6 +109,7 @@ processors:
       tag: set_timestamp
       on_failure:
         - append:
+            tag: append_error_message_4512bd14
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -121,6 +122,7 @@ processors:
       tag: convert_persistence_timestamp
       on_failure:
         - append:
+            tag: append_error_message_62c01212
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -133,6 +135,7 @@ processors:
       tag: convert_client_timestamp
       on_failure:
         - append:
+            tag: append_error_message_ff605dc2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
@@ -151,6 +154,7 @@ processors:
       tag: set_pipeline_error_into_event_kind
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/withsecure_elements/manifest.yml
+++ b/packages/withsecure_elements/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: withsecure_elements
 title: "WithSecure Elements"
-version: "0.3.2"
+version: "0.4.0"
 source:
   license: "Elastic-2.0"
 description: "Ingest WithSecure Elements incidents and security events data"

--- a/packages/withsecure_elements/manifest.yml
+++ b/packages/withsecure_elements/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: withsecure_elements
 title: "WithSecure Elements"
-version: "0.3.1"
+version: "0.3.2"
 source:
   license: "Elastic-2.0"
 description: "Ingest WithSecure Elements incidents and security events data"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
ssi: add processor tags and preserve_original_event on failure (4/4)

Tag every ingest pipeline processor across the 15 SSI-owned packages in
this final batch with a `<name>_<content hash>` identifier, so that
failure telemetry can attribute an error to the step that produced it
rather than collapsing same-type processors into one bucket. All 3724
processors across the 42 pipeline files now carry a tag, including
those nested inside `on_failure` handlers and `foreach` bodies, and
those in the pipeline-level `on_failure` block.

The hash is taken over the processor's content together with every
processor enclosing it, with `tag` keys stripped. This makes uniqueness
mechanical rather than positional, which matters: an earlier revision
kept the plain name on whichever duplicate came first, and that handed
`set_event_start_from_device_first_seen` to a processor setting
`host.type`, `set_host_hostname_from_health_appliance_host` to one
setting `host.name`, and `vul_id_is_long` to the script converting
`qid`. Hashing over the enclosing chain also gives identical constructs
the same identity in every package, so a single query aggregates
failures for one step across the whole estate; the hash carries that
identity, the readable prefix is for humans. Tags that said nothing --
`script_<hash>`, `drop_<hash>` -- are re-seeded from the processor's
`description`.

Unlike the other three batches, no package here needed
preserve_original_event adding to its pipeline-level on_failure; all
fifteen already had it.

Four fixes ride along, each recorded in the affected package's
changelog:

  - bitsight: event.original was removed at processor 7 of 23, before
    everything that records an error, so pipeline_error documents never
    retained the payload the preserve_original_event tagging exists to
    keep. It was the only package here still carrying that pattern, and
    pipeline tests missed it because the test config presets the tag.
  - withsecure_elements: the pipeline-level on_failure handlers set
    error.message instead of appending, discarding what processor-level
    handlers had already recorded.
  - extrahop: the participants.id on_failure handler removed the
    unrelated object_id field. Unreachable, as convert to string cannot
    fail, but the tag would have entrenched it.
  - swimlane: a duplicated no-op rename of swimlane.audit_log.category
    is removed rather than given a disambiguating tag.

These are enhancements, so the packages take a minor version bump.

Updates #20558

```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #20558
