### PR TITLE
[kolide, f5_bigip, cisco_umbrella] Add Terraform resource labels

### DIFF
--- a/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
+++ b/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "security-service-integrations"
+      project  = "integrations-aws_bedrock-package"
     }
   }
 }

--- a/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
+++ b/packages/aws_bedrock/data_stream/invocation/_dev/deploy/tf/main.tf
@@ -10,11 +10,6 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
-
-      division = "engineering"
-      org      = "obs"
-      team     = "security-service-integrations"
-      project  = "integrations-aws_bedrock-package"
     }
   }
 }

--- a/packages/cisco_umbrella/_dev/deploy/tf/main.tf
+++ b/packages/cisco_umbrella/_dev/deploy/tf/main.tf
@@ -6,6 +6,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-cisco_umbrella-package"
     }
   }
 }

--- a/packages/cisco_umbrella/_dev/deploy/tf/main.tf
+++ b/packages/cisco_umbrella/_dev/deploy/tf/main.tf
@@ -9,8 +9,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-cisco_umbrella-package"
+      team     = "integration-experience"              # owner.github in manifest.yml
+      project  = "integrations-cisco_umbrella-package" # name in manifest.yml
     }
   }
 }

--- a/packages/f5_bigip/_dev/deploy/tf/main.tf
+++ b/packages/f5_bigip/_dev/deploy/tf/main.tf
@@ -7,6 +7,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-f5_bigip-package"
     }
   }
 }

--- a/packages/f5_bigip/_dev/deploy/tf/main.tf
+++ b/packages/f5_bigip/_dev/deploy/tf/main.tf
@@ -10,8 +10,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-f5_bigip-package"
+      team     = "integration-experience"       # owner.github in manifest.yml
+      project  = "integrations-f5_bigip-package" # name in manifest.yml
     }
   }
 }

--- a/packages/kolide/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/audit/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-kolide-package"
     }
   }
 }

--- a/packages/kolide/data_stream/audit/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/audit/_dev/deploy/tf/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-kolide-package"
+      team     = "integration-experience"      # owner.github in manifest.yml
+      project  = "integrations-kolide-package" # name in manifest.yml
     }
   }
 }

--- a/packages/kolide/data_stream/auth/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/auth/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-kolide-package"
     }
   }
 }

--- a/packages/kolide/data_stream/auth/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/auth/_dev/deploy/tf/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-kolide-package"
+      team     = "integration-experience"      # owner.github in manifest.yml
+      project  = "integrations-kolide-package" # name in manifest.yml
     }
   }
 }

--- a/packages/kolide/data_stream/device_check/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/device_check/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-kolide-package"
     }
   }
 }

--- a/packages/kolide/data_stream/device_check/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/device_check/_dev/deploy/tf/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-kolide-package"
+      team     = "integration-experience"      # owner.github in manifest.yml
+      project  = "integrations-kolide-package" # name in manifest.yml
     }
   }
 }

--- a/packages/kolide/data_stream/osquery_result/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/osquery_result/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-kolide-package"
     }
   }
 }

--- a/packages/kolide/data_stream/osquery_result/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/osquery_result/_dev/deploy/tf/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-kolide-package"
+      team     = "integration-experience"      # owner.github in manifest.yml
+      project  = "integrations-kolide-package" # name in manifest.yml
     }
   }
 }

--- a/packages/kolide/data_stream/osquery_status/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/osquery_status/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "integration-experience"
+      project  = "integrations-kolide-package"
     }
   }
 }

--- a/packages/kolide/data_stream/osquery_status/_dev/deploy/tf/main.tf
+++ b/packages/kolide/data_stream/osquery_status/_dev/deploy/tf/main.tf
@@ -13,8 +13,8 @@ provider "aws" {
 
       division = "engineering"
       org      = "obs"
-      team     = "integration-experience"
-      project  = "integrations-kolide-package"
+      team     = "integration-experience"      # owner.github in manifest.yml
+      project  = "integrations-kolide-package" # name in manifest.yml
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Enhancement
-->

## Proposed commit message

```
[kolide, f5_bigip, cisco_umbrella] Add Terraform resource labels

Add four standard resource labels to the AWS provider `default_tags`
block in all Terraform `main.tf` files for the following packages:

- kolide (5 data streams: audit, auth, device_check, osquery_result, osquery_status)
- f5_bigip (1 file)
- cisco_umbrella (1 file)

Labels added to each file:

  division = "engineering"
  org      = "obs"
  team     = "<team derived from owner.github in manifest.yml>"
  project  = "integrations-<package_name>-package"

The `team` value is derived from the `owner.github` field in each
package's `manifest.yml`, and `project` follows the pattern
`integrations-<package_name>-package` using the `name` field.
```

## Author's Checklist

- [ ] All 7 `main.tf` files updated with the correct `team` and `project` values derived from their respective `manifest.yml`

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).