### PR TITLE
[cloud_security_posture] GCP lifecycle fields + metering_state transform for CSPM metering

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -25,6 +25,9 @@
     - description: Index GCP compute instance lifecycle fields (`resource.lifecycle.*`) at ingest, lifted from the unindexed `resource.raw` payload, for serverless CSPM metering.
       type: enhancement
       link: https://github.com/elastic/security-team/issues/17662
+    - description: Add the `metering_state` transform, maintaining per-incarnation scan state for stateful serverless CSPM metering.
+      type: enhancement
+      link: https://github.com/elastic/security-team/issues/17662
 - version: "3.5.0"
   changes:
     - description: Release version 3.5.0

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -20,6 +20,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.6.0"
+  changes:
+    - description: Index GCP compute instance lifecycle fields (`resource.lifecycle.*`) at ingest, lifted from the unindexed `resource.raw` payload, for serverless CSPM metering.
+      type: enhancement
+      link: https://github.com/elastic/security-team/issues/17662
 - version: "3.5.0"
   changes:
     - description: Release version 3.5.0

--- a/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-gcp-lifecycle.json
+++ b/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-gcp-lifecycle.json
@@ -1,0 +1,174 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "rule": {
+                "benchmark": {
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "rule_number": "4.1",
+                    "id": "cis_gcp",
+                    "version": "v2.0.0",
+                    "posture_type": "cspm"
+                }
+            },
+            "cloud": {
+                "provider": "gcp",
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                }
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/stopped-vm",
+                "name": "stopped-vm",
+                "type": "cloud-compute",
+                "sub_type": "gcp-compute-instance",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "status": "TERMINATED",
+                            "creationTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStartTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStopTimestamp": "2026-07-08T08:58:00.000-07:00"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "rule": {
+                "benchmark": {
+                    "name": "CIS Amazon Web Services Foundations",
+                    "rule_number": "2.1.1",
+                    "id": "cis_aws",
+                    "version": "v3.0.0",
+                    "posture_type": "cspm"
+                }
+            },
+            "cloud": {
+                "provider": "aws",
+                "account": {
+                    "id": "123456789012",
+                    "name": "Test Account"
+                }
+            },
+            "resource": {
+                "id": "arn:aws:s3:::test-bucket",
+                "name": "test-bucket",
+                "type": "cloud-storage",
+                "sub_type": "aws-s3"
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "rule": {
+                "benchmark": {
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "rule_number": "4.1",
+                    "id": "cis_gcp",
+                    "version": "v2.0.0",
+                    "posture_type": "cspm"
+                }
+            },
+            "cloud": {
+                "provider": "gcp",
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                }
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/malformed-vm",
+                "name": "malformed-vm",
+                "type": "cloud-compute",
+                "sub_type": "gcp-compute-instance",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "status": "RUNNING",
+                            "creationTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStartTimestamp": "not-a-timestamp"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "rule": {
+                "benchmark": {
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "rule_number": "4.1",
+                    "id": "cis_gcp",
+                    "version": "v2.0.0",
+                    "posture_type": "cspm"
+                }
+            },
+            "cloud": {
+                "provider": "gcp",
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                }
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/native-vm",
+                "name": "native-vm",
+                "type": "cloud-compute",
+                "sub_type": "gcp-compute-instance",
+                "lifecycle": {
+                    "status": "RUNNING",
+                    "incarnation": "2026-06-01T00:00:00.000-07:00",
+                    "created_at": "2026-06-01T00:00:00.000-07:00",
+                    "last_started_at": "2026-07-01T00:00:00.000-07:00"
+                },
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "status": "TERMINATED",
+                            "creationTimestamp": "2026-01-01T00:00:00.000-07:00",
+                            "lastStartTimestamp": "2026-01-02T00:00:00.000-07:00",
+                            "lastStopTimestamp": "2026-01-03T00:00:00.000-07:00"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "rule": {
+                "benchmark": {
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "rule_number": "4.1",
+                    "id": "cis_gcp",
+                    "version": "v2.0.0",
+                    "posture_type": "cspm"
+                }
+            },
+            "cloud": {
+                "provider": "gcp",
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                }
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/malformed-start-vm",
+                "name": "malformed-start-vm",
+                "type": "cloud-compute",
+                "sub_type": "gcp-compute-instance",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "status": "TERMINATED",
+                            "creationTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStartTimestamp": "not-a-timestamp",
+                            "lastStopTimestamp": "2026-07-08T08:58:00.000-07:00"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-gcp-lifecycle.json-expected.json
+++ b/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-gcp-lifecycle.json-expected.json
@@ -1,0 +1,225 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "cloud": {
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                },
+                "provider": "gcp"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "observer": {
+                "vendor": "Elastic"
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/stopped-vm",
+                "lifecycle": {
+                    "created_at": "2026-07-08T01:58:00.000-07:00",
+                    "incarnation": "2026-07-08T01:58:00.000-07:00",
+                    "last_run_ms": 25200000,
+                    "last_started_at": "2026-07-08T01:58:00.000-07:00",
+                    "last_stopped_at": "2026-07-08T08:58:00.000-07:00",
+                    "status": "TERMINATED"
+                },
+                "name": "stopped-vm",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "creationTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStartTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStopTimestamp": "2026-07-08T08:58:00.000-07:00",
+                            "status": "TERMINATED"
+                        }
+                    }
+                },
+                "sub_type": "gcp-compute-instance",
+                "type": "cloud-compute"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_gcp",
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "posture_type": "cspm",
+                    "rule_number": "4.1",
+                    "version": "v2.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "cloud": {
+                "account": {
+                    "id": "123456789012",
+                    "name": "Test Account"
+                },
+                "provider": "aws"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "observer": {
+                "vendor": "Elastic"
+            },
+            "resource": {
+                "id": "arn:aws:s3:::test-bucket",
+                "name": "test-bucket",
+                "sub_type": "aws-s3",
+                "type": "cloud-storage"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_aws",
+                    "name": "CIS Amazon Web Services Foundations",
+                    "posture_type": "cspm",
+                    "rule_number": "2.1.1",
+                    "version": "v3.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "cloud": {
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                },
+                "provider": "gcp"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "observer": {
+                "vendor": "Elastic"
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/malformed-vm",
+                "lifecycle": {
+                    "created_at": "2026-07-08T01:58:00.000-07:00",
+                    "incarnation": "2026-07-08T01:58:00.000-07:00",
+                    "last_started_at": "not-a-timestamp",
+                    "status": "RUNNING"
+                },
+                "name": "malformed-vm",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "creationTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStartTimestamp": "not-a-timestamp",
+                            "status": "RUNNING"
+                        }
+                    }
+                },
+                "sub_type": "gcp-compute-instance",
+                "type": "cloud-compute"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_gcp",
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "posture_type": "cspm",
+                    "rule_number": "4.1",
+                    "version": "v2.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "cloud": {
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                },
+                "provider": "gcp"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "observer": {
+                "vendor": "Elastic"
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/native-vm",
+                "lifecycle": {
+                    "created_at": "2026-06-01T00:00:00.000-07:00",
+                    "incarnation": "2026-06-01T00:00:00.000-07:00",
+                    "last_started_at": "2026-07-01T00:00:00.000-07:00",
+                    "status": "RUNNING"
+                },
+                "name": "native-vm",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "creationTimestamp": "2026-01-01T00:00:00.000-07:00",
+                            "lastStartTimestamp": "2026-01-02T00:00:00.000-07:00",
+                            "lastStopTimestamp": "2026-01-03T00:00:00.000-07:00",
+                            "status": "TERMINATED"
+                        }
+                    }
+                },
+                "sub_type": "gcp-compute-instance",
+                "type": "cloud-compute"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_gcp",
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "posture_type": "cspm",
+                    "rule_number": "4.1",
+                    "version": "v2.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-08T16:00:00.000Z",
+            "cloud": {
+                "account": {
+                    "id": "test-project",
+                    "name": "Test Project"
+                },
+                "provider": "gcp"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "observer": {
+                "vendor": "Elastic"
+            },
+            "resource": {
+                "id": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/malformed-start-vm",
+                "lifecycle": {
+                    "created_at": "2026-07-08T01:58:00.000-07:00",
+                    "incarnation": "2026-07-08T01:58:00.000-07:00",
+                    "last_started_at": "not-a-timestamp",
+                    "last_stopped_at": "2026-07-08T08:58:00.000-07:00",
+                    "status": "TERMINATED"
+                },
+                "name": "malformed-start-vm",
+                "raw": {
+                    "resource": {
+                        "data": {
+                            "creationTimestamp": "2026-07-08T01:58:00.000-07:00",
+                            "lastStartTimestamp": "not-a-timestamp",
+                            "lastStopTimestamp": "2026-07-08T08:58:00.000-07:00",
+                            "status": "TERMINATED"
+                        }
+                    }
+                },
+                "sub_type": "gcp-compute-instance",
+                "type": "cloud-compute"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_gcp",
+                    "name": "CIS Google Cloud Platform Foundation",
+                    "posture_type": "cspm",
+                    "rule_number": "4.1",
+                    "version": "v2.0.0"
+                }
+            }
+        }
+    ]
+}

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -44,6 +44,42 @@ processors:
     field: host.name
     tag: set_host_name_lowercase
     ignore_missing: true
+- script:
+    tag: lift_gcp_compute_lifecycle
+    description: >-
+      Lift GCP compute lifecycle fields from resource.raw (not queryable:
+      the findings index template sets dynamic: false and
+      resource.raw.resource.data is declared enabled: false) into indexed
+      resource.lifecycle.* fields for CSPM metering
+      (https://github.com/elastic/security-team/issues/17662).
+      Skips docs that already carry lifecycle fields
+      (future cloudbeat versions may emit them natively).
+    if: >-
+      ctx.resource?.sub_type == 'gcp-compute-instance' &&
+      ctx.resource?.lifecycle == null &&
+      ctx.resource?.raw?.resource?.data != null
+    ignore_failure: true
+    lang: painless
+    source: |
+      def data = ctx.resource.raw.resource.data;
+      Map lc = new HashMap();
+      if (data.status instanceof String) { lc.status = data.status; }
+      if (data.creationTimestamp instanceof String) {
+        lc.incarnation = data.creationTimestamp;
+        lc.created_at = data.creationTimestamp;
+      }
+      if (data.lastStartTimestamp instanceof String) { lc.last_started_at = data.lastStartTimestamp; }
+      if (data.lastStopTimestamp instanceof String) { lc.last_stopped_at = data.lastStopTimestamp; }
+      if (lc.isEmpty()) { return; }
+      // Assign before parsing: an unparseable timestamp throws, and ignore_failure
+      // swallows the throw without rolling back what was already written to ctx,
+      // so the rest of the lift survives and only last_run_ms is lost.
+      ctx.resource.lifecycle = lc;
+      if (data.lastStartTimestamp instanceof String && data.lastStopTimestamp instanceof String) {
+        long startMs = ZonedDateTime.parse(data.lastStartTimestamp).toInstant().toEpochMilli();
+        long stopMs = ZonedDateTime.parse(data.lastStopTimestamp).toInstant().toEpochMilli();
+        lc.last_run_ms = stopMs - startMs;
+      }
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/data_stream/findings/fields/resource.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/resource.yml
@@ -9,3 +9,52 @@
       type: keyword
     - name: sub_type
       type: keyword
+    # Declared at this depth, rather than on `raw` as a whole, because
+    # elastic-package's document validator only suppresses undefined-field
+    # errors ONE level below a disabled object (findParentElementDefinition in
+    # internal/fields/validate.go looks at the immediate parent only). Pipeline
+    # test fixtures must therefore keep the payload flat under `data`.
+    # Production is unaffected either way: the index template's `dynamic: false`
+    # already stops anything under `raw` from being indexed at any depth.
+    - name: raw.resource.data
+      type: object
+      enabled: false
+      description: >-
+        Raw resource payload as returned by the cloud provider. Stored but not
+        indexed, to keep its arbitrary provider-defined shape from exploding the
+        field count. Fields needed for queries are lifted out of it at ingest,
+        see resource.lifecycle.
+    - name: lifecycle
+      type: group
+      description: >-
+        Lifecycle state of the resource, lifted at ingest from resource.raw,
+        which is not queryable because the findings index template sets
+        dynamic: false and resource.raw.resource.data is declared
+        enabled: false. Currently populated for gcp-compute-instance; other
+        providers may populate the same fields later. Used by serverless CSPM
+        metering (https://github.com/elastic/security-team/issues/17662).
+      fields:
+        - name: status
+          type: keyword
+          description: >-
+            Provider-reported lifecycle status of the resource, verbatim
+            (for example RUNNING or TERMINATED for GCP compute instances).
+        - name: incarnation
+          type: keyword
+          description: >-
+            Creation timestamp of the resource as an opaque identity token,
+            used to tell apart re-created resources that reuse the same name.
+        - name: created_at
+          type: date
+          description: Time at which the resource was created.
+        - name: last_started_at
+          type: date
+          description: Time at which the resource was last started.
+        - name: last_stopped_at
+          type: date
+          description: Time at which the resource was last stopped.
+        - name: last_run_ms
+          type: long
+          description: >-
+            Duration in milliseconds of the resource's last completed run,
+            precomputed as last_stopped_at minus last_started_at.

--- a/packages/cloud_security_posture/elasticsearch/transform/metering_state/fields/fields.yml
+++ b/packages/cloud_security_posture/elasticsearch/transform/metering_state/fields/fields.yml
@@ -1,0 +1,33 @@
+- name: resource.id
+  type: keyword
+  description: Identifier of the scanned resource.
+- name: resource.sub_type
+  type: keyword
+  description: Resource sub type, e.g. gcp-compute-instance.
+- name: resource.lifecycle.incarnation
+  type: keyword
+  description: Creation timestamp of this physical instance, used to keep a re-created resource that reuses a name from inheriting the previous one's state.
+- name: cloud.account.id
+  type: keyword
+  description: Cloud account the resource belongs to.
+- name: posture_type
+  type: keyword
+  description: Posture type of the findings this state was built from.
+- name: first_seen
+  type: date
+  description: Earliest scan timestamp for this incarnation.
+- name: last_seen
+  type: date
+  description: Latest scan timestamp for this incarnation.
+- name: span_ms
+  type: long
+  description: last_seen minus first_seen. Greater than zero means the incarnation was seen on at least two scans.
+- name: last_started_at
+  type: date
+  description: Most recent start time reported for this incarnation.
+- name: last_stopped_at
+  type: date
+  description: Most recent stop time reported for this incarnation.
+- name: last_run_ms
+  type: long
+  description: Duration of the run that ended at last_stopped_at. Absent when the instance never stopped; negative when it was restarted after its last stop.

--- a/packages/cloud_security_posture/elasticsearch/transform/metering_state/manifest.yml
+++ b/packages/cloud_security_posture/elasticsearch/transform/metering_state/manifest.yml
@@ -1,0 +1,5 @@
+start: true
+destination_index_template:
+  mappings:
+    dynamic: false
+    date_detection: false

--- a/packages/cloud_security_posture/elasticsearch/transform/metering_state/transform.yml
+++ b/packages/cloud_security_posture/elasticsearch/transform/metering_state/transform.yml
@@ -1,0 +1,86 @@
+source:
+  index:
+    - "logs-cloud_security_posture.findings-*"
+  query:
+    term:
+      rule.benchmark.posture_type: cspm
+dest:
+  index: "logs-cloud_security_posture.metering_state-default"
+pivot:
+  group_by:
+    resource.id:
+      terms:
+        field: resource.id
+    resource.lifecycle.incarnation:
+      terms:
+        field: resource.lifecycle.incarnation
+        missing_bucket: true
+    resource.sub_type:
+      terms:
+        field: resource.sub_type
+    cloud.account.id:
+      terms:
+        field: cloud.account.id
+    posture_type:
+      terms:
+        field: rule.benchmark.posture_type
+  aggregations:
+    first_seen:
+      min:
+        field: "@timestamp"
+    last_seen:
+      max:
+        field: "@timestamp"
+    # > 0 means this incarnation was seen on at least two scans.
+    span_ms:
+      bucket_script:
+        buckets_path:
+          first: first_seen
+          last: last_seen
+        script: "params.last - params.first"
+    # max, not top_metrics: top_metrics emits the STRING "null" for a metric
+    # absent from a bucket, which a date/long mapping rejects, dropping the whole
+    # document. max is equivalent here because these timestamps are monotonic
+    # within one incarnation, and the incarnation is part of the group key.
+    last_started_at:
+      max:
+        field: resource.lifecycle.last_started_at
+    last_stopped_at:
+      max:
+        field: resource.lifecycle.last_stopped_at
+    # Duration of the run that ended at last_stopped_at. Default gap_policy
+    # 'skip' leaves it absent when the instance never stopped. A NEGATIVE value
+    # means the instance was started again after its last stop, i.e. it is
+    # running now — that is how the billing query tells a restarted-and-running
+    # instance from a stopped one.
+    last_run_ms:
+      bucket_script:
+        buckets_path:
+          start: last_started_at
+          stop: last_stopped_at
+        script: "params.stop - params.start"
+description: Per-incarnation scan state (first/last seen, lifecycle) for stateful CSPM metering
+frequency: 5m
+sync:
+  time:
+    field: event.ingested
+    delay: 60s
+retention_policy:
+  time:
+    field: last_seen
+    max_age: 7d
+settings:
+  unattended: true
+  # top_metrics/bucket_script output mappings are not reliably deduced; the
+  # destination_index_template in manifest.yml pins them instead.
+  deduce_mappings: false
+_meta:
+  managed: true
+  # Bump this version to delete, reinstall, and restart the transform during package
+  # install. Required for any change to this file.
+  fleet_transform_version: 0.1.0
+  # Install and run under the installing user's credentials rather than the
+  # kibana system user. The elastic/kibana service account has no create_index
+  # or write privileges on the destination index, so a kibana-system install
+  # fails with a security_exception and the transform is never registered.
+  run_as_kibana_system: false

--- a/packages/cloud_security_posture/elasticsearch/transform/metering_state/transform.yml
+++ b/packages/cloud_security_posture/elasticsearch/transform/metering_state/transform.yml
@@ -79,8 +79,9 @@ _meta:
   # Bump this version to delete, reinstall, and restart the transform during package
   # install. Required for any change to this file.
   fleet_transform_version: 0.1.0
-  # Install and run under the installing user's credentials rather than the
-  # kibana system user. The elastic/kibana service account has no create_index
-  # or write privileges on the destination index, so a kibana-system install
-  # fails with a security_exception and the transform is never registered.
-  run_as_kibana_system: false
+  # run_as_kibana_system is deliberately left unset (defaults to true). This is
+  # an internal Elastic transform writing a system index that a Kibana
+  # background task bills from — not user data — so it runs as the internal
+  # user, matching the misconfiguration transform in this package. Setting it
+  # false would install under the logged-in user's credentials, which is for
+  # integration data that must stay scoped to what that user can read.

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.5.0"
+version: "3.6.0"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Summary

Adds the package-side support for stateful serverless CSPM metering: the ingest pipeline indexes GCP compute lifecycle fields, and a new `metering_state` transform maintains the per-incarnation scan state that the metering task bills from.

> [!WARNING]
> **Draft — blocked.** The transform runs as `kibana_system`, which does not yet have write privileges on its destination index. See Blocking dependency.

Related:
- https://github.com/elastic/security-team/issues/17662
- Blocked on ES grant: https://github.com/elastic/elasticsearch/issues/156939
- Kibana side (billing query + tests): https://github.com/elastic/kibana/pull/285268

---

### What's here

**1. Ingest pipeline** — lifts GCP compute lifecycle data out of the unindexed `resource.raw` payload into indexed `resource.lifecycle.*` fields (`status`, `incarnation`, `created_at`, `last_started_at`, `last_stopped_at`, `last_run_ms`). Without this the metering transform has nothing to group or sort on.

**2. `metering_state` transform** — a pivot transform writing one document per `(resource.id, incarnation, sub_type, account, posture_type)` into `logs-cloud_security_posture.metering_state-default`.

Grouping on `resource.lifecycle.incarnation` is the point: a spot VM that is destroyed and re-created under the same name starts a fresh bucket instead of inheriting the previous instance's `first_seen`, so `span_ms` never bridges two physically different machines.

Three design decisions worth review attention:

- **Runs as the internal user.** `run_as_kibana_system` is left unset (defaults to `true`), matching the `misconfiguration` transform in this package. This writes a system index that a Kibana background task bills from, not user data. Fleet's guidance is that internal packages touching system indices run as the internal user; `false` is for integration data that must stay scoped to what the installing user can read.
- **`max` + `bucket_script`, not `top_metrics`.** `top_metrics` emits the *string* `"null"` for a metric absent from a bucket, which the `date`/`long` destination mappings reject — dropping the whole document. That silently excluded every non-GCP resource and every never-stopped instance. `max` is equivalent here because these timestamps are monotonic within one incarnation, and the incarnation is part of the group key.
- **`last_run_ms` is signed on purpose.** `stop - start`; absent when the instance never stopped (default `gap_policy: skip`), negative when it was restarted after its last stop. The billing query uses that sign to tell a restarted-and-running instance from a stopped one, now that lifecycle status is no longer carried in the state document.

---

### Blocking dependency

The `elastic/kibana` service account needs write access to the destination index:

```
logs-cloud_security_posture.metering_state-default*
  -> create_index, index, delete, manage
```

Today it holds only `read`, via its `logs-*.*` grant — enough for the metering task's billing query, not enough for the transform to create and write the index. Without it, install fails with:

```
Cannot create transform [logs-cloud_security_posture.metering_state-default-0.1.0]
because user elastic/kibana lacks the required permissions
[logs-cloud_security_posture.metering_state-default:[delete, index]]
```

This is the same routine addition already made for `logs-cloud_security_posture.scores-default*`, `logs-cloud_security_posture.findings_latest-default*` and `security_solution-*.misconfiguration_latest-*` — all of which exist so this package's other assets can be provisioned.

---

### Aside: a Fleet bug found on the way here

An earlier revision set `run_as_kibana_system: false`. That is the wrong choice for system data, but it also surfaced what looks like a general Fleet defect worth reporting separately:

`run_reinstall_packages_for_global_asset_update.ts` → `reinstallPackageForInstallation` → `installPackage({ force: true })` with **no `request`**. `force: true` routes the transform into `transformsToRemoveWithDestIndex` (`install.ts:308-311`), which deletes the destination index; but with no `request`, `generateTransformSecondaryAuthHeaders` returns `undefined` (`transform_api_keys.ts:53-54`), so that delete runs as `elastic/kibana` and is denied.

By inspection this should affect any package using `run_as_kibana_system: false` whose destination index is outside the service account's grants — e.g. `logs-axonius_latest.dest_adapter-1`, which matches only `logs-*.*` (read). **I have not confirmed that against those packages**, and it is surprising enough to want a Fleet maintainer's read before it is treated as fact. It does not affect this PR now that the transform runs as the internal user.

---

### Test plan

```bash
elastic-package lint          # passes
elastic-package build         # produces cloud_security_posture-3.6.0.zip
```

Pipeline tests for the lifecycle fields are in `_dev/test/pipeline/test-gcp-lifecycle.json`.

End-to-end against a serverless FTR Kibana pointed at a local EPR serving this package:
1. `elastic-package build` in this package.
2. Run `docker.elastic.co/kibana-ci/package-registry-distribution:lite` with `package_paths` covering both `/packages/package-storage` and a mount of `integrations/build/packages`.
3. Start the serverless security FTR with `--xpack.fleet.registryUrl` pointed at it and `CLOUD_SECURITY_PLUGIN_VERSION` set to `3.6.0`.
4. Until the grant above lands, expect the transform install to fail with the `security_exception` quoted in Blocking dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)