### PR TITLE
[Oracle] Covert multi-line double-quoted SQL queries to single-line format

### DIFF
--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.31.4"
   changes:
-    - description: Format the SQLS in yaml file to make it single line.
+    - description: Convert multi-line double-quoted SQL queries to single-line format.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/18965
+      link: https://github.com/elastic/integrations/pull/20654
 - version: "1.31.3"
   changes:
     - description: Update the Oracle Integration documentation regarding tablespace permissions.

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.4"
+  changes:
+    - description: Format the SQLS in yaml file to make it single line.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18965
 - version: "1.31.3"
   changes:
     - description: Update the Oracle Integration documentation regarding tablespace permissions.

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.31.4"
   changes:
     - description: Convert multi-line double-quoted SQL queries to single-line format.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/20654
 - version: "1.31.3"
   changes:

--- a/packages/oracle/data_stream/tablespace/agent/stream/stream.yml.hbs
+++ b/packages/oracle/data_stream/tablespace/agent/stream/stream.yml.hbs
@@ -14,96 +14,10 @@ raw_data.enabled: true
 driver: "oracle"
 dynamic_metric_name_filter: "{{dynamic_metric_name_filter}}"
 sql_queries: 
-  - query: "WITH data_files
-     AS (SELECT file_name,
-                file_id,
-                tablespace_name,
-                bytes,
-                status,
-                maxbytes,
-                user_bytes,
-                online_status
-         FROM   sys.dba_data_files
-         UNION
-         SELECT file_name,
-                file_id,
-                tablespace_name,
-                bytes,
-                status,
-                maxbytes,
-                user_bytes,
-                status AS ONLINE_STATUS
-         FROM   sys.dba_temp_files),
-     spaces
-     AS (SELECT b.tablespace_name TB_NAME,
-              (b.tbs_size - a.free_space) AS TB_SIZE_USED,
-              a.free_space AS TB_SIZE_FREE
-         FROM   (SELECT tablespace_name,
-                        SUM(bytes) AS free_space
-                 FROM   dba_free_space
-                 GROUP  BY tablespace_name) a,
-                (SELECT tablespace_name,
-                        SUM(bytes) AS tbs_size
-                 FROM   dba_data_files
-                 GROUP  BY tablespace_name) b
-         WHERE  a.tablespace_name(+) = b.tablespace_name
-                AND a.tablespace_name != 'TEMP'),
-     temp_spaces
-     AS (SELECT tablespace_name,
-                tablespace_size,
-                allocated_space,
-                free_space
-         FROM   dba_temp_free_space
-         WHERE  tablespace_name = 'TEMP'),
-     details
-     AS (SELECT df.file_name,
-                df.file_id,
-                df.tablespace_name,
-                df.bytes,
-                df.status,
-                df.maxbytes,
-                df.user_bytes,
-                df.online_status,
-                sp.tb_size_used,
-                sp.tb_size_free
-         FROM   data_files df,
-                spaces sp
-         WHERE  df.tablespace_name = sp.tb_name
-         UNION
-         SELECT df.file_name,
-                df.file_id,
-                df.tablespace_name,
-                df.bytes,
-                df.status,
-                df.maxbytes,
-                df.user_bytes,
-                df.online_status,
-                tsp.tablespace_size - tsp.free_space AS TB_SIZE_USED,
-                tsp.free_space                       AS TB_SIZE_FREE
-         FROM   data_files df,
-                temp_spaces tsp
-         WHERE  df.tablespace_name = tsp.tablespace_name)
-SELECT file_name,
-       file_id,
-       tablespace_name,
-       bytes,
-       status,
-       maxbytes,
-       user_bytes,
-       online_status,
-       tb_size_used,
-       tb_size_free,
-       SUM(bytes)
-         over() AS TOTAL_BYTES
-FROM   details"
+  - query: "WITH data_files AS (SELECT file_name, file_id, tablespace_name, bytes, status, maxbytes, user_bytes, online_status FROM sys.dba_data_files UNION SELECT file_name, file_id, tablespace_name, bytes, status, maxbytes, user_bytes, status AS ONLINE_STATUS FROM sys.dba_temp_files), spaces AS (SELECT b.tablespace_name TB_NAME, (b.tbs_size - a.free_space) AS TB_SIZE_USED, a.free_space AS TB_SIZE_FREE FROM (SELECT tablespace_name, SUM(bytes) AS free_space FROM dba_free_space GROUP BY tablespace_name) a, (SELECT tablespace_name, SUM(bytes) AS tbs_size FROM dba_data_files GROUP BY tablespace_name) b WHERE a.tablespace_name(+) = b.tablespace_name AND a.tablespace_name != 'TEMP'), temp_spaces AS (SELECT tablespace_name, tablespace_size, allocated_space, free_space FROM dba_temp_free_space WHERE tablespace_name = 'TEMP'), details AS (SELECT df.file_name, df.file_id, df.tablespace_name, df.bytes, df.status, df.maxbytes, df.user_bytes, df.online_status, sp.tb_size_used, sp.tb_size_free FROM data_files df, spaces sp WHERE df.tablespace_name = sp.tb_name UNION SELECT df.file_name, df.file_id, df.tablespace_name, df.bytes, df.status, df.maxbytes, df.user_bytes, df.online_status, tsp.tablespace_size - tsp.free_space AS TB_SIZE_USED, tsp.free_space AS TB_SIZE_FREE FROM data_files df, temp_spaces tsp WHERE df.tablespace_name = tsp.tablespace_name) SELECT file_name, file_id, tablespace_name, bytes, status, maxbytes, user_bytes, online_status, tb_size_used, tb_size_free, SUM(bytes) over() AS TOTAL_BYTES FROM details"
     response_format: table  
 {{#if enable_extended_space_metrics}}
-  - query: "SELECT a.tablespace_name,
-(a.tablespace_size * b.block_size) as tb_extended_total,
-((a.tablespace_size - a.used_space) * b.block_size) as tb_extended_free,
-(a.used_space * b.block_size) as tb_extended_used
-FROM dba_tablespace_usage_metrics a JOIN dba_tablespaces b
-ON a.tablespace_name = b.tablespace_name"
+  - query: "SELECT a.tablespace_name, (a.tablespace_size * b.block_size) as tb_extended_total, ((a.tablespace_size - a.used_space) * b.block_size) as tb_extended_free, (a.used_space * b.block_size) as tb_extended_used FROM dba_tablespace_usage_metrics a JOIN dba_tablespaces b ON a.tablespace_name = b.tablespace_name"
     response_format: table
 {{/if}}
 {{#if processors}}

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: oracle
 title: "Oracle"
-version: "1.31.3"
+version: "1.31.4"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:


### PR DESCRIPTION

- Bug

## Proposed commit message

Convert multi-line double-quoted SQL queries to single-line format so there are no embedded newlines to strip. This fix avoids causing ORA-00923 "FROM keyword not found where expected" errors in the Oracle integration's tablespace dataset.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Integration tests

## How to test this PR locally

- `elastic-package build && elastic-package stack up -v -d --services package-registry`

## Related issues

- https://github.com/elastic/kibana/pull/252345

## Screenshots

<img width="1680" height="1353" alt="screencapture-localhost-57237-app-dashboards-2026-08-11-12_18_19" src="https://github.com/user-attachments/assets/e5b143aa-7613-4ddf-857f-56950808c27d" />
