### PR TITLE
elasticsearch: point changelog at #20787

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Wire index mode and codec through the index_pivot transform, normalize missing values to standard/default in the monitoring_indices and index metrics ingest pipelines, and add dashboard visualizations for index mode and codec adoption. Requires Metricbeat 8.19+ (beats#49237) to collect elasticsearch.index.mode and elasticsearch.index.codec in the index metricset source data.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/20784
+      link: https://github.com/elastic/integrations/pull/20787
 - version: "1.22.0"
   changes:
     - description: Add security_stats data stream to collect per-node Document Level Security (DLS) bitset cache metrics from the Security Stats API (requires Elasticsearch 9.2+).


### PR DESCRIPTION
## Summary

- Point `packages/elasticsearch/changelog.yml` at #20787 so the package changelog check matches this review-fix PR.

## Test plan

- [ ] Confirm the changelog check on #20787 passes after merge.


Made with [Cursor](https://cursor.com)