### PR TITLE
aws_securityhub: raise total_fields limit to prevent transform failures

### DIFF
--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Raise finding and transform destination `total_fields.limit` from 2000 to 5000 to prevent transform failures as dynamic resource fields grow.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/0
 - version: "1.2.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Raise finding and transform destination `total_fields.limit` from 2000 to 5000 to prevent transform failures as dynamic resource fields grow.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/0
+      link: https://github.com/elastic/integrations/pull/20405
     - description: Bump transform versions and destination index names so the new field limit is applied on upgrade.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/0
+      link: https://github.com/elastic/integrations/pull/20405
 - version: "1.2.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Raise finding and transform destination `total_fields.limit` from 2000 to 5000 to prevent transform failures as dynamic resource fields grow.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/20405
+      link: https://github.com/elastic/integrations/pull/20603
     - description: Bump transform versions and destination index names so the new field limit is applied on upgrade.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/20405
+      link: https://github.com/elastic/integrations/pull/20603
 - version: "1.2.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -4,6 +4,9 @@
     - description: Raise finding and transform destination `total_fields.limit` from 2000 to 5000 to prevent transform failures as dynamic resource fields grow.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/0
+    - description: Bump transform versions and destination index names so the new field limit is applied on upgrade.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/0
 - version: "1.2.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/aws_securityhub/data_stream/finding/manifest.yml
+++ b/packages/aws_securityhub/data_stream/finding/manifest.yml
@@ -6,7 +6,7 @@ elasticsearch:
       index:
         mapping:
           total_fields:
-            limit: 2000
+            limit: 5000
 streams:
   - input: cel
     title: Finding

--- a/packages/aws_securityhub/elasticsearch/transform/latest_cdr_vulnerabilities/manifest.yml
+++ b/packages/aws_securityhub/elasticsearch/transform/latest_cdr_vulnerabilities/manifest.yml
@@ -4,4 +4,4 @@ destination_index_template:
     index:
       mapping:
         total_fields:
-            limit: 2000
+            limit: 5000

--- a/packages/aws_securityhub/elasticsearch/transform/latest_cdr_vulnerabilities/transform.yml
+++ b/packages/aws_securityhub/elasticsearch/transform/latest_cdr_vulnerabilities/transform.yml
@@ -21,7 +21,7 @@ source:
               - data_frozen
               - data_cold
 dest:
-  index: "security_solution-aws_securityhub.vulnerability_latest-v1"
+  index: "security_solution-aws_securityhub.vulnerability_latest-v2"
   aliases:
     - alias: "security_solution-aws_securityhub.vulnerability_latest"
       move_on_creation: true
@@ -45,4 +45,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.2.0
+  fleet_transform_version: 0.3.0

--- a/packages/aws_securityhub/elasticsearch/transform/latest_findings/manifest.yml
+++ b/packages/aws_securityhub/elasticsearch/transform/latest_findings/manifest.yml
@@ -13,4 +13,4 @@ destination_index_template:
     index:
       mapping:
         total_fields:
-            limit: 2000
+            limit: 5000

--- a/packages/aws_securityhub/elasticsearch/transform/latest_findings/transform.yml
+++ b/packages/aws_securityhub/elasticsearch/transform/latest_findings/transform.yml
@@ -8,7 +8,7 @@ source:
         - exists:
             field: error.message
 dest:
-  index: "logs-aws_securityhub_latest.dest_finding-1"
+  index: "logs-aws_securityhub_latest.dest_finding-2"
   aliases:
     - alias: "logs-aws_securityhub_latest.finding"
       move_on_creation: true
@@ -38,5 +38,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0
   run_as_kibana_system: false

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_securityhub
 title: "AWS Security Hub"
-version: 1.2.1
+version: 1.2.2
 source:
   license: "Elastic-2.0"
 description: Collect logs from AWS Security Hub with Elastic Agent.


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws_securityhub: raise total_fields limit to prevent transform failures

The finding data stream already declares ~1,570 fields against a 2000
total_fields.limit, leaving little room for the resource subtrees that
map dynamically: resources.data covers only two of the ASFF detail
schemas, and resources.tags keys are customer-defined. The
latest_findings transform destination hits that ceiling and goes
health red; the data stream itself survives only because logs@settings
sets ignore_dynamic_beyond_limit, silently dropping the excess.

Raise the limit to 5000 on the finding stream and both transform
destinations. Bump fleet_transform_version and the destination index
names so the new setting reaches existing installations, since Fleet
skips reinstalling the destination index template when the transform
version is unchanged and does not delete the destination index on
upgrade.
```


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/20604
