### PR TITLE
[Microsoft SQL Server] Convert multi-line availability_groups SQL query to single-line format

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.17.1"
+  changes:
+    - description: Fix `availability_groups` SQL query being split across multiple lines, which caused missing whitespace between keywords (e.g. `FROM`, `JOIN`) when the YAML was folded by some Elastic Agent versions.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.17.0"
   changes:
     - description: Add `mssql.metrics.buffer_cache_hit_ratio_pct` field to the `performance` data stream

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `availability_groups` SQL query being split across multiple lines, which caused missing whitespace between keywords (e.g. `FROM`, `JOIN`) when the YAML was folded by some Elastic Agent versions.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20655
 - version: "2.17.0"
   changes:
     - description: Add `mssql.metrics.buffer_cache_hit_ratio_pct` field to the `performance` data stream

--- a/packages/microsoft_sqlserver/data_stream/availability_groups/agent/stream/stream.yml.hbs
+++ b/packages/microsoft_sqlserver/data_stream/availability_groups/agent/stream/stream.yml.hbs
@@ -7,18 +7,7 @@ merge_results: false
 driver: "mssql"
 sql_queries:
   # Availability groups metrics
-  - query: "SELECT
-    @@servername AS server_name,
-    ag.name,
-    CONVERT(NVARCHAR(36), ag.group_id) AS group_id,
-    ags.primary_replica,
-    ags.synchronization_health,
-    ags.synchronization_health_desc,
-    ags.primary_recovery_health,
-    ags.secondary_recovery_health
-FROM sys.dm_hadr_availability_group_states ags
-JOIN sys.availability_groups ag 
-    ON ags.group_id = ag.group_id;"
+  - query: "SELECT @@servername AS server_name, ag.name, CONVERT(NVARCHAR(36), ag.group_id) AS group_id, ags.primary_replica, ags.synchronization_health, ags.synchronization_health_desc, ags.primary_recovery_health, ags.secondary_recovery_health FROM sys.dm_hadr_availability_group_states ags JOIN sys.availability_groups ag ON ags.group_id = ag.group_id;"
     response_format: table
 {{#if processors}}
 processors:

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "2.17.0"
+version: "2.17.1"
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

The `availability_groups` SQL query in `microsoft_sqlserver` was written as a
multi-line double-quoted YAML scalar, with the `FROM`/`JOIN` continuation
lines starting at column 0 while the `SELECT` columns above them were
indented 4 spaces. Depending on the YAML parser version bundled with a given
Elastic Agent release, this inconsistent indentation caused line folding to
drop the separating space between lines, concatenating keywords together
(e.g. `secondary_recovery_healthFROM`, `agsJOIN`) and breaking the query on
some agent versions but not others.

This PR collapses the query into a single line, matching the pattern already
used by the `performance` and `transaction_log` data streams in this same
package, which removes the line-folding ambiguity entirely. This mirrors the
same fix applied to Oracle in #20654 for an identical root cause.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [ ] Confirm the single-line query is semantically identical to the original (no SQL logic changed, only whitespace/line-break formatting)
- [ ] Validate the assembled Fleet policy query no longer concatenates keywords on 9.4.3 / 9.4.4 / 9.5.0 agent versions, per the original report

## How to test this PR locally

**Executed by agent (this session):**
```
cd packages/microsoft_sqlserver
elastic-package lint
```
Result: `Lint the package ... Done` (passed).

**Reviewer instructions (not yet run):**
Enroll Elastic Agent versions 9.4.3, 9.4.4, and 9.5.0 with this package's `availability_groups` data stream enabled, then fetch the assembled policy and confirm correct spacing in the query, e.g.:
```
curl -sk -u elastic:changeme \
  "https://127.0.0.1:5601/api/fleet/agent_policies/<policy_id>/full" \
  -H "kbn-xsrf: true" | jq '.item.inputs[].streams[] | select(.data_stream.dataset == "microsoft_sqlserver.availability_groups") | .sql_queries[].query'
```
Confirm no missing space before `FROM`/`JOIN` on any of the three versions.

## Related issues

- Relates https://github.com/elastic/integrations/pull/20654

## Screenshots

N/A — no UI, form, or dashboard changes.