### PR TITLE
[Cisco Meraki] Fix SSL settings not being rendered in the TCP stream template

### DIFF
--- a/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
@@ -35,3 +35,8 @@ services:
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=tcp /sample_logs/cisco-meraki.log
+  cisco_meraki-log-tls:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    volumes:
+      - ./sample_logs:/sample_logs:ro
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8687 -p=tls --insecure /sample_logs/cisco-meraki.log

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix SSL settings not being rendered in the TCP stream template.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20701
 - version: "1.31.2"
   changes:
     - description: Fix grok pattern to support `Blocked RA Packet` and `Blocked DHCP Packet` events in addition to `Blocked ARP Packet` events.

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.3"
+  changes:
+    - description: Fix SSL settings not being rendered in the TCP stream template.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.31.2"
   changes:
     - description: Fix grok pattern to support `Blocked RA Packet` and `Blocked DHCP Packet` events in addition to `Blocked ARP Packet` events.

--- a/packages/cisco_meraki/data_stream/log/_dev/test/system/test-tls-config.yml
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/system/test-tls-config.yml
@@ -1,3 +1,4 @@
+wait_for_data_timeout: 1m
 service: cisco_meraki-log-tls
 service_notify_signal: SIGHUP
 input: tcp

--- a/packages/cisco_meraki/data_stream/log/_dev/test/system/test-tls-config.yml
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/system/test-tls-config.yml
@@ -1,0 +1,62 @@
+service: cisco_meraki-log-tls
+service_notify_signal: SIGHUP
+input: tcp
+data_stream:
+  vars:
+    listen_address: 0.0.0.0
+    listen_port: 8687
+    preserve_original_event: true
+    ssl: |
+      key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDhCLvLsQAHufsN
+        U+u1x/CequAUphfXZqLhDo2Eo/holfBS0+ey4bnzPL6lS9NFL5JkLQA2gYESqsXU
+        /Ru8E76Az1egzMwT3TVAPLVU8NbrxBqeNiQa2m9wC37HQy4qC9OxL28LUoKtFjxS
+        cD1sa0oikXCJN1a3BSoAf9iiZ/dxz4WVfrNhrzq2JFXjravY84n5ujkZOg45Pg70
+        4vHOeg0rBbIoSNfjDUVZWjwC95K1BMN3msOTL9juv/EDa6BujqCxl+G1nY7JPFDL
+        SHWis65p+1AAa5xieYDb47vyJ0SSR7lEURTXZOkkM6k5JWfgkATEmGzRxPkOloIT
+        Xg9ag1OlAgMBAAECggEAEHfPJmzhj68wjB0kFr13AmWG2Hv/Kqg8KzQhbx+AwkaW
+        u7j+L70NGpvLZ9VQtLNyhxoz9cksZO1SZO/Q48aeHlcOFppmJN3/U6AdtQWa9M35
+        FLLpmX16wjxVHsfvzOvopgLOoYl8PqZt66qDFDgVyMnT7na6RdJ+7GJuvBPXq+Bc
+        vgThvAZitHSAOhnBFYmTMlBi6AzOMMsaFlgE3Xf9v3M0pAKItPRKMhXlC3MyvA/v
+        jgbra4Ib+0ryohggHheHB3bn3Jgv7iFKoW9OQSePVxacJ+kfr9H+No5g495URzqR
+        mx/96WCiv3rAh3ct8Sk/C4/3zMC8fUueDJIVjhgw0QKBgQD8NufLINNkIpBrLoCS
+        972oFEjZB2u6EusQ7X9raROqpaw26ZSu+zSHeIKCGQ93M3aRb3FpdGeOxgZ095MV
+        8a+nlh4stOvHj2Mm5YhTBDUavTC7o9aVR3Od5eTXUpHnaJpNI/uyIcKupeK1UJnV
+        UlBLeIwo/vJ1gsVrKMMAJkuKbwKBgQDkaWRRd0w2gUIbCTGf203BqXft0VdIiOW7
+        +gnkeaNHAf09XljzxMcQzrB8kG63aKVGbJffphEfzxtiJ+HRQVH+7QpKRhU/GHmu
+        +6OKkxTcxJm5zhoRFxcSi2wG4PWmUGJvc7ss1OJGcaOUxwocCepO7N/jfdDz9Uke
+        KnA+YWOdKwKBgQDteZkYlojT0QOgF8HyH5gQyUCqMKWLJ0LzxltiPCbLV4Dml1pq
+        w5Z7M8nWS1hXiTpLx93GSFc1hFkSCwYP9GfK6Lryp0sVtHnMZvTMDbseuSJImwRx
+        vDwtYQfugg1lEQWwOoBEAiu3m/PxernNtNprpU57T0nlwUK3GkM5QdWAuwKBgQCZ
+        ZF3GiANapzupxGbbH//8Cr9LqsafI7CEqMpz8WxBh4h16iJ6sq+tDeFgBe8UpOY5
+        gTwNKg1d+0w8guQYD3HtbWr3rlEeamVtqfiOW3ArQqyqJ0tCJuuLvK3zgKf35Qv2
+        JRaSaPT8sdxVUcXsRoxgLJu+vwPQke1koMN4YRbwuQKBgQDJiZ/WSeqa5oIqkXbn
+        hjm7RXKaf2oE1U/bNjdSFtdEP7T4vUvvr7Hq2f/jiBLtCE7w16PJjKx9iIq2+jMl
+        qIY43Sk9bdi5FxtYTHda0hwrbH274P+QVcVs5PXCT0TGktOleHGBlXaaPrxl9iCh
+        8tmmxZZYa5aQxEO/lxB9xQKaiQ==
+        -----END PRIVATE KEY-----
+      certificate: |
+        -----BEGIN CERTIFICATE-----
+        MIIDazCCAlOgAwIBAgIUW5TDu1tJMY2Oa7PsL+BQSmeWqz0wDQYJKoZIhvcNAQEL
+        BQAwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+        GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTEwMDEwNTAwMjNaFw0yMTEw
+        MDIwNTAwMjNaMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+        HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+        AQUAA4IBDwAwggEKAoIBAQDhCLvLsQAHufsNU+u1x/CequAUphfXZqLhDo2Eo/ho
+        lfBS0+ey4bnzPL6lS9NFL5JkLQA2gYESqsXU/Ru8E76Az1egzMwT3TVAPLVU8Nbr
+        xBqeNiQa2m9wC37HQy4qC9OxL28LUoKtFjxScD1sa0oikXCJN1a3BSoAf9iiZ/dx
+        z4WVfrNhrzq2JFXjravY84n5ujkZOg45Pg704vHOeg0rBbIoSNfjDUVZWjwC95K1
+        BMN3msOTL9juv/EDa6BujqCxl+G1nY7JPFDLSHWis65p+1AAa5xieYDb47vyJ0SS
+        R7lEURTXZOkkM6k5JWfgkATEmGzRxPkOloITXg9ag1OlAgMBAAGjUzBRMB0GA1Ud
+        DgQWBBRYUSKDHBBE9Q6fTeTqogicCxcXwDAfBgNVHSMEGDAWgBRYUSKDHBBE9Q6f
+        TeTqogicCxcXwDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBc
+        T8B+GpvPy9NQ700LsywRPY0L9IJCKiu6j3TP1tqqSPjAC/cg9ac+bFXuWOu7V+KJ
+        s09Q/pItq9SLX6UvnfRzTxu5lCBwwGX9cL131mTIu5SmFo7Eks+sorbiIarWDMoC
+        e+9An3GFpagW+YhOt4BdIM5lTqoeodzganDBsOUZI9aDAj2Yo5h2O7r6Wd12cb6T
+        mz8vMfB2eG8BxU20ZMfkdERWjiyXHOSBQqeqfkV8d9370gMu5RcJNcIgnbmTRdho
+        X3HJFiimZVaNjXATqmC/y2A1KXvJdamPLy3mGXkW2cFLoPCdK2OZFUHqiuc1bigA
+        qEf55SihFqErRMeURPPF
+        -----END CERTIFICATE-----
+assert:
+  hit_count: 204

--- a/packages/cisco_meraki/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cisco_meraki/data_stream/log/agent/stream/tcp.yml.hbs
@@ -13,6 +13,10 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
+
 fields_under_root: true
 fields:
   _conf:

--- a/packages/cisco_meraki/data_stream/log/manifest.yml
+++ b/packages/cisco_meraki/data_stream/log/manifest.yml
@@ -106,9 +106,8 @@ streams:
         required: false
         show_user: false
         default: |
-          enabled: false
-          certificate: "/etc/pki/client/cert.pem"
-          key: "/etc/pki/client/cert.key"
+          #certificate: "/etc/server/cert.pem"
+          #key: "/etc/server/key.pem"
       - name: tags
         type: text
         title: Tags

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.31.2"
+version: "1.31.3"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

[Cisco Meraki] Fix SSL settings not being rendered in the TCP stream template

The TCP agent stream template for the cisco_meraki `log` data stream did not emit the `ssl` block, even though the data stream manifest already exposed an `ssl` YAML variable. Configured TLS settings were therefore dropped at policy-render time and the listener always ran as plaintext TCP.

This change follows the standard Elastic TCP input pattern already used by the package's webhook stream (`http_endpoint.yml.hbs`) and by other syslog integrations:



When `ssl` is set, Filebeat/Agent enables TLS on the TCP listener using the user-supplied certificate and key. The existing default (`enabled: false` plus placeholder cert paths) still renders, which is expected: Filebeat ignores the cert paths while SSL is disabled, so plaintext TCP collection is unchanged.

Coverage is added with the usual TCP/TLS system-test pattern:
- A `cisco_meraki-log-tls` docker-compose service using `elastic/stream` (`-p=tls --insecure`) that waits for `SIGHUP`, then replays `cisco-meraki.log` to `elastic-agent:8687`.
- A `test-tls-config.yml` that selects the TCP input, binds `0.0.0.0:8687`, injects the shared throwaway test cert/key, waits up to `1m` for data, and asserts 204 hits (one per sample-log line).

No ingest-pipeline, field-mapping, or syslog-parsing changes. Package version is 1.31.3.


Users who configured SSL in the Meraki TCP integration UI had those settings silently ignored, so syslog over TLS could not be collected. Rendering `ssl` in the TCP template makes the existing policy field actually take effect. The TLS system test exists so this path cannot regress without CI noticing.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
