### PR TITLE
Rename Vercel and Supabase package titles to include OpenTelemetry

### DIFF
--- a/packages/supabase/changelog.yml
+++ b/packages/supabase/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Rename package title to "Supabase (OpenTelemetry)" to clarify the integration's OpenTelemetry-based collection.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.1.1"
   changes:
     - description: Set agentless deployment mode `release` field to `beta`.

--- a/packages/supabase/changelog.yml
+++ b/packages/supabase/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Rename package title to "Supabase (OpenTelemetry)" to clarify the integration's OpenTelemetry-based collection.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20723
 - version: "0.1.1"
   changes:
     - description: Set agentless deployment mode `release` field to `beta`.

--- a/packages/supabase/manifest.yml
+++ b/packages/supabase/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.6.2"
 name: supabase
-title: "Supabase"
-version: 0.1.1
+title: "Supabase (OpenTelemetry)"
+version: 0.1.2
 source:
   license: "Elastic-2.0"
 description: >-

--- a/packages/vercel/changelog.yml
+++ b/packages/vercel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Rename package title to "Vercel (OpenTelemetry)" to clarify the integration's OpenTelemetry-based collection.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.1.1"
   changes:
     - description: Update managed endpoint path

--- a/packages/vercel/changelog.yml
+++ b/packages/vercel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Rename package title to "Vercel (OpenTelemetry)" to clarify the integration's OpenTelemetry-based collection.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20723
 - version: "0.1.1"
   changes:
     - description: Update managed endpoint path

--- a/packages/vercel/manifest.yml
+++ b/packages/vercel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.6.2"
 name: vercel
-title: "Vercel"
-version: 0.1.1
+title: "Vercel (OpenTelemetry)"
+version: 0.1.2
 description: >-
   Send Vercel logs, audit logs, Web Analytics, and Speed Insights to Elastic
   with Vercel Drains and the Elastic Cloud managed OpenTelemetry endpoint.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Renamed the `vercel` and `supabase` integration titles to `Vercel (OpenTelemetry)` and `Supabase (OpenTelemetry)` respectively, to make it explicit that both integrations collect data via the OpenTelemetry Collector rather than a native Elastic Agent input. This follows the same naming convention already used by other OTel-based packages in this repo (e.g. `aws_ec2_otel` -> "AWS EC2 Metrics OpenTelemetry Assets").

Bumped both packages to a patch version (`0.1.1` -> `0.1.2`) and added a corresponding `changelog.yml` entry for each, consistent with prior title-only rename changes in this repo.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm the new titles ("Vercel (OpenTelemetry)", "Supabase (OpenTelemetry)") render correctly in the Fleet integrations catalog and detail pages after building/installing the packages.
- [ ] Confirm the package `name` fields (`vercel`, `supabase`) are unchanged, so existing policies/agent configs referencing these packages are unaffected by the title-only rename.

## How to test this PR locally

Executed by agent:
- `cd packages/vercel && elastic-package lint` → `Done` (no errors)
- `cd packages/supabase && elastic-package lint` → `Done` (no errors)

Reviewer instructions:
- Run `elastic-package build` for `packages/vercel` and `packages/supabase`.
- Install the built packages in a Kibana Fleet instance and confirm the integration list and detail pages show `Vercel (OpenTelemetry)` and `Supabase (OpenTelemetry)`.

## Related issues

- N/A

## Screenshots

N/A