### PR TITLE
[snort] Guard set event.created against null @timestamp.

### DIFF
--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.21.3"
   changes:
-    - description: Add ignore_failure to the set event.created processor to prevent pipeline errors when @timestamp is absent at ingest time.
+    - description: Add ignore_empty_value to the set event.created processor to prevent pipeline errors when @timestamp is absent at ingest time.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.2"

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add ignore_empty_value to the set event.created processor to prevent pipeline errors when @timestamp is absent at ingest time.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20696
 - version: "1.21.2"
   changes:
     - description: Remove top level note from docs

--- a/packages/snort/changelog.yml
+++ b/packages/snort/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.3"
+  changes:
+    - description: Add ignore_failure to the set event.created processor to prevent pipeline errors when @timestamp is absent at ingest time.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.2"
   changes:
     - description: Remove top level note from docs

--- a/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -27,6 +27,7 @@ processors:
       tag: set_event_created_e3f09e3b
       field: event.created
       copy_from: '@timestamp'
+      ignore_failure: true
   - grok:
       tag: grok_event_original_302e2f2f
       field: event.original

--- a/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -27,7 +27,7 @@ processors:
       tag: set_event_created_e3f09e3b
       field: event.created
       copy_from: '@timestamp'
-      ignore_failure: true
+      ignore_empty_value: true
   - grok:
       tag: grok_event_original_302e2f2f
       field: event.original

--- a/packages/snort/manifest.yml
+++ b/packages/snort/manifest.yml
@@ -1,6 +1,6 @@
 name: snort
 title: Snort
-version: "1.21.2"
+version: "1.21.3"
 description: Collect logs from Snort with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Executive summary

Added `ignore_empty_value: true` to the `set` processor that copies `@timestamp` into `event.created` in the Snort log ingest pipeline. Without this flag, the processor throws an error when `@timestamp` is absent at ingest time — a condition that can occur during certain ingestion scenarios. The fix prevents pipeline failures by silently skipping the copy when the source field is empty or missing.

## Proposed commit message

```
[snort] Guard set event.created against null @timestamp.
```

## Root cause

The `set` processor tagged `set_event_created_e3f09e3b` executes `copy_from: '@timestamp'` with no null guard at the very top of the pipeline, before any date parsing populates `@timestamp`; when the ingest document arrives with a null or missing `@timestamp`, the processor throws and routes the event to the on_failure handler, producing a `pipeline_error` document.

## Approach

Add `ignore_failure: true` to the `set_event_created_e3f09e3b` processor in `default.yml` to prevent it from failing when `@timestamp` is absent or null at ingest time. The processor's intent is to snapshot the ingest-time timestamp into `event.created` before the downstream `date` processors overwrite `@timestamp` with the parsed log timestamp; the guard makes this safe without changing normal-path behavior. Bump the package version to 1.21.3 with a patch changelog entry.

## Implementation

1. Step 1: In `packages/snort/data_stream/log/elasticsearch/ingest_pipeline/default.yml` lines 27-29, add `ignore_failure: true` to the `set_event_created_e3f09e3b` processor so it silently no-ops instead of throwing when `@timestamp` is null or absent.
2. Step 2: Bump `version` in `packages/snort/manifest.yml` from `1.21.2` to `1.21.3`.
3. Step 3: Prepend a new entry to `packages/snort/changelog.yml` for version `1.21.3` with `type: bugfix` describing the null-guard fix on the `set_event_created` processor.

## Pipeline changes

- Add `ignore_failure: true` to the `set` processor tagged `set_event_created_e3f09e3b` in `default.yml` (currently lines 27-29); no other processors are changed.

## Field / mapping changes

—

## Sanitized error message

`Processor 'set' with tag 'set_event_created_e3f09e3b' in pipeline 'logs-snort.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<110>Jun 27 00:24:22 host-1.example.local alice.johnson	198.51.100.10	0	126	success	Login on account	1782519862349
```

## Reviewer concerns

- `ignore_empty_value: true` means `event.created` will be unset in records where `@timestamp` is genuinely absent; downstream queries or detection rules that rely on `event.created` being populated should be reviewed to ensure they handle this case.
- The changelog `link` field references `pull/1`, which is a placeholder and should be updated to the real PR number before merging.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: snort.log [PIPELINE_FIX]: Processor 'set' with tag 'set_event_created_e3f09e3b' in pipeline 'logs-…
- **Pipeline case**: `fa5648277f6c99d9`
