### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
       url: https://www.elastic.co/integrations/
 spec:
   type: library
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production
   dependsOn:
@@ -33,7 +33,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -59,7 +59,7 @@ spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
@@ -122,7 +122,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -150,7 +150,7 @@ spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -170,7 +170,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -226,7 +226,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: 'true'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -246,7 +246,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -276,7 +276,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: 'true'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -295,7 +295,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -319,7 +319,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -339,7 +339,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -363,7 +363,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
@@ -381,7 +381,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -405,7 +405,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
@@ -425,7 +425,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -449,7 +449,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main !backport-*'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
       url: https://www.elastic.co/integrations/
 spec:
   type: library
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   lifecycle: production
   dependsOn:
@@ -33,7 +33,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -59,7 +59,7 @@ spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
@@ -122,7 +122,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -150,7 +150,7 @@ spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -170,7 +170,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -226,7 +226,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: 'true'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -246,7 +246,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -276,7 +276,7 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: 'true'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -295,7 +295,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -319,7 +319,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         observablt-ci:
           access_level: MANAGE_BUILD_AND_READ
@@ -339,7 +339,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -363,7 +363,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
@@ -381,7 +381,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -405,7 +405,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
@@ -425,7 +425,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -449,7 +449,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main !backport-*'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
Catches up catalog-info.yaml to the GitHub team's actual current name (ingest-fp was renamed to Streams).