### PR TITLE
[ssi] Add Terraform resource labels to SSI packages (batch 3)

### DIFF
--- a/packages/amazon_security_lake/data_stream/event/_dev/deploy/tf/main.tf
+++ b/packages/amazon_security_lake/data_stream/event/_dev/deploy/tf/main.tf
@@ -16,6 +16,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-amazon_security_lake-package" # name from manifest.yml
     }
   }
 }

--- a/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
+++ b/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-aws_bedrock-package"
     }
   }
 }

--- a/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
+++ b/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-aws_bedrock-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-aws_bedrock-package" # name from manifest.yml
     }
   }
 }

--- a/packages/beyondtrust_epm/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/beyondtrust_epm/data_stream/audit/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-beyondtrust_epm-package"
     }
   }
 }

--- a/packages/beyondtrust_epm/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/beyondtrust_epm/data_stream/audit/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-beyondtrust_epm-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-beyondtrust_epm-package" # name from manifest.yml
     }
   }
 }

--- a/packages/beyondtrust_epm/data_stream/event/_dev/deploy/tf/main.tf
+++ b/packages/beyondtrust_epm/data_stream/event/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-beyondtrust_epm-package"
     }
   }
 }

--- a/packages/beyondtrust_epm/data_stream/event/_dev/deploy/tf/main.tf
+++ b/packages/beyondtrust_epm/data_stream/event/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-beyondtrust_epm-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-beyondtrust_epm-package" # name from manifest.yml
     }
   }
 }

--- a/packages/canva/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/canva/data_stream/audit/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-canva-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-canva-package" # name from manifest.yml
     }
   }
 }

--- a/packages/canva/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/canva/data_stream/audit/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-canva-package"
     }
   }
 }

--- a/packages/carbon_black_cloud/_dev/deploy/tf/main.tf
+++ b/packages/carbon_black_cloud/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-carbon_black_cloud-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-carbon_black_cloud-package" # name from manifest.yml
     }
   }
 }

--- a/packages/carbon_black_cloud/_dev/deploy/tf/main.tf
+++ b/packages/carbon_black_cloud/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-carbon_black_cloud-package"
     }
   }
 }

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/_dev/deploy/tf/main.tf
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-carbon_black_cloud-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-carbon_black_cloud-package" # name from manifest.yml
     }
   }
 }

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/_dev/deploy/tf/main.tf
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-carbon_black_cloud-package"
     }
   }
 }

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/_dev/deploy/tf/main.tf
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-carbon_black_cloud-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-carbon_black_cloud-package" # name from manifest.yml
     }
   }
 }

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/_dev/deploy/tf/main.tf
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-carbon_black_cloud-package"
     }
   }
 }

--- a/packages/crowdstrike/_dev/benchmark/system/deploy/tf/main.tf
+++ b/packages/crowdstrike/_dev/benchmark/system/deploy/tf/main.tf
@@ -6,6 +6,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-crowdstrike-package"
     }
   }
 }

--- a/packages/crowdstrike/_dev/benchmark/system/deploy/tf/main.tf
+++ b/packages/crowdstrike/_dev/benchmark/system/deploy/tf/main.tf
@@ -9,8 +9,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-crowdstrike-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-crowdstrike-package" # name from manifest.yml
     }
   }
 }

--- a/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
+++ b/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
@@ -6,6 +6,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-crowdstrike-package"
     }
   }
 }

--- a/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
+++ b/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
@@ -9,8 +9,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-crowdstrike-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-crowdstrike-package" # name from manifest.yml
     }
   }
 }

--- a/packages/github/_dev/deploy/tf/main.tf
+++ b/packages/github/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-github-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-github-package" # name from manifest.yml
     }
   }
 }

--- a/packages/github/_dev/deploy/tf/main.tf
+++ b/packages/github/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-github-package"
     }
   }
 }

--- a/packages/imperva_cloud_waf/_dev/deploy/tf/main.tf
+++ b/packages/imperva_cloud_waf/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-imperva_cloud_waf-package"
+      team     = "security-service-integrations" # owner.github from manifest.yml
+      project  = "integrations-imperva_cloud_waf-package" # name from manifest.yml
     }
   }
 }

--- a/packages/imperva_cloud_waf/_dev/deploy/tf/main.tf
+++ b/packages/imperva_cloud_waf/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-imperva_cloud_waf-package"
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Enhancement
-->

## Proposed commit message

```
[ssi] Add Terraform resource labels to SSI packages (batch 3)

Add four standard resource labels to the AWS provider `default_tags`
block in all Terraform `main.tf` files for the following packages:

- amazon_security_lake (1 data streams: event)
- aws_bedrock (1 data streams: invocation)
- beyondtrust_epm (2 data streams: audit, event)
- canva (1 data stream: audit)
- carbon_black_cloud (3 files: root deploy, endpoint_event, watchlist_hit)
- crowdstrike (2 files: fdr data stream, benchmark)
- github (1 file: root deploy)
- imperva_cloud_waf (1 file: root deploy)

Labels added to each file:

  division = "engineering"
  org      = "obs"
  team     = "security-service-integrations"
  project  = "integrations-<package_name>-package"

The `team` value is derived from the `owner.github` field in each
package's `manifest.yml`, and `project` follows the pattern
`integrations-<package_name>-package` using the `name` field.

Continues the work started in #20704.
```

## Author's Checklist

- [ ] All 12 `main.tf` files updated with the correct `team` and `project` values derived from their respective `manifest.yml`

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).