### PR TITLE
[Crowdstrike] Mask AWS access_key_id policy variable as secret

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Mask AWS access_key_id policy variable as secret for FDR data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20615
 - version: "4.6.0"
   changes:
     - description: Set the User-Agent header for HTTP requests to CrowdStrike API endpoints.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.7.0"
+  changes:
+    - description: Mask AWS access_key_id policy variable as secret for FDR data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "4.6.0"
   changes:
     - description: Set the User-Agent header for HTTP requests to CrowdStrike API endpoints.

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/policy/test-aws-s3-credentials.expected
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/policy/test-aws-s3-credentials.expected
@@ -1,0 +1,249 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: crowdstrike
+      name: test-aws-s3-credentials-crowdstrike
+      streams:
+        - access_key_id: ${SECRET_0}
+          data_stream:
+            dataset: crowdstrike.fdr
+          fields:
+            _conf:
+                enable_deduplication: false
+                enable_geoip_destination_ip: true
+                enable_geoip_observer_ip: true
+                enable_geoip_source_ip: true
+                long_fields: index_long_fields
+                long_fields_max_length: 1024
+                prune_fields: true
+          fields_under_root: true
+          max_number_of_messages: 5
+          number_of_workers: 5
+          processors:
+            - add_locale: null
+            - decode_json_fields:
+                fields: message
+                target: crowdstrike
+            - else:
+                - else:
+                    - cache:
+                        backend:
+                            file:
+                                id: aidmaster
+                        get:
+                            ignore_missing: true
+                            key_field: crowdstrike.aid
+                            target_field: metadata.host
+                    - cache:
+                        backend:
+                            file:
+                                id: userinfo
+                        get:
+                            ignore_missing: true
+                            key_field: crowdstrike.UserSid
+                            target_field: metadata.user
+                  if:
+                    contains:
+                        log.file.path: userinfo
+                  then:
+                    - cache:
+                        backend:
+                            capacity: 0
+                            file:
+                                id: userinfo
+                                write_interval: 0
+                        put:
+                            ignore_missing: true
+                            key_field: crowdstrike.UserSid_readable
+                            ttl: 168h
+                            value_field: crowdstrike
+              if:
+                contains:
+                    log.file.path: aidmaster
+              then:
+                - cache:
+                    backend:
+                        capacity: 0
+                        file:
+                            id: aidmaster
+                            write_interval: 0
+                    put:
+                        ignore_missing: true
+                        key_field: crowdstrike.aid
+                        ttl: 168h
+                        value_field: crowdstrike
+            - drop_fields:
+                fields:
+                    - crowdstrike
+          publisher_pipeline.disable_host: true
+          queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/test-queue
+          secret_access_key: ${SECRET_1}
+          sqs.notification_parsing_script.source: |
+            function parse(n) {
+              var m = JSON.parse(n);
+              var evts = [];
+              var files = m.files;
+              var bucket = m.bucket;
+              var records = m.Records;
+              var message = m.Message;
+              var topic_arn = m.TopicArn;
+              // Checks if not FDR queue
+              if (!Array.isArray(files) || (files.length == 0) || bucket == null || bucket == "") {
+                // Checks if event notification is S3 -> SQS or S3 -> SNS -> SQS.
+                if ((records != null && records.length != 0) || (message != null && topic_arn != null)) {
+                  // When notification is from S3 -> SNS -> SQS, records need to be extracted from message.
+                  if (records == null || records.length == 0) {
+                    var p = JSON.parse(message);
+                    records = p.Records;
+                  }
+                  if (records != null && records.length != 0) {
+                    records.forEach(function(f){
+                      if (f.s3 && f.s3.bucket && f.s3.bucket.name && f.s3.object && f.s3.object.key) {
+                        var evt = new S3EventV2();
+                        evt.SetS3BucketName(f.s3.bucket.name);
+                        evt.SetS3ObjectKey(f.s3.object.key);
+                        if (f.s3.bucket.arn) {
+                          evt.SetS3BucketARN(f.s3.bucket.arn);
+                        }
+                        if (f.awsRegion) {
+                          evt.SetAWSRegion(f.awsRegion);
+                        }
+                        if (f.eventName) {
+                          evt.SetEventName(f.eventName);
+                        }
+                        if (f.eventSource) {
+                          evt.SetEventSource(f.eventSource);
+                        }
+                        evts.push(evt);
+                      }
+                    });
+                  }
+                }
+                // Checks if event notification is S3 -> EventBridge -> SQS
+                else if (m.detail != null && m.detail.bucket != null && m.detail.object != null && m.detail.bucket.name != null && m.detail.object.key != null) {
+                  var evt = new S3EventV2();
+                  evt.SetS3BucketName(m.detail.bucket.name);
+                  evt.SetS3ObjectKey(m.detail.object.key);
+                  if (Array.isArray(m.resources) && m.resources.length > 0) {
+                    evt.SetS3BucketARN(m.resources[0]);
+                  }
+                  if (m.source != null && m.source == "aws.s3") {
+                    evt.SetEventSource("aws:s3");
+                  }
+                  if (m['detail-type'] == "Object Created") {
+                    evt.SetEventName("ObjectCreated:Put");
+                  }
+                  evts.push(evt);
+                }
+              } else {
+                // FDR queue
+                files.sort(function(a, b) {
+                  var isMetadata = function(a) {
+                    return a.path && ((a.path.indexOf("aidmaster") !== -1) || (a.path.indexOf("userinfo") !== -1));
+                  };
+                  var cmp = function(a, b) {
+                    if (a < b) {
+                      return -1;
+                    }
+                    if (a > b) {
+                      return 1;
+                    }
+                    return 0;
+                  };
+                  if (isMetadata(a) === isMetadata(b)) {
+                    return cmp(a.path, b.path);
+                  }
+                  if (isMetadata(a)) {
+                    return -1;
+                  }
+                  return 1;
+                });
+                files.forEach(function(f){
+                  var evt = new S3EventV2();
+                  evt.SetS3BucketName(bucket);
+                  evt.SetS3ObjectKey(f.path);
+                  evts.push(evt);
+                });
+              }
+              return evts;
+            }
+            function test() {
+              // Test FDR queue
+              var fdrEvents = parse("{\"bucket\":\"fdrBucket\",\"files\":[{\"path\":\"prefix/aidmaster\",\"size\":89118480,\"checksum\":\"d0f566f37295e46f28c75f71ddce9422\"},{\"path\":\"prefix/data\"}]}");
+              if (fdrEvents.length !== 2) {
+                throw "expecting two events";
+              }
+              if (fdrEvents[0].S3.Bucket.Name !== "fdrBucket") {
+                  throw "expected bucket === fdrBucket";
+              }
+              if (fdrEvents[0].S3.Object.Key !== "prefix/aidmaster") {
+                  throw "expected object key === prefix/aidmaster";
+              }
+              if (fdrEvents[1].S3.Object.Key !== "prefix/data") {
+                  throw "expected object key === prefix/data";
+              }
+              // Test S3 -> SQS
+              var sqsEvents = parse("{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"2025-05-27T11:38:32.511Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:DKASHW31673218\"},\"requestParameters\":{\"sourceIPAddress\":\"81.2.69.142\"},\"responseElements\":{\"x-amz-request-id\":\"adqw312EASDS\",\"x-amz-id-2\":\"SD312ESDAD/ASDASDQX1E21XE/6aeP0eHq4aYCvF\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"test-sqs-cs-s3-evt-notif-sqs\",\"bucket\":{\"name\":\"test-sqs-cs-s3\",\"ownerIdentity\":{\"principalId\":\"321DSAVDW2E1\"},\"arn\":\"arn:aws:s3:::test-sqs-cs-s3\"},\"object\":{\"key\":\"fdr-sample.log\",\"size\":114782,\"eTag\":\"41cdbd1843a4c49ef0255e2ccd48cb9d\",\"sequencer\":\"006835A4387B4406AF\"}}}]}");
+              if (sqsEvents.length !== 1) {
+                throw "expecting one events";
+              }
+              if (sqsEvents[0].S3.Bucket.Name !== "test-sqs-cs-s3") {
+                  throw "expected bucket === test-sqs-cs-s3";
+              }
+              if (sqsEvents[0].S3.Bucket.ARN !== "arn:aws:s3:::test-sqs-cs-s3") {
+                  throw "expected Bucket ARN === arn:aws:s3:::test-sqs-cs-s3";
+              }
+              if (sqsEvents[0].S3.Object.Key !== "fdr-sample.log") {
+                  throw "expected object key === fdr-sample.log";
+              }
+              // Test S3 -> SNS -> SQS
+              var snsEvents = parse("{\"Type\": \"Notification\",\"MessageId\": \"1066e639-8697-5211-9bbe-86a369b14af5\",\"TopicArn\": \"arn:aws:sns:us-east-2:11111111111:test-crowds-sns\",\"Subject\": \"Amazon S3 Notification\",\"Message\": \"{\\\"Records\\\":[{\\\"eventVersion\\\":\\\"2.1\\\",\\\"eventSource\\\":\\\"aws:s3\\\",\\\"awsRegion\\\":\\\"us-east-2\\\",\\\"eventTime\\\":\\\"2025-05-11T18:31:01.609Z\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"userIdentity\\\":{\\\"principalId\\\":\\\"AWS:PRINCIPALID\\\"},\\\"requestParameters\\\":{\\\"sourceIPAddress\\\":\\\"81.2.69.192\\\"},\\\"responseElements\\\":{\\\"x-amz-request-id\\\":\\\"dsaddwqdqd\\\",\\\"x-amz-id-2\\\":\\\"w1esdasdadpY=\\\"},\\\"s3\\\":{\\\"s3SchemaVersion\\\":\\\"1.0\\\",\\\"configurationId\\\":\\\"test-crowds-s3-notif\\\",\\\"bucket\\\":{\\\"name\\\":\\\"test-crowds-s3-buck\\\",\\\"ownerIdentity\\\":{\\\"principalId\\\":\\\"asdascedqwdq\\\"},\\\"arn\\\":\\\"arn:aws:s3:::test-crowds-s3-buck\\\"},\\\"object\\\":{\\\"key\\\":\\\"fdr-0_userinfo.log\\\",\\\"size\\\":489,\\\"eTag\\\":\\\"349c96ed5531edce2233ad417123736d\\\",\\\"sequencer\\\":\\\"006820ECE595B767EC\\\"}}}]}\",\"Timestamp\": \"2025-05-11T18:31:02.037Z\",\"SignatureVersion\": \"1\",\"Signature\": \"W131adsfwefQSF223SAsdddsaas+dsdadfadqweweweaxaDSCQQW==\",\"SigningCertURL\": \"https://sns.us-east-2.amazonaws.com/SimpleNotificationService-9c6465fa7f48f5cacd23014631ec1136.pem\",\"UnsubscribeURL\": \"https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:11111111111:test-crowds-sns:c2e6ff87-e009-4694-866a-5ceb79691a01\"}");
+              if (snsEvents.length !== 1) {
+                throw "expecting one events";
+              }
+              if (snsEvents[0].S3.Bucket.Name !== "test-crowds-s3-buck") {
+                  throw "expected bucket === test-crowds-s3-buck";
+              }
+              if (snsEvents[0].AWSRegion !== "us-east-2") {
+                  throw "expected AWS region === us-east-2";
+              }
+              // Test S3 -> EventBridge -> SQS
+              var ebEvents = parse("{\"version\":\"0\",\"id\":\"78fee647-ef01-0e61-507f-d19baef343f5\",\"detail-type\":\"Object Created\",\"source\":\"aws.s3\",\"account\":\"11111111111\",\"time\":\"2025-05-11T19:26:39Z\",\"region\":\"ap-south-1\",\"resources\":[\"arn:aws:s3:::test-eb-crowds-s3-buck\"],\"detail\":{\"version\":\"0\",\"bucket\":{\"name\":\"test-eb-crowds-s3-buck\"},\"object\":{\"key\":\"fdr-0_aidmaster.log\",\"size\":4414,\"etag\":\"a06a88462e6950f0be3bb83230047e87\",\"sequencer\":\"006820F9EF8D8284D4\"},\"request-id\":\"321987SDASD1W9\",\"requester\":\"11111111111\",\"source-ip-address\":\"89.160.20.128\",\"reason\":\"PutObject\"}}");
+              if (ebEvents.length !== 1) {
+                throw "expecting one events";
+              }
+              if (ebEvents[0].S3.Bucket.Name !== "test-eb-crowds-s3-buck") {
+                  throw "expected bucket === test-eb-crowds-s3-buck";
+              }
+              if (ebEvents[0].S3.Bucket.ARN !== "arn:aws:s3:::test-eb-crowds-s3-buck") {
+                  throw "expected Bucket ARN === arn:aws:s3:::test-eb-crowds-s3-buck";
+              }
+              if (ebEvents[0].S3.Object.Key !== "fdr-0_aidmaster.log") {
+                  throw "expected object key === fdr-0_aidmaster.log";
+              }
+            }
+          tags:
+            - preserve_original_event
+            - forwarded
+            - crowdstrike-fdr
+      type: aws-s3
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-crowdstrike.fdr-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}
+    - {}

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/policy/test-aws-s3-credentials.yml
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/policy/test-aws-s3-credentials.yml
@@ -1,0 +1,7 @@
+input: aws-s3
+data_stream:
+  vars:
+    access_key_id: FAKE_AWS_ACCESS_KEY_ID_FOR_TESTS_ONLY
+    secret_access_key: FAKE_AWS_SECRET_ACCESS_KEY_FOR_TESTS_ONLY
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/test-queue
+    preserve_original_event: true

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -15,12 +15,12 @@ streams:
     enabled: false
     vars:
       - name: access_key_id
-        type: text
+        type: password
         title: Access Key ID
         multi: false
         required: false
         show_user: true
-        secret: false
+        secret: true
       - name: secret_access_key
         type: password
         title: Secret Access Key

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "4.6.0"
+version: "4.7.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
## Proposed commit message

```
  crowdstrike: Mask FDR access_key_id as a secret policy variable.

  Mask the FDR aws-s3 `access_key_id` policy variable as secret by changing
  `type` from `text` to `password` and `secret` from `false` to `true`, so AWS
  access key IDs are masked in Fleet like `secret_access_key` and
  `session_token`.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

## Related issues

- Closes #20571