### PR TITLE
[xm_cyber] Add Client Identification Header to all API Requests

### DIFF
--- a/packages/xm_cyber/changelog.yml
+++ b/packages/xm_cyber/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Add X-XMCYBER-CONNECTOR-NAME-VERSION client identification header to all API requests.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/xm_cyber/changelog.yml
+++ b/packages/xm_cyber/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add X-XMCYBER-CONNECTOR-NAME-VERSION client identification header to all API requests.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20618
 - version: "0.1.2"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/xm_cyber/data_stream/audit_trail/agent/stream/cel.yml.hbs
+++ b/packages/xm_cyber/data_stream/audit_trail/agent/stream/cel.yml.hbs
@@ -19,6 +19,7 @@ max_executions: {{max_executions}}
 state:
   api_key: {{api_key}}
   page_size: {{page_size}}
+  connector_id: Elastic-XM-Cyber/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_key
@@ -37,6 +38,7 @@ program: |-
               "Header": {
                 "X-Api-Key": [state.api_key],
                 "Content-Type": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(authResp,
@@ -80,6 +82,7 @@ program: |-
               "Header": {
                 "Authorization": ["Bearer " + tok.access],
                 "Content-Type": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(resp,
@@ -105,7 +108,10 @@ program: |-
                 {"refreshToken": tok.refresh}.encode_json()
               ).with(
                 {
-                  "Header": {"Content-Type": ["application/json"]},
+                  "Header": {
+                    "Content-Type": ["application/json"],
+                    "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
+                  },
                 }
               ).do_request().as(refResp,
                   refResp.Body.decode_json().as(ro,

--- a/packages/xm_cyber/data_stream/device/agent/stream/cel.yml.hbs
+++ b/packages/xm_cyber/data_stream/device/agent/stream/cel.yml.hbs
@@ -19,6 +19,7 @@ max_executions: {{max_executions}}
 state:
   api_key: {{api_key}}
   page_size: {{page_size}}
+  connector_id: Elastic-XM-Cyber/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_key
@@ -37,6 +38,7 @@ program: |
             "Header": {
               "X-Api-Key": [state.api_key],
               "Content-Type": ["application/json"],
+              "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
             },
           }
         ).do_request().as(authResp,
@@ -92,6 +94,7 @@ program: |
               "Header": {
                 "Authorization": ["Bearer " + tok.access],
                 "Accept": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(resp,
@@ -118,7 +121,10 @@ program: |
                 {"refreshToken": tok.refresh}.encode_json()
               ).with(
                 {
-                  "Header": {"Content-Type": ["application/json"]},
+                  "Header": {
+                    "Content-Type": ["application/json"],
+                    "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
+                  },
                 }
               ).do_request().as(refResp,
                 refResp.Body.decode_json().as(ro,

--- a/packages/xm_cyber/data_stream/entity_inventory/agent/stream/cel.yml.hbs
+++ b/packages/xm_cyber/data_stream/entity_inventory/agent/stream/cel.yml.hbs
@@ -20,6 +20,7 @@ state:
   url: {{url}}
   api_key: {{api_key}}
   page_size: {{page_size}}
+  connector_id: Elastic-XM-Cyber/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_key
@@ -37,6 +38,7 @@ program: |
               "Header": {
                 "X-Api-Key": [state.api_key],
                 "Content-Type": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(authResp,
@@ -79,6 +81,7 @@ program: |
               "Header": {
                 "Authorization": ["Bearer " + tok.access],
                 "Content-Type": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(resp,
@@ -105,7 +108,10 @@ program: |
                 {"refreshToken": tok.refresh}.encode_json()
               ).with(
                 {
-                  "Header": {"Content-Type": ["application/json"]},
+                  "Header": {
+                    "Content-Type": ["application/json"],
+                    "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
+                  },
                 }
               ).do_request().as(refResp,
                 refResp.Body.decode_json().as(ro,

--- a/packages/xm_cyber/data_stream/product/agent/stream/cel.yml.hbs
+++ b/packages/xm_cyber/data_stream/product/agent/stream/cel.yml.hbs
@@ -19,6 +19,7 @@ max_executions: {{max_executions}}
 state:
   api_key: {{api_key}}
   page_size: {{page_size}}
+  connector_id: Elastic-XM-Cyber/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_key
@@ -37,6 +38,7 @@ program: |
               "Header": {
                 "X-Api-Key": [state.api_key],
                 "Content-Type": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(authResp,
@@ -92,6 +94,7 @@ program: |
                 "Header": {
                   "Authorization": ["Bearer " + tok.access],
                   "Accept": ["application/json"],
+                  "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
                 },
               }
             ).do_request().as(resp,
@@ -118,7 +121,10 @@ program: |
                   {"refreshToken": tok.refresh}.encode_json()
                 ).with(
                   {
-                    "Header": {"Content-Type": ["application/json"]},
+                    "Header": {
+                      "Content-Type": ["application/json"],
+                      "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
+                    },
                   }
                 ).do_request().as(refResp,
                   refResp.Body.decode_json().as(ro,

--- a/packages/xm_cyber/data_stream/risk_score/agent/stream/cel.yml.hbs
+++ b/packages/xm_cyber/data_stream/risk_score/agent/stream/cel.yml.hbs
@@ -20,6 +20,7 @@ state:
   initial_interval: {{initial_interval}}
   resolution: 1
   api_key: {{api_key}}
+  connector_id: Elastic-XM-Cyber/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_key
@@ -37,6 +38,7 @@ program: |
               "Header": {
                 "X-Api-Key": [state.api_key],
                 "Content-Type": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(authResp,
@@ -90,6 +92,7 @@ program: |
                 "Header": {
                   "Authorization": ["Bearer " + tok.access],
                   "Content-Type": ["application/json"],
+                  "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
                 },
               }
             ).do_request().as(scoreResp,
@@ -133,7 +136,10 @@ program: |
                   {"refreshToken": tok.refresh}.encode_json()
                 ).with(
                   {
-                    "Header": {"Content-Type": ["application/json"]},
+                    "Header": {
+                      "Content-Type": ["application/json"],
+                      "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
+                    },
                   }
                 ).do_request().as(refResp,
                   refResp.Body.decode_json().as(ro,

--- a/packages/xm_cyber/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/xm_cyber/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -19,6 +19,7 @@ max_executions: {{max_executions}}
 state:
   api_key: {{api_key}}
   page_size: {{page_size}}
+  connector_id: Elastic-XM-Cyber/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}unknown{{/if}}
 redact:
   fields:
     - api_key
@@ -36,6 +37,7 @@ program: |
             "Header": {
               "X-Api-Key": [state.api_key],
               "Content-Type": ["application/json"],
+              "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
             },
           }
         ).do_request().as(authResp,
@@ -91,6 +93,7 @@ program: |
               "Header": {
                 "Authorization": ["Bearer " + tok.access],
                 "Accept": ["application/json"],
+                "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
               },
             }
           ).do_request().as(resp,
@@ -117,7 +120,10 @@ program: |
                 {"refreshToken": tok.refresh}.encode_json()
               ).with(
                 {
-                  "Header": {"Content-Type": ["application/json"]},
+                  "Header": {
+                    "Content-Type": ["application/json"],
+                    "X-XMCYBER-CONNECTOR-NAME-VERSION": [state.connector_id],
+                  },
                 }
               ).do_request().as(refResp,
                 refResp.Body.decode_json().as(ro,

--- a/packages/xm_cyber/manifest.yml
+++ b/packages/xm_cyber/manifest.yml
@@ -1,7 +1,7 @@
 format_version: '3.4.2'
 name: xm_cyber
 title: XM Cyber
-version: 0.1.2
+version: 0.2.0
 description: Collect logs from XM Cyber with Elastic Agent.
 type: integration
 categories:
@@ -50,7 +50,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: ga
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/xm_cyber/manifest.yml
+++ b/packages/xm_cyber/manifest.yml
@@ -50,6 +50,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: ga
         organization: security
         division: engineering
         team: security-service-integrations


### PR DESCRIPTION
## Proposed commit message

```
xm_cyber: set X-XMCYBER-CONNECTOR-NAME-VERSION header for all HTTP requests

The value of the X-XMCYBER-CONNECTOR-NAME-VERSION header is set to 
Elastic-XM-Cyber/x.y.z where x.y.z is the package version if it is available (this is
the case for stacks at or above 9.3), otherwise the version is set to unknown.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/xm_cyber directory.
- Run the following command to run tests.

> elastic-package test -v

## Related Issues

- Closes https://github.com/elastic/integrations/issues/20259