### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -642,4 +642,4 @@
 /packages/zscaler_zia @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/zscaler_zpa @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/otel_rum_dashboards @elastic/apm-agent-rum
-/packages/otel_android_dashboards @elastic/apm-agent-android @elastic/apm-agent-approvers
+/packages/otel_android_dashboards @elastic/apm-agent-android @elastic/obs-signals-traces-approvers


### PR DESCRIPTION
Replaces the old approvers group name with the new one
