### PR TITLE
[box_events] Fix cursor handling

### DIFF
--- a/packages/box_events/_dev/deploy/docker/files/config.yml
+++ b/packages/box_events/_dev/deploy/docker/files/config.yml
@@ -184,7 +184,7 @@ rules:
                       "type": "event"
                   }
               ],
-              "next_stream_position": "1152922976252290800"
+              "next_stream_position": 1152922976252290800
           }
           `}}
   - path: /2.0/events

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.2"
+  changes:
+    - description: Fix cursor handling.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20774
 - version: "3.5.1"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/box_events/data_stream/events/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/events/agent/stream/httpjson.yml.hbs
@@ -16,14 +16,15 @@ request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
   # If next_stream_position has scientific notation (from an earlier package
-  # version), convert it to a plain integer. Otherwise use the stored string,
-  # or the default initial value.
+  # version), convert it to a plain integer (with a margin to account for
+  # rounding errors). Otherwise use the stored string, or the default initial
+  # value.
   - set:
       target: url.params.stream_position
       value: >-
         [[- if index .cursor "next_stream_position" -]]
           [[- if ne .cursor.next_stream_position (replaceAll "e+" "" .cursor.next_stream_position) -]]
-            [[- toInt .cursor.next_stream_position -]]
+            [[- add (toInt .cursor.next_stream_position) -256 -]]
           [[- else -]]
             [[- .cursor.next_stream_position -]]
           [[- end -]]

--- a/packages/box_events/data_stream/events/agent/stream/httpjson.yml.hbs
+++ b/packages/box_events/data_stream/events/agent/stream/httpjson.yml.hbs
@@ -15,9 +15,21 @@ auth.oauth2:
 request.url: "{{api_url}}/2.0/events"
 request.method: "GET"
 request.transforms:
+  # If next_stream_position has scientific notation (from an earlier package
+  # version), convert it to a plain integer. Otherwise use the stored string,
+  # or the default initial value.
   - set:
       target: url.params.stream_position
-      value: '[[if index .cursor "next_stream_position"]][[.cursor.next_stream_position]][[else]][["0"]][[end]]'
+      value: >-
+        [[- if index .cursor "next_stream_position" -]]
+          [[- if ne .cursor.next_stream_position (replaceAll "e+" "" .cursor.next_stream_position) -]]
+            [[- toInt .cursor.next_stream_position -]]
+          [[- else -]]
+            [[- .cursor.next_stream_position -]]
+          [[- end -]]
+        [[- else -]]
+          [[- "0" -]]
+        [[- end -]]
 {{#if stream_type}}
   - set:
       target: url.params.stream_type
@@ -32,14 +44,16 @@ response.split:
   type: array
   keep_parent: false
 response.pagination:
+  # The next_stream_position may be received as a string or number, but should
+  # be sent (or stored) as a string, without scientific notation.
   - set:
       target: url.params.stream_position
-      value: '[[ if and (index .last_response.body "next_stream_position") (ge (len .last_response.body.entries) {{limit}}) ]][[.last_response.body.next_stream_position]][[end]]'
+      value: '[[ if and (index .last_response.body "next_stream_position") (ge (len .last_response.body.entries) {{limit}}) ]][[.last_response.body.next_stream_position | toJSON | replaceAll "\"" ""]][[end]]'
       fail_on_template_error: true
       do_not_log_failure: true
 cursor:
   next_stream_position:
-    value: '[[.last_response.body.next_stream_position]]'
+    value: '[[if index .last_response.body "next_stream_position"]][[.last_response.body.next_stream_position | toJSON | replaceAll "\"" ""]][[end]]'
 tags:
 {{#if preserve_original_event}}
 - preserve_original_event

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.6.1"
 name: box_events
 title: Box Events
-version: "3.5.1"
+version: "3.5.2"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[box_events] Fix next_stream_position handling

In #17118 it was assumed that next_stream_position has a string value.
It's still documented[1] as having either a string or int64 value, and
is returned as a number. The number needs special handling to avoid
being formatted with scientific notation and breaking the next request.

Now both types are handled. Cursor values in scientific notation are
converted so they can be used as plain integer strings.

[1]: https://developer.box.com/reference/get-events#response-next-stream-position-one-of-0
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Related issues

- Relates #17118
- Relates #14319