### PR TITLE
[cisco_ftd] Fix grok for 106023 to allow port 0 in ACL deny events.

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix grok pattern for message ID 106023 to allow port 0 in source and destination port fields, which is valid in UDP ACL deny events where no port is tracked.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20635
 - version: "3.13.9"
   changes:
     - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and Users account has expired rejection reasons.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.10"
+  changes:
+    - description: Fix grok pattern for message ID 106023 to allow port 0 in source and destination port fields, which is valid in UDP ACL deny events where no port is tracked.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.13.9"
   changes:
     - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and Users account has expired rejection reasons.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log
@@ -6,3 +6,4 @@ Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack
 May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 175.16.199.1/0 laddr 192.168.2.2/0 type 3 code 1
 <131>Jun 05 2026 07:15:18 ALHB1FW01 : %FTD-3-106010: Deny inbound protocol 112 src Inside:10.10.10.10 dst Outside:10.133.123.123
 <131>Jun 05 2026 07:15:18 ALHB1FW01 : %FTD-3-106010: Deny inbound tcp src Inside:10.10.10.10/443 dst Outside:10.133.123.123/51325
+<188>Jun 27 2026 15:29:37 host-1.example.local : %FTD-4-106023: Deny udp src outside:203.0.113.20/0 dst public:198.51.100.10/60503 by access-group "TEST_ACCESS_GROUP" [0x878d852f, 0x0]

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -606,6 +606,128 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-27T15:29:37.000Z",
+            "cisco": {
+                "ftd": {
+                    "destination_interface": "public",
+                    "rule_name": "TEST_ACCESS_GROUP",
+                    "source_interface": "outside"
+                }
+            },
+            "destination": {
+                "address": "198.51.100.10",
+                "as": {
+                    "number": 64501,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Amsterdam",
+                    "continent_name": "Europe",
+                    "country_iso_code": "NL",
+                    "country_name": "Netherlands",
+                    "location": {
+                        "lat": 52.37404,
+                        "lon": 4.88969
+                    },
+                    "region_iso_code": "NL-NH",
+                    "region_name": "North Holland"
+                },
+                "ip": "198.51.100.10",
+                "port": 60503
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106023",
+                "kind": "event",
+                "original": "<188>Jun 27 2026 15:29:37 host-1.example.local : %FTD-4-106023: Deny udp src outside:203.0.113.20/0 dst public:198.51.100.10/60503 by access-group \"TEST_ACCESS_GROUP\" [0x878d852f, 0x0]",
+                "outcome": "failure",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "host-1.example.local"
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 188,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "network": {
+                "iana_number": "17",
+                "transport": "udp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "public"
+                    }
+                },
+                "hostname": "host-1.example.local",
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host-1.example.local"
+                ],
+                "ip": [
+                    "203.0.113.20",
+                    "198.51.100.10"
+                ]
+            },
+            "source": {
+                "address": "203.0.113.20",
+                "as": {
+                    "number": 64502,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Madrid",
+                    "continent_name": "Europe",
+                    "country_iso_code": "ES",
+                    "country_name": "Spain",
+                    "location": {
+                        "lat": 40.41639,
+                        "lon": -3.7025
+                    },
+                    "region_iso_code": "ES-M",
+                    "region_name": "Madrid"
+                },
+                "ip": "203.0.113.20",
+                "port": 0
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -340,7 +340,7 @@ processors:
       field: "message"
       description: "106023"
       patterns:
-        - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{POSINT:source.port})?\s*(\(%{CISCO_USER:_temp_.cisco.source_username}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{POSINT:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
+        - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{NUMBER:source.port})?\s*(\(%{CISCO_USER:_temp_.cisco.source_username}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{NUMBER:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
       pattern_definitions:
         HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z_-]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z_-]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.13.9"
+version: "3.13.10"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

The grok pattern for Cisco FTD message ID 106023 was updated to replace `POSINT` (positive integer, excludes zero) with `NUMBER` for source and destination port capture groups. This allows port 0 to be matched, which is valid in UDP ACL deny events where no port is tracked at the transport layer. A new pipeline test fixture was added to verify the fix with a real-world UDP/port-0 log sample.

## Proposed commit message

```
[cisco_ftd] Fix grok for 106023 to allow port 0 in ACL deny events.
```

## Root cause

The grok pattern for message ID 106023 uses %{POSINT:source.port} inside an optional group (/%{POSINT:source.port})?, but POSINT ([1-9][0-9]*) does not match the digit 0. When the source port is 0 (valid in UDP ACL deny events where no source port is tracked), the optional group fails to consume '/0', leaving '/0 dst ...' as the unmatched remainder so the mandatory literal 'dst' cannot align and the entire grok fails.

## Approach

In the grok processor with tag grok_message_f79236ca (line 336-347 of default.yml), replace both %{POSINT:source.port} and %{POSINT:destination.port} with %{NUMBER:source.port} and %{NUMBER:destination.port} respectively. POSINT matches only positive non-zero integers ([1-9][0-9]*), causing the optional port capture groups to silently skip '/0' without consuming it, so the literal 'dst' keyword cannot match the remaining '/0 dst ...' portion of the string. NUMBER matches zero and any non-negative integer. A companion test fixture line will be added to test-asa-fix.log (and its expected output) covering the port-0 UDP deny case from the sanitized event.

## Implementation

1. Step 1: Edit packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml line 342 — in the grok pattern for tag grok_message_f79236ca, replace (/%{POSINT:source.port})? with (/%{NUMBER:source.port})? and (/%{POSINT:destination.port})? with (/%{NUMBER:destination.port})?
2. Step 2: Add the sanitized test event as a new line in packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log: '<188>Jun 27 2026 15:29:37 host-1.example.local : %FTD-4-106023: Deny udp src outside:203.0.113.20/0 dst public:198.51.100.10/60503 by access-group "TEST_ACCESS_GROUP" [0x878d852f, 0x0]'
3. Step 3: Update packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json to add the expected parsed output for the new port-0 test event, with source.port=0, destination.port=60503, source.address=203.0.113.20, destination.address=198.51.100.10, event.outcome=Deny, network.transport=udp, and cisco.ftd.list_id=TEST_ACCESS_GROUP
4. Step 4: Add a new changelog entry in packages/cisco_ftd/changelog.yml for version 3.13.5 (patch bump from 3.13.4) with type 'bugfix' describing the fix
5. Step 5: Update the version field in packages/cisco_ftd/manifest.yml from 3.13.4 to 3.13.5
6. Step 6: Run 'elastic-package test pipeline' targeting the cisco_ftd package to validate the fix and updated expected output

## Pipeline changes

- In grok processor tag=grok_message_f79236ca (default.yml line 342): replace %{POSINT:source.port} with %{NUMBER:source.port} inside the optional group (/%{POSINT:source.port})? → (/%{NUMBER:source.port})?
- In same grok processor (default.yml line 342): replace %{POSINT:destination.port} with %{NUMBER:destination.port} inside the optional group (/%{POSINT:destination.port})? → (/%{NUMBER:destination.port})?

## Field / mapping changes

—

## Sanitized error message

`Processor 'grok' with tag 'grok_message_f79236ca' in pipeline 'logs-cisco_ftd.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<188>Jun 27 2026 15:29:37 host-1.example.local : %FTD-4-106023: Deny udp src outside:203.0.113.20/0 dst public:198.51.100.10/60503 by access-group "TEST_ACCESS_GROUP" [0x878d852f, 0x0]
```

## Reviewer concerns

• The `source.port` and `destination.port` fields now map via `NUMBER` instead of `POSINT`, which means the grok pattern will technically also accept negative integers or floating-point values from malformed input — downstream type coercion to `long` in Elasticsearch should reject those, but it is worth confirming the field mapping enforces integer type.
• The changelog PR link is a placeholder (`https://github.com/elastic/integrations/pull/1`) and must be updated to the real PR URL before merge.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: medium
- **Tags**: pipeline, processors, test-fixture, ingest
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_ftd.log [PIPELINE_FIX]: Processor 'grok' with tag 'grok_message_f79236ca' in pipeline 'logs-cisc…
- **Pipeline case**: `5da3daef56ae4fa4`
