### PR TITLE
[cisco_ftd] Fix 111010 grok to capture usernames with spaces.

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.10"
+  changes:
+    - description: Fix grok pattern for message 111010 to capture usernames containing spaces.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.13.9"
   changes:
     - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and Users account has expired rejection reasons.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix grok pattern for message 111010 to capture usernames containing spaces.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20664
 - version: "3.13.9"
   changes:
     - description: Fix grok REASON pattern for message 113005 to include Account has been locked out and Users account has expired rejection reasons.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log
@@ -58,3 +58,4 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 <166>May 01 2026 09:24:32Z  %FTD-6-113005: %ASA-6-113005: AAA user authentication Rejected : reason = Password has expired : server = 192.0.2.20 : user = engineer@elastic.co : user IP = 198.51.100.30
 <182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30
 <182>Jul  7 11:22:54 198.51.100.10 %FTD-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 203.0.113.20 : user = ***** : user IP = 192.0.2.30
+<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111010: User 'alice.johnson test', running 'N/A (test)' from IP 0.0.0.0, executed 'show running-config zero-trust'

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -4486,6 +4486,75 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-07-07T14:12:01.000Z",
+            "cisco": {
+                "ftd": {
+                    "command_line_arguments": "'show running-config zero-trust'"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "111010",
+                "kind": "event",
+                "original": "<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111010: User 'alice.johnson test', running 'N/A (test)' from IP 0.0.0.0, executed 'show running-config zero-trust'",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "198.51.100.10"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 22
+                    },
+                    "priority": 181,
+                    "severity": {
+                        "code": 5
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "198.51.100.10",
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.10"
+                ],
+                "ip": [
+                    "0.0.0.0"
+                ],
+                "user": [
+                    "alice.johnson test"
+                ]
+            },
+            "server": {
+                "user": {
+                    "name": "alice.johnson test"
+                }
+            },
+            "source": {
+                "address": "0.0.0.0",
+                "ip": "0.0.0.0"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -416,7 +416,7 @@ processors:
       field: "message"
       description: "111010"
       patterns:
-        - "User '%{NOTSPACE:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"
+        - "User '%{DATA:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"
   - grok:
       tag: grok_message_6379a243
       if: "ctx._temp_.cisco.message_id == '113004'"

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.13.9"
+version: "3.13.10"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Changed the grok pattern for message 111010 in the Cisco FTD ingest pipeline from `%{NOTSPACE:server.user.name}` to `%{DATA:server.user.name}` to allow usernames containing spaces (e.g. `alice.johnson test`) to be captured correctly. The `NOTSPACE` pattern stops at whitespace, causing parsing failures for any username with a space character. `DATA` matches any character sequence including spaces while still being bounded by the surrounding single-quote delimiters in the log format.

## Proposed commit message

```
[cisco_ftd] Fix 111010 grok to capture usernames with spaces.
```

## Root cause

The grok pattern for message_id 111010 (tagged `grok_message_5ccd264e`) uses `%{NOTSPACE:server.user.name}` to capture the username between Cisco's wrapping single quotes, but `NOTSPACE` stops at the first whitespace character — causing the entire pattern to fail for usernames containing spaces such as `alice.johnson test`. The single-quote delimiters in the log format make `%{DATA:server.user.name}` (which matches any characters including spaces, bounded by the surrounding literal `'`) the correct substitute.

## Approach

Replace `%{NOTSPACE:server.user.name}` with `%{DATA:server.user.name}` in the grok processor tagged `grok_message_5ccd264e` (message_id 111010) in default.yml. The `DATA` pattern matches any characters including spaces, making it suitable for quoted usernames delimited by surrounding literal single-quote characters and a trailing comma. Add a pipeline test fixture (appended to test-ftd-fix.log and its expected JSON) using the sanitized event `<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111010: User 'alice.johnson test', running 'N/A (test)' from IP 0.0.0.0, executed 'show running-config zero-trust'` to cover the spaces-in-username case.

## Implementation

1. Step 1: Edit `packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml` at line 418 — in the grok processor tagged `grok_message_5ccd264e` (message_id 111010), replace `%{NOTSPACE:server.user.name}` with `%{DATA:server.user.name}` in the single existing pattern: change `"User '%{NOTSPACE:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"` to `"User '%{DATA:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"`.
2. Step 2: Append the sanitized test event `<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111010: User 'alice.johnson test', running 'N/A (test)' from IP 0.0.0.0, executed 'show running-config zero-trust'` as a new line in `packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log`.
3. Step 3: Append the corresponding expected output entry to `packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json`, including `server.user.name: 'alice.johnson test'`, `source.address: '0.0.0.0'`, `event.code: '111010'`, `event.action: 'configuration'`, and `related.user: ['alice.johnson test']`.
4. Step 4: Add a new changelog entry to `packages/cisco_ftd/changelog.yml` with type `bugfix` and bump the package version from `3.13.4` to `3.13.5` in both `changelog.yml` and `packages/cisco_ftd/manifest.yml`.
5. Step 5: Run `elastic-package test pipeline --data-streams log` from the `packages/cisco_ftd` directory to validate the fix and confirm the expected JSON matches.

## Pipeline changes

- In grok processor tag `grok_message_5ccd264e` (line 418 of default.yml, message_id 111010): change `%{NOTSPACE:server.user.name}` to `%{DATA:server.user.name}` in the pattern `"User '%{NOTSPACE:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"`

## Field / mapping changes

—

## Sanitized error message

`[pipeline error]`

## Sanitized log (`event_sanitized` excerpt)

```json
<181>Jul  7 14:12:01 198.51.100.10 %FTD-5-111010: User 'alice.johnson test', running 'N/A (test)' from IP 0.0.0.0, executed 'show running-config zero-trust'
```

## Reviewer concerns

- `DATA` is a greedy pattern; correctness relies entirely on the surrounding single-quote delimiters in the raw log message. If a malformed log line omits the closing quote, the match could span unexpectedly far — though this is an inherent risk with the source log format rather than the fix itself.
- The expected test output sets `server.user.name` to `alice.johnson test` and also populates `related.user` with the same value — reviewers should confirm the downstream `related.user` append processor handles multi-word usernames correctly in all code paths.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: medium
- **Tags**: pipeline, processors, test-fixture, ingest
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_ftd.log [PIPELINE_FIX]: [pipeline error]
- **Pipeline case**: `09ad51fca03da16d`
