### PR TITLE
[cisco_asa] Fix 611101/611102 parse failure when IP address is absent.

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.12"
+  changes:
+    - description: Fix 611101/611102 parse failure when IP address is absent by converting dissect to an anchored grok pattern with an optional IP segment.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.45.11"
   changes:
     - description: Add 'User was not found' as a valid rejection reason for ASA 113005 messages.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix 611101/611102 parse failure when IP address is absent by converting dissect to an anchored grok pattern with an optional IP segment.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20657
 - version: "2.45.11"
   changes:
     - description: Add 'User was not found' as a valid rejection reason for ASA 113005 messages.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -194,3 +194,5 @@ May  5 18:40:50 dev_01: %ASA-6-305011: Built dynamic TCP translation from fw111:
 <166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20
 Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : reason = User was not found : server = 0.0.0.0 : user = alice.johnson : user IP = 198.51.100.20
 <140>Jun 27 00:53:12 host-1.example.local : %ASA-6-737016: IPAA: Session=0x0e5fc000, Freeing local pool address 198.51.100.10
+Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101: User authentication succeeded: Uname: alice.johnson
+Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611102: User authentication failed: Uname: alice.johnson

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -194,5 +194,5 @@ May  5 18:40:50 dev_01: %ASA-6-305011: Built dynamic TCP translation from fw111:
 <166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20
 Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : reason = User was not found : server = 0.0.0.0 : user = alice.johnson : user IP = 198.51.100.20
 <140>Jun 27 00:53:12 host-1.example.local : %ASA-6-737016: IPAA: Session=0x0e5fc000, Freeing local pool address 198.51.100.10
-Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101: User authentication succeeded: Uname: alice.johnson
-Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611102: User authentication failed: Uname: alice.johnson
+Apr 27 02:03:03 dev01: %ASA-6-611101: User authentication succeeded: Uname: alice.johnson
+Apr 27 02:03:03 dev01: %ASA-6-611102: User authentication failed: Uname: alice.johnson

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -13682,7 +13682,7 @@
             ]
         },
         {
-            "@timestamp": "2026-06-26T20:21:48.000Z",
+            "@timestamp": "2026-04-27T02:03:03.000Z",
             "ecs": {
                 "version": "8.17.0"
             },
@@ -13694,7 +13694,7 @@
                 ],
                 "code": "611101",
                 "kind": "event",
-                "original": "Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101: User authentication succeeded: Uname: alice.johnson",
+                "original": "Apr 27 02:03:03 dev01: %ASA-6-611101: User authentication succeeded: Uname: alice.johnson",
                 "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
@@ -13704,23 +13704,20 @@
                 ]
             },
             "host": {
-                "hostname": "198.51.100.10"
+                "hostname": "dev01"
             },
             "log": {
                 "level": "informational"
             },
             "observer": {
-                "hostname": "198.51.100.10",
+                "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
             },
-            "process": {
-                "name": "Jun"
-            },
             "related": {
                 "hosts": [
-                    "198.51.100.10"
+                    "dev01"
                 ],
                 "user": [
                     "alice.johnson"
@@ -13736,7 +13733,7 @@
             ]
         },
         {
-            "@timestamp": "2026-06-26T20:21:48.000Z",
+            "@timestamp": "2026-04-27T02:03:03.000Z",
             "ecs": {
                 "version": "8.17.0"
             },
@@ -13748,7 +13745,7 @@
                 ],
                 "code": "611102",
                 "kind": "event",
-                "original": "Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611102: User authentication failed: Uname: alice.johnson",
+                "original": "Apr 27 02:03:03 dev01: %ASA-6-611102: User authentication failed: Uname: alice.johnson",
                 "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
@@ -13758,23 +13755,20 @@
                 ]
             },
             "host": {
-                "hostname": "198.51.100.10"
+                "hostname": "dev01"
             },
             "log": {
                 "level": "informational"
             },
             "observer": {
-                "hostname": "198.51.100.10",
+                "hostname": "dev01",
                 "product": "asa",
                 "type": "firewall",
                 "vendor": "Cisco"
             },
-            "process": {
-                "name": "Jun"
-            },
             "related": {
                 "hosts": [
-                    "198.51.100.10"
+                    "dev01"
                 ],
                 "user": [
                     "alice.johnson"

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -13680,6 +13680,114 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-26T20:21:48.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "logged-in",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "611101",
+                "kind": "event",
+                "original": "Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101: User authentication succeeded: Uname: alice.johnson",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "process": {
+                "name": "Jun"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "user": [
+                    "alice.johnson"
+                ]
+            },
+            "server": {
+                "user": {
+                    "name": "alice.johnson"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-06-26T20:21:48.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "611102",
+                "kind": "event",
+                "original": "Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611102: User authentication failed: Uname: alice.johnson",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "process": {
+                "name": "Jun"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "user": [
+                    "alice.johnson"
+                ]
+            },
+            "server": {
+                "user": {
+                    "name": "alice.johnson"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -949,12 +949,13 @@ processors:
       field: "message"
       description: "609002"
       pattern: "Teardown local-host %{_temp_.cisco.source_interface}:%{source.address} duration %{_temp_.duration_hms}"
-  - dissect:
+  - grok:
       if: '["611102", "611101"].contains(ctx._temp_.cisco.message_id)'
       tag: parse_611101-611102
       field: "message"
       description: "611102, 611101"
-      pattern: 'User authentication %{}: IP address: %{source.address}, Uname: %{server.user.name}'
+      patterns:
+        - '^User authentication %{DATA}:(?:\s*IP address: %{IP:source.address},)? Uname: %{GREEDYDATA:server.user.name}$'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '710003'"
       tag: parse_710003

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -955,7 +955,7 @@ processors:
       field: "message"
       description: "611102, 611101"
       patterns:
-        - '^User authentication %{DATA}:(?:\s*IP address: %{IP:source.address},)? Uname: %{GREEDYDATA:server.user.name}$'
+        - '^User authentication %{DATA}:(?:\s*IP address: %{IP:source.address},)? Uname: %{DATA:server.user.name}$'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '710003'"
       tag: parse_710003

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.11"
+version: "2.45.12"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

The dissect processor for Cisco ASA message IDs 611101 and 611102 required a literal 'IP address: ...' segment in the message, causing a parse failure when ASA emits these messages without an IP address (common in web VPN or local authentication scenarios). The fix replaces the dissect processor with a grok processor whose pattern wraps the IP segment in a non-capturing optional group, so both forms parse correctly. Two new test fixtures confirm the no-IP variant now succeeds.

## Proposed commit message

```
[cisco_asa] Fix 611101/611102 parse failure when IP address is absent.
```

## Root cause

The `parse_611101-611102` processor uses `dissect` with a fixed literal `IP address: %{source.address}, ` segment, but Cisco ASA 611101/611102 messages from console or local sessions omit the IP address entirely. `dissect` has no support for optional segments, so the processor fails whenever the IP address is absent; converting to `grok` with an anchored optional non-capturing group resolves both variants in a single pattern.

## Approach

Replace the existing `dissect` processor tagged `parse_611101-611102` (line 952–957 of default.yml) with a `grok` processor using a single anchored pattern (`^…$`) that makes the `, IP address: <addr>` segment optional via a non-capturing group. The pattern `^User authentication %{DATA}:(?:\s*IP address: %{IP:source.address},)? Uname: %{GREEDYDATA:server.user.name}$` handles both IP-present and IP-absent (console/local session) variants in one processor. Two new test fixture lines (611101 and 611102 no-IP) are added with matching expected documents.

## Implementation

1. Step 1: In `packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml`, replace the `dissect` processor at lines 952–957 (tag: `parse_611101-611102`) with a `grok` processor. Keep the same `if` condition `['611102', '611101'].contains(ctx._temp_.cisco.message_id)` and `field: message`. Use the anchored pattern: `'^User authentication %{DATA}:(?:\s*IP address: %{IP:source.address},)? Uname: %{GREEDYDATA:server.user.name}$'`. The leading `^` and trailing `$` anchors prevent partial matches; the `(?:\s*IP address: %{IP:source.address},)?` group is optional, capturing `source.address` only when present.
2. Step 2: Add a new raw log line to `packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log` for the no-IP 611101 case using the sanitized event: `Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101: User authentication succeeded: Uname: alice.johnson`. Also add a no-IP 611102 line: `Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611102: User authentication failed: Uname: alice.johnson`.
3. Step 3: Append two corresponding expected JSON documents to `packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json`. Each document must include `server.user.name: alice.johnson`, `related.user: [alice.johnson]`, correct `event.outcome` (`success` for 611101, `failure` for 611102), plus `event.action`, `event.category`, and `event.type` from the existing message_id map — but must NOT include `source.address`, `source.ip`, or `related.ip` fields (no IP to populate).
4. Step 4: Bump the patch version in `packages/cisco_asa/manifest.yml` from `2.45.2` to `2.45.3` and add a `bugfix` changelog entry: `Fix 611101/611102 parse failure when IP address is absent by converting dissect to an anchored grok pattern with an optional IP segment.`
5. Step 5: Run `elastic-package test pipeline -d data_stream/log` from `packages/cisco_asa/` to confirm all existing IP-present test cases continue to pass and the two new no-IP cases pass as well.

## Pipeline changes

- Replace the `dissect` processor (tag: `parse_611101-611102`, lines 952–957) with a `grok` processor using the same `if` condition and field, with the anchored pattern: `'^User authentication %{DATA}:(?:\s*IP address: %{IP:source.address},)? Uname: %{GREEDYDATA:server.user.name}$'`. The `^` anchor prevents partial leading matches; the `$` anchor prevents partial trailing matches; the optional non-capturing group `(?:...)?` captures `source.address` only when the IP address segment is present.

## Field / mapping changes

—

## Sanitized error message

`Processor 'dissect' with tag 'parse_611101-611102' in pipeline 'logs-cisco_asa.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101: User authentication succeeded: Uname: alice.johnson
```

## Reviewer concerns

- The two new test log lines use a double-timestamp syslog format (`Jun 26 20:21:48 198.51.100.10 Jun 27 00:21:48 %ASA-6-611101:...`), which causes `process.name` to be populated with `"Jun"` in the expected output — this is a quirk of the test-data construction and may not reflect real-world ASA syslog output faithfully.
- No explicit test line was added for the IP-present variant of 611101/611102 to assert backward compatibility; this assumes pre-existing test coverage handles that path.
- The grok `%{DATA}` capture in `%{DATA}:` is greedy but is bounded by the literal colon, and `%{DATA:server.user.name}$` is anchored at end-of-string — both are correct here but worth a reviewer double-check.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: medium
- **Tags**: pipeline, processors, ingest, test-fixture
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_asa.log [MISSING_CASE]: Processor 'dissect' with tag 'parse_611101-611102' in pipeline 'logs-cis…
- **Pipeline case**: `745e0753ef4f7390`
