### PR TITLE
[aws_logs] Add Terraform resource labels

### DIFF
--- a/packages/aws_logs/data_stream/generic/_dev/deploy/tf/main.tf
+++ b/packages/aws_logs/data_stream/generic/_dev/deploy/tf/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "obs-ds-hosted-services" # owner.github in packages/aws_logs/manifest.yml
+      project  = "integrations-aws_logs-package" # name in packages/aws_logs/manifest.yml
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Enhancement
-->

## Proposed commit message

```
[aws_logs] Add Terraform resource labels to aws_logs package

Add four standard resource labels to the AWS provider `default_tags`
block in the Terraform `main.tf` file for the aws_logs package:

  division = "engineering"
  org      = "obs"
  team     = "obs-ds-hosted-services"
  project  = "integrations-aws_logs-package"

The `team` value is derived from the `owner.github` field in the
package's `manifest.yml`, and `project` follows the pattern
`integrations-<package_name>-package` using the `name` field.
```

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).