### PR TITLE
[streams-ui] Transfer fleet_server package and Buildkite permissions to streams-ui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -273,7 +273,7 @@
 /packages/fim @elastic/sec-linux-platform
 /packages/fireeye @elastic/integration-experience
 /packages/first_epss @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/fleet_server @elastic/fleet
+/packages/fleet_server @elastic/streams-ui
 /packages/forcepoint_web @elastic/integration-experience
 /packages/forescout @elastic/integration-experience
 /packages/forgerock @elastic/security-service-integrations @elastic/sit-crest-contractors

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -73,7 +73,7 @@ spec:
           access_level: BUILD_AND_READ
         elastic-agent-data-plane:
           access_level: BUILD_AND_READ
-        fleet:
+        streams-ui:
           access_level: BUILD_AND_READ
         integration-experience:
           access_level: BUILD_AND_READ

--- a/packages/fleet_server/manifest.yml
+++ b/packages/fleet_server/manifest.yml
@@ -11,7 +11,7 @@ conditions:
   elastic:
     subscription: basic
 owner:
-  github: elastic/fleet
+  github: elastic/streams-ui
   type: elastic
 icons:
   - src: /img/logo_fleet_server.svg


### PR DESCRIPTION
## Summary

Transfers `elastic/fleet` ownership references to `elastic/streams-ui` across three files as part of the `elastic/fleet` → `elastic/streams-ui` team rename.

Part of the Ingest UI → Streams UI re-org ([tracking issue](https://github.com/elastic/ingest-dev/issues/8740)).

## Changes

### `.github/CODEOWNERS`
`/packages/fleet_server @elastic/fleet` → `@elastic/streams-ui`

### `packages/fleet_server/manifest.yml`
`owner.github: elastic/fleet` → `elastic/streams-ui`

### `catalog-info.yaml`
`fleet: BUILD_AND_READ` → `streams-ui: BUILD_AND_READ` in the integrations Buildkite pipeline teams block
