### PR TITLE
[ssi] Add Terraform resource labels to SSI packages (batch 1)

### DIFF
--- a/packages/jamf_protect/data_stream/alerts/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/alerts/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-jamf_protect-package"
     }
   }
 }

--- a/packages/jamf_protect/data_stream/alerts/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/alerts/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-jamf_protect-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-jamf_protect-package" # name in manifest.yml
     }
   }
 }

--- a/packages/jamf_protect/data_stream/telemetry/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/telemetry/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-jamf_protect-package"
     }
   }
 }

--- a/packages/jamf_protect/data_stream/telemetry/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/telemetry/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-jamf_protect-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-jamf_protect-package" # name in manifest.yml
     }
   }
 }

--- a/packages/jamf_protect/data_stream/telemetry_legacy/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-jamf_protect-package"
     }
   }
 }

--- a/packages/jamf_protect/data_stream/telemetry_legacy/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-jamf_protect-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-jamf_protect-package" # name in manifest.yml
     }
   }
 }

--- a/packages/jamf_protect/data_stream/web_threat_events/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/web_threat_events/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-jamf_protect-package"
     }
   }
 }

--- a/packages/jamf_protect/data_stream/web_threat_events/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/web_threat_events/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-jamf_protect-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-jamf_protect-package" # name in manifest.yml
     }
   }
 }

--- a/packages/jamf_protect/data_stream/web_traffic_events/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/web_traffic_events/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-jamf_protect-package"
     }
   }
 }

--- a/packages/jamf_protect/data_stream/web_traffic_events/_dev/deploy/tf/main.tf
+++ b/packages/jamf_protect/data_stream/web_traffic_events/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-jamf_protect-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-jamf_protect-package" # name in manifest.yml
     }
   }
 }

--- a/packages/netskope/data_stream/transaction/_dev/deploy/tf/main.tf
+++ b/packages/netskope/data_stream/transaction/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-netskope-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-netskope-package" # name in manifest.yml
     }
   }
 }

--- a/packages/netskope/data_stream/transaction/_dev/deploy/tf/main.tf
+++ b/packages/netskope/data_stream/transaction/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       aws_branch       = var.BRANCH
       aws_build        = var.BUILD_ID
       aws_created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-netskope-package"
     }
   }
 }

--- a/packages/sentinel_one_cloud_funnel/_dev/deploy/tf/main.tf
+++ b/packages/sentinel_one_cloud_funnel/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-sentinel_one_cloud_funnel-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-sentinel_one_cloud_funnel-package" # name in manifest.yml
     }
   }
 }

--- a/packages/sentinel_one_cloud_funnel/_dev/deploy/tf/main.tf
+++ b/packages/sentinel_one_cloud_funnel/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-sentinel_one_cloud_funnel-package"
     }
   }
 }

--- a/packages/servicenow/_dev/deploy/tf/main.tf
+++ b/packages/servicenow/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-servicenow-package"
     }
   }
 }

--- a/packages/servicenow/_dev/deploy/tf/main.tf
+++ b/packages/servicenow/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-servicenow-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-servicenow-package" # name in manifest.yml
     }
   }
 }

--- a/packages/sublime_security/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/sublime_security/data_stream/audit/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-sublime_security-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-sublime_security-package" # name in manifest.yml
     }
   }
 }

--- a/packages/sublime_security/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/sublime_security/data_stream/audit/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-sublime_security-package"
     }
   }
 }

--- a/packages/sublime_security/data_stream/email_message/_dev/deploy/tf/main.tf
+++ b/packages/sublime_security/data_stream/email_message/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-sublime_security-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-sublime_security-package" # name in manifest.yml
     }
   }
 }

--- a/packages/sublime_security/data_stream/email_message/_dev/deploy/tf/main.tf
+++ b/packages/sublime_security/data_stream/email_message/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-sublime_security-package"
     }
   }
 }

--- a/packages/sublime_security/data_stream/message_event/_dev/deploy/tf/main.tf
+++ b/packages/sublime_security/data_stream/message_event/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-sublime_security-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-sublime_security-package" # name in manifest.yml
     }
   }
 }

--- a/packages/sublime_security/data_stream/message_event/_dev/deploy/tf/main.tf
+++ b/packages/sublime_security/data_stream/message_event/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-sublime_security-package"
     }
   }
 }

--- a/packages/symantec_endpoint_security/data_stream/event/_dev/deploy/tf/main.tf
+++ b/packages/symantec_endpoint_security/data_stream/event/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-symantec_endpoint_security-package"
     }
   }
 }

--- a/packages/symantec_endpoint_security/data_stream/event/_dev/deploy/tf/main.tf
+++ b/packages/symantec_endpoint_security/data_stream/event/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-symantec_endpoint_security-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-symantec_endpoint_security-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/action_history/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/action_history/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-tanium-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-tanium-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/action_history/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/action_history/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-tanium-package"
     }
   }
 }

--- a/packages/tanium/data_stream/client_status/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/client_status/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-tanium-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-tanium-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/client_status/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/client_status/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-tanium-package"
     }
   }
 }

--- a/packages/tanium/data_stream/discover/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/discover/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-tanium-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-tanium-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/discover/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/discover/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-tanium-package"
     }
   }
 }

--- a/packages/tanium/data_stream/endpoint_config/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/endpoint_config/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-tanium-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-tanium-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/endpoint_config/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/endpoint_config/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-tanium-package"
     }
   }
 }

--- a/packages/tanium/data_stream/reporting/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/reporting/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-tanium-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-tanium-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/reporting/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/reporting/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-tanium-package"
     }
   }
 }

--- a/packages/tanium/data_stream/threat_response/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/threat_response/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-tanium-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-tanium-package" # name in manifest.yml
     }
   }
 }

--- a/packages/tanium/data_stream/threat_response/_dev/deploy/tf/main.tf
+++ b/packages/tanium/data_stream/threat_response/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-tanium-package"
     }
   }
 }

--- a/packages/trellix_edr_cloud/_dev/deploy/tf/main.tf
+++ b/packages/trellix_edr_cloud/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-trellix_edr_cloud-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-trellix_edr_cloud-package" # name in manifest.yml
     }
   }
 }

--- a/packages/trellix_edr_cloud/_dev/deploy/tf/main.tf
+++ b/packages/trellix_edr_cloud/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-trellix_edr_cloud-package"
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Enhancement
-->

## Proposed commit message

```
[ssi] Add Terraform resource labels to SSI packages (batch 1)

Add four standard resource labels to the AWS provider `default_tags`
block in all Terraform `main.tf` files for the following packages:

- jamf_protect (5 data streams)
- netskope (1 data stream)
- sentinel_one_cloud_funnel (1 data stream)
- servicenow (1 data stream)
- sublime_security (3 data streams)
- symantec_endpoint_security (1 data stream)
- tanium (6 data streams)
- trellix_edr_cloud (1 data stream)

Labels added to each file:

  division = "engineering"
  org      = "obs"
  team     = "security-service-integrations"
  project  = "integrations-<package_name>-package"

The `team` value is derived from the `owner.github` field in each
package's `manifest.yml`, and `project` follows the pattern
`integrations-<package_name>-package` using the `name` field.
```

## Author's Checklist

- [ ] All 19 `main.tf` files updated with the correct `team` and `project` values derived from their respective `manifest.yml`

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).