### PR TITLE
[system] - Categorize `systemd` lifecycle events in syslog pipeline

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,12 @@
 # later versions go on top
+- version: "2.23.0"
+  changes:
+    - description: Set `event.kind` to `event` for `system.syslog` records collected through the log input, matching the journald pipeline so all syslog events carry a consistent ECS event categorization.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/1111
+    - description: Categorize systemd `Started`/`Stopped` unit lifecycle messages in `system.syslog` with `event.category`, `event.type`, and `event.action`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/1111
 - version: "2.22.4"
   changes:
     - description: Replace the journald `facilities` option with equivalent `SYSLOG_FACILITY` matches in the auth and syslog streams, fixing silent collection failure on hosts with journalctl older than 245 (e.g. RHEL 8), where `journalctl --facility` is not supported.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Set `event.kind` to `event` for `system.syslog` records collected through the log input, matching the journald pipeline so all syslog events carry a consistent ECS event categorization.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/1111
+      link: https://github.com/elastic/integrations/issues/20730
     - description: Categorize systemd `Started`/`Stopped` unit lifecycle messages in `system.syslog` with `event.category`, `event.type`, and `event.action`.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/1111
+      link: https://github.com/elastic/integrations/issues/20730
 - version: "2.22.4"
   changes:
     - description: Replace the journald `facilities` option with equivalent `SYSLOG_FACILITY` matches in the auth and syslog streams, fixing silent collection failure on hosts with journalctl older than 245 (e.g. RHEL 8), where `journalctl --facility` is not supported.

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-darwin-syslog.log-expected.json
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-darwin-syslog.log-expected.json
@@ -6,6 +6,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.419 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp performSelfUpdateWithEngine:] Finished self update check.",
                 "timezone": "GMT-0200"
             },
@@ -30,6 +31,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.420 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp updateProductWithProductID:usingEngine:] Checking for updates for \"All Products\" using engine <KSUpdateEngine:0x100341a00\n\t\tticketStore=<KSPersistentTicketStore:0x100204520 store=<KSKeyedPersistentStore:0x100213290\n\t\t\tpath=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore\"\n\t\t\tlockFile=<KSLockFile:0x1002160e0\n\t\t\t\tpath=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore.lock\"\n\t\t\t\tlocked=NO\n\t\t\t>\n\t\t>>\n\t\tprocessor=<KSActionProcessor:0x1003bb5f0\n\t\t\tdelegate=<KSUpdateEngine:0x100341a00>\n\t\t\tisProcessing=NO actionsCompleted=0 progress=0.00\n\t\t\terrors=0 currentActionErrors=0\n\t\t\tevents=0 currentActionEvents=0\n\t\t\tactionQueue=( )\n\t\t>\n\t\tdelegate=(null)\n\t\tserverInfoStore=(null)\n\t\terrors=0\n\t>",
                 "timezone": "GMT-0200"
             },
@@ -54,6 +56,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.421 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateEngine updateAllExceptProduct:] KSUpdateEngine updating all installed products, except:'com.google.Keystone'.",
                 "timezone": "GMT-0200"
             },
@@ -78,6 +81,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.422 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSCheckAction performAction] KSCheckAction checking 2 ticket(s).",
                 "timezone": "GMT-0200"
             },
@@ -102,6 +106,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.428 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateCheckAction performAction] KSUpdateCheckAction starting update check for ticket(s): {(\n\t\t<KSTicket:0x100550bd0\n\t\t\tproductID=com.google.Chrome\n\t\t\tversion=54.0.2840.98\n\t\t\txc=<KSPathExistenceChecker:0x1005507d0 path=/Applications/Google Chrome.app>\n\t\t\tserverType=Omaha\n\t\t\turl=https://tools.google.com/service/update2\n\t\t\tcreationDate=2015-06-25 15:40:23\n\t\t\ttagPath=/Applications/Google Chrome.app/Contents/Info.plist\n\t\t\ttagKey=KSChannelID\n\t\t\tbrandPath=/Users/tsg/Library/Google/Google Chrome Brand.plist\n\t\t\tbrandKey=KSBrandID\n\t\t\tversionPath=/Applications/Google Chrome.app/Contents/Info.plist\n\t\t\tversionKey=KSVersion\n\t\t\tcohort=1:1y5:gy3@0.05\n\t\t\tcohortName=Stable\n\t\t\tticketVersion=1\n\t\t>,\n\t\t<KSTicket:0x100555140\n\t\t\tproductID=com.google.GoogleDrive\n\t\t\tversion=1.32.3889.0961\n\t\t\txc=<KSPathExistenceChecker:0x100554490 path=/Applications/Google Drive.app>\n\t\t\tserverType=Omaha\n\t\t\turl=https://tools.google.com/service/update2\n\t\t\tcreationDate=2015-09-11 20:38:12\n\t\t\tticketVersion=1\n\t\t>\n\t)}\n\tUsing server: <KSOmahaServer:0x100555120\n\t\tengine=<KSUpdateEngine:0x100341a00>\n\t>",
                 "timezone": "GMT-0200"
             },
@@ -126,6 +131,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:28 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:28.446 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] +[KSCodeSigningVerification verifyBundle:applicationId:error:] KSCodeSigningVerification verifying code signing for '/Applications/Google Chrome.app' with the requirement 'anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU]=\"EQHXZ8M8AV\" and (identifier=\"com.google.Chrome\")'",
                 "timezone": "GMT-0200"
             },
@@ -150,6 +156,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:29 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:29.430 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] +[KSCodeSigningVerification verifyBundle:applicationId:error:] KSCodeSigningVerification verifying code signing for '/Applications/Google Drive.app' with the requirement 'anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU]=\"EQHXZ8M8AV\" and (identifier=\"com.google.GoogleDrive\")'",
                 "timezone": "GMT-0200"
             },
@@ -174,6 +181,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.115 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateCheckAction performAction] KSUpdateCheckAction running KSServerUpdateRequest: <KSOmahaServerUpdateRequest:0x100480470\n\t\tserver=<KSOmahaServer:0x100555120>\n\t\turl=\"https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822\"\n\t\tfallbackURLs=(\n\t\t\thttp://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1617080069\n\t\t)\n\t\trunningFetchers=0\n\t\ttickets=2\n\t\tbody=\n\t\t\t<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n\t\t\t<request protocol=\"3.0\" version=\"KeystoneAgent-1.2.6.1370\" ismachine=\"0\" requestid=\"{8F3B41E7-420E-4526-887D-C40439FD9A8E}\" dedup=\"cr\" sessionid=\"{3BD434BD-06BC-40C7-9A27-EFE887A149E3}\">\n\t\t\t    <os platform=\"mac\" version=\"10.12\" arch=\"x86_64h\" sp=\"10.12.0_x86_64h\"></os>\n\t\t\t    <app appid=\"com.google.Chrome\" version=\"54.0.2840.98\" cohort=\"1:1y5:gy3@0.05\" cohortname=\"Stable\" lang=\"en-us\" installage=\"536\" installdate=\"3479\" brand=\"GGRO\" _numaccounts=\"1\" _numsignedin=\"1\" signed=\"1\">\n\t\t\t        <ping r=\"1\" rd=\"3633\" a=\"1\" ad=\"3633\" ping_freshness=\"{6001AB3C-5253-44A9-94A9-CD4493ED14F9}\"></ping>\n\t\t\t        <updatecheck></updatecheck>\n\t\t\t    </app>\n\t\t\t    <app appid=\"com.google.GoogleDrive\" version=\"1.32.3889.0961\" lang=\"en-us\" installage=\"458\" installdate=\"3479\" brand=\"GGLG\" signed=\"1\">\n\t\t\t        <ping r=\"1\" rd=\"3633\" a=\"1\" ad=\"3633\" ping_freshness=\"{1BFFDCCA-5966-4598-819C-C1D075E480C5}\"></ping>\n\t\t\t        <updatecheck></updatecheck>\n\t\t\t    </app>\n\t\t\t</request>\n\t\theaders={\n\t\t\t\"X-GoogleUpdate-Interactivity\" = bg;\n\t\t}\n\t>",
                 "timezone": "GMT-0200"
             },
@@ -198,6 +206,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.116 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher beginFetchWithDelegate:] KSOutOfProcessFetcher start fetch from URL: \"https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822\"",
                 "timezone": "GMT-0200"
             },
@@ -222,6 +231,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.117 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher(PrivateMethods) launchedHelperTaskForToolPath:error:] KSOutOfProcessFetcher launched '/Users/tsg/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/MacOS/ksfetch' with process id: 21414",
                 "timezone": "GMT-0200"
             },
@@ -246,6 +256,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.118 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher beginFetchWithDelegate:] KSOutOfProcessFetcher sending both request and download file location to the helper.",
                 "timezone": "GMT-0200"
             },
@@ -270,6 +281,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.118 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] KSSendAllDataToHelper() KSHelperTool wrote 2383 bytes to the helper input.",
                 "timezone": "GMT-0200"
             },
@@ -294,6 +306,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.118 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher beginFetchWithDelegate:] Closing the file handle.",
                 "timezone": "GMT-0200"
             },
@@ -318,6 +331,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.118 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher beginFetchWithDelegate:] KSOutOfProcessFetcher fetching from URL: \"https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822\"",
                 "timezone": "GMT-0200"
             },
@@ -342,6 +356,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.149 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] KSHelperReceiveAllData() KSHelperTool read 2383 bytes from stdin.",
                 "timezone": "GMT-0200"
             },
@@ -366,6 +381,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.151 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] main() Fetcher received a request: <NSMutableURLRequest: 0x100119140> { URL: https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822 }",
                 "timezone": "GMT-0200"
             },
@@ -390,6 +406,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.151 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] main() Fetcher received a download path: /tmp/KSOutOfProcessFetcher.QTqOLkktQz/download",
                 "timezone": "GMT-0200"
             },
@@ -414,6 +431,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.152 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] main() ksfetch fetching URL (<NSMutableURLRequest: 0x100119140> { URL: https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822 }) to folder:/tmp/KSOutOfProcessFetcher.QTqOLkktQz/download",
                 "timezone": "GMT-0200"
             },
@@ -438,6 +456,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.152 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] main() Setting up download file handles...",
                 "timezone": "GMT-0200"
             },
@@ -462,6 +481,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.348 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] -[FetchDelegate fetcher:finishedWithData:] Fetcher downloaded successfully data of length: 0",
                 "timezone": "GMT-0200"
             },
@@ -486,6 +506,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.348 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] main() ksfetch done fetching.",
                 "timezone": "GMT-0200"
             },
@@ -510,6 +531,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key ksfetch[21414]: 2016-12-13 11:35:30.351 ksfetch[21414/0x7fffcc3f93c0] [lvl=2] main() Fetcher is exiting.",
                 "timezone": "GMT-0200"
             },
@@ -534,6 +556,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.354 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher(PrivateMethods) helperErrorAvailable:] KSOutOfProcessFetcher helper tool raw STDERR:\n\t:\t<>",
                 "timezone": "GMT-0200"
             },
@@ -558,6 +581,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.354 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOutOfProcessFetcher(PrivateMethods) helperDidTerminate:] KSOutOfProcessFetcher fetch ended for URL: \"https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822\"",
                 "timezone": "GMT-0200"
             },
@@ -582,6 +606,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.355 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateCheckAction(KSServerUpdateRequestDelegate) serverRequest:fetchedWithResponse:] KSUpdateCheckAction received KSServerUpdateResponse: <KSOmahaServerUpdateResponse:0x100559060\n\t\tserver=<KSOmahaServer:0x100555120>\n\t\turl=\"https://tools.google.com/service/update2?cup2hreq=423332d883f010d5b10e169646ed851278047f76e6c5d4dbfa2233ef66e3b141&cup2key=6:1566315822\"\n\t\ttickets=2\n\t\tstatus=200\n\t\tdata=\n\t\t\t<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n\t\t\t<response protocol=\"3.0\" server=\"prod\">\n\t\t\t    <daystart elapsed_days=\"3634\" elapsed_seconds=\"9330\"></daystart>\n\t\t\t    <app appid=\"com.google.Chrome\" cohort=\"1:1y5:gy3@0.05\" cohortname=\"Stable\" status=\"ok\">\n\t\t\t        <ping status=\"ok\"></ping>\n\t\t\t        <updatecheck status=\"noupdate\"></updatecheck>\n\t\t\t    </app>\n\t\t\t    <app appid=\"com.google.GoogleDrive\" cohort=\"\" cohortname=\"\" status=\"ok\">\n\t\t\t        <ping status=\"ok\"></ping>\n\t\t\t        <updatecheck status=\"noupdate\"></updatecheck>\n\t\t\t    </app>\n\t\t\t</response>\n\t>",
                 "timezone": "GMT-0200"
             },
@@ -606,6 +631,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.356 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSOmahaServer updateInfosForUpdateResponse:updateRequest:infoStore:upToDateTickets:updatedTickets:events:errors:] Response passed CUP validation.",
                 "timezone": "GMT-0200"
             },
@@ -630,6 +656,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.381 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateCheckAction(PrivateMethods) finishAction] KSUpdateCheckAction found updates: {( )}",
                 "timezone": "GMT-0200"
             },
@@ -654,6 +681,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.384 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSPrefetchAction performAction] KSPrefetchAction no updates to prefetch.",
                 "timezone": "GMT-0200"
             },
@@ -678,6 +706,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.384 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSMultiUpdateAction performAction] KSSilentUpdateAction had no updates to apply.",
                 "timezone": "GMT-0200"
             },
@@ -702,6 +731,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.384 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSMultiUpdateAction performAction] KSPromptAction had no updates to apply.",
                 "timezone": "GMT-0200"
             },
@@ -726,6 +756,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.384 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp(KeystoneDelegate) updateEngineFinishedWithErrors:] Keystone finished: errors=0",
                 "timezone": "GMT-0200"
             },
@@ -750,6 +781,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:30 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:30.385 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSUpdateEngine(PrivateMethods) updateFinish] KSUpdateEngine update processing complete.",
                 "timezone": "GMT-0200"
             },
@@ -774,6 +806,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:31 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:31.142 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp updateProductWithProductID:usingEngine:] Done checking for updates for '\"All Products\"' using engine <KSUpdateEngine:0x100341a00\n\t\tticketStore=<KSPersistentTicketStore:0x100204520 store=<KSKeyedPersistentStore:0x100213290\n\t\t\tpath=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore\"\n\t\t\tlockFile=<KSLockFile:0x1002160e0\n\t\t\t\tpath=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore.lock\"\n\t\t\t\tlocked=NO\n\t\t\t>\n\t\t>>\n\t\tprocessor=<KSActionProcessor:0x1002769e0\n\t\t\tdelegate=<KSUpdateEngine:0x100341a00>\n\t\t\tisProcessing=NO actionsCompleted=0 progress=0.00\n\t\t\terrors=0 currentActionErrors=0\n\t\t\tevents=0 currentActionEvents=0\n\t\t\tactionQueue=( )\n\t\t>\n\t\tdelegate=<KSAgentApp: 0x10052a250>\n\t\tserverInfoStore=<KSServerPrivateInfoStore:0x100317b40 path=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/Servers\">\n\t\terrors=0\n\t>",
                 "timezone": "GMT-0200"
             },
@@ -798,6 +831,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:31 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:31.302 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentUploader fetcher:finishedWithData:] Successfully uploaded stats to <NSMutableURLRequest: 0x1003cbcd0> { URL: https://tools.google.com/service/update2 }",
                 "timezone": "GMT-0200"
             },
@@ -822,6 +856,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:31 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:31.431 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp uploadStats:] Successfully uploaded stats <KSStatsCollection:0x100212570 path=\"/Users/tsg/Library/Google/GoogleSoftwareUpdate/Stats/Keystone.stats\", count=5, stats={\n\t    checks = 2;\n\t    tickets = 2;\n\t    usertickets = 3;\n\t    validtickets = 2;\n\t    validusertickets = 3;\n\t}>",
                 "timezone": "GMT-0200"
             },
@@ -846,6 +881,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:32 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:32.508 GoogleSoftwareUpdateAgent[21412/0x700007399000] [lvl=2] -[KSAgentApp(KeystoneThread) runKeystonesInThreadWithArg:] Finished with engine thread",
                 "timezone": "GMT-0200"
             },
@@ -870,6 +906,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:32 a-mac-with-esc-key GoogleSoftwareUpdateAgent[21412]: 2016-12-13 11:35:32.825 GoogleSoftwareUpdateAgent[21412/0x7fffcc3f93c0] [lvl=2] -[KSAgentApp checkForUpdates] Finished update check.",
                 "timezone": "GMT-0200"
             },
@@ -894,6 +931,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:35:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000a8499d0 holds 0x2121212121212121 instead of 0x600006a22fa0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -918,6 +956,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:37:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f047240 holds 0x2121212121212121 instead of 0x608002231220. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -942,6 +981,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:38:45 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21498]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -965,6 +1005,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:39:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000a256990 holds 0x2121212121212121 instead of 0x600006a22420. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -989,6 +1030,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:41:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x6080096475d0 holds 0x2121212121212121 instead of 0x608004e21280. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1013,6 +1055,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:41:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -1037,6 +1080,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:42:55 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21556]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1060,6 +1104,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:45:18 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -1083,6 +1128,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:45:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000a85a860 holds 0x2121212121212121 instead of 0x600004a3b9a0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1107,6 +1153,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:47:06 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21581]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1130,6 +1177,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:47:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x608009840580 holds 0x2121212121212121 instead of 0x608004a22940. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1154,6 +1202,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:49:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x608009c5b700 holds 0x2121212121212121 instead of 0x608005830020. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1178,6 +1227,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:51:17 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21586]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1201,6 +1251,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:51:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800ee592d0 holds 0x2121212121212121 instead of 0x608005627220. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1225,6 +1276,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:51:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -1249,6 +1301,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:53:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000c648290 holds 0x2121212121212121 instead of 0x6000050242a0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1273,6 +1326,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:55:28 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21589]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1296,6 +1350,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:55:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600009840460 holds 0x2121212121212121 instead of 0x60000122e940. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1320,6 +1375,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:56:30 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -1343,6 +1399,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:57:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000ee5b730 holds 0x2121212121212121 instead of 0x600007821c20. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1367,6 +1424,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 11:59:40 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21946]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1390,6 +1448,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:01:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600006a49940 holds 0x2121212121212121 instead of 0x6000078202e0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1414,6 +1473,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:01:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -1438,6 +1498,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:03:04 a-mac-with-esc-key Slack Helper[55199]: Invoked notification with id: d63743fb-f17b-4e9e-97d0-88e0e7304682",
                 "timezone": "GMT-0200"
             },
@@ -1462,6 +1523,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:03:51 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21966]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1485,6 +1547,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:05:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f043dc0 holds 0x2121212121212121 instead of 0x6080026228c0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1509,6 +1572,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:08:02 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[21981]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1532,6 +1596,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:09:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x608009a53600 holds 0x2121212121212121 instead of 0x608000629420. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1556,6 +1621,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:11:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f259c30 holds 0x2121212121212121 instead of 0x608004a21c20. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1580,6 +1646,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:11:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -1604,6 +1671,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:12:13 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22226]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1627,6 +1695,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:13:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000c647d80 holds 0x2121212121212121 instead of 0x600006e3ee80. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1651,6 +1720,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:15:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f053a80 holds 0x2121212121212121 instead of 0x608007227ce0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1675,6 +1745,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:16:24 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22241]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1698,6 +1769,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:17:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000a64ce80 holds 0x2121212121212121 instead of 0x600006629940. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1722,6 +1794,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:19:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000a843580 holds 0x2121212121212121 instead of 0x600006629540. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1746,6 +1819,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:20:35 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22254]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1769,6 +1843,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:21:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f45b910 holds 0x2121212121212121 instead of 0x608005822c40. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1793,6 +1868,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:21:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -1817,6 +1893,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:23:13 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -1840,6 +1917,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:23:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000ea5edf0 holds 0x2121212121212121 instead of 0x600003a35a60. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1864,6 +1942,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:24:46 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22265]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1887,6 +1966,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:28:43 a-mac-with-esc-key Slack Helper[55199]: Invoked notification with id: 52bf37d9-0c4e-4276-8789-9fc7704bdf5b",
                 "timezone": "GMT-0200"
             },
@@ -1911,6 +1991,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:28:57 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22292]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -1934,6 +2015,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:29:06 a-mac-with-esc-key Slack Helper[55199]: Invoked notification with id: c6c7e356-60a7-4b9e-a9b1-ecc2b8ad09f2",
                 "timezone": "GMT-0200"
             },
@@ -1958,6 +2040,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:29:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f246430 holds 0x2121212121212121 instead of 0x608001c26d00. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -1982,6 +2065,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:31:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800c85fd80 holds 0x2121212121212121 instead of 0x608005a3a420. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2006,6 +2090,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:31:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -2030,6 +2115,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:33:08 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22305]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -2053,6 +2139,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:33:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600006452400 holds 0x2121212121212121 instead of 0x60000763bac0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2077,6 +2164,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:35:56 a-mac-with-esc-key GoogleSoftwareUpdateAgent[22318]: 2016-12-13 12:35:56.416 GoogleSoftwareUpdateAgent[22318/0x7fffcc3f93c0] [lvl=2] -[KSAgentApp setupLoggerOutput] Agent settings: <KSAgentSettings:0x100505750 bundleID=com.google.Keystone.Agent lastCheck=2016-12-13 10:35:32 +0000 checkInterval=18000.000000 uiDisplayInterval=604800.000000 sleepInterval=1800.000000 jitterInterval=900 maxRunInterval=0.000000 isConsoleUser=1 ticketStorePath=/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore runMode=3 daemonUpdateEngineBrokerServiceName=com.google.Keystone.Daemon.UpdateEngine daemonAdministrationServiceName=com.google.Keystone.Daemon.Administration logEverything=0 logBufferSize=2048 alwaysPromptForUpdates=0 productIDToUpdate=(null) lastUIDisplayed=(null) alwaysShowStatusItem=0 updateCheckTag=(null) printResults=NO userInitiated=NO>",
                 "timezone": "GMT-0200"
             },
@@ -2101,6 +2189,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:37:20 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22324]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -2124,6 +2213,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:37:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f24d0f0 holds 0x2121212121212121 instead of 0x608007423ee0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2148,6 +2238,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:39:28 a-mac-with-esc-key Slack Helper[55199]: Invoked notification with id: aa608788-d049-4d1a-9112-521c71702371",
                 "timezone": "GMT-0200"
             },
@@ -2172,6 +2263,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:41:06 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -2195,6 +2287,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:41:26 a-mac-with-esc-key Slack Helper[55199]: Invoked notification with id: d75f9ec1-a8fd-41c2-a45e-6df2952f0702",
                 "timezone": "GMT-0200"
             },
@@ -2219,6 +2312,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:41:30 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22336]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -2242,6 +2336,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:41:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800a2535a0 holds 0x2121212121212121 instead of 0x608003828e20. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2266,6 +2361,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:41:57 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -2290,6 +2386,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:43:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f241d50 holds 0x2121212121212121 instead of 0x60800562f380. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2314,6 +2411,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:45:41 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22348]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -2337,6 +2435,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:45:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000c444450 holds 0x2121212121212121 instead of 0x600007237f00. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2361,6 +2460,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:47:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000c4424a0 holds 0x2121212121212121 instead of 0x600007026520. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -2385,6 +2485,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:13 a-mac-with-esc-key logd[63]: _handle_cache_delete_with_urgency(0x7fc55c429b40, 0, 1)",
                 "timezone": "GMT-0200"
             },
@@ -2409,6 +2510,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:13 a-mac-with-esc-key logd[63]: _volume_contains_cached_data(is /private/var/db/diagnostics/ in /) - YES",
                 "timezone": "GMT-0200"
             },
@@ -2433,6 +2535,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:13 a-mac-with-esc-key logd[63]: Purged 0 bytes from log files.",
                 "timezone": "GMT-0200"
             },
@@ -2457,6 +2560,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:13 a-mac-with-esc-key logd[63]: _purge_uuidtext enter - 1",
                 "timezone": "GMT-0200"
             },
@@ -2481,6 +2585,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:14 a-mac-with-esc-key logd[63]: _purge_uuidtext got 1023 UUIDs and 3 slibs from inflight logs",
                 "timezone": "GMT-0200"
             },
@@ -2505,6 +2610,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:14 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -2528,6 +2634,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:24 a-mac-with-esc-key logd[63]: _purge_uuidtext got 1303 UUIDs and 3 slibs from inflight and persistent logs",
                 "timezone": "GMT-0200"
             },
@@ -2552,6 +2659,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:24 a-mac-with-esc-key logd[63]: _purge_uuidtext processing shared lib uuid 00000000-0000-0000-0000-000000000000",
                 "timezone": "GMT-0200"
             },
@@ -2576,6 +2684,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:24 a-mac-with-esc-key logd[63]: _purge_uuidtext processing shared lib uuid 519BE6A1-940A-3142-975F-4EF4F41A89B3",
                 "timezone": "GMT-0200"
             },
@@ -2600,6 +2709,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:24 a-mac-with-esc-key logd[63]: _purge_uuidtext processing shared lib uuid C43133F6-64A3-3F65-997F-0E985A66E971",
                 "timezone": "GMT-0200"
             },
@@ -2624,6 +2734,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:24 a-mac-with-esc-key logd[63]: _purge_uuidtext got 2260 UUIDs and 3 slibs from inflight and persistent logs and slibs",
                 "timezone": "GMT-0200"
             },
@@ -2648,6 +2759,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:24 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 00000000-0000-0000-0000-000000000000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2672,6 +2784,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:27 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 1BD0C00C-0885-4C02-B522-D1E9CBDE84E7 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2696,6 +2809,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:29 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 40E9BF5F-FF7F-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2720,6 +2834,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 60E9BF5F-FF7F-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2744,6 +2859,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 66A56E12-C69B-4249-BC49-760C03F3700A mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2768,6 +2884,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F0308-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2792,6 +2909,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F190B-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2816,6 +2934,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F3C07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2840,6 +2959,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F6107-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2864,6 +2984,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F800A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2888,6 +3009,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F8102-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2912,6 +3034,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700F9401-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2936,6 +3059,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700FD70E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2960,6 +3084,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700FD900-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -2984,6 +3109,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700FEE0B-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3008,6 +3134,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 700FF904-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3032,6 +3159,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701F1C0F-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3056,6 +3184,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701F2F0E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3080,6 +3209,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701F4C02-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3104,6 +3234,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701FAE07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3128,6 +3259,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701FBD0F-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3152,6 +3284,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701FE80B-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3176,6 +3309,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701FEF07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3200,6 +3334,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701FF700-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3224,6 +3359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 701FF90D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3248,6 +3384,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 702F5E0E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3272,6 +3409,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 702F6503-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3296,6 +3434,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 702F6B06-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3320,6 +3459,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 702FEB0B-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3344,6 +3484,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 702FFC01-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3368,6 +3509,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703F0E06-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3392,6 +3534,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703F4A0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3416,6 +3559,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703F8C07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3440,6 +3584,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703F9405-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3464,6 +3609,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703FA300-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3488,6 +3634,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703FC709-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3512,6 +3659,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703FD007-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3536,6 +3684,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 703FED05-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3560,6 +3709,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704F0003-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3584,6 +3734,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704F550C-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3608,6 +3759,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704F750A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3632,6 +3784,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704F8102-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3656,6 +3809,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704F8C0C-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3680,6 +3834,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704F8D09-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3704,6 +3859,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704FB402-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3728,6 +3884,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 704FBB01-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3752,6 +3909,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705F030E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3776,6 +3934,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705F2D10-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3800,6 +3959,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705F3B01-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3824,6 +3984,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705F4E0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3848,6 +4009,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705FA30D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3872,6 +4034,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705FDA05-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3896,6 +4059,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 705FDF03-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3920,6 +4084,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 706F5101-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3944,6 +4109,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 706F6300-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3968,6 +4134,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 706F6E05-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -3992,6 +4159,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 706FE207-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4016,6 +4184,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 706FEC00-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4040,6 +4209,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 706FFB07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4064,6 +4234,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707F0907-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4088,6 +4259,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707F6A04-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4112,6 +4284,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707F7B00-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4136,6 +4309,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707F9B0D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4160,6 +4334,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707FAD09-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4184,6 +4359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707FB80A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4208,6 +4384,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707FD809-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4232,6 +4409,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 707FE404-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4256,6 +4434,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708F3207-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4280,6 +4459,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708F3402-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4304,6 +4484,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708F3809-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4328,6 +4509,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708F470F-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4352,6 +4534,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708F8A00-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4376,6 +4559,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708F9F0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4400,6 +4584,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708FB403-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4424,6 +4609,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708FC507-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4448,6 +4634,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708FDC07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4472,6 +4659,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708FEA0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4496,6 +4684,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 708FFC08-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4520,6 +4709,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F1005-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4544,6 +4734,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F1E0D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4568,6 +4759,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F4C0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4592,6 +4784,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F5F08-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4616,6 +4809,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F6306-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4640,6 +4834,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F6903-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4664,6 +4859,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709F980E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4688,6 +4884,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FA80C-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4712,6 +4909,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FE302-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4736,6 +4934,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FE808-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4760,6 +4959,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FE809-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4784,6 +4984,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FED00-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4808,6 +5009,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FEF02-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4832,6 +5034,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 709FEF0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4856,6 +5059,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF070C-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4880,6 +5084,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF2108-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4904,6 +5109,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF270C-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4928,6 +5134,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF390B-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4952,6 +5159,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF4A0D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -4976,6 +5184,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF6D06-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5000,6 +5209,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF700E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5024,6 +5234,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF810D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5048,6 +5259,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AF9D02-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5072,6 +5284,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AFA200-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5096,6 +5309,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AFBE07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5120,6 +5334,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70AFCC02-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5144,6 +5359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BF210E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5168,6 +5384,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BF4C0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5192,6 +5409,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BF9000-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5216,6 +5434,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BF9302-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5240,6 +5459,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BFC302-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5264,6 +5484,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BFD507-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5288,6 +5509,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BFD605-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5312,6 +5534,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BFE302-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5336,6 +5559,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70BFFF03-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5360,6 +5584,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF0210-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5384,6 +5609,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF0603-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5408,6 +5634,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF0802-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5432,6 +5659,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF180F-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5456,6 +5684,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF1902-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5480,6 +5709,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF4A07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5504,6 +5734,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF530D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5528,6 +5759,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF590D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5552,6 +5784,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CF770D-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5576,6 +5809,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CFA700-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5600,6 +5834,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CFC804-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5624,6 +5859,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CFE00C-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5648,6 +5884,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CFEA09-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5672,6 +5909,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70CFED0B-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5696,6 +5934,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70DF4B07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5720,6 +5959,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70DF7301-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5744,6 +5984,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70DFA303-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5768,6 +6009,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70DFCB0E-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5792,6 +6034,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70DFDD01-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5816,6 +6059,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70DFE504-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5840,6 +6084,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70E9BF5F-FF7F-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5864,6 +6109,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EF2F0A-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5888,6 +6134,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EF4609-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5912,6 +6159,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EF5D05-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5936,6 +6184,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EF7F07-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5960,6 +6209,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EF8606-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -5984,6 +6234,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EFA406-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6008,6 +6259,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EFA60F-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6032,6 +6284,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EFC606-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6056,6 +6309,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70EFD407-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6080,6 +6334,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70FF0207-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6104,6 +6359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70FF1E04-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6128,6 +6384,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70FF6F01-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6152,6 +6409,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70FF7703-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6176,6 +6434,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:31 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 70FF9708-0070-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6200,6 +6459,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:32 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for 80E8BF5F-FF7F-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6224,6 +6484,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:32 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for A0E8BF5F-FF7F-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6248,6 +6509,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:32 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for A0E9BF5F-FF7F-0000-FD68-88C3FF7F0000 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6272,6 +6534,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:32 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for B22412E8-3691-4FA9-95EA-C5B9E2A3C572 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6296,6 +6559,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext uuidtext file for F011D7E8-7633-3668-9455-53893C4F4B33 mentioned but not found",
                 "timezone": "GMT-0200"
             },
@@ -6320,6 +6584,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext tree walked",
                 "timezone": "GMT-0200"
             },
@@ -6344,6 +6609,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/00/0E757A4E2C3108A74D6C5A996AAAAB",
                 "timezone": "GMT-0200"
             },
@@ -6368,6 +6634,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/00/F2131643943190B32FE35236EA4864",
                 "timezone": "GMT-0200"
             },
@@ -6392,6 +6659,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/06/608E438FDA3E28B9A262F575FE0E75",
                 "timezone": "GMT-0200"
             },
@@ -6416,6 +6684,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/09/35918C5C783B8AB2E6B75B12056F3C",
                 "timezone": "GMT-0200"
             },
@@ -6440,6 +6709,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/11/DD409E112F373398E6DA86BF046EC9",
                 "timezone": "GMT-0200"
             },
@@ -6464,6 +6734,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/14/65FB07456D36EC9EC80462D86BB21B",
                 "timezone": "GMT-0200"
             },
@@ -6488,6 +6759,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:33 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/18/A779EC17953910996D134A28F5C564",
                 "timezone": "GMT-0200"
             },
@@ -6512,6 +6784,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/19/57E846B04C32FBAD78821B285B0D18",
                 "timezone": "GMT-0200"
             },
@@ -6536,6 +6809,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/1E/79F11C7D5333F1BD0630540535F725",
                 "timezone": "GMT-0200"
             },
@@ -6560,6 +6834,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/1E/9811DDA51A3BE9A4A748AD394DBE73",
                 "timezone": "GMT-0200"
             },
@@ -6584,6 +6859,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/23/099C5F0A853312A9BD5694C15D228C",
                 "timezone": "GMT-0200"
             },
@@ -6608,6 +6884,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/27/FBA267162735F8B5A6BF29E3A7670E",
                 "timezone": "GMT-0200"
             },
@@ -6632,6 +6909,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/39/2980D3CAF73E2A94ED57F74979F1D9",
                 "timezone": "GMT-0200"
             },
@@ -6656,6 +6934,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/3E/67870101A7359F88CCB9BD6681FC93",
                 "timezone": "GMT-0200"
             },
@@ -6680,6 +6959,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/41/C51F4A33E03ACF86603802C9E6FFDE",
                 "timezone": "GMT-0200"
             },
@@ -6704,6 +6984,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/42/BF3535B92C3272BA41F8A9BC267F3B",
                 "timezone": "GMT-0200"
             },
@@ -6728,6 +7009,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/42/C18E8D6CEE37FF8DCD1390244CF38E",
                 "timezone": "GMT-0200"
             },
@@ -6752,6 +7034,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/53/4B25B3C583361EADD5CB938678868C",
                 "timezone": "GMT-0200"
             },
@@ -6776,6 +7059,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/54/090A60831C3233A4F0022DB86FF8B8",
                 "timezone": "GMT-0200"
             },
@@ -6800,6 +7084,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/56/8EBEC4BC8230848898534D17830BB6",
                 "timezone": "GMT-0200"
             },
@@ -6824,6 +7109,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/57/58C9F966E631669B74E6625D40C806",
                 "timezone": "GMT-0200"
             },
@@ -6848,6 +7134,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/5E/F7315AF27B31A6A38D6364704D4FFC",
                 "timezone": "GMT-0200"
             },
@@ -6872,6 +7159,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/5F/2B940389D136F2817A41C784D530CB",
                 "timezone": "GMT-0200"
             },
@@ -6896,6 +7184,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/62/196B2A409236898AAD3A1520C53191",
                 "timezone": "GMT-0200"
             },
@@ -6920,6 +7209,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/65/2D3DB29CBA32E297A65465CBA36B01",
                 "timezone": "GMT-0200"
             },
@@ -6944,6 +7234,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/67/58A21E3D2B3620952A68EC384CC1AF",
                 "timezone": "GMT-0200"
             },
@@ -6968,6 +7259,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/69/ADA53CBD3A3E31B08CFD85B12D52E1",
                 "timezone": "GMT-0200"
             },
@@ -6992,6 +7284,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/72/FB1BBBCA3E30E89802A68B8B2B07F1",
                 "timezone": "GMT-0200"
             },
@@ -7016,6 +7309,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/74/702F7027E834ACB0057983649FFB29",
                 "timezone": "GMT-0200"
             },
@@ -7040,6 +7334,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/75/B25BA663DB34EC9AAC6971BBE817EB",
                 "timezone": "GMT-0200"
             },
@@ -7064,6 +7359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/75/B88148A6E233F8AFF323294DE561E0",
                 "timezone": "GMT-0200"
             },
@@ -7088,6 +7384,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/76/2702DC49823F9E8292BB022D6BAF84",
                 "timezone": "GMT-0200"
             },
@@ -7112,6 +7409,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/76/73D347C0F834879F9438D542975A23",
                 "timezone": "GMT-0200"
             },
@@ -7136,6 +7434,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/78/397DF6C0253FD383E4AFAE3DD2E49C",
                 "timezone": "GMT-0200"
             },
@@ -7160,6 +7459,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/7F/BCC184181A3913ADC50E38F950D098",
                 "timezone": "GMT-0200"
             },
@@ -7184,6 +7484,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/81/12B328744938E1ACF2846B35CD83B4",
                 "timezone": "GMT-0200"
             },
@@ -7208,6 +7509,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/82/3CB803D77334D0B5C759685022D876",
                 "timezone": "GMT-0200"
             },
@@ -7232,6 +7534,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/8A/860FB569623B81B0511956EC82CEA3",
                 "timezone": "GMT-0200"
             },
@@ -7256,6 +7559,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/90/9D581D35E7358AA75371D3A038142D",
                 "timezone": "GMT-0200"
             },
@@ -7280,6 +7584,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/99/AC7E971E8C3319AD0514626D763823",
                 "timezone": "GMT-0200"
             },
@@ -7304,6 +7609,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/9A/53817F2101396598311DB81D851FBA",
                 "timezone": "GMT-0200"
             },
@@ -7328,6 +7634,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/9B/2EB7A3E93A3641B38EAD32B1CBE412",
                 "timezone": "GMT-0200"
             },
@@ -7352,6 +7659,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/9F/E64976D7223E7F992BB3287AF23301",
                 "timezone": "GMT-0200"
             },
@@ -7376,6 +7684,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/A7/8C02A56C0F3A9D90CAD8C92842B9A9",
                 "timezone": "GMT-0200"
             },
@@ -7400,6 +7709,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/A9/733CC25E7239F98BC0812C5D7AF135",
                 "timezone": "GMT-0200"
             },
@@ -7424,6 +7734,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/AB/450D449D5432C9B30A439A35B29931",
                 "timezone": "GMT-0200"
             },
@@ -7448,6 +7759,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/B0/AF101031AA3188A08CF1517F800B2C",
                 "timezone": "GMT-0200"
             },
@@ -7472,6 +7784,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/B4/77C958888B3AB092FD097D2C9A1B13",
                 "timezone": "GMT-0200"
             },
@@ -7496,6 +7809,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/B4/BDFB4CAE49386B963E2C7A296B7D20",
                 "timezone": "GMT-0200"
             },
@@ -7520,6 +7834,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/B5/0CBF2789673C6AB67F80F199CFD499",
                 "timezone": "GMT-0200"
             },
@@ -7544,6 +7859,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/B6/41F64AD9923AD19AED8A35325FB04E",
                 "timezone": "GMT-0200"
             },
@@ -7568,6 +7884,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/B6/566C8F2EA7349EB2C02647D2F69F97",
                 "timezone": "GMT-0200"
             },
@@ -7592,6 +7909,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/BA/2A57BB4346303EA1E87862E6752057",
                 "timezone": "GMT-0200"
             },
@@ -7616,6 +7934,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/C0/2D31E981553F31B0E9C36C232EE607",
                 "timezone": "GMT-0200"
             },
@@ -7640,6 +7959,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/C0/E060E4E9373D4D9B4A930D3291F052",
                 "timezone": "GMT-0200"
             },
@@ -7664,6 +7984,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/C2/531C46380A3DA489F7752C2FE6AEA0",
                 "timezone": "GMT-0200"
             },
@@ -7688,6 +8009,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/C9/17C064F3903260A7DC304FABDDC3FD",
                 "timezone": "GMT-0200"
             },
@@ -7712,6 +8034,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/CD/E2995BDA593F96B16EF1AE92AF31D8",
                 "timezone": "GMT-0200"
             },
@@ -7736,6 +8059,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/CE/EE9ADE6F813CD78A1308F14010F463",
                 "timezone": "GMT-0200"
             },
@@ -7760,6 +8084,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/D1/7E3015AC923AFE89BAFE6411B96431",
                 "timezone": "GMT-0200"
             },
@@ -7784,6 +8109,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/D3/AE090906EC3F058A04EE77A574C8B3",
                 "timezone": "GMT-0200"
             },
@@ -7808,6 +8134,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/DA/BAD1584258317A8483FE9CF10547BD",
                 "timezone": "GMT-0200"
             },
@@ -7832,6 +8159,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/DD/CCB6FD639830F39A5D87247D54F616",
                 "timezone": "GMT-0200"
             },
@@ -7856,6 +8184,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/E1/05E61475463784975FC5278723D08C",
                 "timezone": "GMT-0200"
             },
@@ -7880,6 +8209,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/E1/B515E0321E3B85B90F01D623DC9047",
                 "timezone": "GMT-0200"
             },
@@ -7904,6 +8234,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/E2/8DBEF43A0A37008A26AE9F016435F3",
                 "timezone": "GMT-0200"
             },
@@ -7928,6 +8259,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/E3/55D24FAC0838679583537F319C7B72",
                 "timezone": "GMT-0200"
             },
@@ -7952,6 +8284,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/EF/8522BAF9393808A2E6018507233133",
                 "timezone": "GMT-0200"
             },
@@ -7976,6 +8309,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext unlinking /var/db/uuidtext/FC/F7262CC2703E32BD3808B2D50C74F0",
                 "timezone": "GMT-0200"
             },
@@ -8000,6 +8334,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext total: 2209, in_use:2104, marked:23, recent:13, deleted 69",
                 "timezone": "GMT-0200"
             },
@@ -8024,6 +8359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext slib tree cleaned up (0)",
                 "timezone": "GMT-0200"
             },
@@ -8048,6 +8384,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext uuid tree cleaned up (3)",
                 "timezone": "GMT-0200"
             },
@@ -8072,6 +8409,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: _purge_uuidtext cleaned up (0)",
                 "timezone": "GMT-0200"
             },
@@ -8096,6 +8434,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:34 a-mac-with-esc-key logd[63]: Purged 5816519 bytes from uuidtext.",
                 "timezone": "GMT-0200"
             },
@@ -8120,6 +8459,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:52 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22360]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8143,6 +8483,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:49:57 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600011443d90 holds 0x2121212121212121 instead of 0x600006e206c0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8167,6 +8508,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:51:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800ac568a0 holds 0x2121212121212121 instead of 0x608003630680. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8191,6 +8533,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:51:58 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -8215,6 +8558,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:53:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000664ad50 holds 0x2121212121212121 instead of 0x600006c31140. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8239,6 +8583,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:54:03 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22370]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8262,6 +8607,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:55:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x6000060446c0 holds 0x2121212121212121 instead of 0x600006c34d60. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8286,6 +8632,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:57:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000c645c20 holds 0x2121212121212121 instead of 0x600002e295c0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8310,6 +8657,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:58:14 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[22382]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8333,6 +8681,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 12:59:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800fe59330 holds 0x2121212121212121 instead of 0x608004030e80. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8357,6 +8706,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:01:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000ec41a20 holds 0x2121212121212121 instead of 0x600002e2d920. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8381,6 +8731,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:01:58 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -8405,6 +8756,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:03:19 a-mac-with-esc-key Preview[24046]: BUG in libdispatch client: kevent[EVFILT_MACHPORT] monitored resource vanished before the source cancel handler was invoked",
                 "timezone": "GMT-0200"
             },
@@ -8429,6 +8781,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:03:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x608007645da0 holds 0x2121212121212121 instead of 0x6080044252a0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8453,6 +8806,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:05:26 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25276]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8476,6 +8830,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:05:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000c643b20 holds 0x2121212121212121 instead of 0x6000036340a0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8500,6 +8855,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:07:26 a-mac-with-esc-key Slack Helper[55199]: Invoked notification with id: 7cc1869b-ba48-4307-8474-0bc68cd9c71d",
                 "timezone": "GMT-0200"
             },
@@ -8524,6 +8880,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:07:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600007852ee0 holds 0x2121212121212121 instead of 0x600006a22780. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8548,6 +8905,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:09:37 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25878]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8571,6 +8929,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:09:49 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -8594,6 +8953,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:13:48 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25888]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8617,6 +8977,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:13:48 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -8641,6 +9002,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:13:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60001125b6a0 holds 0x2121212121212121 instead of 0x600007234ce0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8665,6 +9027,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:15:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600006a41480 holds 0x2121212121212121 instead of 0x600003a2e920. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8689,6 +9052,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:17:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600005a46cd0 holds 0x2121212121212121 instead of 0x60000582bd00. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8713,6 +9077,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:17:59 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25896]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8736,6 +9101,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:19:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800ee5b730 holds 0x2121212121212121 instead of 0x6080072264c0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8760,6 +9126,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:21:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f65cb10 holds 0x2121212121212121 instead of 0x6080046351c0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8784,6 +9151,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:22:10 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25914]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8807,6 +9175,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:23:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x600008c56780 holds 0x2121212121212121 instead of 0x600006624600. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8831,6 +9200,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:23:58 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -8855,6 +9225,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:25:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f65d7a0 holds 0x2121212121212121 instead of 0x608003a3d9a0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8879,6 +9250,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:26:21 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25923]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8902,6 +9274,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:27:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000785e8e0 holds 0x2121212121212121 instead of 0x600006622ba0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8926,6 +9299,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:29:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60801005a980 holds 0x2121212121212121 instead of 0x608001a3f8a0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8950,6 +9324,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:30:33 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[25940]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -8973,6 +9348,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:31:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000d6588b0 holds 0x2121212121212121 instead of 0x600002a3dd60. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -8997,6 +9373,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:32:28 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.imfoundation.IMRemoteURLConnectionAgent): Unknown key for integer: _DirtyJetsamMemoryLimit",
                 "timezone": "GMT-0200"
             },
@@ -9020,6 +9397,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:33:58 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60800f459990 holds 0x2121212121212121 instead of 0x60800463e7e0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -9044,6 +9422,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:33:58 a-mac-with-esc-key syslogd[46]: ASL Sender Statistics",
                 "timezone": "GMT-0200"
             },
@@ -9068,6 +9447,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:34:44 a-mac-with-esc-key com.apple.xpc.launchd[1] (com.apple.quicklook[26381]): Endpoint has been activated through legacy launch(3) APIs. Please switch to XPC or bootstrap_check_in(): com.apple.quicklook",
                 "timezone": "GMT-0200"
             },
@@ -9091,6 +9471,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:35:59 a-mac-with-esc-key Google Chrome[85294]: objc[85294]: __weak variable at 0x60000be429b0 holds 0x2121212121212121 instead of 0x600003c325e0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.",
                 "timezone": "GMT-0200"
             },
@@ -9115,6 +9496,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "Dec 13 13:36:19 a-mac-with-esc-key GoogleSoftwareUpdateAgent[27321]: 2016-12-13 13:36:19.906 GoogleSoftwareUpdateAgent[27321/0x7fffcc3f93c0] [lvl=2] -[KSAgentApp setupLoggerOutput] Agent settings: <KSAgentSettings:0x100228060 bundleID=com.google.Keystone.Agent lastCheck=2016-12-13 10:35:32 +0000 checkInterval=18000.000000 uiDisplayInterval=604800.000000 sleepInterval=1800.000000 jitterInterval=900 maxRunInterval=0.000000 isConsoleUser=1 ticketStorePath=/Users/tsg/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore runMode=3 daemonUpdateEngineBrokerServiceName=com.google.Keystone.Daemon.UpdateEngine daemonAdministrationServiceName=com.google.Keystone.Daemon.Administration logEverything=0 logBufferSize=2048 alwaysPromptForUpdates=0 productIDToUpdate=(null) lastUIDisplayed=(null) alwaysShowStatusItem=0 updateCheckTag=(null) printResults=NO userInitiated=NO>",
                 "timezone": "GMT-0200"
             },

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-preserve-event-original.log-expected.json
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-preserve-event-original.log-expected.json
@@ -6,6 +6,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "2019-06-14T10:40:20.912134 localhost sudo: pam_unix(sudo-i:session): session opened for user root by userauth3(uid=0)"
             },
             "host": {

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-suse-syslog.log-expected.json
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-suse-syslog.log-expected.json
@@ -6,6 +6,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "2018-08-14T14:30:02.203151+02:00 linux-sqrz systemd[4179]: Stopped target Basic System.",
                 "timezone": "GMT-0200"
             },
@@ -30,6 +31,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "kind": "event",
                 "original": "2018-08-14T14:30:02.203251+02:00 linux-sqrz systemd[4179]: Stopped target Paths.",
                 "timezone": "GMT-0200"
             },

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd-journald.json
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd-journald.json
@@ -1,0 +1,162 @@
+{
+    "events": [
+        {
+            "@timestamp": "2025-05-27T11:19:35.000Z",
+            "process": {
+                "args_count": 1,
+                "pid": 1,
+                "command_line": "/lib/systemd/systemd",
+                "args": [
+                    "/lib/systemd/systemd"
+                ]
+            },
+            "event": {
+                "created": "2025-05-27T11:19:35.100Z",
+                "kind": "event"
+            },
+            "journald": {
+                "process": {
+                    "name": "systemd",
+                    "executable": "/usr/lib/systemd/systemd",
+                    "capabilities": "1ffffffffff",
+                    "command_line": "/lib/systemd/systemd"
+                },
+                "code": {
+                    "file": "src/core/job.c",
+                    "line": 940,
+                    "func": "job_log_done_status_message"
+                },
+                "pid": 1,
+                "host": {
+                    "boot_id": "9d65da94a1514b2caab5600711fa1844"
+                },
+                "custom": {
+                    "invocation_id": "b3f78ac21c8e4d219386127bd1b1e304",
+                    "job_id": "3286",
+                    "unit": "rsyslog.service",
+                    "tid": "1",
+                    "job_type": "stop",
+                    "job_result": "done"
+                }
+            },
+            "input": {
+                "type": "journald"
+            },
+            "systemd": {
+                "slice": "-.slice",
+                "unit": "init.scope",
+                "transport": "journal",
+                "cgroup": "/init.scope"
+            },
+            "log": {
+                "syslog": {
+                    "facility": {
+                        "code": 3
+                    },
+                    "priority": 6
+                }
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "host": {
+                "hostname": "bullseye",
+                "id": "9a7aa218396d47b1b17218a99918bae4",
+                "name": "bullseye"
+            },
+            "message": "Stopped System Logging Service.",
+            "syslog": {
+                "priority": 6,
+                "facility": 3,
+                "identifier": "systemd"
+            },
+            "message_id": "9d1aaa27d60140bd96365438aad20286",
+            "agent": {
+                "id": "b8704002-45df-4114-a79e-3128e0d12be2",
+                "name": "bullseye",
+                "type": "filebeat",
+                "version": "8.15.42",
+                "ephemeral_id": "e1d60a48-0e06-46c1-b7ca-430a468c5029"
+            }
+        },
+        {
+            "@timestamp": "2025-05-27T11:19:35.500Z",
+            "process": {
+                "args_count": 1,
+                "pid": 1,
+                "command_line": "/lib/systemd/systemd",
+                "args": [
+                    "/lib/systemd/systemd"
+                ]
+            },
+            "event": {
+                "created": "2025-05-27T11:19:35.600Z",
+                "kind": "event"
+            },
+            "journald": {
+                "process": {
+                    "name": "systemd",
+                    "executable": "/usr/lib/systemd/systemd",
+                    "capabilities": "1ffffffffff",
+                    "command_line": "/lib/systemd/systemd"
+                },
+                "code": {
+                    "file": "src/core/job.c",
+                    "line": 940,
+                    "func": "job_log_done_status_message"
+                },
+                "pid": 1,
+                "host": {
+                    "boot_id": "9d65da94a1514b2caab5600711fa1844"
+                },
+                "custom": {
+                    "invocation_id": "77e0d6c5f4de4d78a0b0d7d3a29f78a2",
+                    "job_id": "3287",
+                    "unit": "rsyslog.service",
+                    "tid": "1",
+                    "job_type": "start",
+                    "job_result": "done"
+                }
+            },
+            "input": {
+                "type": "journald"
+            },
+            "systemd": {
+                "slice": "-.slice",
+                "unit": "init.scope",
+                "transport": "journal",
+                "cgroup": "/init.scope"
+            },
+            "log": {
+                "syslog": {
+                    "facility": {
+                        "code": 3
+                    },
+                    "priority": 6
+                }
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "host": {
+                "hostname": "bullseye",
+                "id": "9a7aa218396d47b1b17218a99918bae4",
+                "name": "bullseye"
+            },
+            "message": "Started System Logging Service.",
+            "syslog": {
+                "priority": 6,
+                "facility": 3,
+                "identifier": "systemd"
+            },
+            "message_id": "39f53479d3a045ac8e11786248231fbf",
+            "agent": {
+                "id": "b8704002-45df-4114-a79e-3128e0d12be2",
+                "name": "bullseye",
+                "type": "filebeat",
+                "version": "8.15.42",
+                "ephemeral_id": "e1d60a48-0e06-46c1-b7ca-430a468c5029"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd-journald.json-config.yml
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd-journald.json-config.yml
@@ -1,0 +1,4 @@
+dynamic_fields:
+  event.ingested: ^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$
+fields:
+  input.type: journald

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd-journald.json-expected.json
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd-journald.json-expected.json
@@ -1,0 +1,118 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-05-27T11:19:35.000Z",
+            "agent": {
+                "ephemeral_id": "e1d60a48-0e06-46c1-b7ca-430a468c5029",
+                "id": "b8704002-45df-4114-a79e-3128e0d12be2",
+                "name": "bullseye",
+                "type": "filebeat",
+                "version": "8.15.42"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "service-stop",
+                "category": [
+                    "process"
+                ],
+                "created": "2025-05-27T11:19:35.100Z",
+                "ingested": "2026-08-18T10:57:06.906577542Z",
+                "kind": "event",
+                "original": "Stopped System Logging Service.",
+                "type": [
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "bullseye",
+                "id": "9a7aa218396d47b1b17218a99918bae4",
+                "name": "bullseye"
+            },
+            "input": {
+                "type": "journald"
+            },
+            "log": {
+                "syslog": {
+                    "facility": {
+                        "code": 3
+                    },
+                    "priority": 6
+                }
+            },
+            "message": "Stopped System Logging Service.",
+            "process": {
+                "args": [
+                    "/lib/systemd/systemd"
+                ],
+                "args_count": 1,
+                "command_line": "/lib/systemd/systemd",
+                "name": "systemd",
+                "pid": 1
+            },
+            "related": {
+                "hosts": [
+                    "bullseye"
+                ]
+            }
+        },
+        {
+            "@timestamp": "2025-05-27T11:19:35.500Z",
+            "agent": {
+                "ephemeral_id": "e1d60a48-0e06-46c1-b7ca-430a468c5029",
+                "id": "b8704002-45df-4114-a79e-3128e0d12be2",
+                "name": "bullseye",
+                "type": "filebeat",
+                "version": "8.15.42"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "service-start",
+                "category": [
+                    "process"
+                ],
+                "created": "2025-05-27T11:19:35.600Z",
+                "ingested": "2026-08-18T10:57:06.906593292Z",
+                "kind": "event",
+                "original": "Started System Logging Service.",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "bullseye",
+                "id": "9a7aa218396d47b1b17218a99918bae4",
+                "name": "bullseye"
+            },
+            "input": {
+                "type": "journald"
+            },
+            "log": {
+                "syslog": {
+                    "facility": {
+                        "code": 3
+                    },
+                    "priority": 6
+                }
+            },
+            "message": "Started System Logging Service.",
+            "process": {
+                "args": [
+                    "/lib/systemd/systemd"
+                ],
+                "args_count": 1,
+                "command_line": "/lib/systemd/systemd",
+                "name": "systemd",
+                "pid": 1
+            },
+            "related": {
+                "hosts": [
+                    "bullseye"
+                ]
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd.log
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd.log
@@ -1,0 +1,4 @@
+May 27 11:19:35 hostname systemd[1]: Stopped System Logging Service.
+May 27 11:19:35 hostname systemd[1]: Started System Logging Service.
+May 27 11:19:36 hostname systemd[1]: Started ssh.service - OpenBSD Secure Shell server.
+May 27 11:19:37 hostname systemd[1]: Stopped target Multi-User System.

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd.log-config.yml
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd.log-config.yml
@@ -1,0 +1,6 @@
+dynamic_fields:
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}-[0-9]{2}:[0-9]{2}$"
+fields:
+  event:
+    timezone: "GMT-0200"
+  input.type: log

--- a/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd.log-expected.json
+++ b/packages/system/data_stream/syslog/_dev/test/pipeline/test-systemd.log-expected.json
@@ -1,0 +1,125 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-05-27T11:19:35.000-02:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-stop",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "May 27 11:19:35 hostname systemd[1]: Stopped System Logging Service.",
+                "timezone": "GMT-0200",
+                "type": [
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "hostname"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "Stopped System Logging Service.",
+            "process": {
+                "name": "systemd",
+                "pid": 1
+            },
+            "system": {
+                "syslog": {}
+            }
+        },
+        {
+            "@timestamp": "2026-05-27T11:19:35.000-02:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-start",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "May 27 11:19:35 hostname systemd[1]: Started System Logging Service.",
+                "timezone": "GMT-0200",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "hostname"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "Started System Logging Service.",
+            "process": {
+                "name": "systemd",
+                "pid": 1
+            },
+            "system": {
+                "syslog": {}
+            }
+        },
+        {
+            "@timestamp": "2026-05-27T11:19:36.000-02:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-start",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "May 27 11:19:36 hostname systemd[1]: Started ssh.service - OpenBSD Secure Shell server.",
+                "timezone": "GMT-0200",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "hostname"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "Started ssh.service - OpenBSD Secure Shell server.",
+            "process": {
+                "name": "systemd",
+                "pid": 1
+            },
+            "system": {
+                "syslog": {}
+            }
+        },
+        {
+            "@timestamp": "2026-05-27T11:19:37.000-02:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event",
+                "original": "May 27 11:19:37 hostname systemd[1]: Stopped target Multi-User System.",
+                "timezone": "GMT-0200"
+            },
+            "host": {
+                "hostname": "hostname"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "Stopped target Multi-User System.",
+            "process": {
+                "name": "systemd",
+                "pid": 1
+            },
+            "system": {
+                "syslog": {}
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/syslog/elasticsearch/ingest_pipeline/journald.yml
+++ b/packages/system/data_stream/syslog/elasticsearch/ingest_pipeline/journald.yml
@@ -19,6 +19,27 @@ processors:
   - set:
       field: event.kind
       value: event
+  - script:
+      description: >-
+        Categorize systemd unit lifecycle messages. Only the completed
+        'Started'/'Stopped' templates are matched; 'Stopped target' is
+        excluded because targets are synchronization points, not services.
+        event.outcome is intentionally not set: a 'Stopped' line is identical
+        for clean shutdowns and crashed units, so outcome cannot be derived
+        from a single message.
+      tag: script_categorize_systemd_lifecycle
+      if: ctx.process?.name == 'systemd' && ctx.message != null
+      lang: painless
+      source: >-
+        if (ctx.message.startsWith('Started ')) {
+          ctx.event.category = ['process'];
+          ctx.event.type = ['start'];
+          ctx.event.action = 'service-start';
+        } else if (ctx.message.startsWith('Stopped ') && !ctx.message.startsWith('Stopped target ')) {
+          ctx.event.category = ['process'];
+          ctx.event.type = ['end'];
+          ctx.event.action = 'service-stop';
+        }
   - append:
       field: related.hosts
       value: "{{host.hostname}}"

--- a/packages/system/data_stream/syslog/elasticsearch/ingest_pipeline/log.yml
+++ b/packages/system/data_stream/syslog/elasticsearch/ingest_pipeline/log.yml
@@ -43,6 +43,7 @@ processors:
   - set:
       field: event.kind
       value: event
+      tag: set_event_kind
       description: Set event.kind to event for syslog log records.
   - script:
       description: >-
@@ -52,7 +53,7 @@ processors:
         event.outcome is intentionally not set: a 'Stopped' line is identical
         for clean shutdowns and crashed units, so outcome cannot be derived
         from a single message.
-      tag: script-categorize-systemd-lifecycle
+      tag: script_categorize_systemd_lifecycle
       if: ctx.process?.name == 'systemd' && ctx.message != null
       lang: painless
       source: >-

--- a/packages/system/data_stream/syslog/elasticsearch/ingest_pipeline/log.yml
+++ b/packages/system/data_stream/syslog/elasticsearch/ingest_pipeline/log.yml
@@ -41,6 +41,31 @@ processors:
   - remove:
       field: system.syslog.timestamp
   - set:
+      field: event.kind
+      value: event
+      description: Set event.kind to event for syslog log records.
+  - script:
+      description: >-
+        Categorize systemd unit lifecycle messages. Only the completed
+        'Started'/'Stopped' templates are matched; 'Stopped target' is
+        excluded because targets are synchronization points, not services.
+        event.outcome is intentionally not set: a 'Stopped' line is identical
+        for clean shutdowns and crashed units, so outcome cannot be derived
+        from a single message.
+      tag: script-categorize-systemd-lifecycle
+      if: ctx.process?.name == 'systemd' && ctx.message != null
+      lang: painless
+      source: >-
+        if (ctx.message.startsWith('Started ')) {
+          ctx.event.category = ['process'];
+          ctx.event.type = ['start'];
+          ctx.event.action = 'service-start';
+        } else if (ctx.message.startsWith('Stopped ') && !ctx.message.startsWith('Stopped target ')) {
+          ctx.event.category = ['process'];
+          ctx.event.type = ['end'];
+          ctx.event.action = 'service-stop';
+        }
+  - set:
       field: ecs.version
       value: 8.11.0
 on_failure:

--- a/packages/system/data_stream/syslog/sample_event.json
+++ b/packages/system/data_stream/syslog/sample_event.json
@@ -24,6 +24,7 @@
         "agent_id_status": "verified",
         "dataset": "system.syslog",
         "ingested": "2023-10-31T04:49:59Z",
+        "kind": "event",
         "original": "1986-04-26T01:23:45.388424+04:00 rmbkmonitor04 thermald: constraint_0_power_limit_uw exceeded.",
         "timezone": "+00:00"
     },

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.22.4"
+version: "2.23.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug
- Enhancement

## Proposed commit message
```
system: categorize systemd lifecycle events in syslog pipeline

The log-input path of the system.syslog data stream set no ECS event
fields, so records like systemd service starts and stops carried no
event.kind, event.category, event.type, or event.action.

Set event.kind to "event" for all log-input records, matching the
journald pipeline. Categorize systemd "Started"/"Stopped" unit
lifecycle messages as category "process" with type "start"/"end" and
action "service-start"/"service-stop". "Stopped target" lines are
excluded because targets are synchronization points, not services.

event.outcome is intentionally not set: a "Stopped" line is identical
for clean shutdowns and crashed units, so outcome cannot be derived
from a single syslog message.

Fixes #19258
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #19258


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
