### PR TITLE
[crowdstrike] Ignore User Agent Fields in the Policy Test

### DIFF
--- a/packages/crowdstrike/_dev/test/config.yml
+++ b/packages/crowdstrike/_dev/test/config.yml
@@ -1,0 +1,4 @@
+policy:
+  ignore_fields:
+    - state.user_agent
+    - user_agent


### PR DESCRIPTION
## Proposed commit message

```
crowdstrike: Ignore user_agent fields in policy tests

The CrowdStrike User-Agent embeds the package version, so policy tests fail when the rendered 
value is Elastic-crowdstrike/<version> instead of the hardcoded unknown. Ignore state.user_agent 
on CEL streams and user_agent on the Falcon streaming input so those comparisons stay stable 
across version bumps.
```
NOTE: This does not require changelog entry as this is the fix applied for policy test.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/crowdstrike directory.
- Run the following command to run tests.

> elastic-package test -v