### PR TITLE
Chargeback 0.5.0: Serverless support, Cloud Console monitoring as a usage source, fielddata fix

### DIFF
--- a/packages/chargeback/changelog.yml
+++ b/packages/chargeback/changelog.yml
@@ -1,4 +1,15 @@
 # later versions go on top
+- version: "0.5.0"
+  changes:
+    - description: "Elastic Cloud Serverless support: billing_realized_pool also matches Serverless capacity SKUs (deployment_type elasticsearch with elasticsearch.*-search-vcu_*, elasticsearch.*-ingest-vcu_*, elasticsearch.retained_*), so serverless projects get an allocatable capacity pool. Previously only ECH *.es.data*.* node SKUs matched, leaving every serverless cost row is_allocatable false and billing_realized_pool_lookup empty for serverless projects, so no serverless cost could be attributed to a tier or data stream. ML VCU is deliberately excluded to match ECH semantics, where ML is cost_category platform."
+      type: enhancement
+      link: https://github.com/elastic/elasticsearch-chargeback/pull/106
+    - description: "Usage transforms also source .monitoring-es-*, so Chargeback works with Elastic Cloud Console Logs and metrics (Cloud-managed Metricbeat) instead of requiring the Agent-based Elasticsearch integration. The index metricset carries the same field names the transforms already expect; the two it lacks (elasticsearch.index.datastream and elasticsearch.index.tier) are covered by the existing Painless fallbacks on index.name and index.tier_preference."
+      type: enhancement
+      link: https://github.com/elastic/elasticsearch-chargeback/pull/106
+    - description: "Fix Fielddata is disabled on [elasticsearch.cluster.name] causing the transforms to retry forever. Where the .monitoring-es-mb index template is not governing the .monitoring-es-8-mb data stream, dynamic mapping produces text plus a .keyword subfield and a terms aggregation on the text field throws. elasticsearch.cluster.name, index.name, index.datastream, index.tier and index.tier_preference are now read through keyword runtime fields that prefer the .keyword subfield when the mapping has one and fall back to the field itself; both branches use doc values. Also affects cluster_capacity_utilization, which has sourced .monitoring-es-* since 0.4.0."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/pull/106
 - version: 0.4.3
   changes:
     - description: "Fix LOOKUP JOIN on composite_key when lookup indices were dynamically mapped as text (JOIN with right field [composite_key] of type [TEXT]). Dashboard ES|QL now joins on composite_key.keyword after casting a left-side ck key, and composite_key mappings use a keyword multifield. Drop composite_key between chained joins to avoid ambiguous references."

--- a/packages/chargeback/elasticsearch/transform/billing_cluster_cost/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_cluster_cost/transform.yml
@@ -30,7 +30,7 @@ source:
           emit('');
 dest:
   index: billing_cluster_cost_lookup
-  pipeline: 0.4.3-billing
+  pipeline: 0.5.0-billing
 frequency: 60m
 sync:
   time:
@@ -69,4 +69,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/billing_realized_pool/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_realized_pool/transform.yml
@@ -30,6 +30,26 @@ source:
                     - wildcard:
                         ess.billing.sku: "*.es.datacontent.*"
                   minimum_should_match: 1
+        # Serverless projects (deployment_type: elasticsearch) bill VCU and retained storage
+        # instead of ECH data-tier node SKUs, so the *.es.data*.* patterns above never match
+        # them. Without this their cost stays is_allocatable: false and
+        # billing_realized_pool_lookup has no serverless rows, leaving the dashboards with no
+        # pool to allocate against. Search and ingest VCU plus retained storage are the
+        # serverless equivalent of data-tier capacity. ML VCU is deliberately excluded to
+        # match ECH semantics, where ML is cost_category "platform" and not allocatable.
+        - bool:
+            must:
+              - term:
+                  ess.billing.deployment_type: elasticsearch
+              - bool:
+                  should:
+                    - wildcard:
+                        ess.billing.sku: "elasticsearch.*-search-vcu_*"
+                    - wildcard:
+                        ess.billing.sku: "elasticsearch.*-ingest-vcu_*"
+                    - wildcard:
+                        ess.billing.sku: "elasticsearch.retained_*"
+                  minimum_should_match: 1
       minimum_should_match: 1
   runtime_mappings:
     deployment_group:
@@ -55,7 +75,7 @@ source:
           emit('');
 dest:
   index: billing_realized_pool_lookup
-  pipeline: 0.4.3-realized_pool
+  pipeline: 0.5.0-realized_pool
 frequency: 60m
 sync:
   time:
@@ -95,4 +115,4 @@ settings:
 _meta:
   managed: true
   run_as_kibana_system: false
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
@@ -57,7 +57,7 @@ source:
         source: "emit(50)"
 dest:
   index: chargeback_conf_lookup
-  pipeline: 0.4.3-chargeback_conf_lookup
+  pipeline: 0.5.0-chargeback_conf_lookup
 pivot:
   group_by:
     config_join_key:
@@ -106,4 +106,4 @@ settings:
 _meta:
   managed: true
   run_as_kibana_system: false
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/transform.yml
@@ -21,7 +21,25 @@ source:
               - data_frozen
               - data_content
               - data
+  # These read whichever of <field> / <field>.keyword the mapping actually makes
+  # aggregatable. Where the .monitoring-es-mb index template is not governing the
+  # .monitoring-es-8-mb data stream, dynamic mapping produces `text` plus a `.keyword`
+  # subfield, and a terms aggregation on the text field fails with "Fielddata is
+  # disabled ... Will automatically retry [1/-1]" - retrying forever without ever
+  # producing a row. Both branches below use doc values, so there is no _source penalty.
   runtime_mappings:
+    cb_cluster_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.cluster.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.cluster.name') && !doc['elasticsearch.cluster.name'].empty) {
+            emit(doc['elasticsearch.cluster.name'].value.toString());
+          }
     node_disk_used_pct:
       type: double
       script:
@@ -33,7 +51,7 @@ source:
           }
 dest:
   index: cluster_capacity_utilization_lookup
-  pipeline: 0.4.3-capacity_utilization
+  pipeline: 0.5.0-capacity_utilization
 frequency: 60m
 sync:
   time:
@@ -47,7 +65,7 @@ pivot:
         calendar_interval: 1d
     cluster_name:
       terms:
-        field: elasticsearch.cluster.name
+        field: cb_cluster_name
   aggregations:
     heap_used_pct_p95:
       percentiles:
@@ -65,4 +83,4 @@ settings:
 _meta:
   managed: true
   run_as_kibana_system: false
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/cluster_datastream_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_datastream_contribution/transform.yml
@@ -3,9 +3,58 @@ source:
   index:
     - "monitoring-indices*"
     - "*:monitoring-indices*"
+    # Elastic Cloud Console "Logs and metrics" (Cloud-managed Metricbeat) writes the
+    # .monitoring-es-8-mb data stream, whose "index" metricset carries the same field names as
+    # the Elasticsearch integration index_pivot output, so Chargeback can run without the
+    # Agent-based Elasticsearch integration. Serverless usage is also collected into an index
+    # matching monitoring-indices*, which the first pattern already covers.
+    - ".monitoring-es-*"
+  # These read whichever of <field> / <field>.keyword the mapping actually makes
+  # aggregatable. Where the .monitoring-es-mb index template is not governing the
+  # .monitoring-es-8-mb data stream, dynamic mapping produces `text` plus a `.keyword`
+  # subfield, and a terms aggregation on the text field fails with "Fielddata is
+  # disabled ... Will automatically retry [1/-1]" - retrying forever without ever
+  # producing a row. Both branches below use doc values, so there is no _source penalty.
+  runtime_mappings:
+    cb_cluster_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.cluster.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.cluster.name') && !doc['elasticsearch.cluster.name'].empty) {
+            emit(doc['elasticsearch.cluster.name'].value.toString());
+          }
+    cb_index_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.name') && !doc['elasticsearch.index.name'].empty) {
+            emit(doc['elasticsearch.index.name'].value.toString());
+          }
+    cb_index_datastream:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.datastream.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.datastream') && !doc['elasticsearch.index.datastream'].empty) {
+            emit(doc['elasticsearch.index.datastream'].value.toString());
+          }
 dest:
   index: cluster_datastream_contribution_lookup
-  pipeline: 0.4.3-usage
+  pipeline: 0.5.0-usage
 frequency: 60m
 sync:
   time:
@@ -19,18 +68,18 @@ pivot:
         calendar_interval: 1d
     cluster_name:
       terms:
-        field: elasticsearch.cluster.name
+        field: cb_cluster_name
     datastream:
       terms:
         script:
           lang: painless
           source: >
-            if (doc.containsKey('elasticsearch.index.datastream') && !doc['elasticsearch.index.datastream'].empty) {
-              return doc['elasticsearch.index.datastream'].value;
+            if (doc.containsKey('cb_index_datastream') && !doc['cb_index_datastream'].empty) {
+              return doc['cb_index_datastream'].value;
             }
 
-            def name = doc.containsKey('elasticsearch.index.name') && !doc['elasticsearch.index.name'].empty
-              ? doc['elasticsearch.index.name'].value
+            def name = doc.containsKey('cb_index_name') && !doc['cb_index_name'].empty
+              ? doc['cb_index_name'].value
               : null;
             if (name == null) return 'unknown';
 
@@ -61,4 +110,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/cluster_deployment_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_deployment_contribution/transform.yml
@@ -4,9 +4,34 @@ source:
     # Wildcard matches default monitoring-indices and custom pivot destinations named monitoring-indices* (Elasticsearch integration).
     - "monitoring-indices*"
     - "*:monitoring-indices*" # Same pattern on all remote clusters (CCS).
+    # Elastic Cloud Console "Logs and metrics" (Cloud-managed Metricbeat) writes the
+    # .monitoring-es-8-mb data stream, whose "index" metricset carries the same field names as
+    # the Elasticsearch integration index_pivot output, so Chargeback can run without the
+    # Agent-based Elasticsearch integration. Serverless usage is also collected into an index
+    # matching monitoring-indices*, which the first pattern already covers.
+    - ".monitoring-es-*"
+  # These read whichever of <field> / <field>.keyword the mapping actually makes
+  # aggregatable. Where the .monitoring-es-mb index template is not governing the
+  # .monitoring-es-8-mb data stream, dynamic mapping produces `text` plus a `.keyword`
+  # subfield, and a terms aggregation on the text field fails with "Fielddata is
+  # disabled ... Will automatically retry [1/-1]" - retrying forever without ever
+  # producing a row. Both branches below use doc values, so there is no _source penalty.
+  runtime_mappings:
+    cb_cluster_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.cluster.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.cluster.name') && !doc['elasticsearch.cluster.name'].empty) {
+            emit(doc['elasticsearch.cluster.name'].value.toString());
+          }
 dest:
   index: cluster_deployment_contribution_lookup
-  pipeline: 0.4.3-usage
+  pipeline: 0.5.0-usage
 frequency: 60m
 sync:
   time:
@@ -20,7 +45,7 @@ pivot:
         calendar_interval: 1d
     cluster_name:
       terms:
-        field: elasticsearch.cluster.name
+        field: cb_cluster_name
   aggregations:
     deployment_sum_indexing_time:
       sum:
@@ -43,4 +68,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/cluster_tier_and_ds_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_tier_and_ds_contribution/transform.yml
@@ -3,9 +3,82 @@ source:
   index:
     - "monitoring-indices*"
     - "*:monitoring-indices*"
+    # Elastic Cloud Console "Logs and metrics" (Cloud-managed Metricbeat) writes the
+    # .monitoring-es-8-mb data stream, whose "index" metricset carries the same field names as
+    # the Elasticsearch integration index_pivot output, so Chargeback can run without the
+    # Agent-based Elasticsearch integration. Serverless usage is also collected into an index
+    # matching monitoring-indices*, which the first pattern already covers.
+    - ".monitoring-es-*"
+  # These read whichever of <field> / <field>.keyword the mapping actually makes
+  # aggregatable. Where the .monitoring-es-mb index template is not governing the
+  # .monitoring-es-8-mb data stream, dynamic mapping produces `text` plus a `.keyword`
+  # subfield, and a terms aggregation on the text field fails with "Fielddata is
+  # disabled ... Will automatically retry [1/-1]" - retrying forever without ever
+  # producing a row. Both branches below use doc values, so there is no _source penalty.
+  runtime_mappings:
+    cb_cluster_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.cluster.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.cluster.name') && !doc['elasticsearch.cluster.name'].empty) {
+            emit(doc['elasticsearch.cluster.name'].value.toString());
+          }
+    cb_index_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.name') && !doc['elasticsearch.index.name'].empty) {
+            emit(doc['elasticsearch.index.name'].value.toString());
+          }
+    cb_index_datastream:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.datastream.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.datastream') && !doc['elasticsearch.index.datastream'].empty) {
+            emit(doc['elasticsearch.index.datastream'].value.toString());
+          }
+    cb_index_tier:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.tier.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
+            emit(doc['elasticsearch.index.tier'].value.toString());
+          }
+    cb_index_tier_preference:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.tier_preference.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty) {
+            emit(doc['elasticsearch.index.tier_preference'].value.toString());
+          }
 dest:
   index: cluster_tier_and_datastream_contribution_lookup
-  pipeline: 0.4.3-usage
+  pipeline: 0.5.0-usage
 frequency: 60m
 sync:
   time:
@@ -19,17 +92,17 @@ pivot:
         calendar_interval: 1d
     cluster_name:
       terms:
-        field: elasticsearch.cluster.name
+        field: cb_cluster_name
     tier:
       terms:
         script:
           lang: painless
           source: >
-            if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
-              def tier = doc['elasticsearch.index.tier'].value;
+            if (doc.containsKey('cb_index_tier') && !doc['cb_index_tier'].empty) {
+              def tier = doc['cb_index_tier'].value;
               if (tier != null && tier != 'unknown') return tier;
             }
-            def pref = doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty ? doc['elasticsearch.index.tier_preference'].value : null;
+            def pref = doc.containsKey('cb_index_tier_preference') && !doc['cb_index_tier_preference'].empty ? doc['cb_index_tier_preference'].value : null;
             if (pref == null) return 'unknown';
             if (pref.contains('data_hot') || pref.contains('data_content')) return 'hot/content';
             if (pref.contains('data_warm')) return 'warm';
@@ -41,12 +114,12 @@ pivot:
         script:
           lang: painless
           source: >
-            if (doc.containsKey('elasticsearch.index.datastream') && !doc['elasticsearch.index.datastream'].empty) {
-              return doc['elasticsearch.index.datastream'].value;
+            if (doc.containsKey('cb_index_datastream') && !doc['cb_index_datastream'].empty) {
+              return doc['cb_index_datastream'].value;
             }
 
-            def name = doc.containsKey('elasticsearch.index.name') && !doc['elasticsearch.index.name'].empty
-              ? doc['elasticsearch.index.name'].value
+            def name = doc.containsKey('cb_index_name') && !doc['cb_index_name'].empty
+              ? doc['cb_index_name'].value
               : null;
             if (name == null) return 'unknown';
 
@@ -77,4 +150,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/elasticsearch/transform/cluster_tier_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_tier_contribution/transform.yml
@@ -3,9 +3,58 @@ source:
   index:
     - "monitoring-indices*"
     - "*:monitoring-indices*"
+    # Elastic Cloud Console "Logs and metrics" (Cloud-managed Metricbeat) writes the
+    # .monitoring-es-8-mb data stream, whose "index" metricset carries the same field names as
+    # the Elasticsearch integration index_pivot output, so Chargeback can run without the
+    # Agent-based Elasticsearch integration. Serverless usage is also collected into an index
+    # matching monitoring-indices*, which the first pattern already covers.
+    - ".monitoring-es-*"
+  # These read whichever of <field> / <field>.keyword the mapping actually makes
+  # aggregatable. Where the .monitoring-es-mb index template is not governing the
+  # .monitoring-es-8-mb data stream, dynamic mapping produces `text` plus a `.keyword`
+  # subfield, and a terms aggregation on the text field fails with "Fielddata is
+  # disabled ... Will automatically retry [1/-1]" - retrying forever without ever
+  # producing a row. Both branches below use doc values, so there is no _source penalty.
+  runtime_mappings:
+    cb_cluster_name:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.cluster.name.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.cluster.name') && !doc['elasticsearch.cluster.name'].empty) {
+            emit(doc['elasticsearch.cluster.name'].value.toString());
+          }
+    cb_index_tier:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.tier.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
+            emit(doc['elasticsearch.index.tier'].value.toString());
+          }
+    cb_index_tier_preference:
+      type: keyword
+      script:
+        source: |
+          String kw = 'elasticsearch.index.tier_preference.keyword';
+          if (doc.containsKey(kw)) {
+            if (!doc[kw].empty) { emit(doc[kw].value.toString()); }
+            return;
+          }
+          if (doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty) {
+            emit(doc['elasticsearch.index.tier_preference'].value.toString());
+          }
 dest:
   index: cluster_tier_contribution_lookup
-  pipeline: 0.4.3-usage
+  pipeline: 0.5.0-usage
 frequency: 60m
 sync:
   time:
@@ -19,18 +68,18 @@ pivot:
         calendar_interval: 1d
     cluster_name:
       terms:
-        field: elasticsearch.cluster.name
+        field: cb_cluster_name
     tier:
       terms:
         script:
           lang: painless
           source: >
-            if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
-              def tier = doc['elasticsearch.index.tier'].value;
+            if (doc.containsKey('cb_index_tier') && !doc['cb_index_tier'].empty) {
+              def tier = doc['cb_index_tier'].value;
               if (tier != null && tier != 'unknown') return tier;
             }
             
-            def pref = doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty ? doc['elasticsearch.index.tier_preference'].value : null;
+            def pref = doc.containsKey('cb_index_tier_preference') && !doc['cb_index_tier_preference'].empty ? doc['cb_index_tier_preference'].value : null;
             if (pref == null) return 'unknown';
             if (pref.contains('data_hot') || pref.contains('data_content')) return 'hot/content';
             if (pref.contains('data_warm')) return 'warm';
@@ -59,4 +108,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.3
+  fleet_transform_version: 0.5.0

--- a/packages/chargeback/manifest.yml
+++ b/packages/chargeback/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: chargeback
 title: "Chargeback"
-version: 0.4.3
+version: 0.5.0
 description: "This package calculates chargeback based on billing and consumption data"
 type: integration
 categories:


### PR DESCRIPTION
Companion to **elastic/elasticsearch-chargeback#106**. Base is `wip-johannes-chargeback` per [PR_AND_RELEASE_CHECKLIST.md](https://github.com/elastic/elasticsearch-chargeback/blob/main/scripts/PR_AND_RELEASE_CHECKLIST.md). Rebased onto the current branch head (0.4.3), so 0.4.2 and 0.4.3 are preserved.

Three changes, one release. Only `packages/chargeback/` is touched.

## 1. Serverless cost becomes allocatable

`billing_realized_pool` matched only ECH data-tier node SKUs (`*.es.datahot.*` and friends). Serverless projects bill VCU and retained storage, so nothing matched — every serverless cost row stayed `is_allocatable: false` and `billing_realized_pool_lookup` had no serverless rows, leaving the dashboards with no pool to allocate against.

Now also matches `deployment_type: elasticsearch` with `elasticsearch.*-search-vcu_*`, `elasticsearch.*-ingest-vcu_*`, `elasticsearch.retained_*`.

**ML VCU is deliberately excluded**, matching how ECH treats ML as `cost_category: platform`. Worth a reviewer opinion — on the test org, ML VCU was the single largest serverless line item (338 of ~855 ECU), so including it would materially change allocation. Excluding it keeps the pool to things the usage signals actually explain.

Verified on ECH 9.4.3: matches **1,597 ECH docs unchanged** plus **947 serverless docs across two serverless projects**, and produces 242 days of pool rows for a project that previously had none.

## 2. `.monitoring-es-*` as a usage source

The four usage transforms also source `.monitoring-es-*`, so Chargeback works with **Elastic Cloud Console → Logs and metrics** (Cloud-managed Metricbeat) instead of requiring the Agent-based Elasticsearch integration. The `index` metricset carries the same field names the transforms already expect; the two it lacks (`elasticsearch.index.datastream`, `elasticsearch.index.tier`) are already covered by the existing Painless fallbacks on `index.name` and `index.tier_preference`.

This is also what lets Serverless usage be collected into an index matching `monitoring-indices*` and picked up with no further transform change (see the companion PR's `serverless/` assets).

## 3. Fix: `Fielddata is disabled`, retrying forever

Reported while testing the companion PR:

```
Transform encountered an exception: [Fielddata is disabled on [elasticsearch.cluster.name]
in [.ds-.monitoring-es-8-mb-...]. Text fields are not optimised for operations that require
per-document field data like aggregations and sorting...]; Will automatically retry [1/-1]
```

Cause is the mapping, not the data. Where the `.monitoring-es-mb` template (patterns `.monitoring-es-8-*`) governs the data stream, the string fields are `keyword` and a `terms` aggregation works. Where it does not, dynamic mapping produces `text` **plus a `.keyword` subfield**, and aggregating the text field throws — then retries forever without ever producing a row.

`elasticsearch.cluster.name`, `index.name`, `index.datastream`, `index.tier` and `index.tier_preference` are now read through keyword runtime fields that prefer the `.keyword` subfield when the mapping has one and otherwise read the field directly. **Both branches use doc values**, so there is no `_source` penalty.

This is the same class of dynamic-text-mapping problem 0.4.3 fixed for `composite_key`.

**Scope note:** `cluster_capacity_utilization` has sourced `.monitoring-es-*` **and** grouped by `terms` on `elasticsearch.cluster.name` **since 0.4.0**, so this failure predates the serverless work on any affected cluster. Adding `.monitoring-es-*` to the usage transforms widened the exposure. All five are fixed here.

I first tried a `_source`-based runtime field and rejected it: it doubled preview time and was not metric-equivalent (99 of 100 groups differed, with a deterministic control run confirming the gap was real rather than noise).

## Verification — and what I could not run

Please treat this as **not yet E2E-verified**, and read the caveat.

Done:
- All 34 package YAML files parse; no runtime field is self-referential; no residual raw doc-values access to the five fields outside the runtime definitions.
- Every patched transform definition was read straight from this source and submitted to `POST _transform/_preview` against a live ECH 9.4.3 cluster with real billing and monitoring data. All six relevant transforms return rows:

  ```
  PASS  cluster_deployment_contribution    rows=12
  PASS  cluster_tier_contribution          rows=18
  PASS  cluster_datastream_contribution    rows=100
  PASS  cluster_tier_and_ds_contribution   rows=100
  PASS  cluster_capacity_utilization       rows=2
  PASS  billing_realized_pool              rows=100
  ```

- The fielddata fix was proven by reproducing the reporter's mapping on a throwaway `text` + `.keyword` index: grouping on the raw field returns the identical `Fielddata is disabled` error, the runtime-field grouping returns the correct value. On a correctly-mapped cluster the substitution is metric-for-metric identical (same group set, zero differing metrics across a 100-group preview).

**Not done, and I could not do it here:** `elastic-package build`, `elastic-package test`, and `scripts/run_e2e_tests.sh`. That machine has Docker but no `go`, no `elastic-package` and no `jq`, so I could not build the package or run the 12-ERU E2E scenario. **Someone with the toolchain needs to run `./scripts/release_chargeback.sh --cleanup-first --replace-dashboard` and paste the step-12 output into both PRs before merge.** The companion PR deliberately ships no zip for the same reason — the artifact must be an `elastic-package build` of this branch, not a hand-assembled one.

## Reviewer questions

1. **ML VCU exclusion** — agree, or should serverless ML VCU be allocatable?
2. **`.monitoring-es-*` as a supported source** — happy to have it on by default for everyone, or would you prefer it gated so only Cloud Console users opt in? It broadens what the transforms read for every install.
3. Version **0.5.0** assumed as the next minor after 0.4.3. Say the word if you would rather this land as 0.4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)