### PR TITLE
[ti_misp] Add a configurable Refetch Interval for Threat Attributes data stream

### DIFF
--- a/packages/ti_misp/_dev/build/docs/README.md
+++ b/packages/ti_misp/_dev/build/docs/README.md
@@ -28,18 +28,18 @@ This data stream uses the `/attributes/restSearch` API endpoint which returns mo
 #### Expiration of Indicators of Compromise (IOCs)
 The ingested IOCs expire after certain duration which is indicated by the `decayed` field. An [Elastic Transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html) is created to faciliate only active IOCs be available to the end users. This transform creates destination indices named `logs-ti_misp_latest.dest_threat_attributes-*` which only contains active and unexpired IOCs. The latest destination index also has an alias named `logs-ti_misp_latest.threat_attributes`. When querying for active indicators or setting up indicator match rules, only use the latest destination indices or the alias to avoid false positives from expired IOCs. Dashboards for `Threat Attributes` datastream are also pointing to the latest destination indices containing active IoCs. Please read [ILM Policy](#ilm-policy) below which is added to avoid unbounded growth on source datastream `.ds-logs-ti_misp.threat_attributes-*` indices.
 
-#### Daily Refetch Mode
+#### Refetch Mode
 By default, the integration uses incremental updates, only fetching attributes that have been modified since the last poll (tracked via an internal cursor). However, MISP's decay scores are dynamic and decrease over time, which means an attribute's decay status may change without the attribute itself being modified. In such cases, incremental updates would not capture the updated decay state.
 
-To address this, users can enable the `Enable Daily Refetch` toggle. When enabled, the integration will:
-1. **Perform a daily full refetch**: Every 24 hours, the cursor is reset and all attributes from the configured `Initial Interval` are re-fetched from MISP.
+To address this, users can enable the `Enable Refetch` toggle. When enabled, the integration will:
+1. **Perform a full refetch**: Every `Refetch Interval` (default 24 hours), the cursor is reset and all attributes from the configured `Initial Interval` are re-fetched from MISP.
 2. **Update decay states**: Thanks to the re-ingest of all attributes with their current decay scores from MISP, it removes any that have since been marked as decayed from destination indices.
 
 This approach ensures that:
 - The destination indices stay aligned with MISP's current view of valid indicators
 - Attributes that become decayed in MISP are automatically removed in the next refetch cycle from destination indices
 
-**Note**: This mode will re-ingest all attributes within the `Initial Interval` window, which may result in higher data volume during the refetch period. The transform handles deduplication via unique keys. Attributes already marked as decayed by MISP's decay models during ingestion will be removed immediately.
+**Note**: This mode will re-ingest all attributes within the `Initial Interval` window, which may result in higher data volume during the refetch period. Short refetch intervals amplify that volume. The transform handles deduplication via unique keys. Attributes already marked as decayed by MISP's decay models during ingestion will be removed immediately.
 
 #### Handling Orphaned IOCs
 Some IOCs may never get decayed/expired and will continue to stay in the latest destination indices `logs-ti_misp_latest.dest_threat_attributes-*`. To avoid any false positives from such orphaned IOCs, users are allowed to configure `IOC Expiration Duration` parameter while setting up the integration. This parameter deletes all data inside the destination indices `logs-ti_misp_latest.dest_threat_attributes-*` after this specified duration is reached, defaults to `90d` after attribute's `max(last_seen, timestamp)`. Note that `IOC Expiration Duration` parameter only exists to add a fail-safe default expiration in case IOCs never expire.

--- a/packages/ti_misp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_misp/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   misp:
-    image: docker.elastic.co/observability/stream:v0.18.0
+    image: docker.elastic.co/observability/stream:v0.25.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_misp/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_misp/_dev/deploy/docker/files/config.yml
@@ -404,7 +404,38 @@ rules:
               }
             ]
           }
-  - path: /attributes/restSearch # sequence 3, page 1 (repeats)
+  # =============================================================================================
+  # /attributes/restSearch  (threat_attributes data stream)
+  # =============================================================================================
+  #
+  # A FULL fetch always sends `timestamp = now - initial_interval` (a large, "current" epoch), so it
+  # only matches the catch-all `timestamp":"\d+"` rule at the very BOTTOM ("fresh full-fetch").
+  # Incremental polls send a fixed historical cursor value and match the SPECIFIC rules above it.
+  # That is why the fresh-full-fetch rule is listed last.
+  #
+  # REQUEST TIMELINE for the daily-refetch test (interval=1s, initial_interval=10s, refetch_interval=5s
+  # -> a refetch fires ~5s after the first poll):
+  #
+  #   STEP 1  (t~0s, page 1) first poll, no cursor -> FULL fetch -> "fresh full-fetch" rule,
+  #           rolling response[0] = dataset A (ids 1-2). cursor.timestamp -> 1412320446 (A's max ts).
+  #   STEP 1b (t~0s, page 2) -> "full-fetch page 2" rule -> empty -> stops pagination.
+  #   STEP 2  (t~1s, page 1) not yet time to refetch -> cursor 1412320446 -> "STEP 2" rule ->
+  #           8 attributes. cursor.timestamp -> 1700667505 (their max ts).
+  #   STEP 2b (t~1s, page 2) -> "STEP 2 page 2" rule -> empty -> stops pagination.
+  #   STEP 3  (t~2-4s, page 1) not yet time to refetch -> cursor 1700667505 -> "STEP 3" rule -> empty.
+  #   STEP 4  (t~5s, page 1) refetch_interval elapsed -> FULL fetch -> "fresh full-fetch" rule,
+  #           rolling response[1] = dataset B (ids 9001-9003). cursor.timestamp -> 1750000002.
+  #   STEP 4b (t~5s, page 2) -> "full-fetch page 2" rule -> empty -> stops pagination.
+  #   STEP 5  (t~6-9s, page 1) not yet time to refetch -> cursor 1750000002 -> "STEP 5" rule -> empty.
+  #   STEP 6  (t~10s) next refetch -> "fresh full-fetch" rolls back to dataset A (same _ids -> overwrite,
+  #           no new docs); the cycle repeats. Total unique docs stays 13.
+  #
+  # Indexed unique docs: dataset A (2) + STEP 2 attributes (8) + dataset B (3) = 13 => assert.hit_count.
+  #
+  # The default (non-refetch) test runs STEP 1 -> STEP 2 -> STEP 3 only, never advances the rolling
+  # response to dataset B, and asserts hit_count = 10.
+  # ---------------------------------------------------------------------------------------------
+  - path: /attributes/restSearch # STEP 3: incremental polls, cursor=1700667505 (max ts of STEP 2) -> empty (repeats)
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -420,7 +451,7 @@ rules:
           X-Rate-Limit-Reset:
             - "60"
         body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
-  - path: /attributes/restSearch # sequence 2, page 2
+  - path: /attributes/restSearch # STEP 2b: pagination page 2 for STEP 2 (cursor=1412320446) -> empty
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -436,7 +467,7 @@ rules:
           X-Rate-Limit-Reset:
             - "60"
         body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
-  - path: /attributes/restSearch # sequence 2, page 1
+  - path: /attributes/restSearch # STEP 2: first incremental poll, cursor=1412320446 (max ts of dataset A) -> 8 attributes
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -998,7 +1029,7 @@ rules:
               ]
             }
           }
-  - path: /attributes/restSearch # sequence 1, page 2
+  - path: /attributes/restSearch # STEP 1b/4b: pagination page 2 of every full fetch -> empty (stops pagination)
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -1014,7 +1045,27 @@ rules:
           X-Rate-Limit-Reset:
             - "60"
         body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
-  - path: /attributes/restSearch # sequence 1, page 1
+  - path: /attributes/restSearch # STEP 5: incremental polls after the refetch, cursor=1750000002 (max ts of dataset B) -> empty
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"includeDecayScore":"true","limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"1750000002"/
+    responses:
+      - status_code: 200
+        headers:
+          X-Rate-Limit-Limit:
+            - "10"
+          X-Rate-Limit-Remaining:
+            - "100"
+          X-Rate-Limit-Reset:
+            - "60"
+        body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
+  # "fresh full-fetch" rule: served on STEP 1 (first poll) and STEP 4 (each refetch). Both send
+  # timestamp = now - initial_interval, which only this catch-all `\d+` rule matches, so it must be
+  # LAST (below every specific incremental rule). Its responses roll: response[0] = dataset A on the
+  # first full-fetch, response[1] = dataset B on the refetch. See the timeline above.
+  - path: /attributes/restSearch # STEP 1 & STEP 4: fresh full-fetch page 1 (rolling: dataset A, then dataset B on the refetch)
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -1085,6 +1136,102 @@ rules:
                     "info": "OSINT ShellShock scanning IPs from OpenDNS",
                     "orgc_id": "2",
                     "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
+                  }
+                }
+              ]
+            }
+          }
+      - status_code: 200
+        headers:
+          X-Rate-Limit-Limit:
+            - "10"
+          X-Rate-Limit-Remaining:
+            - "100"
+          X-Rate-Limit-Reset:
+            - "60"
+        body: |-
+          {
+            "response": {
+              "Attribute": [
+                {
+                  "id": "9001",
+                  "event_id": "9001",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "link",
+                  "to_ids": false,
+                  "uuid": "9a1b2c3d-0001-4a57-bfb8-1fda950d2101",
+                  "timestamp": "1750000000",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "refetch cycle test attribute 1",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "http://refetch.example.test/one",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "9001",
+                    "info": "Refetch cycle test event",
+                    "orgc_id": "2",
+                    "uuid": "9a1b2c3d-0000-4f8f-bb11-6d13950d2100"
+                  }
+                },
+                {
+                  "id": "9002",
+                  "event_id": "9001",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "text",
+                  "to_ids": false,
+                  "uuid": "9a1b2c3d-0002-4a57-bfb8-1fda950d2102",
+                  "timestamp": "1750000001",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "refetch cycle test attribute 2",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "Refetch cycle test text",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "9001",
+                    "info": "Refetch cycle test event",
+                    "orgc_id": "2",
+                    "uuid": "9a1b2c3d-0000-4f8f-bb11-6d13950d2100"
+                  }
+                },
+                {
+                  "id": "9003",
+                  "event_id": "9001",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "comment",
+                  "to_ids": false,
+                  "uuid": "9a1b2c3d-0003-4a57-bfb8-1fda950d2103",
+                  "timestamp": "1750000002",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "refetch cycle test attribute 3",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "Refetch cycle test comment",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "9001",
+                    "info": "Refetch cycle test event",
+                    "orgc_id": "2",
+                    "uuid": "9a1b2c3d-0000-4f8f-bb11-6d13950d2100"
                   }
                 }
               ]

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.0"
+  changes:
+    - description: Add a configurable `Refetch Interval` for Threat Attributes data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.45.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add a configurable `Refetch Interval` for Threat Attributes data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20801
 - version: "1.45.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/ti_misp/data_stream/threat_attributes/_dev/test/system/test-daily-refetch-config.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/_dev/test/system/test-daily-refetch-config.yml
@@ -1,3 +1,4 @@
+wait_for_data_timeout: 1m
 input: httpjson
 service: misp
 vars: ~
@@ -10,7 +11,8 @@ data_stream:
     initial_interval: 10s
     enable_request_tracer: true
     daily_refetch: true
-    refetch_interval: 24h
+    # Low refetch interval so the elapsed-time refetch branch fires within the test window.
+    refetch_interval: 5s
     ioc_expiration_duration: 5d
 assert:
-  hit_count: 10
+  hit_count: 13

--- a/packages/ti_misp/data_stream/threat_attributes/_dev/test/system/test-daily-refetch-config.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/_dev/test/system/test-daily-refetch-config.yml
@@ -10,6 +10,7 @@ data_stream:
     initial_interval: 10s
     enable_request_tracer: true
     daily_refetch: true
+    refetch_interval: 24h
     ioc_expiration_duration: 5d
 assert:
   hit_count: 10

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -49,15 +49,15 @@ request.transforms:
     target: body.returnFormat
     value: json
 {{#if daily_refetch}}
-# Daily refetch mode: every 24 hours, reset the request window to initial_interval to re-fetch all
-# attributes (picking up current decay scores). The decision is made here in the request transform,
+# Refetch mode: every refetch_interval, reset the request window to initial_interval to re-fetch
+# all attributes (picking up current decay scores). The decision is made here in the request transform,
 # where the cursor state is readable. The chosen refetch marker is echoed through url.params so the
 # cursor value template can persist it: httpjson evaluates cursor templates with an empty .cursor, so
 # the cursor field cannot read its own previous value, but it can read .last_response.url.params.
 - set:
     target: body.timestamp
     value: |-
-      [[- $dailyRefetchDuration := (parseDuration "24h") -]]
+      [[- $dailyRefetchDuration := (parseDuration "{{refetch_interval}}") -]]
       [[- $initialInterval := (parseDuration "-{{initial_interval}}") -]]
       [[- $initialTimestamp := (now $initialInterval).Unix -]]
       [[- $isDailyRefetch := true -]]
@@ -94,7 +94,7 @@ request.transforms:
     # parameter is ignored by the server. This mirrors the existing url.params.timestamp workaround.
     target: url.params.daily_refetch_at
     value: |-
-      [[- $dailyRefetchDuration := (parseDuration "24h") -]]
+      [[- $dailyRefetchDuration := (parseDuration "{{refetch_interval}}") -]]
       [[- $isDailyRefetch := true -]]
       [[- if index .cursor "last_daily_refetch" -]]
         [[- $lastRefetch := (parseDate .cursor.last_daily_refetch "RFC3339") -]]

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -37,13 +37,22 @@ streams:
         description: How far back to look for indicators the first time the agent is started. Supported units for this parameter are h/m/s.
       - name: daily_refetch
         type: bool
-        title: Enable Daily Refetch
+        title: Enable Refetch
         multi: false
         required: false
         show_user: true
         default: false
         description: >-
-          When enabled, the integration performs a daily full refetch of all attributes from the MISP API (every 24 hours), ignoring the cursor and re-fetching from Initial Interval. This ensures decay scores are updated and attributes marked as decayed by MISP's decay models are removed from destination indices.
+          When enabled, the integration periodically performs a full refetch of all attributes from the MISP API, ignoring the cursor and re-fetching from Initial Interval. The cadence is controlled by Refetch Interval (default 24 hours). This ensures decay scores are updated and attributes marked as decayed by MISP's decay models are removed from destination indices.
+      - name: refetch_interval
+        type: text
+        title: Refetch Interval
+        multi: false
+        required: true
+        show_user: true
+        default: 24h
+        description: >-
+          How often to perform a full refetch of all attributes when `Enable Refetch` is on. Supported units for this parameter are h/m/s. Short intervals re-ingest the full Initial Interval window and can produce high data volume.
       - name: ioc_expiration_duration
         type: text
         title: IOC Expiration Duration

--- a/packages/ti_misp/data_stream/threat_attributes/sample_event.json
+++ b/packages/ti_misp/data_stream/threat_attributes/sample_event.json
@@ -1,22 +1,22 @@
 {
     "@timestamp": "2014-10-03T07:14:05.000Z",
     "agent": {
-        "ephemeral_id": "4fbc6e3b-1cde-4af3-b94e-1d1a466727f8",
-        "id": "36862468-ab0e-46c3-90f7-c056d53448bf",
-        "name": "elastic-agent-10722",
+        "ephemeral_id": "f168658d-c93b-49ce-9cd4-adc2bc90a386",
+        "id": "8430f420-48a5-495a-bfeb-95437d5a76c4",
+        "name": "elastic-agent-44954",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "ti_misp.threat_attributes",
-        "namespace": "87784",
+        "namespace": "84697",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "36862468-ab0e-46c3-90f7-c056d53448bf",
+        "id": "8430f420-48a5-495a-bfeb-95437d5a76c4",
         "snapshot": false,
         "version": "8.19.4"
     },
@@ -25,9 +25,9 @@
         "category": [
             "threat"
         ],
-        "created": "2026-08-19T09:41:28.780Z",
+        "created": "2026-08-21T06:12:23.358Z",
         "dataset": "ti_misp.threat_attributes",
-        "ingested": "2026-08-19T09:41:31Z",
+        "ingested": "2026-08-21T06:12:26Z",
         "kind": "enrichment",
         "original": "{\"Event\":{\"distribution\":\"3\",\"id\":\"1\",\"info\":\"OSINT ShellShock scanning IPs from OpenDNS\",\"org_id\":\"1\",\"orgc_id\":\"2\",\"uuid\":\"542e4c9c-cadc-4f8f-bb11-6d13950d210b\"},\"category\":\"External analysis\",\"comment\":\"\",\"deleted\":false,\"disable_correlation\":false,\"distribution\":\"5\",\"event_id\":\"1\",\"first_seen\":null,\"id\":\"1\",\"last_seen\":null,\"object_id\":\"0\",\"object_relation\":null,\"sharing_group_id\":\"0\",\"timestamp\":\"1412320445\",\"to_ids\":false,\"type\":\"link\",\"uuid\":\"542e4cbd-ee78-4a57-bfb8-1fda950d210b\",\"value\":\"http://labs.opendns.com/2014/10/02/opendns-and-bash/\"}",
         "type": [

--- a/packages/ti_misp/data_stream/threat_attributes/sample_event.json
+++ b/packages/ti_misp/data_stream/threat_attributes/sample_event.json
@@ -1,35 +1,34 @@
 {
     "@timestamp": "2014-10-03T07:14:05.000Z",
     "agent": {
-        "ephemeral_id": "8840bb4d-14f5-474c-a674-58b87780cf68",
-        "id": "6b0fdd15-672d-4d68-8efe-da26fe41c131",
-        "name": "elastic-agent-27049",
+        "ephemeral_id": "4fbc6e3b-1cde-4af3-b94e-1d1a466727f8",
+        "id": "36862468-ab0e-46c3-90f7-c056d53448bf",
+        "name": "elastic-agent-10722",
         "type": "filebeat",
-        "version": "9.2.1"
+        "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "ti_misp.threat_attributes",
-        "namespace": "90086",
+        "namespace": "87784",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "6b0fdd15-672d-4d68-8efe-da26fe41c131",
+        "id": "36862468-ab0e-46c3-90f7-c056d53448bf",
         "snapshot": false,
-        "version": "9.2.1"
+        "version": "8.19.4"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "threat"
         ],
-        "created": "2025-12-23T16:17:09.559Z",
+        "created": "2026-08-19T09:41:28.780Z",
         "dataset": "ti_misp.threat_attributes",
-        "ingested": "2025-12-23T16:17:12Z",
+        "ingested": "2026-08-19T09:41:31Z",
         "kind": "enrichment",
-        "module": "ti_misp",
         "original": "{\"Event\":{\"distribution\":\"3\",\"id\":\"1\",\"info\":\"OSINT ShellShock scanning IPs from OpenDNS\",\"org_id\":\"1\",\"orgc_id\":\"2\",\"uuid\":\"542e4c9c-cadc-4f8f-bb11-6d13950d210b\"},\"category\":\"External analysis\",\"comment\":\"\",\"deleted\":false,\"disable_correlation\":false,\"distribution\":\"5\",\"event_id\":\"1\",\"first_seen\":null,\"id\":\"1\",\"last_seen\":null,\"object_id\":\"0\",\"object_relation\":null,\"sharing_group_id\":\"0\",\"timestamp\":\"1412320445\",\"to_ids\":false,\"type\":\"link\",\"uuid\":\"542e4cbd-ee78-4a57-bfb8-1fda950d210b\",\"value\":\"http://labs.opendns.com/2014/10/02/opendns-and-bash/\"}",
         "type": [
             "indicator"
@@ -37,9 +36,6 @@
     },
     "input": {
         "type": "httpjson"
-    },
-    "labels": {
-        "is_ioc_transform_source": "true"
     },
     "misp": {
         "attribute": {
@@ -76,7 +72,6 @@
     ],
     "threat": {
         "feed": {
-            "dashboard_id": "ti_misp-56ed8040-6c7d-11ec-9bce-f7a4dc94c294",
             "name": "MISP"
         },
         "indicator": {

--- a/packages/ti_misp/docs/README.md
+++ b/packages/ti_misp/docs/README.md
@@ -269,18 +269,18 @@ This data stream uses the `/attributes/restSearch` API endpoint which returns mo
 #### Expiration of Indicators of Compromise (IOCs)
 The ingested IOCs expire after certain duration which is indicated by the `decayed` field. An [Elastic Transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html) is created to faciliate only active IOCs be available to the end users. This transform creates destination indices named `logs-ti_misp_latest.dest_threat_attributes-*` which only contains active and unexpired IOCs. The latest destination index also has an alias named `logs-ti_misp_latest.threat_attributes`. When querying for active indicators or setting up indicator match rules, only use the latest destination indices or the alias to avoid false positives from expired IOCs. Dashboards for `Threat Attributes` datastream are also pointing to the latest destination indices containing active IoCs. Please read [ILM Policy](#ilm-policy) below which is added to avoid unbounded growth on source datastream `.ds-logs-ti_misp.threat_attributes-*` indices.
 
-#### Daily Refetch Mode
+#### Refetch Mode
 By default, the integration uses incremental updates, only fetching attributes that have been modified since the last poll (tracked via an internal cursor). However, MISP's decay scores are dynamic and decrease over time, which means an attribute's decay status may change without the attribute itself being modified. In such cases, incremental updates would not capture the updated decay state.
 
-To address this, users can enable the `Enable Daily Refetch` toggle. When enabled, the integration will:
-1. **Perform a daily full refetch**: Every 24 hours, the cursor is reset and all attributes from the configured `Initial Interval` are re-fetched from MISP.
+To address this, users can enable the `Enable Refetch` toggle. When enabled, the integration will:
+1. **Perform a full refetch**: Every `Refetch Interval` (default 24 hours), the cursor is reset and all attributes from the configured `Initial Interval` are re-fetched from MISP.
 2. **Update decay states**: Thanks to the re-ingest of all attributes with their current decay scores from MISP, it removes any that have since been marked as decayed from destination indices.
 
 This approach ensures that:
 - The destination indices stay aligned with MISP's current view of valid indicators
 - Attributes that become decayed in MISP are automatically removed in the next refetch cycle from destination indices
 
-**Note**: This mode will re-ingest all attributes within the `Initial Interval` window, which may result in higher data volume during the refetch period. The transform handles deduplication via unique keys. Attributes already marked as decayed by MISP's decay models during ingestion will be removed immediately.
+**Note**: This mode will re-ingest all attributes within the `Initial Interval` window, which may result in higher data volume during the refetch period. Short refetch intervals amplify that volume. The transform handles deduplication via unique keys. Attributes already marked as decayed by MISP's decay models during ingestion will be removed immediately.
 
 #### Handling Orphaned IOCs
 Some IOCs may never get decayed/expired and will continue to stay in the latest destination indices `logs-ti_misp_latest.dest_threat_attributes-*`. To avoid any false positives from such orphaned IOCs, users are allowed to configure `IOC Expiration Duration` parameter while setting up the integration. This parameter deletes all data inside the destination indices `logs-ti_misp_latest.dest_threat_attributes-*` after this specified duration is reached, defaults to `90d` after attribute's `max(last_seen, timestamp)`. Note that `IOC Expiration Duration` parameter only exists to add a fail-safe default expiration in case IOCs never expire.

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.45.0"
+version: "1.46.0"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.3.2"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
ti_misp: add a configurable `Refetch Interval` for Threat Attributes data stream
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/ti_misp directory.
- Run the following command to run tests.

> elastic-package test -v
