### PR TITLE
[juniper_srx] Fix script_cleanup_system trim() on non-String values.

### DIFF
--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix script_cleanup_system Painless script to guard against null values and non-String typed values before calling trim().
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20673
 - version: "1.27.2"
   changes:
     - description: Fix Syslog Parsing without syslog version

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.3"
+  changes:
+    - description: Fix script_cleanup_system Painless script to guard against null values and non-String typed values before calling trim().
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.27.2"
   changes:
     - description: Fix Syslog Parsing without syslog version

--- a/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log
+++ b/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log
@@ -22,3 +22,4 @@
 <166>1 2023-05-08T10:54:24.756+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC nh_fabric_fill_jnhinfo: ABCDE: Test default message 123456
 <166> 2023-05-08T10:54:24.756+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC nh_fabric_fill_jnhinfo: ABCDE: Test default message 123456
 <43>1 2026-06-26T09:58:50.439-04:00 host-1.example.local kernel - - - host-1.example.local kernel: Can't assign requested address
+<27>1 2023-05-04T15:19:33.984+10:00 AB1234-A-AB-AB01C-ABC kmd 9159 - - IKE negotiation failed with error: Timed out. IKE Version: 1, Local: 89.160.20.112/500, Local: 89.160.20.113/500, VR-ID: 5

--- a/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log
+++ b/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log
@@ -21,3 +21,4 @@
 <167>1 2023-05-08T10:54:24.704+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC Copying remote chassis chassis 1, IP: 81.2.69.192
 <166>1 2023-05-08T10:54:24.756+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC nh_fabric_fill_jnhinfo: ABCDE: Test default message 123456
 <166> 2023-05-08T10:54:24.756+10:00 AB1234-A-AB-AB01C-ABC - - - - AB1234-A-AB-AB01C-ABC nh_fabric_fill_jnhinfo: ABCDE: Test default message 123456
+<43>1 2026-06-26T09:58:50.439-04:00 host-1.example.local kernel - - - host-1.example.local kernel: Can't assign requested address

--- a/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
+++ b/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
@@ -1246,6 +1246,59 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2023-05-04T05:19:33.984Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "original": "<27>1 2023-05-04T15:19:33.984+10:00 AB1234-A-AB-AB01C-ABC kmd 9159 - - IKE negotiation failed with error: Timed out. IKE Version: 1, Local: 89.160.20.112/500, Local: 89.160.20.113/500, VR-ID: 5",
+                "severity": 27
+            },
+            "host": {
+                "name": "AB1234-A-AB-AB01C-ABC"
+            },
+            "juniper": {
+                "srx": {
+                    "log_type": "system",
+                    "negotiation": {
+                        "err_msg": "Timed out",
+                        "message": "failed with error: Timed out. IKE Version: 1, Local: 89.160.20.112/500, Local: 89.160.20.113/500, VR-ID: 5",
+                        "type": "IKE"
+                    },
+                    "process": "kmd",
+                    "system": {
+                        "ike_version": 1,
+                        "local": [
+                            "89.160.20.112/500",
+                            "89.160.20.113/500"
+                        ],
+                        "vr_id": "5"
+                    }
+                }
+            },
+            "log": {
+                "level": "error"
+            },
+            "message": "IKE Version: 1, Local: 89.160.20.112/500, Local: 89.160.20.113/500, VR-ID: 5",
+            "observer": {
+                "name": "AB1234-A-AB-AB01C-ABC",
+                "product": "SRX",
+                "type": "firewall",
+                "vendor": "Juniper"
+            },
+            "process": {
+                "name": "kmd",
+                "pid": 9159
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
+++ b/packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
@@ -1206,6 +1206,46 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-26T13:58:50.439Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "original": "<43>1 2026-06-26T09:58:50.439-04:00 host-1.example.local kernel - - - host-1.example.local kernel: Can't assign requested address",
+                "severity": 43
+            },
+            "host": {
+                "name": "host-1.example.local"
+            },
+            "juniper": {
+                "srx": {
+                    "log_type": "system",
+                    "process": "kernel",
+                    "tag": "kernel"
+                }
+            },
+            "log": {
+                "level": "error"
+            },
+            "message": "Can't assign requested address",
+            "observer": {
+                "name": "host-1.example.local",
+                "product": "SRX",
+                "type": "firewall",
+                "vendor": "Juniper"
+            },
+            "process": {
+                "name": "kernel"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -327,7 +327,7 @@ processors:
     tag: "script_cleanup_system"
     if: ctx.juniper?.srx?.system != null
     source: >-
-        ctx.juniper.srx.system = ctx.juniper.srx.system.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().replace(' ', '_').replace('-', '_').toLowerCase(), e -> e.getValue().trim()));
+        ctx.juniper.srx.system = ctx.juniper.srx.system.entrySet().stream().filter(e -> e.getValue() != null).collect(Collectors.toMap(e -> e.getKey().replace(' ', '_').replace('-', '_').toLowerCase(), e -> e.getValue() instanceof String ? ((String) e.getValue()).trim() : e.getValue()));
 
 #######################
 ## SRX System Fields ##

--- a/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
+++ b/packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml
@@ -327,7 +327,7 @@ processors:
     tag: "script_cleanup_system"
     if: ctx.juniper?.srx?.system != null
     source: >-
-        ctx.juniper.srx.system = ctx.juniper.srx.system.entrySet().stream().filter(e -> e.getValue() != null).collect(Collectors.toMap(e -> e.getKey().replace(' ', '_').replace('-', '_').toLowerCase(), e -> e.getValue() instanceof String ? ((String) e.getValue()).trim() : e.getValue()));
+        ctx.juniper.srx.system = ctx.juniper.srx.system.entrySet().stream().filter(e -> e.getValue() != null).collect(Collectors.toMap(e -> e.getKey().replace(' ', '_').replace('-', '_').toLowerCase(), e -> { def v = e.getValue(); if (v instanceof String) { return ((String) v).trim(); } if (v instanceof List) { return v.stream().map(i -> i instanceof String ? ((String) i).trim() : i).collect(Collectors.toList()); } return v; }));
 
 #######################
 ## SRX System Fields ##

--- a/packages/juniper_srx/manifest.yml
+++ b/packages/juniper_srx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: juniper_srx
 title: Juniper SRX
-version: "1.27.2"
+version: "1.27.3"
 description: Collect logs from Juniper SRX devices with Elastic Agent.
 categories: ["network", "security", "firewall_security"]
 type: integration


### PR DESCRIPTION
## Executive summary

The Painless script in the `script_cleanup_system` processor was calling `.trim()` directly on all map values without first checking whether each value is non-null and of type String. This caused a NullPointerException (or equivalent runtime failure) when any entry in `juniper.srx.system` held a null value or a non-String typed value (e.g., integers, booleans). The fix adds a `.filter()` step to remove null-valued entries before collection, and uses an `instanceof String` guard so `.trim()` is only applied to String values—non-String values are passed through unchanged.

## Proposed commit message

```
[juniper_srx] Fix script_cleanup_system trim() on non-String values.
```

## Root cause

The `script_cleanup_system` Painless script (system.yml line 325-330) calls `e.getValue().trim()` on every entry in `ctx.juniper.srx.system` without guarding for null values or non-String types. Upstream convert processors (`convert_dpdk_port_number_to_int`, `convert_dpdk_port_state_to_int`, `convert_swt_port_state_to_int`, `convert_rtlog_conn_error_status_to_long`) can place Integer or Long values into sub-fields of `juniper.srx.system`, and the KV processor can produce null values; calling `.trim()` on an Integer, Long, or null in Painless throws an exception that surfaces as the `[on_failure_message]` pipeline error.

## Approach

Guard the `script_cleanup_system` Painless script in system.yml against null values and non-String typed values before calling `.trim()`. Replace the unconditional `e -> e.getValue().trim()` lambda with a null-filtering stream step and a conditional that calls `.trim()` only when the value is a String instance, otherwise passes the value through unchanged. Add a test fixture covering the sanitized event (`<43>1 2026-06-26T09:58:50.439-04:00 host-1.example.local 198.51.100.10: Can't assign requested address`) to exercise the fixed code path.

## Implementation

1. Step 1: Edit `packages/juniper_srx/data_stream/log/elasticsearch/ingest_pipeline/system.yml` at line 330 — replace the single-line script source with a guarded version that (a) filters out null-valued entries before collecting, and (b) uses a ternary to call `.trim()` only when the value is a String instance, otherwise passing the value through as-is. New source: `ctx.juniper.srx.system = ctx.juniper.srx.system.entrySet().stream().filter(e -> e.getValue() != null).collect(Collectors.toMap(e -> e.getKey().replace(' ', '_').replace('-', '_').toLowerCase(), e -> e.getValue() instanceof String ? ((String) e.getValue()).trim() : e.getValue()));`
2. Step 2: Add the sanitized reproducer event as a new line in `packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log`: `<43>1 2026-06-26T09:58:50.439-04:00 host-1.example.local 198.51.100.10: Can't assign requested address`
3. Step 3: Regenerate the expected output file `packages/juniper_srx/data_stream/log/_dev/test/pipeline/test-system.log-expected.json` by running `elastic-package test pipeline --generate` (or manually appending a matching expected entry for the new test case) to capture the correct parsed output for the new fixture event.
4. Step 4: Run `elastic-package test pipeline` against the juniper_srx package to confirm all existing tests still pass and the new fixture no longer triggers the `[on_failure_message]` error.
5. Step 5: Bump `packages/juniper_srx/manifest.yml` version from `1.27.1` to `1.27.2` and prepend a `bugfix` entry to `packages/juniper_srx/changelog.yml` referencing the Sentinel case.

## Pipeline changes

- Modify script processor tagged `script_cleanup_system` (system.yml line 325-330): add `.filter(e -> e.getValue() != null)` before `.collect(...)` to skip null-valued entries, and change the value mapper from `e -> e.getValue().trim()` to `e -> e.getValue() instanceof String ? ((String) e.getValue()).trim() : e.getValue()` to handle Integer/Long values safely without type-cast exceptions.

## Field / mapping changes

—

## Sanitized error message

`Processor 'script' with tag 'script_cleanup_system' in pipeline 'logs-juniper_srx.log-system' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<43>1 2026-06-26T09:58:50.439-04:00 host-1.example.local 198.51.100.10: Can't assign requested address
```

## Reviewer concerns

- The fix silently drops map entries with null values rather than preserving them (e.g., as null or empty string); this could hide fields that were previously indexed as null, though null fields are generally not useful in Elasticsearch.
- The new test fixture message (`Can't assign requested address`) exercises a kernel syslog entry that triggers this code path, but the root cause (a null or non-String value in the system map) is not directly represented in the new test log line—reviewers should confirm the existing or new fixture actually exercises the null/non-String guard paths.
- The changelog link points to `pull/1` which appears to be a placeholder and should be updated to the real PR number before merge.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: medium
- **Tags**: pipeline, processors, ingest, test-fixture
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: juniper_srx.log [PIPELINE_FIX]: Processor 'script' with tag 'script_cleanup_system' in pipeline 'logs-ju…
- **Pipeline case**: `113cbc33dfb0c21b`
