### PR TITLE
[windows] Fix Sysmon Event ID 7 pipeline failure when dll.code_signature is missing

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix Sysmon Event ID 7 pipeline failure when `dll.code_signature` is missing.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/18014
+      link: https://github.com/elastic/integrations/pull/20796
 - version: "3.9.0"
   changes:
     - description: Parse Windows Security scheduled task XML and task names into structured winlog.scheduled_task.* fields for detection and hunting.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.9.1"
+  changes:
+    - description: Fix Sysmon Event ID 7 pipeline failure when `dll.code_signature` is missing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/18014
 - version: "3.9.0"
   changes:
     - description: Parse Windows Security scheduled task XML and task names into structured winlog.scheduled_task.* fields for detection and hunting.

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-image-loaded-failed-signature.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-image-loaded-failed-signature.json
@@ -1,0 +1,55 @@
+{
+    "events": [
+        {
+            "@timestamp": "2021-05-05T15:30:51.694Z",
+            "log": {
+                "level": "information"
+            },
+            "event": {
+                "original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>7</EventID><Version>3</Version><Level>4</Level><Task>7</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2020-10-28T02:39:26.388325200Z'/><EventRecordID>10685</EventRecordID><Correlation/><Execution ProcessID='1676' ThreadID='4796'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>vagrant</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2020-10-28 02:39:26.374</Data><Data Name='ProcessGuid'>{9f32b55f-d9de-5f98-f006-000000000600}</Data><Data Name='ProcessId'>5184</Data><Data Name='Image'>C:\\Windows\\System32\\dllhost.exe</Data><Data Name='ImageLoaded'>C:\\Windows\\System32\\IDStore.dll</Data><Data Name='FileVersion'>10.0.17763.1 (WinBuild.160101.0800)</Data><Data Name='Description'>Identity Store</Data><Data Name='Product'>Microsoft« Windows« Operating System</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>IdStore.dll</Data><Data Name='Hashes'>SHA1=9955A1C071C44A7CEECC0D928A9CFB7F64CC3F93,MD5=C7C45610F644906E6F7D664EF2E45B08,SHA256=4808F1101F4E42387D8DDB7A355668BAE3BF6F781C42D3BCD82E23446B1DEB3E,IMPHASH=194F3797B52231028C718B6D776C6853</Data><Data Name='Signed'>failed: Invalid hash</Data><Data Name='Signature'>-</Data><Data Name='SignatureStatus'>-</Data><Data Name='User'>DOMAIN\\username</Data></EventData></Event>",
+                "code": "7",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "winlog": {
+                "event_id": "7",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "version": 3,
+                "level": "information",
+                "process": {
+                    "pid": 1676,
+                    "thread": {
+                        "id": 4796
+                    }
+                },
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "vagrant",
+                "opcode": "Info",
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "time_created": "2020-10-28T02:39:26.388Z",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "event_data": {
+                    "UtcTime": "2020-10-28 02:39:26.374",
+                    "ProcessGuid": "{9f32b55f-d9de-5f98-f006-000000000600}",
+                    "Hashes": "SHA1=9955A1C071C44A7CEECC0D928A9CFB7F64CC3F93,MD5=C7C45610F644906E6F7D664EF2E45B08,SHA256=4808F1101F4E42387D8DDB7A355668BAE3BF6F781C42D3BCD82E23446B1DEB3E,IMPHASH=194F3797B52231028C718B6D776C6853",
+                    "Signed": "failed: Invalid hash",
+                    "SignatureStatus": "-",
+                    "ProcessId": "5184",
+                    "Image": "C:\\Windows\\System32\\dllhost.exe",
+                    "Description": "Identity Store",
+                    "Product": "Microsoft« Windows« Operating System",
+                    "Company": "Microsoft Corporation",
+                    "RuleName": "-",
+                    "OriginalFileName": "IdStore.dll",
+                    "ImageLoaded": "C:\\Windows\\System32\\IDStore.dll",
+                    "FileVersion": "10.0.17763.1 (WinBuild.160101.0800)",
+                    "Signature": "-",
+                    "User": "DOMAIN\\username"
+                },
+                "record_id": 10685
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-image-loaded-failed-signature.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-image-loaded-failed-signature.json-expected.json
@@ -1,0 +1,124 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2020-10-28T02:39:26.374Z",
+            "dll": {
+                "code_signature": {
+                    "status": "failed: Invalid hash"
+                },
+                "hash": {
+                    "md5": "c7c45610f644906e6f7d664ef2e45b08",
+                    "sha1": "9955a1c071c44a7ceecc0d928a9cfb7f64cc3f93",
+                    "sha256": "4808f1101f4e42387d8ddb7a355668bae3bf6f781c42d3bcd82e23446b1deb3e"
+                },
+                "name": "IDStore.dll",
+                "path": "C:\\Windows\\System32\\IDStore.dll",
+                "pe": {
+                    "imphash": "194f3797b52231028c718b6d776c6853",
+                    "original_file_name": "IdStore.dll"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": [
+                    "Image loaded",
+                    "load"
+                ],
+                "category": [
+                    "process",
+                    "library"
+                ],
+                "code": "7",
+                "created": "2020-10-28T02:39:26.388Z",
+                "kind": "event",
+                "original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>7</EventID><Version>3</Version><Level>4</Level><Task>7</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2020-10-28T02:39:26.388325200Z'/><EventRecordID>10685</EventRecordID><Correlation/><Execution ProcessID='1676' ThreadID='4796'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>vagrant</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2020-10-28 02:39:26.374</Data><Data Name='ProcessGuid'>{9f32b55f-d9de-5f98-f006-000000000600}</Data><Data Name='ProcessId'>5184</Data><Data Name='Image'>C:\\Windows\\System32\\dllhost.exe</Data><Data Name='ImageLoaded'>C:\\Windows\\System32\\IDStore.dll</Data><Data Name='FileVersion'>10.0.17763.1 (WinBuild.160101.0800)</Data><Data Name='Description'>Identity Store</Data><Data Name='Product'>Microsoft« Windows« Operating System</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>IdStore.dll</Data><Data Name='Hashes'>SHA1=9955A1C071C44A7CEECC0D928A9CFB7F64CC3F93,MD5=C7C45610F644906E6F7D664EF2E45B08,SHA256=4808F1101F4E42387D8DDB7A355668BAE3BF6F781C42D3BCD82E23446B1DEB3E,IMPHASH=194F3797B52231028C718B6D776C6853</Data><Data Name='Signed'>failed: Invalid hash</Data><Data Name='Signature'>-</Data><Data Name='SignatureStatus'>-</Data><Data Name='User'>DOMAIN\\username</Data></EventData></Event>",
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "change",
+                    "start"
+                ]
+            },
+            "file": {
+                "code_signature": {
+                    "trusted": false
+                },
+                "directory": "C:\\Windows\\System32",
+                "extension": "dll",
+                "hash": {
+                    "md5": "c7c45610f644906e6f7d664ef2e45b08",
+                    "sha1": "9955a1c071c44a7ceecc0d928a9cfb7f64cc3f93",
+                    "sha256": "4808f1101f4e42387d8ddb7a355668bae3bf6f781c42d3bcd82e23446b1deb3e"
+                },
+                "name": "IDStore.dll",
+                "path": "C:\\Windows\\System32\\IDStore.dll",
+                "pe": {
+                    "company": "Microsoft Corporation",
+                    "description": "Identity Store",
+                    "file_version": "10.0.17763.1 (WinBuild.160101.0800)",
+                    "imphash": "194f3797b52231028c718b6d776c6853",
+                    "original_file_name": "IdStore.dll",
+                    "product": "Microsoft« Windows« Operating System"
+                }
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{9f32b55f-d9de-5f98-f006-000000000600}",
+                "executable": "C:\\Windows\\System32\\dllhost.exe",
+                "name": "dllhost.exe",
+                "pid": 5184
+            },
+            "related": {
+                "hash": [
+                    "4808f1101f4e42387d8ddb7a355668bae3bf6f781c42d3bcd82e23446b1deb3e",
+                    "9955a1c071c44a7ceecc0d928a9cfb7f64cc3f93",
+                    "c7c45610f644906e6f7d664ef2e45b08",
+                    "194f3797b52231028c718b6d776c6853"
+                ],
+                "user": [
+                    "username"
+                ]
+            },
+            "user": {
+                "domain": "DOMAIN",
+                "id": "S-1-5-18",
+                "name": "username"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "vagrant",
+                "event_data": {
+                    "Company": "Microsoft Corporation",
+                    "Description": "Identity Store",
+                    "FileVersion": "10.0.17763.1 (WinBuild.160101.0800)",
+                    "Product": "Microsoft« Windows« Operating System",
+                    "Signed": "failed: Invalid hash"
+                },
+                "event_id": "7",
+                "opcode": "Info",
+                "process": {
+                    "pid": 1676,
+                    "thread": {
+                        "id": 4796
+                    }
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "10685",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 3
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -737,15 +737,12 @@ processors:
         } else if (ctx.winlog?.event_data?.Signed instanceof String && ctx.winlog.event_data.Signed.startsWith("failed:")) {
           status = ctx.winlog.event_data.Signed;
         }
-        if (status != null) {
-          if (ctx.dll == null) {
-            ctx.dll = new HashMap();
-          }
-          if (ctx.dll.code_signature == null) {
-            ctx.dll.code_signature = new HashMap();
-          }
-          ctx.dll.code_signature.status = status;
+        if (status == null) {
+          return;
         }
+        ctx.dll = ctx.dll ?: [:];
+        ctx.dll.code_signature = ctx.dll.code_signature ?: [:];
+        ctx.dll.code_signature.status = status;
   - set:
       field: dll.hash
       copy_from: _temp.hashes

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -729,12 +729,22 @@ processors:
       lang: painless
       if: ctx.event.code == "7"
       source: |-
+        def status = null;
         if (ctx.winlog?.event_data?.Signed == 'true') {
-          ctx.dll.code_signature.status = "trusted";
+          status = "trusted";
         } else if (ctx.winlog?.event_data?.SignatureStatus == "Unavailable") {
-          ctx.dll.code_signature.status = "Unavailable";
+          status = "Unavailable";
         } else if (ctx.winlog?.event_data?.Signed instanceof String && ctx.winlog.event_data.Signed.startsWith("failed:")) {
-          ctx.dll.code_signature.status = ctx.winlog.event_data.Signed;
+          status = ctx.winlog.event_data.Signed;
+        }
+        if (status != null) {
+          if (ctx.dll == null) {
+            ctx.dll = new HashMap();
+          }
+          if (ctx.dll.code_signature == null) {
+            ctx.dll.code_signature = new HashMap();
+          }
+          ctx.dll.code_signature.status = status;
         }
   - set:
       field: dll.hash

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-image-loaded-failed-signature.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-image-loaded-failed-signature.json
@@ -1,0 +1,55 @@
+{
+    "events": [
+        {
+            "@timestamp": "2021-05-05T15:30:51.694Z",
+            "log": {
+                "level": "information"
+            },
+            "event": {
+                "original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>7</EventID><Version>3</Version><Level>4</Level><Task>7</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2020-10-28T02:39:26.388325200Z'/><EventRecordID>10685</EventRecordID><Correlation/><Execution ProcessID='1676' ThreadID='4796'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>vagrant</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2020-10-28 02:39:26.374</Data><Data Name='ProcessGuid'>{9f32b55f-d9de-5f98-f006-000000000600}</Data><Data Name='ProcessId'>5184</Data><Data Name='Image'>C:\\Windows\\System32\\dllhost.exe</Data><Data Name='ImageLoaded'>C:\\Windows\\System32\\IDStore.dll</Data><Data Name='FileVersion'>10.0.17763.1 (WinBuild.160101.0800)</Data><Data Name='Description'>Identity Store</Data><Data Name='Product'>Microsoft« Windows« Operating System</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>IdStore.dll</Data><Data Name='Hashes'>SHA1=9955A1C071C44A7CEECC0D928A9CFB7F64CC3F93,MD5=C7C45610F644906E6F7D664EF2E45B08,SHA256=4808F1101F4E42387D8DDB7A355668BAE3BF6F781C42D3BCD82E23446B1DEB3E,IMPHASH=194F3797B52231028C718B6D776C6853</Data><Data Name='Signed'>failed: Invalid hash</Data><Data Name='Signature'>-</Data><Data Name='SignatureStatus'>-</Data><Data Name='User'>DOMAIN\\username</Data></EventData></Event>",
+                "code": "7",
+                "kind": "event",
+                "provider": "Microsoft-Windows-Sysmon"
+            },
+            "winlog": {
+                "event_id": "7",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "version": 3,
+                "level": "information",
+                "process": {
+                    "pid": 1676,
+                    "thread": {
+                        "id": 4796
+                    }
+                },
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "vagrant",
+                "opcode": "Info",
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "time_created": "2020-10-28T02:39:26.388Z",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "event_data": {
+                    "UtcTime": "2020-10-28 02:39:26.374",
+                    "ProcessGuid": "{9f32b55f-d9de-5f98-f006-000000000600}",
+                    "Hashes": "SHA1=9955A1C071C44A7CEECC0D928A9CFB7F64CC3F93,MD5=C7C45610F644906E6F7D664EF2E45B08,SHA256=4808F1101F4E42387D8DDB7A355668BAE3BF6F781C42D3BCD82E23446B1DEB3E,IMPHASH=194F3797B52231028C718B6D776C6853",
+                    "Signed": "failed: Invalid hash",
+                    "SignatureStatus": "-",
+                    "ProcessId": "5184",
+                    "Image": "C:\\Windows\\System32\\dllhost.exe",
+                    "Description": "Identity Store",
+                    "Product": "Microsoft« Windows« Operating System",
+                    "Company": "Microsoft Corporation",
+                    "RuleName": "-",
+                    "OriginalFileName": "IdStore.dll",
+                    "ImageLoaded": "C:\\Windows\\System32\\IDStore.dll",
+                    "FileVersion": "10.0.17763.1 (WinBuild.160101.0800)",
+                    "Signature": "-",
+                    "User": "DOMAIN\\username"
+                },
+                "record_id": 10685
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-image-loaded-failed-signature.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-image-loaded-failed-signature.json-expected.json
@@ -1,0 +1,118 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2020-10-28T02:39:26.374Z",
+            "dll": {
+                "code_signature": {
+                    "status": "failed: Invalid hash"
+                },
+                "hash": {
+                    "md5": "c7c45610f644906e6f7d664ef2e45b08",
+                    "sha1": "9955a1c071c44a7ceecc0d928a9cfb7f64cc3f93",
+                    "sha256": "4808f1101f4e42387d8ddb7a355668bae3bf6f781c42d3bcd82e23446b1deb3e"
+                },
+                "name": "IDStore.dll",
+                "path": "C:\\Windows\\System32\\IDStore.dll",
+                "pe": {
+                    "imphash": "194f3797b52231028c718b6d776c6853",
+                    "original_file_name": "IdStore.dll"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": [
+                    "Image loaded",
+                    "load"
+                ],
+                "category": [
+                    "process",
+                    "library"
+                ],
+                "code": "7",
+                "created": "2020-10-28T02:39:26.388Z",
+                "kind": "event",
+                "original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/><EventID>7</EventID><Version>3</Version><Level>4</Level><Task>7</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2020-10-28T02:39:26.388325200Z'/><EventRecordID>10685</EventRecordID><Correlation/><Execution ProcessID='1676' ThreadID='4796'/><Channel>Microsoft-Windows-Sysmon/Operational</Channel><Computer>vagrant</Computer><Security UserID='S-1-5-18'/></System><EventData><Data Name='RuleName'>-</Data><Data Name='UtcTime'>2020-10-28 02:39:26.374</Data><Data Name='ProcessGuid'>{9f32b55f-d9de-5f98-f006-000000000600}</Data><Data Name='ProcessId'>5184</Data><Data Name='Image'>C:\\Windows\\System32\\dllhost.exe</Data><Data Name='ImageLoaded'>C:\\Windows\\System32\\IDStore.dll</Data><Data Name='FileVersion'>10.0.17763.1 (WinBuild.160101.0800)</Data><Data Name='Description'>Identity Store</Data><Data Name='Product'>Microsoft« Windows« Operating System</Data><Data Name='Company'>Microsoft Corporation</Data><Data Name='OriginalFileName'>IdStore.dll</Data><Data Name='Hashes'>SHA1=9955A1C071C44A7CEECC0D928A9CFB7F64CC3F93,MD5=C7C45610F644906E6F7D664EF2E45B08,SHA256=4808F1101F4E42387D8DDB7A355668BAE3BF6F781C42D3BCD82E23446B1DEB3E,IMPHASH=194F3797B52231028C718B6D776C6853</Data><Data Name='Signed'>failed: Invalid hash</Data><Data Name='Signature'>-</Data><Data Name='SignatureStatus'>-</Data><Data Name='User'>DOMAIN\\username</Data></EventData></Event>",
+                "provider": "Microsoft-Windows-Sysmon",
+                "type": [
+                    "change",
+                    "start"
+                ]
+            },
+            "file": {
+                "code_signature": {
+                    "trusted": false
+                },
+                "directory": "C:\\Windows\\System32",
+                "extension": "dll",
+                "hash": {
+                    "md5": "c7c45610f644906e6f7d664ef2e45b08",
+                    "sha1": "9955a1c071c44a7ceecc0d928a9cfb7f64cc3f93",
+                    "sha256": "4808f1101f4e42387d8ddb7a355668bae3bf6f781c42d3bcd82e23446b1deb3e"
+                },
+                "name": "IDStore.dll",
+                "path": "C:\\Windows\\System32\\IDStore.dll",
+                "pe": {
+                    "company": "Microsoft Corporation",
+                    "description": "Identity Store",
+                    "file_version": "10.0.17763.1 (WinBuild.160101.0800)",
+                    "imphash": "194f3797b52231028c718b6d776c6853",
+                    "original_file_name": "IdStore.dll",
+                    "product": "Microsoft« Windows« Operating System"
+                }
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "entity_id": "{9f32b55f-d9de-5f98-f006-000000000600}",
+                "executable": "C:\\Windows\\System32\\dllhost.exe",
+                "name": "dllhost.exe",
+                "pid": 5184
+            },
+            "related": {
+                "hash": [
+                    "4808f1101f4e42387d8ddb7a355668bae3bf6f781c42d3bcd82e23446b1deb3e",
+                    "9955a1c071c44a7ceecc0d928a9cfb7f64cc3f93",
+                    "c7c45610f644906e6f7d664ef2e45b08",
+                    "194f3797b52231028c718b6d776c6853"
+                ],
+                "user": [
+                    "username"
+                ]
+            },
+            "user": {
+                "domain": "DOMAIN",
+                "id": "S-1-5-18",
+                "name": "username"
+            },
+            "winlog": {
+                "channel": "Microsoft-Windows-Sysmon/Operational",
+                "computer_name": "vagrant",
+                "event_data": {
+                    "Company": "Microsoft Corporation",
+                    "Description": "Identity Store",
+                    "FileVersion": "10.0.17763.1 (WinBuild.160101.0800)",
+                    "Product": "Microsoft« Windows« Operating System",
+                    "Signed": "failed: Invalid hash"
+                },
+                "event_id": "7",
+                "opcode": "Info",
+                "process": {
+                    "pid": 1676,
+                    "thread": {
+                        "id": 4796
+                    }
+                },
+                "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
+                "provider_name": "Microsoft-Windows-Sysmon",
+                "record_id": "10685",
+                "user": {
+                    "identifier": "S-1-5-18"
+                },
+                "version": 3
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -737,15 +737,12 @@ processors:
         } else if (ctx.winlog?.event_data?.Signed instanceof String && ctx.winlog.event_data.Signed.startsWith("failed:")) {
           status = ctx.winlog.event_data.Signed;
         }
-        if (status != null) {
-          if (ctx.dll == null) {
-            ctx.dll = new HashMap();
-          }
-          if (ctx.dll.code_signature == null) {
-            ctx.dll.code_signature = new HashMap();
-          }
-          ctx.dll.code_signature.status = status;
+        if (status == null) {
+          return;
         }
+        ctx.dll = ctx.dll ?: [:];
+        ctx.dll.code_signature = ctx.dll.code_signature ?: [:];
+        ctx.dll.code_signature.status = status;
   - set:
       field: dll.hash
       copy_from: _temp.hashes

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -729,12 +729,22 @@ processors:
       lang: painless
       if: ctx.event.code == "7"
       source: |-
+        def status = null;
         if (ctx.winlog?.event_data?.Signed == 'true') {
-          ctx.dll.code_signature.status = "trusted";
+          status = "trusted";
         } else if (ctx.winlog?.event_data?.SignatureStatus == "Unavailable") {
-          ctx.dll.code_signature.status = "Unavailable";
+          status = "Unavailable";
         } else if (ctx.winlog?.event_data?.Signed instanceof String && ctx.winlog.event_data.Signed.startsWith("failed:")) {
-          ctx.dll.code_signature.status = ctx.winlog.event_data.Signed;
+          status = ctx.winlog.event_data.Signed;
+        }
+        if (status != null) {
+          if (ctx.dll == null) {
+            ctx.dll = new HashMap();
+          }
+          if (ctx.dll.code_signature == null) {
+            ctx.dll.code_signature = new HashMap();
+          }
+          ctx.dll.code_signature.status = status;
         }
   - set:
       field: dll.hash

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 3.9.0
+version: 3.9.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Fix Sysmon Event ID 7 pipeline failure when dll.code_signature is missing

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Related issues

- Closes #18014