### PR TITLE
[qualys_vmdr] request 4Gi of memory for agentless deployments

### DIFF
--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.20.0"
+  changes:
+    - description: Request 4Gi of memory for agentless deployments to avoid out-of-memory restarts in the asset_host_detection data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20579
 - version: "6.19.4"
   changes:
     - description: Fix deduplication in the asset_host_detection data stream.

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.19.4"
+version: "6.20.0"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:
@@ -45,6 +45,9 @@ policy_templates:
         organization: security
         division: engineering
         team: security-service-integrations
+        resources:
+          requests:
+            memory: 4Gi # Due to the large volume of data being processed in memory, a 4 GB allocation is required for agentless deployment.
     inputs:
       - type: cel
         title: Collect Qualys VMDR data via API


### PR DESCRIPTION
Proposed commit message:

```
qualys_vmdr: request 4Gi of memory for agentless deployments

The asset_host_detection input previously inherited the default agentless
memory allocation, which is not sufficient for the default batch size of 1000
hosts.

At publish time the CEL program holds the full host batch, the knowledge base
map accumulated across every paginated request for that batch, and the
flattened event array in memory simultaneously. Building the events copies the
entire host record once per detection, so peak usage scales with hosts x
detections-per-host rather than with the batch size alone.

Request 4Gi to match the other vulnerability management and security packages
 (rapid7_insightvm, m365_defender, microsoft_defender_endpoint, ti_crowdstrike).
```

## Why 4Gi

`asset_host_detection` accumulates several large structures in CEL state at the same time before it can publish. In
[`input.yml.hbs`] https://github.com/elastic/integrations/blob/main/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs#L206-L223):

- `state.worklist.AHD_LIST` holds the full host batch - `truncation_limit` is set  from `batch_size`, which defaults to 1000. In practice ~700 batch size is the limit with the current memory setup.
- `state.worklist.KB_MAP` grows monotonically across every paginated  `/api/4.0/fo/knowledge_base/vuln/` request for that batch  (`host_qid_list_query_limit`, default 500 QIDs per request).
- The events array is then built with  `AHD_LIST.map(h, h.DETECTION_LIST.DETECTION.map(v, h.with({...}))).flatten()`.

That last step is the amplifier: `h.with({...})` copies the entire host record once per detection and inlines its knowledge base entry, so peak usage scales with hosts × detections-per-host, not with `batch_size` alone and it happens while both source structures are still live.

This matches the four packages already owned by `security-service-integrations` that request 4Gi: `rapid7_insightvm` (same vulnerability-management and CDR workload shape),`m365_defender`, `microsoft_defender_endpoint` and `ti_crowdstrike`.



## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.

## How to test this PR locally

This change only adds the agentless resource request to the package manifest; there is no ingest, mapping or dashboard change, so the existing tests are unaffected.

To validate the manifest against the spec:

```
cd packages/qualys_vmdr
elastic-package check
```
