### PR TITLE
Add versioned root IaC blueprints and per-package iac patches/links

### DIFF
--- a/blueprints/aws/federated-identity/account/v1/account.cloudformation.json
+++ b/blueprints/aws/federated-identity/account/v1/account.cloudformation.json
@@ -1,0 +1,82 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Elastic Federated Identity role for AWS — canonical base blueprint for single-account deployments. The cloud-iac-provisioner loads this template and appends RFC 6902 patches from each enabled integration as separate AWS::IAM::Policy resources.",
+  "Parameters": {
+    "ElasticResourceId": {
+      "Type": "String",
+      "Description": "Elastic resource ID (deployment component ID or serverless project ID). Used to construct the ExternalId trust condition, uniquely scoping this role to the Elastic deployment."
+    },
+    "ElasticRoleARN": {
+      "Type": "String",
+      "Default": "arn:aws:iam::254766567737:role/cloud_connectors",
+      "Description": "Elastic's super-role ARN that this role will trust. Change only for non-production Elastic environments."
+    }
+  },
+  "Resources": {
+    "ElasticFederatedIdentityRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": { "Fn::Sub": "ElasticFederatedIdentity-${AWS::StackName}" },
+        "Path": "/",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": { "Ref": "ElasticRoleARN" }
+              },
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "sts:ExternalId": {
+                    "Fn::Join": [
+                      "-",
+                      [
+                        { "Ref": "ElasticResourceId" },
+                        {
+                          "Fn::Select": [
+                            2,
+                            { "Fn::Split": ["/", { "Ref": "AWS::StackId" }] }
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": []
+      }
+    }
+  },
+  "Outputs": {
+    "RoleArn": {
+      "Description": "ARN of the Elastic Federated Identity role. Paste this into Kibana when configuring the integration.",
+      "Value": { "Fn::GetAtt": ["ElasticFederatedIdentityRole", "Arn"] }
+    },
+    "ExternalId": {
+      "Description": "Full ExternalId used in the trust condition. Paste this into Kibana when configuring the integration.",
+      "Value": {
+        "Fn::Join": [
+          "-",
+          [
+            { "Ref": "ElasticResourceId" },
+            {
+              "Fn::Select": [
+                2,
+                { "Fn::Split": ["/", { "Ref": "AWS::StackId" }] }
+              ]
+            }
+          ]
+        ]
+      }
+    },
+    "StackId": {
+      "Description": "CloudFormation stack ID. Store in Kibana to construct stack-update URLs when additional integrations are enabled.",
+      "Value": { "Ref": "AWS::StackId" }
+    }
+  }
+}

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add iac/ JSON patches and a linked versioned federated-identity account base template (aws/federated-identity/account/v1).
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20728
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "7.2.0"
+  changes:
+    - description: Add iac/ JSON patches and a linked versioned federated-identity account base template (aws/federated-identity/account/v1).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "7.1.1"
   changes:
     - description: Add `data_stream.namespace` to the Amazon Inspector vulnerability latest transform's unique key so findings are tracked per namespace, preventing findings ingested into non-default namespaces from being dropped or conflated in the latest index. Bump transform's destination suffix to `-v2`.

--- a/packages/aws/iac/account.cloudformation.json.link
+++ b/packages/aws/iac/account.cloudformation.json.link
@@ -1,0 +1,1 @@
+../../../blueprints/aws/federated-identity/account/v1/account.cloudformation.json 469bf9341e21fc2fc2e9690d7c0ed76d2f0e5073db7ff8298656e469e60add73

--- a/packages/aws/iac/aws-federated-identity-account-apigateway.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-apigateway.cloudformation.patches.json
@@ -1,0 +1,30 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSAPIGatewayPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSAPIGateway",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "APIGatewayReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "apigateway:GET"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-awshealth.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-awshealth.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSHealthPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSHealth",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "HealthReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "health:DescribeEvents",
+                "health:DescribeEventDetails",
+                "health:DescribeAffectedEntities"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-billing.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-billing.cloudformation.patches.json
@@ -1,0 +1,30 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSBillingPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSBilling",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "BillingReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ce:GetCostAndUsage"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
@@ -1,0 +1,27 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSCloudWatchInputPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSCloudWatchInput",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CloudWatchInputBase",
+              "Effect": "Allow",
+              "Action": [
+                "logs:DescribeLogGroups",
+                "logs:FilterLogEvents"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-config.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-config.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSConfigPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSConfig",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "ConfigReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "config:DescribeConfigRules",
+                "config:DescribeComplianceByConfigRule",
+                "config:GetComplianceDetailsByConfigRule"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-dynamodb.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-dynamodb.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSDynamoDBPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSDynamoDB",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "DynamoDBReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "dynamodb:ListTables",
+                "dynamodb:DescribeTable"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-ebs.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-ebs.cloudformation.patches.json
@@ -1,0 +1,30 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSEBSPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSEBS",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "EBSReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeVolumes"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-ec2.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-ec2.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSEC2Policy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSEC2",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "EC2ReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-ecs.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-ecs.cloudformation.patches.json
@@ -1,0 +1,33 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSECSPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSECS",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "ECSReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ecs:ListClusters",
+                "ecs:DescribeClusters",
+                "ecs:ListServices",
+                "ecs:DescribeServices"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-elb.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-elb.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSELBPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSELB",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "ELBReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetHealth"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-emr.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-emr.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSEMRPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSEMR",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "EMRReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "elasticmapreduce:ListClusters",
+                "elasticmapreduce:DescribeCluster"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-firewall.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-firewall.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSFirewallPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSFirewall",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "FirewallReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "network-firewall:ListFirewalls",
+                "network-firewall:DescribeFirewall"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-guardduty.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-guardduty.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSGuardDutyPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSGuardDuty",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "GuardDutyReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "guardduty:ListDetectors",
+                "guardduty:ListFindings",
+                "guardduty:GetFindings"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-inspector.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-inspector.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSInspectorPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSInspector",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "InspectorReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "inspector2:ListFindings",
+                "inspector2:ListCoverage"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-kafka.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-kafka.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSKafkaPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSKafka",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "KafkaReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "kafka:ListClusters",
+                "kafka:DescribeCluster",
+                "kafka:ListNodes"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-kinesis.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-kinesis.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSKinesisPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSKinesis",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "KinesisReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "kinesis:ListStreams",
+                "kinesis:DescribeStreamSummary",
+                "kinesis:ListShards"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-lambda.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-lambda.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSLambdaPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSLambda",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "LambdaReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "lambda:ListFunctions",
+                "lambda:GetFunction"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
@@ -1,0 +1,29 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSMetricsInputPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSMetricsInput",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "MetricsInputBase",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeRegions",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:GetMetricData",
+                "tag:GetResources"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-natgateway.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-natgateway.cloudformation.patches.json
@@ -1,0 +1,30 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSNATGatewayPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSNATGateway",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "NATGatewayReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeNatGateways"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-rds.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-rds.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSRDSPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSRDS",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "RDSReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "rds:ListTagsForResource"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-redshift.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-redshift.cloudformation.patches.json
@@ -1,0 +1,30 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSRedshiftPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSRedshift",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "RedshiftReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "redshift:DescribeClusters"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSS3InputPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSS3Input",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "S3InputBase",
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject",
+                "s3:ListBucket",
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueAttributes"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-s3.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-s3.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSS3Policy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSS3",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "S3BucketAccess",
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketTagging"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-s3_storage_lens.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-s3_storage_lens.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSS3StorageLensPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSS3StorageLens",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "S3StorageLensAccess",
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListStorageLensConfigurations",
+                "s3:GetStorageLensConfiguration"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-securityhub.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-securityhub.cloudformation.patches.json
@@ -1,0 +1,34 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSSecurityHubPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSSecurityHub",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "SecurityHubReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "securityhub:GetFindings",
+                "securityhub:BatchGetSecurityControls",
+                "securityhub:GetInsights",
+                "securityhub:ListInsights",
+                "securityhub:GetInsightResults"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-sns.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-sns.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSSNSPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSSNS",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "SNSReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "sns:ListTopics",
+                "sns:GetTopicAttributes"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-sqs.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-sqs.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSSQSPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSSQS",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "SQSReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "sqs:ListQueues",
+                "sqs:GetQueueAttributes"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-transitgateway.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-transitgateway.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSTransitGatewayPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSTransitGateway",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "TransitGatewayReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeTransitGateways",
+                "ec2:DescribeTransitGatewayAttachments"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account-vpn.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account-vpn.cloudformation.patches.json
@@ -1,0 +1,31 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSVPNPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSVPN",
+        "Roles": [
+          {
+            "Ref": "ElasticFederatedIdentityRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "VPNReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeVpnConnections",
+                "ec2:DescribeVpnGateways"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/iac/aws-federated-identity-account.cloudformation.patches.json
+++ b/packages/aws/iac/aws-federated-identity-account.cloudformation.patches.json
@@ -1,0 +1,26 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticAWSBasePolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticAWSBase",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AWSBase",
+              "Effect": "Allow",
+              "Action": [
+                "sts:GetCallerIdentity"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.6.1
+format_version: 3.7.0
 name: aws
 title: AWS
-version: 7.1.1
+version: 7.2.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -150,6 +150,11 @@ var_groups:
         title: Shared Credentials
         vars: [shared_credential_file, credential_profile_name]
         hide_in_deployment_modes: [agentless]
+iac_blueprints:
+  - id: aws/federated-identity/account/v1
+    format: cloudformation
+    title: "AWS federated identity role (base)"
+    patches: iac/aws-federated-identity-account.cloudformation.patches.json
 policy_templates:
   - name: awshealth
     title: AWS Health
@@ -158,6 +163,11 @@ policy_templates:
       - awshealth
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Health federated identity permissions"
+        patches: iac/aws-federated-identity-account-awshealth.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect AWS Health metrics (experimental)
@@ -165,6 +175,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -191,6 +205,11 @@ policy_templates:
       - billing
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Billing federated identity permissions"
+        patches: iac/aws-federated-identity-account-billing.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect billing metrics
@@ -198,6 +217,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -229,10 +252,18 @@ policy_templates:
         title: Collect CloudTrail logs from S3
         description: Collecting logs from CloudTrail using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect CloudTrail logs from CloudWatch
         description: Collecting logs from CloudTrail using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
     icons:
       - src: /img/logo_cloudtrail.svg
         title: AWS Cloudtrail logo
@@ -259,12 +290,20 @@ policy_templates:
         input_group: logs
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
       - type: aws/metrics
         title: Collect metrics from CloudWatch
         description: Collecting metrics using AWS CloudWatch
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -297,6 +336,11 @@ policy_templates:
       - security
       - cloudsecurity_cdr
       - misconfiguration_workflow
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Config federated identity permissions"
+        patches: iac/aws-federated-identity-account-config.cloudformation.patches.json
     inputs:
       - type: cel
         title: Collect AWS Config logs via API
@@ -321,6 +365,11 @@ policy_templates:
     categories:
       - observability
       - datastore
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon DynamoDB federated identity permissions"
+        patches: iac/aws-federated-identity-account-dynamodb.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect dynamodb metrics
@@ -328,6 +377,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -355,6 +408,11 @@ policy_templates:
     categories:
       - observability
       - datastore
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon EBS federated identity permissions"
+        patches: iac/aws-federated-identity-account-ebs.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect EBS metrics
@@ -362,6 +420,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -389,23 +451,40 @@ policy_templates:
       - ec2_metrics
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon EC2 federated identity permissions"
+        patches: iac/aws-federated-identity-account-ec2.cloudformation.patches.json
     inputs:
       - type: aws-s3
         title: Collect EC2 logs from S3
         description: Collecting logs from EC2 using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect EC2 logs from CloudWatch
         description: Collecting logs from EC2 using aws-cloudwatch input
         input_group: logs
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
       - type: aws/metrics
         title: Collect EC2 metrics
         description: Collecting EC2 metrics using AWS CloudWatch
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -433,6 +512,11 @@ policy_templates:
     categories:
       - observability
       - containers
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon ECS federated identity permissions"
+        patches: iac/aws-federated-identity-account-ecs.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect ECS metrics
@@ -440,6 +524,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -463,6 +551,11 @@ policy_templates:
     categories:
       - observability
       - load_balancer
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS ELB federated identity permissions"
+        patches: iac/aws-federated-identity-account-elb.cloudformation.patches.json
     inputs:
       - type: aws-s3
         title: Collect ELB logs from S3
@@ -470,18 +563,30 @@ policy_templates:
         input_group: logs
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect ELB logs from CloudWatch
         description: Collecting logs from ELB using aws-cloudwatch input
         input_group: logs
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
       - type: aws/metrics
         title: Collect ELB metrics
         description: Collecting ELB metrics using AWS CloudWatch
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -529,6 +634,11 @@ policy_templates:
       - lambda_logs
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Lambda federated identity permissions"
+        patches: iac/aws-federated-identity-account-lambda.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect Lambda metrics
@@ -536,12 +646,20 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect lambda logs from CloudWatch
         description: Collecting AWS lambda logs using aws-cloudwatch input
         input_group: logs
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -573,11 +691,20 @@ policy_templates:
     categories:
       - observability
       - network
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS NAT Gateway federated identity permissions"
+        patches: iac/aws-federated-identity-account-natgateway.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect NATGateway metrics
         description: Collect NATGateway metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_natgateway.svg
         title: AWS NATGateway logo
@@ -592,19 +719,36 @@ policy_templates:
     data_streams:
       - firewall_logs
       - firewall_metrics
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Network Firewall federated identity permissions"
+        patches: iac/aws-federated-identity-account-firewall.cloudformation.patches.json
     inputs:
       - type: aws-s3
         title: Collect Network Firewall logs from S3
         description: Collecting logs from Network Firewall using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect Network Firewall logs from CloudWatch
         description: Collecting logs from Network Firewall using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
       - type: aws/metrics
         title: Collect Network Firewall metrics
         description: Collecting AWS Network Firewall metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_firewall.svg
         title: AWS Network Firewall logo
@@ -635,6 +779,11 @@ policy_templates:
     categories:
       - observability
       - datastore
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon RDS federated identity permissions"
+        patches: iac/aws-federated-identity-account-rds.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect RDS metrics
@@ -642,6 +791,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -671,17 +824,30 @@ policy_templates:
     categories:
       - observability
       - datastore
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon S3 federated identity permissions"
+        patches: iac/aws-federated-identity-account-s3.cloudformation.patches.json
     inputs:
       - type: aws-s3
         title: Collect S3 access logs from S3
         description: Collecting S3 access logs using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws/metrics
         title: Collect S3 metrics
         description: Collecting S3 metrics using AWS CloudWatch
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -712,11 +878,20 @@ policy_templates:
       - s3_storage_lens
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon S3 Storage Lens federated identity permissions"
+        patches: iac/aws-federated-identity-account-s3_storage_lens.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect S3 Storage Lens metrics
         description: Collect S3 Storage Lens metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_s3_storage_lens.svg
         title: AWS S3 storage lens logo
@@ -735,6 +910,11 @@ policy_templates:
     categories:
       - observability
       - notification
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon SNS federated identity permissions"
+        patches: iac/aws-federated-identity-account-sns.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect SNS metrics
@@ -742,6 +922,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -768,6 +952,11 @@ policy_templates:
       - sqs
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon SQS federated identity permissions"
+        patches: iac/aws-federated-identity-account-sqs.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect SQS metrics
@@ -775,6 +964,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -801,6 +994,11 @@ policy_templates:
       - transitgateway
     categories:
       - security
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Transit Gateway federated identity permissions"
+        patches: iac/aws-federated-identity-account-transitgateway.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect Transit Gateway metrics
@@ -808,6 +1006,10 @@ policy_templates:
         input_group: metrics
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     deployment_modes:
       default:
         enabled: true
@@ -834,6 +1036,10 @@ policy_templates:
         title: Collect Usage metrics
         description: Collect Usage metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     screenshots:
       - src: /img/metricbeat-aws-usage-overview.png
         title: metricbeat aws sns overview
@@ -852,10 +1058,18 @@ policy_templates:
         title: Collect VPC flow logs from S3
         description: Collecting VPC Flow logs using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect VPC flow logs from CloudWatch
         description: Collecting VPC Flow logs using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
     icons:
       - src: /img/logo_vpcflow.svg
         title: AWS VPC logo
@@ -869,11 +1083,20 @@ policy_templates:
     categories:
       - observability
       - network
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS VPN federated identity permissions"
+        patches: iac/aws-federated-identity-account-vpn.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect VPN metrics
         description: Collect VPN metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_vpn.svg
         title: AWS VPN logo
@@ -892,10 +1115,18 @@ policy_templates:
         title: Collect WAF logs from S3
         description: Collecting WAF logs using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect WAF logs from CloudWatch
         description: Collecting WAF logs using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
     icons:
       - src: /img/logo_waf.svg
         title: AWS VPC logo
@@ -920,10 +1151,18 @@ policy_templates:
         title: Collect Route53 logs
         description: Collecting Route53 logs using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
       - type: aws-s3
         title: Collect Route53 logs
         description: Collecting Route53 logs using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
     icons:
       - src: /img/logo_route53.svg
         title: AWS Route53 logo
@@ -942,6 +1181,10 @@ policy_templates:
         title: Collect CloudFront logs
         description: Collecting CloudFront logs using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
     icons:
       - src: /img/logo_cloudfront.svg
         title: AWS CloudFront logo
@@ -955,11 +1198,20 @@ policy_templates:
     categories:
       - observability
       - datastore
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon Redshift federated identity permissions"
+        patches: iac/aws-federated-identity-account-redshift.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect Amazon Redshift metrics
         description: Collect Amazon Redshift metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_redshift.svg
         title: Amazon Redshift logo
@@ -978,11 +1230,20 @@ policy_templates:
     categories:
       - observability
       - stream_processing
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon Kinesis federated identity permissions"
+        patches: iac/aws-federated-identity-account-kinesis.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect Amazon Kinesis Data Stream metrics
         description: Collect Amazon Kinesis Data Stream metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_kinesis.svg
         title: Amazon Kinesis logo
@@ -1013,6 +1274,11 @@ policy_templates:
       - security
       - cloudsecurity_cdr
       - misconfiguration_workflow
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "AWS Security Hub federated identity permissions"
+        patches: iac/aws-federated-identity-account-securityhub.cloudformation.patches.json
     inputs:
       - type: httpjson
         title: Collect AWS Security Hub CSPM logs via API
@@ -1051,6 +1317,11 @@ policy_templates:
       - security
       - cloudsecurity_cdr
       - vulnerability_workflow
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon Inspector federated identity permissions"
+        patches: iac/aws-federated-identity-account-inspector.cloudformation.patches.json
     inputs:
       - type: httpjson
         title: Collect Amazon Inspector logs via API
@@ -1095,6 +1366,11 @@ policy_templates:
       - guardduty
     categories:
       - cloudsecurity_cdr
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon GuardDuty federated identity permissions"
+        patches: iac/aws-federated-identity-account-guardduty.cloudformation.patches.json
     inputs:
       - type: httpjson
         title: Collect Amazon GuardDuty logs via API
@@ -1104,6 +1380,10 @@ policy_templates:
         description: Collecting Amazon GuardDuty logs via AWS S3 or SQS input.
         hide_in_var_group_options:
           credential_type: [identity_federation]
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
     screenshots:
       - src: /img/guardduty-findings-overview.png
         title: GuardDuty Findings Overview dashboard screenshot
@@ -1130,19 +1410,36 @@ policy_templates:
       - apigateway_logs
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon API Gateway federated identity permissions"
+        patches: iac/aws-federated-identity-account-apigateway.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect API Gateway metrics
         description: Collect API Gateway metrics using AWS CloudWatch.
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
       - type: aws-s3
         title: Collect API Gateway logs from S3
         description: Collecting API Gateway logs using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect API Gateway logs from CloudWatch
         description: Collecting API Gateway logs using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
     screenshots:
       - src: /img/filebeat-aws-apigateway-overview.png
         title: filebeat aws api gateway overview
@@ -1165,19 +1462,36 @@ policy_templates:
       - emr_logs
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon EMR federated identity permissions"
+        patches: iac/aws-federated-identity-account-emr.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect EMR metrics
         description: Collect EMR metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
       - type: aws-s3
         title: Collect EMR logs from S3
         description: Collecting logs from EMR using aws-s3 input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-s3-input.cloudformation.patches.json
       - type: aws-cloudwatch
         title: Collect EMR logs from CloudWatch
         description: Collecting logs from EMR using aws-cloudwatch input
         input_group: logs
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cloudwatch-input.cloudformation.patches.json
     screenshots:
       - src: /img/filebeat-aws-emr-overview.png
         title: filebeat aws emr overview
@@ -1195,11 +1509,20 @@ policy_templates:
       - kafka_metrics
     categories:
       - observability
+    iac_blueprints:
+      - id: aws/federated-identity/account/v1
+        format: cloudformation
+        title: "Amazon MSK federated identity permissions"
+        patches: iac/aws-federated-identity-account-kafka.cloudformation.patches.json
     inputs:
       - type: aws/metrics
         title: Collect Amazon MSK metrics
         description: Collect Amazon MSK metrics using AWS CloudWatch
         input_group: metrics
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-metrics-input.cloudformation.patches.json
     icons:
       - src: /img/logo_msk.svg
         title: Amazon MSK logo

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.8.x - 9.6.x
 # 1.7.x - 9.6.x
 # 1.6.x - 9.5.x
 # 1.5.x - 9.4.x
@@ -9,6 +10,11 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.8.0"
+  changes:
+    - description: Add iac/ JSON patches and a linked versioned federated-identity account base template (aws/federated-identity/account/v1).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.7.1"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -14,7 +14,7 @@
   changes:
     - description: Add iac/ JSON patches and a linked versioned federated-identity account base template (aws/federated-identity/account/v1).
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20728
 - version: "1.7.1"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/iac/account.cloudformation.json.link
+++ b/packages/cloud_asset_inventory/iac/account.cloudformation.json.link
@@ -1,0 +1,1 @@
+../../../blueprints/aws/federated-identity/account/v1/account.cloudformation.json 469bf9341e21fc2fc2e9690d7c0ed76d2f0e5073db7ff8298656e469e60add73

--- a/packages/cloud_asset_inventory/iac/aws-federated-identity-account.cloudformation.patches.json
+++ b/packages/cloud_asset_inventory/iac/aws-federated-identity-account.cloudformation.patches.json
@@ -1,0 +1,57 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedIdentityRole/Properties/ManagedPolicyArns/-",
+    "value": "arn:aws:iam::aws:policy/SecurityAudit"
+  },
+  {
+    "op": "add",
+    "path": "/Resources/ElasticCAISupplementalPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticCAISupplemental",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CAIConfigAccess",
+              "Effect": "Allow",
+              "Action": [
+                "config:ListDiscoveredResources",
+                "config:SelectResourceConfig",
+                "config:SelectAggregateResourceConfig",
+                "config:DescribeConfigurationRecorders",
+                "config:DescribeAggregationAuthorizations",
+                "config:DescribeConfigurationAggregators"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "CAIOrganizationsAccess",
+              "Effect": "Allow",
+              "Action": [
+                "organizations:DescribeOrganization",
+                "organizations:ListAccounts",
+                "organizations:ListAccountsForParent",
+                "organizations:ListOrganizationalUnitsForParent",
+                "organizations:ListRoots"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "CAICrossAccountAccess",
+              "Effect": "Allow",
+              "Action": [
+                "sts:AssumeRole",
+                "sts:GetCallerIdentity"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.2
+format_version: 3.7.0
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.7.1"
+version: "1.8.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"
@@ -81,6 +81,11 @@ policy_templates:
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
             # RESOURCE_ID is the project id for serverless / kibana component id for ess
             default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-asset-inventory-cloud-connectors-ACCOUNT_TYPE-9.2.0.yml&param_ElasticResourceId=RESOURCE_ID
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account.cloudformation.patches.json
+            title: Cloud Asset Discovery federated identity role with SecurityAudit access
       - type: cloudbeat/asset_inventory_azure
         title: Azure Asset Discovery
         description: Azure Asset Discovery

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,6 +1,7 @@
 # newer versions go on top
 # version map:
 # IMPORTANT: this map doesn't apply to serverless where package availability depends on the spec version https://github.com/elastic/kibana/blob/main/config/serverless.yml#L14-L15
+# 3.6.x - 9.6.x
 # 3.5.x - 9.6.x
 # 3.4.x - 9.5.x
 # 3.3.x - 9.4.x
@@ -20,6 +21,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.6.0"
+  changes:
+    - description: Add iac/ JSON patches and a linked versioned federated-identity account base template (aws/federated-identity/account/v1).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.5.0"
   changes:
     - description: Release version 3.5.0

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -25,7 +25,7 @@
   changes:
     - description: Add iac/ JSON patches and a linked versioned federated-identity account base template (aws/federated-identity/account/v1).
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20728
 - version: "3.5.0"
   changes:
     - description: Release version 3.5.0

--- a/packages/cloud_security_posture/iac/account.cloudformation.json.link
+++ b/packages/cloud_security_posture/iac/account.cloudformation.json.link
@@ -1,0 +1,1 @@
+../../../blueprints/aws/federated-identity/account/v1/account.cloudformation.json 469bf9341e21fc2fc2e9690d7c0ed76d2f0e5073db7ff8298656e469e60add73

--- a/packages/cloud_security_posture/iac/aws-federated-identity-account-cnvm.cloudformation.patches.json
+++ b/packages/cloud_security_posture/iac/aws-federated-identity-account-cnvm.cloudformation.patches.json
@@ -1,0 +1,48 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticCNVMPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticCNVM",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CNVMReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeImages",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeRegions",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeTags",
+                "inspector2:ListFindings",
+                "inspector2:BatchGetAccountStatus"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "CNVMScanOperations",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:CreateSnapshot",
+                "ec2:DeleteSnapshot",
+                "ec2:RunInstances",
+                "ec2:TerminateInstances",
+                "ec2:CreateTags",
+                "iam:PassRole",
+                "inspector2:Enable"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/cloud_security_posture/iac/aws-federated-identity-account-eks.cloudformation.patches.json
+++ b/packages/cloud_security_posture/iac/aws-federated-identity-account-eks.cloudformation.patches.json
@@ -1,0 +1,32 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticKSPMEKSPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticKSPMEKS",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "KSPMEKSReadAccess",
+              "Effect": "Allow",
+              "Action": [
+                "eks:DescribeCluster",
+                "eks:ListClusters",
+                "ec2:DescribeInstances",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/cloud_security_posture/iac/aws-federated-identity-account.cloudformation.patches.json
+++ b/packages/cloud_security_posture/iac/aws-federated-identity-account.cloudformation.patches.json
@@ -1,0 +1,35 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedIdentityRole/Properties/ManagedPolicyArns/-",
+    "value": "arn:aws:iam::aws:policy/SecurityAudit"
+  },
+  {
+    "op": "add",
+    "path": "/Resources/ElasticCSPMSupplementalPolicy",
+    "value": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ElasticCSPMSupplemental",
+        "Roles": [{ "Ref": "ElasticFederatedIdentityRole" }],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CSPMSupplemental",
+              "Effect": "Allow",
+              "Action": [
+                "access-analyzer:ListAnalyzers",
+                "organizations:DescribeOrganization",
+                "organizations:ListAccounts",
+                "organizations:ListDelegatedAdministrators",
+                "account:GetAlternateContact"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.2
+format_version: 3.7.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.5.0"
+version: "3.6.0"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -99,6 +99,11 @@ policy_templates:
       - type: cloudbeat/cis_eks
         title: Amazon EKS Benchmark
         description: CIS Benchmark for Amazon Elastic Kubernetes Service (EKS)
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-eks.cloudformation.patches.json
+            title: EKS benchmark federated identity role
   - name: cspm
     title: Cloud Security Posture Management (CSPM)
     description: Identify & remediate configuration risks in the Cloud services you leverage
@@ -130,6 +135,11 @@ policy_templates:
       - type: cloudbeat/cis_aws
         title: Amazon Web Services
         description: CIS Benchmark for Amazon Web Services Foundations
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account.cloudformation.patches.json
+            title: CSPM federated identity role with SecurityAudit access
         vars:
           - name: cloud_formation_template
             type: text
@@ -229,6 +239,11 @@ policy_templates:
       - type: cloudbeat/vuln_mgmt_aws
         title: Amazon Web Services Vulnerability Management
         description: Vulnerability scan over running resources
+        iac_blueprints:
+          - id: aws/federated-identity/account/v1
+            format: cloudformation
+            patches: iac/aws-federated-identity-account-cnvm.cloudformation.patches.json
+            title: CNVM federated identity role with EC2 and Inspector2 access
         vars:
           - name: cloud_formation_template
             type: text


### PR DESCRIPTION
## Summary

Host the canonical federated-identity CloudFormation template at the repo root instead of shipping a `elastic_iac_blueprints` registry package.

- Canonical template: `blueprints/aws/federated-identity/account/v1/account.cloudformation.json`
- `packages/{aws,cloud_asset_inventory,cloud_security_posture}/iac/` ships RFC 6902 JSON patches plus `account.cloudformation.json.link` (relative path + sha256 of the versioned root template)
- Manifest `iac_blueprints` ids use `aws/federated-identity/account/v1`
- Package versions: aws `7.2.0`, cloud_asset_inventory `1.8.0`, cloud_security_posture `3.6.0`
- `format_version` bumped to `3.7.0` on these three packages (depends on the companion package-spec PR that adds `iac/` + `iac_blueprints` in 3.7.0)

Does **not** add `packages/elastic_iac_blueprints/`.

## Related

- Relates to https://github.com/elastic/integrations/pull/20240 and POC https://github.com/elastic/integrations/pull/20721 (does not modify them)
- Companion package-spec: https://github.com/elastic/package-spec/pull/1227
- Companion package-registry: https://github.com/elastic/package-registry/pull/1940

## Test plan

- [ ] Confirm `blueprints/aws/federated-identity/account/v1/account.cloudformation.json` is valid CloudFormation JSON
- [ ] Confirm all three `.link` files share the same relative path and sha256
- [ ] Confirm `shasum -a 256` of the root template matches the checksum in the `.link` files
- [ ] Confirm no `packages/elastic_iac_blueprints/` package is present
- [ ] Review `iac_blueprints` ids are `aws/federated-identity/account/v1` (not the unversioned id)
- [ ] After package-spec 3.7.0 lands, run `elastic-package check` for `aws`, `cloud_asset_inventory`, and `cloud_security_posture`
- [ ] After package-registry expose-`iac/` lands, confirm `iac/` (patches + materialized template) is present in the built/pulled package zip