### PR TITLE
[aws_mq] Add Terraform resource labels to aws_mq package

### DIFF
--- a/packages/aws_mq/data_stream/activemq_audit_logs/_dev/deploy/tf/main.tf
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/_dev/deploy/tf/main.tf
@@ -15,6 +15,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "obs-infraobs-integrations" # owner.github in manifest.yml
+      project  = "integrations-aws_mq-package" # name in manifest.yml
     }
   }
 }

--- a/packages/aws_mq/data_stream/activemq_general_logs/_dev/deploy/tf/main.tf
+++ b/packages/aws_mq/data_stream/activemq_general_logs/_dev/deploy/tf/main.tf
@@ -15,6 +15,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "obs-infraobs-integrations" # owner.github in manifest.yml
+      project  = "integrations-aws_mq-package" # name in manifest.yml
     }
   }
 }

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/deploy/tf/main.tf
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/deploy/tf/main.tf
@@ -15,6 +15,11 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+
+      division = "engineering"
+      org      = "obs"
+      team     = "obs-infraobs-integrations" # owner.github in manifest.yml
+      project  = "integrations-aws_mq-package" # name in manifest.yml
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Enhancement
-->

## Proposed commit message

```
[aws_mq] Add Terraform resource labels to aws_mq package

Add four standard resource labels to the AWS provider `default_tags`
block in all Terraform `main.tf` files for the aws_mq package:

- activemq_audit_logs
- activemq_general_logs
- rabbitmq_general_logs

Labels added to each file:

  division = "engineering"
  org      = "obs"
  team     = "obs-infraobs-integrations"
  project  = "integrations-aws_mq-package"

The `team` value is derived from the `owner.github` field in
manifest.yml, and `project` follows the pattern
`integrations-<package_name>-package` using the `name` field.
```

## Author's Checklist

- [ ] All 3 `main.tf` files updated with the correct `team` and `project` values derived from `manifest.yml`

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).