### PR TITLE
system/auth: extract group.name and set event.action for groupadd/groupdel

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.22.3"
+  changes:
+    - description: Fix group.name not being extracted from groupadd messages in the /etc/group and /etc/gshadow formats and from groupdel removal messages. Populate event.action with group-added or group-deleted for these events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/20063
 - version: "2.22.2"
   changes:
     - description: Replace the hardcoded host link in the "[Metrics System] Overview" dashboard with a dashboard-to-dashboard drilldown, so navigation to "[Metrics System] Host Overview" works across Kibana Spaces (including after "Copy to Space").

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
@@ -790,6 +790,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
@@ -766,6 +766,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
@@ -2316,6 +2316,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],
@@ -2327,6 +2328,10 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "id": "1003",
+                "name": "tsg"
             },
             "host": {
                 "hostname": "precise32"
@@ -2354,6 +2359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],
@@ -2365,6 +2371,9 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "name": "tsg"
             },
             "host": {
                 "hostname": "precise32"
@@ -2392,6 +2401,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],
@@ -4642,6 +4652,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],
@@ -4653,6 +4664,10 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "id": "111",
+                "name": "mysql"
             },
             "host": {
                 "hostname": "precise32"
@@ -4680,6 +4695,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],
@@ -4691,6 +4707,9 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "name": "mysql"
             },
             "host": {
                 "hostname": "precise32"
@@ -4718,6 +4737,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
@@ -468,6 +468,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-added",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-groupdel.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-groupdel.log
@@ -1,0 +1,3 @@
+Jul  1 10:56:50 host1 groupadd[3829308]: group added to /etc/gshadow: name=fleet
+Jul  1 11:05:59 host1 groupdel[3870987]: group 'fleet' removed from /etc/gshadow
+Jul  1 11:05:59 host1 groupdel[3870987]: group 'fleet' removed from /etc/group

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-groupdel.log-config.yml
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-groupdel.log-config.yml
@@ -1,0 +1,7 @@
+fields:
+  event:
+    timezone: "+0000"
+  input.type: log
+dynamic_fields:
+  "event.ingested": "^.*$"
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}Z$"

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-groupdel.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-groupdel.log-expected.json
@@ -1,0 +1,130 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-07-01T10:56:50.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-added",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "Jul  1 10:56:50 host1 groupadd[3829308]: group added to /etc/gshadow: name=fleet",
+                "outcome": "success",
+                "timezone": "+0000",
+                "type": [
+                    "group",
+                    "creation"
+                ]
+            },
+            "group": {
+                "name": "fleet"
+            },
+            "host": {
+                "hostname": "host1"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "group added to /etc/gshadow: name=fleet",
+            "process": {
+                "name": "groupadd",
+                "pid": 3829308
+            },
+            "related": {
+                "hosts": [
+                    "host1"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-07-01T11:05:59.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "Jul  1 11:05:59 host1 groupdel[3870987]: group 'fleet' removed from /etc/gshadow",
+                "outcome": "success",
+                "timezone": "+0000",
+                "type": [
+                    "group",
+                    "deletion"
+                ]
+            },
+            "group": {
+                "name": "fleet"
+            },
+            "host": {
+                "hostname": "host1"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "group 'fleet' removed from /etc/gshadow",
+            "process": {
+                "name": "groupdel",
+                "pid": 3870987
+            },
+            "related": {
+                "hosts": [
+                    "host1"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-07-01T11:05:59.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "Jul  1 11:05:59 host1 groupdel[3870987]: group 'fleet' removed from /etc/group",
+                "outcome": "success",
+                "timezone": "+0000",
+                "type": [
+                    "group",
+                    "deletion"
+                ]
+            },
+            "group": {
+                "name": "fleet"
+            },
+            "host": {
+                "hostname": "host1"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "group 'fleet' removed from /etc/group",
+            "process": {
+                "name": "groupdel",
+                "pid": 3870987
+            },
+            "related": {
+                "hosts": [
+                    "host1"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
@@ -51,6 +51,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-deleted",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
@@ -106,6 +106,24 @@ processors:
         - "^delete user '%{USERNAME:_temp.userdel_user}'$"
         - "^removed (?:shadow )?group '%{DATA:_temp.userdel_group}'"
   - grok:
+      description: Extract group name from groupadd messages for /etc/group and /etc/gshadow entries.
+      tag: grok-groupadd
+      field: message
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.process?.name == 'groupadd'
+      patterns:
+        - '^group added to /etc/(?:group|gshadow): name=%{DATA:group.name}(?:, GID=%{NUMBER:group.id})?$'
+  - grok:
+      description: Extract group name from groupdel messages for /etc/group and /etc/gshadow entries.
+      tag: grok-groupdel
+      field: message
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.process?.name == 'groupdel'
+      patterns:
+        - "^group '%{DATA:group.name}' removed from /etc/(?:group|gshadow)$"
+  - grok:
       description: Grok usernames from PAM messages.
       tag: grok-pam-users
       field: message
@@ -621,6 +639,16 @@ processors:
       field: event.type
       value: change
       if: ctx.process?.name != null && ['usermod', 'groupmod'].contains(ctx.process.name)
+  - set:
+      tag: set_action-group-added
+      field: event.action
+      value: group-added
+      if: ctx.process?.name == 'groupadd'
+  - set:
+      tag: set_action-group-deleted
+      field: event.action
+      value: group-deleted
+      if: ctx.process?.name == 'groupdel'
   - append:
       tag: append_related-user-name
       field: related.user

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.22.2"
+version: "2.22.3"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

Fixes #20063

Two bugs in the `system.auth` ingest pipeline for `groupadd` and `groupdel` events:

- **`group.name` not extracted** from the additional message formats Linux emits alongside the primary `new group:` line:
  - `group added to /etc/group: name=fleet, GID=1234` (groupadd)
  - `group added to /etc/gshadow: name=fleet` (groupadd)
  - `group 'fleet' removed from /etc/gshadow` (groupdel)
  - `group 'fleet' removed from /etc/group` (groupdel)

- **`event.action` never set** for groupadd or groupdel events. The pipeline was correctly setting `event.category: iam` and `event.type: [group, creation/deletion]` but left `event.action` empty.

### Changes

- Add `grok-groupadd` processor (conditional on `process.name == 'groupadd'`) to extract `group.name` (and `group.id` where present) from the `/etc/group` and `/etc/gshadow` message formats.
- Add `grok-groupdel` processor (conditional on `process.name == 'groupdel'`) to extract `group.name` from `group 'xxx' removed from /etc/...` messages.
- Add `event.action: group-added` for `groupadd` and `event.action: group-deleted` for `groupdel`.
- Update all affected pipeline test expected outputs.
- Add new `test-groupdel.log` test fixture covering the exact message formats from the issue.

## Test plan

- [ ] All existing `system/auth` pipeline tests pass (`elastic-package test pipeline`)
- [ ] New `test-groupdel.log` test confirms `group.name` and `event.action` are populated for both groupadd and groupdel messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)