### PR TITLE
[cloudflare_logpush] Add Terraform resource labels

### DIFF
--- a/packages/cloudflare_logpush/data_stream/access_request/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/access_request/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/access_request/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/access_request/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/audit/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/audit/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/casb/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/casb/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/casb/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/casb/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/device_posture/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/device_posture/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/device_posture/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/device_posture/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/dns/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/dns/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/dns/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/dns/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/email_security_alerts/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/email_security_alerts/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/email_security_alerts/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/email_security_alerts/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/firewall_event/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/firewall_event/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/gateway_http/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/gateway_http/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/gateway_network/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/gateway_network/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/http_request/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/http_request/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/http_request/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/http_request/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/magic_ids/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/magic_ids/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/nel_report/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/nel_report/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/nel_report/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/nel_report/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/network_analytics/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/network_analytics/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/network_session/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/network_session/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/network_session/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/network_session/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/page_shield_events/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/page_shield_events/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/page_shield_events/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/page_shield_events/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/workers_trace/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-cloudflare_logpush-package"
+      team     = "security-service-integrations" # owner.github in manifest.yml
+      project  = "integrations-cloudflare_logpush-package" # name in manifest.yml
     }
   }
 }

--- a/packages/cloudflare_logpush/data_stream/workers_trace/_dev/deploy/tf/main.tf
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-cloudflare_logpush-package"
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Enhancement
-->

## Proposed commit message

```
[cloudflare_logpush] Add Terraform resource labels

Add four standard resource labels to the AWS provider `default_tags`
block in all 21 Terraform `main.tf` files for the `cloudflare_logpush`
package:

  division = "engineering"
  org      = "obs"
  team     = "security-service-integrations"
  project  = "integrations-cloudflare_logpush-package"

The `team` value is derived from the `owner.github` field in the
package's `manifest.yml`, and `project` follows the pattern
`integrations-<package_name>-package` using the `name` field.
```

## Author's Checklist

- [ ] All 21 `main.tf` files updated with the correct `team` and `project` values derived from `manifest.yml`

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).