### PR TITLE
[windows] Add tags to ingest pipeline processors

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.0"
+  changes:
+    - description: Add tags to ingest pipeline processors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20807
 - version: "3.9.0"
   changes:
     - description: Parse Windows Security scheduled task XML and task names into structured winlog.scheduled_task.* fields for detection and hunting.

--- a/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,11 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -20,27 +22,35 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_64aaa9d8
       field: event.type
       value: ["start"]
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true
@@ -50,34 +60,40 @@ processors:
 
   # Map Windows Process ID to ECS process.pid
   - set:
+      tag: set_process_pid_afdac118
       field: process.pid
       copy_from: winlog.process.pid
       ignore_empty_value: true
       if: ctx.winlog?.process?.pid != null
 
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_failure: true
       ignore_empty_value: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - rename:
+      tag: rename_winlog_user_name_to_user_name_2d2fb22d
       field: winlog.user.name
       target_field: user.name
       ignore_failure: true
@@ -86,67 +102,83 @@ processors:
 
     ## User data fields.
   - convert:
+      tag: convert_winlog_user_data_FileHashLength_3967d2ec
       field: winlog.user_data.FileHashLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FileHashLength_17a02b3b
             field: winlog.user_data.FileHashLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FilePathLength_8c4f65ce
       field: winlog.user_data.FilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FilePathLength_2f5f0f46
             field: winlog.user_data.FilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FqbnLength_b56a8d3a
       field: winlog.user_data.FqbnLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FqbnLength_cdc0bb26
             field: winlog.user_data.FqbnLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FullFilePathLength_7bea1858
       field: winlog.user_data.FullFilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FullFilePathLength_5a67aae1
             field: winlog.user_data.FullFilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_PolicyNameLength_184c5a7a
       field: winlog.user_data.PolicyNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_PolicyNameLength_f4fdcb82
             field: winlog.user_data.PolicyNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleNameLength_eab35a92
       field: winlog.user_data.RuleNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleNameLength_5b4263d6
             field: winlog.user_data.RuleNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleSddlLength_ff375262
       field: winlog.user_data.RuleSddlLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleSddlLength_dc53fcb2
             field: winlog.user_data.RuleSddlLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_TargetProcessId_5f38635c
       field: winlog.user_data.TargetProcessId
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_TargetProcessId_c21e46d4
             field: winlog.user_data.TargetProcessId
             ignore_failure: true
 
@@ -154,6 +186,7 @@ processors:
     ## ECS now requires some fields to be arrays, so extract
     ## them into a temporary field
   - grok:
+      tag: grok_winlog_user_data_Fqbn_e1828b36
       field: winlog.user_data.Fqbn
       ignore_missing: true
       patterns:
@@ -167,31 +200,37 @@ processors:
     ## Use the append processor to create arrays from the single
     ## strings extracted by the previous grok processor
   - append:
+      tag: append_file_x509_subject_common_name_9a908ae2
       field: file.x509.subject.common_name
       value: "{{tmp.file.x509.subject.common_name}}"
       ignore_failure: true
 
   - append:
+      tag: append_file_x509_subject_country_1478046e
       field: file.x509.subject.country
       value: "{{tmp.file.x509.subject.country}}"
       ignore_failure: true
 
   - append:
+      tag: append_file_x509_subject_state_or_province_9f34230a
       field: file.x509.subject.state_or_province
       value: "{{tmp.file.x509.subject.state_or_province}}"
       ignore_failure: true
 
   - append:
+      tag: append_file_x509_subject_organization_397789f2
       field: file.x509.subject.organization
       value: "{{tmp.file.x509.subject.organization}}"
       ignore_failure: true
 
     ## Remove all temporary fields
   - remove:
+      tag: remove_tmp_cbaa8f47
       field: tmp
       ignore_missing: true
 
   - grok:
+      tag: grok_winlog_user_data_FullFilePath_2cd7f249
       field: winlog.user_data.FullFilePath
       ignore_missing: true
       patterns:
@@ -199,12 +238,14 @@ processors:
       if: ctx.winlog?.user_data?.FullFilePath != "-"
 
   - set:
+      tag: set_file_hash_sha256_5e124a25
       field: file.hash.sha256
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true

--- a/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
@@ -251,11 +251,19 @@ processors:
       ignore_missing: true
       
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_4b65e074
-      field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
@@ -252,8 +252,10 @@ processors:
       
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_4b65e074
       field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
@@ -248,11 +248,19 @@ processors:
       ignore_missing: true
       
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_4b65e074
-      field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
@@ -249,8 +249,10 @@ processors:
       
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_4b65e074
       field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,11 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -20,27 +22,35 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_64aaa9d8
       field: event.type
       value: ["start"]
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true
@@ -50,34 +60,40 @@ processors:
 
   # Map Windows Process ID to ECS process.pid
   - set:
+      tag: set_process_pid_afdac118
       field: process.pid
       copy_from: winlog.process.pid
       ignore_empty_value: true
       if: ctx.winlog?.process?.pid != null
 
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_failure: true
       ignore_empty_value: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - rename:
+      tag: rename_winlog_user_name_to_user_name_2d2fb22d
       field: winlog.user.name
       target_field: user.name
       ignore_failure: true
@@ -86,67 +102,83 @@ processors:
 
     ## User data fields.
   - convert:
+      tag: convert_winlog_user_data_FileHashLength_3967d2ec
       field: winlog.user_data.FileHashLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FileHashLength_17a02b3b
             field: winlog.user_data.FileHashLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FilePathLength_8c4f65ce
       field: winlog.user_data.FilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FilePathLength_2f5f0f46
             field: winlog.user_data.FilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FqbnLength_b56a8d3a
       field: winlog.user_data.FqbnLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FqbnLength_cdc0bb26
             field: winlog.user_data.FqbnLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FullFilePathLength_7bea1858
       field: winlog.user_data.FullFilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FullFilePathLength_5a67aae1
             field: winlog.user_data.FullFilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_PolicyNameLength_184c5a7a
       field: winlog.user_data.PolicyNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_PolicyNameLength_f4fdcb82
             field: winlog.user_data.PolicyNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleNameLength_eab35a92
       field: winlog.user_data.RuleNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleNameLength_5b4263d6
             field: winlog.user_data.RuleNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleSddlLength_ff375262
       field: winlog.user_data.RuleSddlLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleSddlLength_dc53fcb2
             field: winlog.user_data.RuleSddlLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_TargetProcessId_5f38635c
       field: winlog.user_data.TargetProcessId
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_TargetProcessId_c21e46d4
             field: winlog.user_data.TargetProcessId
             ignore_failure: true
 
@@ -154,6 +186,7 @@ processors:
     ## ECS now requires some fields to be arrays, so extract
     ## them into a temporary field
   - grok:
+      tag: grok_winlog_user_data_Fqbn_f8c5c58e
       field: winlog.user_data.Fqbn
       ignore_missing: true
       patterns:
@@ -165,30 +198,36 @@ processors:
     ## Use the append processor to create arrays from the single
     ## strings extracted by the previous grok processor
   - append:
+      tag: append_file_x509_subject_country_1478046e
       field: file.x509.subject.country
       value: "{{tmp.file.x509.subject.country}}"
       ignore_failure: true
 
   - append:
+      tag: append_file_x509_subject_state_or_province_9f34230a
       field: file.x509.subject.state_or_province
       value: "{{tmp.file.x509.subject.state_or_province}}"
       ignore_failure: true
 
   - append:
+      tag: append_file_x509_subject_organization_397789f2
       field: file.x509.subject.organization
       value: "{{tmp.file.x509.subject.organization}}"
       ignore_failure: true
 
   - append:
+      tag: append_file_x509_subject_locality_5e1b6229
       field: file.x509.subject.locality
       value: "{{tmp.file.x509.subject.locality}}"
 
     ## Remove all temporary fields
   - remove:
+      tag: remove_tmp_cbaa8f47
       field: tmp
       ignore_missing: true
 
   - grok:
+      tag: grok_winlog_user_data_FullFilePath_2cd7f249
       field: winlog.user_data.FullFilePath
       ignore_missing: true
       patterns:
@@ -196,12 +235,14 @@ processors:
       if: ctx.winlog?.user_data?.FullFilePath != "-"
 
   - set:
+      tag: set_file_hash_sha256_5e124a25
       field: file.hash.sha256
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true

--- a/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
@@ -245,11 +245,19 @@ processors:
       ignore_missing: true
       
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
@@ -246,8 +246,10 @@ processors:
       
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,11 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -20,27 +22,35 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_be99bb6d
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_0382017e
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_c7c167df
             message: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_4e4a3a91
       field: event.code
       value: "{{{winlog.event_id}}}"
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_64aaa9d8
       field: event.type
       value: ["start"]
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true
@@ -48,28 +58,33 @@ processors:
 
   ## User fields.
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_failure: true
       ignore_empty_value: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_1967c9b8
       field: user.domain
       value: "{{{_temp.user_parts.0}}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_1fda8e5e
       field: user.name
       value: "{{{_temp.user_parts.1}}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - rename:
+      tag: rename_winlog_user_name_to_user_name_2d2fb22d
       field: winlog.user.name
       target_field: user.name
       ignore_failure: true
@@ -78,67 +93,83 @@ processors:
 
   ## User data fields.
   - convert:
+      tag: convert_winlog_user_data_FileHashLength_3967d2ec
       field: winlog.user_data.FileHashLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FileHashLength_17a02b3b
             field: winlog.user_data.FileHashLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FilePathLength_8c4f65ce
       field: winlog.user_data.FilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FilePathLength_2f5f0f46
             field: winlog.user_data.FilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FqbnLength_b56a8d3a
       field: winlog.user_data.FqbnLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FqbnLength_cdc0bb26
             field: winlog.user_data.FqbnLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FullFilePathLength_7bea1858
       field: winlog.user_data.FullFilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FullFilePathLength_5a67aae1
             field: winlog.user_data.FullFilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_PolicyNameLength_184c5a7a
       field: winlog.user_data.PolicyNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_PolicyNameLength_f4fdcb82
             field: winlog.user_data.PolicyNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleNameLength_eab35a92
       field: winlog.user_data.RuleNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleNameLength_5b4263d6
             field: winlog.user_data.RuleNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleSddlLength_ff375262
       field: winlog.user_data.RuleSddlLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleSddlLength_dc53fcb2
             field: winlog.user_data.RuleSddlLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_TargetProcessId_5f38635c
       field: winlog.user_data.TargetProcessId
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_TargetProcessId_c21e46d4
             field: winlog.user_data.TargetProcessId
             ignore_failure: true
 
@@ -146,6 +177,7 @@ processors:
     ## ECS now requires some fields to be arrays, so extract
     ## them into a temporary field
   - grok:
+      tag: grok_winlog_user_data_Fqbn_e951ecfb
       field: winlog.user_data.Fqbn
       ignore_missing: true
       patterns:
@@ -157,35 +189,42 @@ processors:
     ## Use the append processor to create arrays from the single
     ## strings extracted by the previous grok processor
   - append:
+      tag: append_file_x509_subject_country_2b29c9bd
       field: file.x509.subject.country
       value: "{{tmp.file.x509.subject.country}}"
       ignore_failure: false
 
   - append:
+      tag: append_file_x509_subject_state_or_province_bc20c061
       field: file.x509.subject.state_or_province
       value: "{{tmp.file.x509.subject.state_or_province}}"
       ignore_failure: false
 
   - append:
+      tag: append_file_x509_subject_organization_5d9bce9d
       field: file.x509.subject.organization
       value: "{{tmp.file.x509.subject.organization}}"
       ignore_failure: false
 
   - append:
+      tag: append_file_x509_subject_locality_5e1b6229
       field: file.x509.subject.locality
       value: "{{tmp.file.x509.subject.locality}}"
 
   - append:
+      tag: append_file_x509_subject_common_name_06aed65f
       field: file.x509.subject.common_name
       value: "{{tmp.file.x509.subject.common_name}}"
       ignore_failure: false
 
     ## Remove all temporary fields
   - remove:
+      tag: remove_tmp_cbaa8f47
       field: tmp
       ignore_missing: true
 
   - grok:
+      tag: grok_winlog_user_data_FullFilePath_2cd7f249
       field: winlog.user_data.FullFilePath
       ignore_missing: true
       patterns:
@@ -193,12 +232,14 @@ processors:
       if: ctx.winlog?.user_data?.FullFilePath != "-"
 
   - set:
+      tag: set_file_hash_sha256_5e124a25
       field: file.hash.sha256
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true

--- a/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
@@ -244,11 +244,19 @@ processors:
       ignore_missing: true
       
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
@@ -245,8 +245,10 @@ processors:
       
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,11 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -20,27 +22,35 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_be99bb6d
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_0382017e
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_c7c167df
             message: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_4e4a3a91
       field: event.code
       value: "{{{winlog.event_id}}}"
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_64aaa9d8
       field: event.type
       value: ["start"]
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true
@@ -48,28 +58,33 @@ processors:
 
   ## User fields.
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_failure: true
       ignore_empty_value: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_1967c9b8
       field: user.domain
       value: "{{{_temp.user_parts.0}}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_1fda8e5e
       field: user.name
       value: "{{{_temp.user_parts.1}}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - rename:
+      tag: rename_winlog_user_name_to_user_name_2d2fb22d
       field: winlog.user.name
       target_field: user.name
       ignore_failure: true
@@ -78,67 +93,83 @@ processors:
 
   ## User data fields.
   - convert:
+      tag: convert_winlog_user_data_FileHashLength_3967d2ec
       field: winlog.user_data.FileHashLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FileHashLength_17a02b3b
             field: winlog.user_data.FileHashLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FilePathLength_8c4f65ce
       field: winlog.user_data.FilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FilePathLength_2f5f0f46
             field: winlog.user_data.FilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FqbnLength_b56a8d3a
       field: winlog.user_data.FqbnLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FqbnLength_cdc0bb26
             field: winlog.user_data.FqbnLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_FullFilePathLength_7bea1858
       field: winlog.user_data.FullFilePathLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_FullFilePathLength_5a67aae1
             field: winlog.user_data.FullFilePathLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_PolicyNameLength_184c5a7a
       field: winlog.user_data.PolicyNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_PolicyNameLength_f4fdcb82
             field: winlog.user_data.PolicyNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleNameLength_eab35a92
       field: winlog.user_data.RuleNameLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleNameLength_5b4263d6
             field: winlog.user_data.RuleNameLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_RuleSddlLength_ff375262
       field: winlog.user_data.RuleSddlLength
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_RuleSddlLength_dc53fcb2
             field: winlog.user_data.RuleSddlLength
             ignore_failure: true
   - convert:
+      tag: convert_winlog_user_data_TargetProcessId_5f38635c
       field: winlog.user_data.TargetProcessId
       type: long
       ignore_missing: true
       on_failure:
         - remove:
+            tag: remove_winlog_user_data_TargetProcessId_c21e46d4
             field: winlog.user_data.TargetProcessId
             ignore_failure: true
 
@@ -146,6 +177,7 @@ processors:
     ## ECS now requires some fields to be arrays, so extract
     ## them into a temporary field
   - grok:
+      tag: grok_winlog_user_data_Fqbn_e951ecfb
       field: winlog.user_data.Fqbn
       ignore_missing: true
       patterns:
@@ -157,34 +189,41 @@ processors:
     ## Use the append processor to create arrays from the single
     ## strings extracted by the previous grok processor
   - append:
+      tag: append_file_x509_subject_locality_5e1b6229
       field: file.x509.subject.locality
       value: "{{tmp.file.x509.subject.locality}}"
 
   - append:
+      tag: append_file_x509_subject_common_name_06aed65f
       field: file.x509.subject.common_name
       value: "{{tmp.file.x509.subject.common_name}}"
       ignore_failure: false
 
   - append:
+      tag: append_file_x509_subject_organization_4e2daea9
       field: file.x509.subject.organization
       value: "{{tmp.file.x509.subject.organization}}"
 
   - append:
+      tag: append_file_x509_subject_country_2b29c9bd
       field: file.x509.subject.country
       value: "{{tmp.file.x509.subject.country}}"
       ignore_failure: false
 
   - append:
+      tag: append_file_x509_subject_state_or_province_bc20c061
       field: file.x509.subject.state_or_province
       value: "{{tmp.file.x509.subject.state_or_province}}"
       ignore_failure: false
 
     ## Remove all temporary fields
   - remove:
+      tag: remove_tmp_cbaa8f47
       field: tmp
       ignore_missing: true
 
   - grok:
+      tag: grok_winlog_user_data_FullFilePath_2cd7f249
       field: winlog.user_data.FullFilePath
       ignore_missing: true
       patterns:
@@ -192,12 +231,14 @@ processors:
       if: ctx.winlog?.user_data?.FullFilePath != "-"
 
   - set:
+      tag: set_file_hash_sha256_5e124a25
       field: file.hash.sha256
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -64,11 +64,19 @@ processors:
       ignore_missing: true
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -65,8 +65,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -2,23 +2,29 @@
 description: Pipeline for Windows forwarded Event Logs
 processors:
   - pipeline:
+      tag: pipeline_6579f6a3
       name: '{{ IngestPipeline "security_default" }}'
       if: ctx.winlog?.channel instanceof String && ctx.winlog.channel.toLowerCase() == "security" && ["Microsoft-Windows-Eventlog", "Microsoft-Windows-Security-Auditing"].contains(ctx.winlog?.provider_name)
   - pipeline:
+      tag: pipeline_1bf6252d
       name: '{{ IngestPipeline "powershell" }}'
       if: ctx.winlog?.channel instanceof String && ctx.winlog.channel.toLowerCase() == "windows powershell"
   - pipeline:
+      tag: pipeline_037aaa55
       name: '{{ IngestPipeline "powershell_operational" }}'
       if: ctx.winlog?.channel instanceof String && ctx.winlog.channel.toLowerCase() == "microsoft-windows-powershell/operational"
   - pipeline:
+      tag: pipeline_c9abb819
       name: '{{ IngestPipeline "sysmon_operational" }}'
       if: ctx.winlog?.channel instanceof String && ctx.winlog.channel.toLowerCase() == "microsoft-windows-sysmon/operational"
 
   - set:
+      tag: set_host_os_type_ab71bfd4
       field: host.os.type
       value: windows
       override: false
   - set:
+      tag: set_host_os_family_3ead466c
       field: host.os.family
       value: windows
       override: false
@@ -26,28 +32,33 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
       if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -536,8 +536,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -535,11 +535,19 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell.yml
@@ -2,6 +2,7 @@
 description: Pipeline for Windows Powershell events
 processors:
   - kv:
+      tag: kv_winlog_event_data_param2_to_winlog_event_data_1bba62f9
       description: Split Event 800 event data fields.
       field: winlog.event_data.param2
       target_field: winlog.event_data
@@ -11,6 +12,7 @@ processors:
       value_split: "="
       if: ctx.winlog?.event_id == "800"
   - script:
+      tag: script_2c51d005
       description: |-
         Split Events 4xx and 600 event data fields.
         Some events can contain multiline values containing also '\n', '\s', and '=' characters,
@@ -45,14 +47,17 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -66,42 +71,53 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_35704029
       field: event.type
       value: ["start"]
       if: ctx.event.code == "400"
   - set:
+      tag: set_event_type_ead6f56f
       field: event.type
       value: ["end"]
       if: ctx.event.code == "403"
   - set:
+      tag: set_event_type_e4a41200
       field: event.type
       value: ["info"]
       if: ctx.event?.type == null
   - convert:
+      tag: convert_winlog_event_data_SequenceNumber_to_event_sequence_9f3e8826
       field: winlog.event_data.SequenceNumber
       target_field: event.sequence
       type: long
       ignore_failure: true 
       ignore_missing: true
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true 
@@ -110,18 +126,21 @@ processors:
   ## Process fields.
 
   - rename:
+      tag: rename_winlog_event_data_HostId_to_process_entity_id_48bc4f37
       field: winlog.event_data.HostId
       target_field: process.entity_id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostId != ""
   - rename:
+      tag: rename_winlog_event_data_HostApplication_to_process_command_line_d4597d8e
       field: winlog.event_data.HostApplication
       target_field: process.command_line
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostApplication != ""
   - rename:
+      tag: rename_winlog_event_data_HostName_to_process_title_e6f2ccaa
       field: winlog.event_data.HostName
       target_field: process.title
       ignore_failure: true
@@ -131,23 +150,27 @@ processors:
   ## User fields.
 
   - split:
+      tag: split_winlog_event_data_UserId_to__temp_user_parts_2ddcfcb6
       field: winlog.event_data.UserId
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.UserId != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - append:
+      tag: append_related_user_54815ed0
       field: related.user
       value: "{{user.name}}"
       ignore_failure: true
@@ -156,22 +179,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
@@ -180,30 +207,35 @@ processors:
   ## PowerShell fields.
 
   - rename:
+      tag: rename_winlog_event_data_NewEngineState_to_powershell_engine_new_state_7bca7a1e
       field: winlog.event_data.NewEngineState
       target_field: powershell.engine.new_state
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.NewEngineState != ""
   - rename:
+      tag: rename_winlog_event_data_PreviousEngineState_to_powershell_engine_previous_state_47d03e95
       field: winlog.event_data.PreviousEngineState
       target_field: powershell.engine.previous_state
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.PreviousEngineState != ""
   - rename:
+      tag: rename_winlog_event_data_NewProviderState_to_powershell_provider_new_state_38528c47
       field: winlog.event_data.NewProviderState
       target_field: powershell.provider.new_state
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.NewProviderState != ""
   - rename:
+      tag: rename_winlog_event_data_ProviderName_to_powershell_provider_name_553c8d44
       field: winlog.event_data.ProviderName
       target_field: powershell.provider.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ProviderName != ""
   - convert:
+      tag: convert_winlog_event_data_DetailTotal_to_powershell_total_9ec908db
       field: winlog.event_data.DetailTotal
       target_field: powershell.total
       type: long
@@ -211,6 +243,7 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DetailTotal != ""
   - convert:
+      tag: convert_winlog_event_data_DetailSequence_to_powershell_sequence_d015a4c8
       field: winlog.event_data.DetailSequence
       target_field: powershell.sequence
       type: long
@@ -218,48 +251,56 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DetailSequence != ""
   - rename:
+      tag: rename_winlog_event_data_EngineVersion_to_powershell_engine_version_89690b88
       field: winlog.event_data.EngineVersion
       target_field: powershell.engine.version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.EngineVersion != ""
   - rename:
+      tag: rename_winlog_event_data_PipelineId_to_powershell_pipeline_id_f6cd8320
       field: winlog.event_data.PipelineId
       target_field: powershell.pipeline_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.PipelineId != ""
   - rename:
+      tag: rename_winlog_event_data_RunspaceId_to_powershell_runspace_id_127766ef
       field: winlog.event_data.RunspaceId
       target_field: powershell.runspace_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.RunspaceId != ""
   - rename:
+      tag: rename_winlog_event_data_HostVersion_to_powershell_process_executable_version_57db9eb2
       field: winlog.event_data.HostVersion
       target_field: powershell.process.executable_version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.HostVersion != ""
   - rename:
+      tag: rename_winlog_event_data_CommandLine_to_powershell_command_value_af88dcd0
       field: winlog.event_data.CommandLine
       target_field: powershell.command.value
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_CommandPath_to_powershell_command_path_59faaaae
       field: winlog.event_data.CommandPath
       target_field: powershell.command.path
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandPath != ""
   - rename:
+      tag: rename_winlog_event_data_CommandName_to_powershell_command_name_5f0b828e
       field: winlog.event_data.CommandName
       target_field: powershell.command.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandName != ""
   - rename:
+      tag: rename_winlog_event_data_CommandType_to_powershell_command_type_15a8cb69
       field: winlog.event_data.CommandType
       target_field: powershell.command.type
       ignore_failure: true
@@ -267,6 +308,7 @@ processors:
       if: ctx.winlog?.event_data?.CommandType != ""
 
   - split:
+      tag: split_winlog_event_data_param3_2773c881
       description: Split Event 800 command invocation details.
       field: winlog.event_data.param3
       separator: "\n"
@@ -274,6 +316,7 @@ processors:
       ignore_missing: true
       if: ctx.event.code == "800"
   - script:
+      tag: script_726ef306
       description: |-
         Parses all command invocation detail raw lines, and converts them to an object, based on their type.
          - for unexpectedly formatted ones: {value: "the raw line as it is"}
@@ -347,11 +390,13 @@ processors:
             }
         }
   - rename:
+      tag: rename__temp_details_to_powershell_command_invocation_details_b64d5930
       field: _temp.details
       target_field: powershell.command.invocation_details
       if: ctx._temp?.details != null && ctx._temp?.details.length > 0
 
   - script:
+      tag: script_8c91ea2d
       description: Implements Windows-like SplitCommandLine
       lang: painless
       if: ctx.process?.command_line != null && ctx.process.command_line != ""
@@ -431,6 +476,7 @@ processors:
         ctx.process.args_count = ctx.process.args.length;
  
   - script:
+      tag: script_3df7b466
       description: Adds file information.
       lang: painless
       if: ctx.winlog?.event_data?.ScriptName != null && ctx.winlog.event_data.ScriptName.length() > 1
@@ -450,6 +496,7 @@ processors:
             }
         }
   - rename:
+      tag: rename_winlog_event_data_ScriptName_to_file_path_d431a754
       field: winlog.event_data.ScriptName
       target_field: file.path
       ignore_failure: true
@@ -457,6 +504,7 @@ processors:
       if: ctx.winlog?.event_data?.ScriptName != ""
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
@@ -464,6 +512,7 @@ processors:
   ## Cleanup.
 
   - remove:
+      tag: remove_966d8acf
       field:
         - _temp
         - winlog.event_data.param1
@@ -478,6 +527,7 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
@@ -743,11 +743,19 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
@@ -744,8 +744,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/powershell_operational.yml
@@ -2,6 +2,7 @@
 description: Pipeline for Windows Powershell/Operational events
 processors:
   - kv:
+      tag: kv_winlog_event_data_ContextInfo_to_winlog_event_data_25c6ca78
       description: Split Event 4103 event data fields.
       field: winlog.event_data.ContextInfo
       target_field: winlog.event_data
@@ -11,6 +12,7 @@ processors:
       value_split: "[:=]"
       if: ctx.winlog?.event_id == "4103"
   - script:
+      tag: script_51ecbf79
       description: Remove spaces from all event_data keys.
       lang: painless
       if: ctx.winlog?.event_data != null
@@ -25,14 +27,17 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -46,42 +51,53 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_737b2f2d
       field: event.type
       value: ["start"]
       if: ctx.event.code == "4105"
   - set:
+      tag: set_event_type_af54cfeb
       field: event.type
       value: ["end"]
       if: ctx.event.code == "4106"
   - set:
+      tag: set_event_type_e4a41200
       field: event.type
       value: ["info"]
       if: ctx.event?.type == null
   - convert:
+      tag: convert_winlog_event_data_SequenceNumber_to_event_sequence_9f3e8826
       field: winlog.event_data.SequenceNumber
       target_field: event.sequence
       type: long
       ignore_failure: true 
       ignore_missing: true
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true 
@@ -90,24 +106,28 @@ processors:
   ## Process fields.
 
   - rename:
+      tag: rename_winlog_event_data_HostID_to_process_entity_id_d763cef7
       field: winlog.event_data.HostID
       target_field: process.entity_id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostID != ""
   - rename:
+      tag: rename_winlog_event_data_HostApplication_to_process_command_line_d4597d8e
       field: winlog.event_data.HostApplication
       target_field: process.command_line
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostApplication != ""
   - rename:
+      tag: rename_winlog_event_data_HostName_to_process_title_e6f2ccaa
       field: winlog.event_data.HostName
       target_field: process.title
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostName != ""
   - set:
+      tag: set_process_pid_8e104e6e
       field: process.pid
       copy_from: winlog.process.pid
       ignore_failure: true
@@ -116,74 +136,87 @@ processors:
   ## User fields.
 
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_failure: true
       ignore_empty_value: true
   - set:
+      tag: set_user_domain_0d623826
       field: user.domain
       copy_from: winlog.user.domain
       ignore_failure: true
       ignore_empty_value: true
   - set:
+      tag: set_user_name_0f6a96c2
       field: user.name
       copy_from: winlog.user.name
       ignore_failure: true
       ignore_empty_value: true
   - append:
+      tag: append_related_user_54815ed0
       field: related.user
       value: "{{user.name}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.user?.name != null
   - append:
+      tag: append_related_hosts_6af32972
       field: related.hosts
       value: "{{user.domain}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.user?.domain != null
   - split:
+      tag: split_winlog_event_data_ConnectedUser_to__temp_connected_user_parts_234c40d8
       field: winlog.event_data.ConnectedUser
       target_field: "_temp.connected_user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.ConnectedUser != null
   - set:
+      tag: set_source_user_domain_0e800325
       field: source.user.domain
       value: "{{_temp.connected_user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.connected_user_parts != null && ctx._temp.connected_user_parts.size() == 2
   - set:
+      tag: set_source_user_name_cc3800e5
       field: source.user.name
       value: "{{_temp.connected_user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.connected_user_parts != null && ctx._temp.connected_user_parts.size() == 2
   - append:
+      tag: append_related_user_a59ec459
       field: related.user
       value: "{{source.user.name}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.source?.user?.name != null
   - rename:
+      tag: rename_user_domain_to_destination_user_domain_9f181953
       field: user.domain
       target_field: destination.user.domain
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.user != null
   - rename:
+      tag: rename_user_name_to_destination_user_name_9b06d685
       field: user.name
       target_field: destination.user.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.user != null
   - set:
+      tag: set_user_domain_dc422317
       field: user.domain
       copy_from: source.user.domain
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.source?.user != null
   - set:
+      tag: set_user_name_462839cb
       field: user.name
       copy_from: source.user.name
       ignore_failure: true
@@ -192,22 +225,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
@@ -216,110 +253,129 @@ processors:
   ## PowerShell fields.
 
   - convert:
+      tag: convert_winlog_event_data_MessageNumber_to_powershell_sequence_9784f8c5
       field: winlog.event_data.MessageNumber
       target_field: powershell.sequence
       type: long
       ignore_failure: true 
       ignore_missing: true
   - convert:
+      tag: convert_winlog_event_data_MessageTotal_to_powershell_total_8148c255
       field: winlog.event_data.MessageTotal
       target_field: powershell.total
       type: long
       ignore_failure: true 
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_ShellID_to_powershell_id_594c4f11
       field: winlog.event_data.ShellID
       target_field: powershell.id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ShellID != ""
   - rename:
+      tag: rename_winlog_event_data_EngineVersion_to_powershell_engine_version_89690b88
       field: winlog.event_data.EngineVersion
       target_field: powershell.engine.version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.EngineVersion != ""
   - rename:
+      tag: rename_winlog_event_data_PipelineID_to_powershell_pipeline_id_5ca77720
       field: winlog.event_data.PipelineID
       target_field: powershell.pipeline_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.PipelineID != ""
   - rename:
+      tag: rename_winlog_event_data_RunspaceID_to_powershell_runspace_id_211147af
       field: winlog.event_data.RunspaceID
       target_field: powershell.runspace_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.RunspaceID != ""
   - rename:
+      tag: rename_winlog_event_data_RunspaceId_to_powershell_runspace_id_127766ef
       field: winlog.event_data.RunspaceId
       target_field: powershell.runspace_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.RunspaceId != ""
   - rename:
+      tag: rename_winlog_event_data_HostVersion_to_powershell_process_executable_version_57db9eb2
       field: winlog.event_data.HostVersion
       target_field: powershell.process.executable_version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.HostVersion != ""
   - rename:
+      tag: rename_winlog_event_data_CommandLine_to_powershell_command_value_af88dcd0
       field: winlog.event_data.CommandLine
       target_field: powershell.command.value
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_CommandPath_to_powershell_command_path_59faaaae
       field: winlog.event_data.CommandPath
       target_field: powershell.command.path
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandPath != ""
   - rename:
+      tag: rename_winlog_event_data_CommandName_to_powershell_command_name_5f0b828e
       field: winlog.event_data.CommandName
       target_field: powershell.command.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandName != ""
   - rename:
+      tag: rename_winlog_event_data_CommandType_to_powershell_command_type_15a8cb69
       field: winlog.event_data.CommandType
       target_field: powershell.command.type
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandType != ""
   - rename:
+      tag: rename_winlog_event_data_ScriptBlockId_to_powershell_file_script_block_id_153de20b
       field: winlog.event_data.ScriptBlockId
       target_field: powershell.file.script_block_id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ScriptBlockId != ""
   - rename:
+      tag: rename_winlog_event_data_ScriptBlockText_to_powershell_file_script_block_text_740f3b05
       field: winlog.event_data.ScriptBlockText
       target_field: powershell.file.script_block_text
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ScriptBlockText != ""
   - trim:
+      tag: trim_powershell_file_script_block_text_ac6bd654
       field: powershell.file.script_block_text
       ignore_missing: true
   - gsub:
+      tag: gsub_powershell_file_script_block_text_to__temp_script_block_no_space_0ad19ecf
       field: powershell.file.script_block_text
       target_field: _temp.script_block_no_space
       pattern: "\\s"
       replacement: ""
       ignore_missing: true
   - fingerprint:
+      tag: fingerprint_44d0ee03
       fields:
         - _temp.script_block_no_space
       target_field: powershell.file.script_block_hash
       ignore_missing: true
   - gsub:
+      tag: gsub_powershell_file_script_block_text_to__temp_script_block_no_signature_f0a2d6bd
       field: powershell.file.script_block_text
       target_field: _temp.script_block_no_signature
       pattern: "(?s)# SIG # Begin signature block.+"
       replacement: ""
       ignore_missing: true
   - script:
+      tag: script_12a4ac79
       lang: painless
       ignore_failure: true
       description: >
@@ -452,6 +508,7 @@ processors:
         ctx.powershell.file.script_block_unique_symbols = uniqueSymbols;
 
   - split:
+      tag: split_winlog_event_data_Payload_d3558e95
       description: Split Event 4103 command invocation details.
       field: winlog.event_data.Payload
       separator: "\n"
@@ -459,6 +516,7 @@ processors:
       ignore_missing: true
       if: ctx.event.code == "4103"
   - script:
+      tag: script_c30da396
       description: |-
         Parses all command invocation detail raw lines, and converts them to an object, based on their type.
          - for unexpectedly formatted ones: {value: "the raw line as it is"}
@@ -532,11 +590,13 @@ processors:
             }
         }
   - rename:
+      tag: rename__temp_details_to_powershell_command_invocation_details_b64d5930
       field: _temp.details
       target_field: powershell.command.invocation_details
       if: ctx._temp?.details != null && ctx._temp?.details.length > 0
 
   - script:
+      tag: script_8c91ea2d
       description: Implements Windows-like SplitCommandLine
       lang: painless
       if: ctx.process?.command_line != null && ctx.process.command_line != ""
@@ -616,12 +676,14 @@ processors:
         ctx.process.args_count = ctx.process.args.length;
  
   - rename:
+      tag: rename_winlog_event_data_Path_to_winlog_event_data_ScriptName_d0223d7a
       field: winlog.event_data.Path
       target_field: winlog.event_data.ScriptName
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.Path != ""
   - script:
+      tag: script_3df7b466
       description: Adds file information.
       lang: painless
       if: ctx.winlog?.event_data?.ScriptName != null && ctx.winlog.event_data.ScriptName.length() > 1
@@ -641,6 +703,7 @@ processors:
             }
         }
   - rename:
+      tag: rename_winlog_event_data_ScriptName_to_file_path_d431a754
       field: winlog.event_data.ScriptName
       target_field: file.path
       ignore_failure: true
@@ -648,6 +711,7 @@ processors:
       if: ctx.winlog?.event_data?.ScriptName != ""
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
@@ -655,6 +719,7 @@ processors:
   ## Cleanup.
 
   - remove:
+      tag: remove_92e1ed50
       field:
         - _temp
         - winlog.event_data.SequenceNumber
@@ -670,6 +735,7 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
@@ -2,18 +2,22 @@
 description: Pipeline for Security events
 processors:
   - convert:
+      tag: convert_event_code_820f5e63
       field: event.code
       type: string
       ignore_missing: true
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - pipeline:
+      tag: pipeline_6a0d1b33
       name: '{{ IngestPipeline "security_standard" }}'
       if: 'ctx.winlog?.provider_name != null && ["Microsoft-Windows-Eventlog", "Microsoft-Windows-Security-Auditing"].contains(ctx.winlog.provider_name)'
   - pipeline:
+      tag: pipeline_3c8bb3a2
       name: '{{ IngestPipeline "security_scheduled_task" }}'
       if: >-
         ctx.winlog != null &&
@@ -31,15 +35,18 @@ processors:
           )
         )
   - remove:
+      tag: remove_winlog__tmp_scheduled_task_a9d51742
       field: winlog._tmp.scheduled_task
       ignore_missing: true
       ignore_failure: true
   - remove:
+      tag: remove_winlog__tmp_025d04d5
       field: winlog._tmp
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?._tmp instanceof Map && ctx.winlog._tmp.size() == 0
   - set:
+      tag: set_winlog_scheduled_task_name_59b64408
       field: winlog.scheduled_task.name
       copy_from: winlog.event_data.TaskName
       ignore_empty_value: true
@@ -50,15 +57,18 @@ processors:
         ctx.event?.code != null &&
         ['4698', '4699', '4700', '4701', '4702'].contains(ctx.event.code)
   - gsub:
+      tag: gsub_source_ip_8a374ea7
       field: source.ip
       pattern: '^\[?::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(?:\](?::[0-9]+)?)?$'
       replacement: '$1'
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -67,14 +77,17 @@ processors:
       - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
+      tag: append_related_ip_244ba6b1
       field: related.ip
       value: '{{source.ip}}'
       allow_duplicates: false
@@ -82,17 +95,21 @@ processors:
         ctx.source?.ip != null &&
         ctx.source.ip != "-"
   - convert:
+      tag: convert_winlog_record_id_e96f501d
       field: winlog.record_id
       type: string
       ignore_missing: true
   - convert:
+      tag: convert_winlog_event_id_d9228ef0
       field: winlog.event_id
       type: string
       ignore_missing: true
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -106,18 +123,23 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
@@ -146,11 +146,19 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_4b65e074
-      field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
@@ -147,8 +147,10 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_4b65e074
       field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_scheduled_task.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_scheduled_task.yml
@@ -376,6 +376,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_tags_219373ea
             description: Mark events when scheduled task normalization fails unexpectedly.
             field: tags
             value: scheduled_task_normalization_failed

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
@@ -4530,6 +4530,7 @@ processors:
           
 on_failure:
   - set:
+      tag: set_error_message_40b8d205
       field: error.message
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
@@ -4529,8 +4529,19 @@ processors:
       ignore_missing: true
           
 on_failure:
-  - set:
-      tag: set_error_message_40b8d205
+  - append:
+      tag: append_error_message_2304b6c8
       field: error.message
       value: |-
-        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+  - set:
+      tag: set_event_kind_f51b77ad
+      field: event.kind
+      value: pipeline_error
+  - append:
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
@@ -3290,6 +3290,7 @@ processors:
     # split member name into parts based on comma ignoring escaped commas
     # https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names
   - split:
+      tag: split_winlog_event_data_MemberName_to__temp_MemberNameParts_c2e48f76
       if: ctx.winlog?.event_data?.MemberName != null
       field: winlog.event_data.MemberName
       target_field: _temp.MemberNameParts
@@ -3414,6 +3415,7 @@ processors:
         }
 
   - set:
+      tag: set_winlog_logon_id_40ea691f
       field: winlog.logon.id
       copy_from: winlog.event_data.TargetLogonId
       ignore_failure: false
@@ -3594,11 +3596,13 @@ processors:
         }
 
   - set:
+      tag: set_winlog_logon_id_c8ebde7f
       field: winlog.logon.id
       copy_from: winlog.event_data.SubjectLogonId
       ignore_failure: true
 
   - set:
+      tag: set_winlog_logon_id_70be5285
       field: winlog.logon.id
       copy_from: winlog.user_data.SubjectLogonId
       ignore_failure: true
@@ -3896,6 +3900,7 @@ processors:
         }
 
   - append:
+      tag: append_related_user_825d5463
       field: related.user
       value: '{{winlog.event_data.SubjectUserName}}'
       allow_duplicates: false
@@ -3906,6 +3911,7 @@ processors:
         ctx.winlog.event_data.SubjectUserName != "-"
 
   - append:
+      tag: append_related_user_1bfafd26
       field: related.user
       value: '{{winlog.event_data.TargetUserName}}'
       allow_duplicates: false
@@ -3917,6 +3923,7 @@ processors:
         ctx.winlog.event_data.TargetUserName != "-"
 
   - split:
+      tag: split_winlog_event_data_PrivilegeList_7e94364a
       field: winlog.event_data.PrivilegeList
       separator: "\\s+"
       if: |-
@@ -3925,16 +3932,19 @@ processors:
         ctx.winlog?.event_data?.PrivilegeList != null
 
   - set:
+      tag: set_user_target_name_5389a9cd
       field: user.target.name
       copy_from: winlog.event_data.OldTargetUserName
       ignore_empty_value: true
 
   - set:
+      tag: set_user_changes_name_90252ef2
       field: user.changes.name
       copy_from: winlog.event_data.NewTargetUserName
       ignore_empty_value: true
 
   - append:
+      tag: append_related_user_4efa74d6
       field: related.user
       value: '{{winlog.event_data.NewTargetUserName}}'
       allow_duplicates: false
@@ -3943,6 +3953,7 @@ processors:
         ctx.winlog.event_data.NewTargetUserName != "-"
 
   - append:
+      tag: append_related_user_ff6ef2c3
       field: related.user
       value: '{{winlog.event_data.OldTargetUserName}}'
       allow_duplicates: false
@@ -3951,6 +3962,7 @@ processors:
         ctx.winlog.event_data.OldTargetUserName != "-"
 
   - set:
+      tag: set_event_reason_98d7cf5a
       field: event.reason
       copy_from: winlog.event_data.OperationType
       if: ctx.event?.code == "5136" && ctx.winlog?.event_data?.OperationType != null
@@ -4009,6 +4021,7 @@ processors:
         }
 
   - set:
+      tag: set_registry_path_641868d3
       description: >-
         Map registry key path from ObjectName for registry audit events only.
         4657 is registry-specific; other IDs are generic object access — match when ObjectType is Key
@@ -4032,6 +4045,7 @@ processors:
         )
 
   - gsub:
+      tag: gsub_winlog_event_data_SidList_235dd056
       description: Normalize separators in the SidList value.
       field: winlog.event_data.SidList
       pattern: '\s+'
@@ -4397,6 +4411,7 @@ processors:
   # Populate network.transport from network.iana_number. 
   #
   - script:
+      tag: script_43bdf2cc
       if: "ctx.network?.iana_number != null && ctx.network?.transport == null"
       lang: painless
       params:
@@ -4432,6 +4447,7 @@ processors:
         ctx.network.put("transport", t)
 
   - script:
+      tag: script_b007664d
       description: Adds file information for file share events.
       # Event codes 5140 (network share object accessed) and 5145 (network share object checked to see
       # if client can be granted desired access) contain file information in the RelativeTargetName
@@ -4484,6 +4500,7 @@ processors:
         }
 
   - script:
+      tag: script_36be1179
       description: Adds file information.
       lang: painless
       if: ctx.file?.name != null
@@ -4493,16 +4510,20 @@ processors:
             ctx.file.extension = ctx.file.name.substring(extIdx+1);
         }
   - rename:
+      tag: rename_winlog_event_data_DirectionDescription_to_network_direction_68ca2fb1
       field: winlog.event_data.DirectionDescription
       target_field: network.direction
       ignore_missing: true
   - lowercase:
+      tag: lowercase_network_direction_e8f881c2
       field: network.direction
       ignore_missing: true
   - community_id:
+      tag: community_id_99f56bc8
       ignore_missing: true
       ignore_failure: true
   - remove:
+      tag: remove_1f8c5875
       field:
         - _temp
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -1588,8 +1588,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -4,14 +4,17 @@ processors:
 ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - rename:
+      tag: rename_winlog_level_to_log_level_2deff502
       field: winlog.level
       target_field: log.level
       ignore_missing: true
@@ -26,14 +29,18 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_d2d52d0f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_2a78d052
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_3ea4cadf
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - date:
+      tag: date_winlog_event_data_UtcTime_5c157047
       field: winlog.event_data.UtcTime
       formats:
         - yyyy-MM-dd HH:mm:ss.SSS
@@ -42,9 +49,11 @@ processors:
       if: ctx.winlog?.event_data?.UtcTime != null
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
 
@@ -251,12 +260,14 @@ processors:
         def hm = new HashMap(params[ctx.event.code]);
         hm.forEach((k, v) -> ctx.event[k] = v);
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true 
       ignore_missing: true
 
   - rename:
+      tag: rename_winlog_event_data_ID_to_error_code_638ee276
       field: winlog.event_data.ID
       target_field: error.code
       ignore_failure: true
@@ -264,6 +275,7 @@ processors:
       if: ctx.event.code == "255" && ctx.winlog?.event_data?.ID != null && ctx.winlog?.event_data?.ID != ""
 
   - rename:
+      tag: rename_winlog_event_data_RuleName_to_rule_name_ff2226fa
       field: winlog.event_data.RuleName
       target_field: rule.name
       ignore_missing: true
@@ -272,6 +284,7 @@ processors:
 
 
   - rename:
+      tag: rename_winlog_event_data_Type_to_message_ca83af02
       field: winlog.event_data.Type
       target_field: message
       ignore_missing: true
@@ -279,12 +292,14 @@ processors:
       if: ctx.event.code == "25" && ctx.winlog?.event_data?.Type != null && ctx.winlog?.event_data?.Type != ""
 
   - rename:
+      tag: rename_winlog_event_data_Hash_to_winlog_event_data_Hashes_07892c03
       field: winlog.event_data.Hash
       target_field: winlog.event_data.Hashes
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Hash != null && ctx.winlog?.event_data?.Hash != ""
   - kv:
+      tag: kv_winlog_event_data_Hashes_to__temp_hashes_ec739711
       field: winlog.event_data.Hashes
       target_field: _temp.hashes
       field_split: ","
@@ -292,6 +307,7 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data?.Hashes != null
   - script:
+      tag: script_cefad630
       lang: painless
       if: ctx._temp?.hashes != null
       source: |-
@@ -330,23 +346,27 @@ processors:
 ## Process fields
 
   - rename:
+      tag: rename__temp_hashes_to_process_hash_8c75f855
       field: _temp.hashes
       target_field: process.hash
       if: |-
         ctx._temp?.hashes != null &&
         ["1", "23", "24", "25", "26"].contains(ctx.event.code)
   - rename:
+      tag: rename_process_hash_imphash_to_process_pe_imphash_b5a09a6c
       field: process.hash.imphash
       target_field: process.pe.imphash
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_ProcessGuid_to_process_entity_id_6c4b3a26
       field: winlog.event_data.ProcessGuid
       target_field: process.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ProcessGuid != null && ctx.winlog?.event_data?.ProcessGuid != ""
   - convert:
+      tag: convert_winlog_event_data_ProcessId_to_process_pid_44fe6e1d
       field: winlog.event_data.ProcessId
       target_field: process.pid
       type: long
@@ -354,24 +374,28 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.ProcessId != null && ctx.winlog?.event_data?.ProcessId != ""
   - rename:
+      tag: rename_winlog_event_data_Image_to_process_executable_7d636c2a
       field: winlog.event_data.Image
       target_field: process.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Image != null && ctx.winlog?.event_data?.Image != ""
   - rename:
+      tag: rename_winlog_event_data_SourceProcessGuid_to_process_entity_id_c0ccaa87
       field: winlog.event_data.SourceProcessGuid
       target_field: process.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceProcessGuid != null && ctx.winlog?.event_data?.SourceProcessGuid != ""
   - rename:
+      tag: rename_winlog_event_data_SourceProcessGUID_to_process_entity_id_98f67f67
       field: winlog.event_data.SourceProcessGUID
       target_field: process.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceProcessGUID != null && ctx.winlog?.event_data?.SourceProcessGUID != ""
   - convert:
+      tag: convert_winlog_event_data_SourceProcessId_to_process_pid_43bab0b0
       field: winlog.event_data.SourceProcessId
       target_field: process.pid
       type: long
@@ -379,6 +403,7 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourceProcessId != null && ctx.winlog?.event_data?.SourceProcessId != ""
   - convert:
+      tag: convert_winlog_event_data_SourceThreadId_to_process_thread_id_5f0cb70b
       field: winlog.event_data.SourceThreadId
       target_field: process.thread.id
       type: long
@@ -386,36 +411,42 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourceThreadId != null && ctx.winlog?.event_data?.SourceThreadId != ""
   - rename:
+      tag: rename_winlog_event_data_SourceImage_to_process_executable_9fd80871
       field: winlog.event_data.SourceImage
       target_field: process.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceImage != null && ctx.winlog?.event_data?.SourceImage != ""
   - rename:
+      tag: rename_winlog_event_data_Destination_to_process_executable_0dd46f33
       field: winlog.event_data.Destination
       target_field: process.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Destination != null && ctx.winlog?.event_data?.Destination != ""
   - rename:
+      tag: rename_winlog_event_data_CommandLine_to_process_command_line_96e30e50
       field: winlog.event_data.CommandLine
       target_field: process.command_line
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.CommandLine != null && ctx.winlog?.event_data?.CommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_CurrentDirectory_to_process_working_directory_608b37f2
       field: winlog.event_data.CurrentDirectory
       target_field: process.working_directory
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.CurrentDirectory != null && ctx.winlog?.event_data?.CurrentDirectory != ""
   - rename:
+      tag: rename_winlog_event_data_ParentProcessGuid_to_process_parent_entity_id_2d954662
       field: winlog.event_data.ParentProcessGuid
       target_field: process.parent.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ParentProcessGuid != null && ctx.winlog?.event_data?.ParentProcessGuid != ""
   - convert:
+      tag: convert_winlog_event_data_ParentProcessId_to_process_parent_pid_c780e8f3
       field: winlog.event_data.ParentProcessId
       target_field: process.parent.pid
       type: long
@@ -423,42 +454,49 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.ParentProcessId != null && ctx.winlog?.event_data?.ParentProcessId != ""
   - rename:
+      tag: rename_winlog_event_data_ParentImage_to_process_parent_executable_bacc688c
       field: winlog.event_data.ParentImage
       target_field: process.parent.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ParentImage != null && ctx.winlog?.event_data?.ParentImage != ""
   - rename:
+      tag: rename_winlog_event_data_ParentCommandLine_to_process_parent_command_line_8601aa2e
       field: winlog.event_data.ParentCommandLine
       target_field: process.parent.command_line
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ParentCommandLine != null && ctx.winlog?.event_data?.ParentCommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_OriginalFileName_to_process_pe_original_file_name_93afff9b
       field: winlog.event_data.OriginalFileName
       target_field: process.pe.original_file_name
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code != "7" && ctx.winlog?.event_data?.OriginalFileName != null && ctx.winlog?.event_data?.OriginalFileName != ""
   - set:
+      tag: set_process_pe_company_c2816db7
       field: process.pe.company
       copy_from: winlog.event_data.Company
       ignore_empty_value: true
       ignore_failure: true
       if: ctx.event.code != "7"
   - set:
+      tag: set_process_pe_description_6e39d255
       field: process.pe.description
       copy_from: winlog.event_data.Description
       ignore_empty_value: true
       ignore_failure: true
       if: ctx.event.code != "7"
   - set:
+      tag: set_process_pe_file_version_7e75767a
       field: process.pe.file_version
       copy_from: winlog.event_data.FileVersion
       ignore_empty_value: true
       ignore_failure: true
       if: ctx.event.code != "7"
   - set:
+      tag: set_process_pe_product_3e168e1f
       field: process.pe.product
       copy_from: winlog.event_data.Product
       ignore_empty_value: true
@@ -466,6 +504,7 @@ processors:
       if: ctx.event.code != "7"
 
   - script:
+      tag: script_85dfd5a9
       description: Implements Windows-like SplitCommandLine
       lang: painless
       if: |-
@@ -556,6 +595,7 @@ processors:
         }
 
   - script:
+      tag: script_f3024ab5
       description: Adds process name information.
       lang: painless
       if: |-
@@ -589,94 +629,111 @@ processors:
 ## File fields
 
   - set:
+      tag: set_file_hash_62c6ed89
       field: file.hash
       copy_from: _temp.hashes
       if: |-
         ctx._temp?.hashes != null &&
         ["6", "7", "15", "26", "29"].contains(ctx.event.code)
   - rename:
+      tag: rename_file_hash_imphash_to_file_pe_imphash_6baf0a60
       field: file.hash.imphash
       target_field: file.pe.imphash
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_TargetFilename_to_file_path_cea5fc4b
       field: winlog.event_data.TargetFilename
       target_field: file.path
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.TargetFilename != null && ctx.winlog?.event_data?.TargetFilename != ""
   - rename:
+      tag: rename_winlog_event_data_Device_to_file_path_dd9b02c1
       field: winlog.event_data.Device
       target_field: file.path
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Device != null && ctx.winlog?.event_data?.Device != ""
   - rename:
+      tag: rename_winlog_event_data_PipeName_to_file_name_fd128394
       field: winlog.event_data.PipeName
       target_field: file.name
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.PipeName != null && ctx.winlog?.event_data?.PipeName != ""
   - rename:
+      tag: rename_winlog_event_data_ImageLoaded_to_file_path_c8f42a6d
       field: winlog.event_data.ImageLoaded
       target_field: file.path
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ImageLoaded != null && ctx.winlog?.event_data?.ImageLoaded != ""
   - set:
+      tag: set_file_code_signature_subject_name_cb55bafb
       field: file.code_signature.subject_name
       copy_from: winlog.event_data.Signature
       ignore_failure: true
       ignore_empty_value: true
   - set:
+      tag: set_file_code_signature_status_a66cac45
       field: file.code_signature.status
       copy_from: winlog.event_data.SignatureStatus
       ignore_failure: true
       ignore_empty_value: true
   - rename:
+      tag: rename_winlog_event_data_OriginalFileName_to_file_pe_original_file_name_869eb5cc
       field: winlog.event_data.OriginalFileName
       target_field: file.pe.original_file_name
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code == "7" && ctx.winlog?.event_data?.OriginalFileName != null && ctx.winlog?.event_data?.OriginalFileName != ""
   - set:
+      tag: set_file_pe_company_56e8dab0
       field: file.pe.company
       copy_from: winlog.event_data.Company
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_pe_description_b329982c
       field: file.pe.description
       copy_from: winlog.event_data.Description
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_pe_file_version_36bcbf21
       field: file.pe.file_version
       copy_from: winlog.event_data.FileVersion
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_pe_product_31604628
       field: file.pe.product
       copy_from: winlog.event_data.Product
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_code_signature_trusted_47d996ad
       field: file.code_signature.trusted
       value: true
       if: ctx.winlog?.event_data?.Signed != null && ctx.winlog.event_data.Signed == 'true'
   - set:
+      tag: set_file_code_signature_trusted_d3049f18
       field: file.code_signature.trusted
       value: false
       if: ctx.winlog?.event_data?.Signed != null && ctx.winlog.event_data.Signed != 'true'
   - set:
+      tag: set_file_code_signature_valid_4fccf922
       field: file.code_signature.valid
       value: true
       if: ctx.winlog?.event_data?.SignatureStatus != null && ctx.winlog?.event_data?.SignatureStatus == "Valid"
 
   - script:
+      tag: script_8bd0d8ed
       description: Adds file information.
       lang: painless
       if: ctx.file?.path != null && ctx.file.path.length() > 1
@@ -699,32 +756,38 @@ processors:
 ## DLL fields
 
   - set:
+      tag: set_dll_name_3629d056
       field: dll.name
       copy_from: file.name
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_dll_path_574a217e
       field: dll.path
       copy_from: file.path
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_dll_code_signature_subject_name_b00b038d
       field: dll.code_signature.subject_name
       copy_from: winlog.event_data.Signature
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_dll_code_signature_trusted_df73491f
       field: dll.code_signature.trusted
       value: true
       if: ctx.event.code == "7" && ctx.winlog?.event_data?.Signed == 'true'
   - set:
+      tag: set_dll_code_signature_trusted_869bf1b0
       field: dll.code_signature.trusted
       value: false
       if: ctx.event.code == "7" && ctx.winlog?.event_data?.Signed != null && ctx.winlog?.event_data?.Signed == 'false'
   - script:
+      tag: script_f9d06e42
       description: Set dll.code_signature.status
       lang: painless
       if: ctx.event.code == "7"
@@ -737,16 +800,19 @@ processors:
           ctx.dll.code_signature.status = ctx.winlog.event_data.Signed;
         }
   - set:
+      tag: set_dll_hash_d3741256
       field: dll.hash
       copy_from: _temp.hashes
       if: |-
         ctx._temp?.hashes != null && ctx.event.code == "7"
   - rename:
+      tag: rename_dll_hash_imphash_to_dll_pe_imphash_f79a6c38
       field: dll.hash.imphash
       target_field: dll.pe.imphash
       ignore_failure: true
       ignore_missing: true
   - set:
+      tag: set_dll_pe_original_file_name_35d387dd
       field: dll.pe.original_file_name
       copy_from: file.pe.original_file_name
       ignore_failure: true
@@ -755,28 +821,33 @@ processors:
 ## Network, Destination, and Source fields
 
   - rename:
+      tag: rename_winlog_event_data_Protocol_to_network_transport_994bcb0d
       field: winlog.event_data.Protocol
       target_field: network.transport
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Protocol != null && ctx.winlog?.event_data?.Protocol != ""
   - rename:
+      tag: rename_winlog_event_data_DestinationPortName_to_network_protocol_edf1f8a0
       field: winlog.event_data.DestinationPortName
       target_field: network.protocol
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code != "22" && ctx.winlog?.event_data?.DestinationPortName != null && ctx.winlog?.event_data?.DestinationPortName != ""
   - rename:
+      tag: rename_winlog_event_data_SourcePortName_to_network_protocol_f1ab163d
       field: winlog.event_data.SourcePortName
       target_field: network.protocol
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code != "22" && ctx.winlog?.event_data?.SourcePortName != null && ctx.winlog?.event_data?.SourcePortName != ""
   - set:
+      tag: set_network_protocol_3c708440
       field: network.protocol
       value: dns
       if: ctx.event.code == "22"
   - convert:
+      tag: convert_winlog_event_data_SourceIp_to_source_ip_a393b286
       field: winlog.event_data.SourceIp
       target_field: source.ip
       type: ip
@@ -784,12 +855,14 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourceIp != null && ctx.winlog?.event_data?.SourceIp != ""
   - rename:
+      tag: rename_winlog_event_data_SourceHostname_to_source_domain_820aedc9
       field: winlog.event_data.SourceHostname
       target_field: source.domain
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceHostname != null && ctx.winlog?.event_data?.SourceHostname != ""
   - convert:
+      tag: convert_winlog_event_data_SourcePort_to_source_port_7e92f2af
       field: winlog.event_data.SourcePort
       target_field: source.port
       type: long
@@ -797,6 +870,7 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourcePort != null && ctx.winlog?.event_data?.SourcePort != ""
   - convert:
+      tag: convert_winlog_event_data_DestinationIp_to_destination_ip_187d4f90
       field: winlog.event_data.DestinationIp
       target_field: destination.ip
       type: ip
@@ -804,12 +878,14 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DestinationIp != null && ctx.winlog?.event_data?.DestinationIp != ""
   - rename:
+      tag: rename_winlog_event_data_DestinationHostname_to_destination_domain_7325d23b
       field: winlog.event_data.DestinationHostname
       target_field: destination.domain
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.DestinationHostname != null && ctx.winlog?.event_data?.DestinationHostname != ""
   - convert:
+      tag: convert_winlog_event_data_DestinationPort_to_destination_port_78f789f5
       field: winlog.event_data.DestinationPort
       target_field: destination.port
       type: long
@@ -817,28 +893,34 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DestinationPort != null && ctx.winlog?.event_data?.DestinationPort != ""
   - rename:
+      tag: rename_winlog_event_data_QueryName_to_dns_question_name_3cd15691
       field: winlog.event_data.QueryName
       target_field: dns.question.name
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.QueryName != null && ctx.winlog?.event_data?.QueryName != ""
   - set:
+      tag: set_network_direction_00ba90c4
       field: network.direction
       value: egress
       if: ctx.winlog?.event_data?.Initiated != null && ctx.winlog?.event_data?.Initiated == "true"
   - set:
+      tag: set_network_direction_13b18f87
       field: network.direction
       value: ingress
       if: ctx.winlog?.event_data?.Initiated != null && ctx.winlog?.event_data?.Initiated == "false"
   - set:
+      tag: set_network_type_bbfc772a
       field: network.type
       value: ipv4
       if: ctx.winlog?.event_data?.SourceIsIpv6 != null && ctx.winlog?.event_data?.SourceIsIpv6 == "false"
   - set:
+      tag: set_network_type_73514339
       field: network.type
       value: ipv6
       if: ctx.winlog?.event_data?.SourceIsIpv6 != null && ctx.winlog?.event_data?.SourceIsIpv6 == "true"
   - script:
+      tag: script_1361f033
       description: |
         Splits the QueryResults field that contains the DNS responses.
         Example: "type:  5 f2.taboola.map.fastly.net;::ffff:151.101.66.2;::ffff:151.101.130.2;::ffff:151.101.194.2;::ffff:151.101.2.2;"
@@ -950,6 +1032,7 @@ processors:
           ctx.related.hosts = relatedHosts;
         }
   - foreach:
+      tag: foreach_dns_answers_3b0b739d
       field: dns.answers
       if: ctx.dns?.answers instanceof List
       ignore_failure: true
@@ -959,6 +1042,7 @@ processors:
           pattern: '^\[?::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(?:\](?::[0-9]+)?)?$'
           replacement: '$1'
   - foreach:
+      tag: foreach_dns_resolved_ip_0d1a1469
       field: dns.resolved_ip
       if: ctx.dns?.resolved_ip instanceof List
       ignore_failure: true
@@ -968,6 +1052,7 @@ processors:
           pattern: '^\[?::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(?:\](?::[0-9]+)?)?$'
           replacement: '$1'
   - foreach:
+      tag: foreach_dns_resolved_ip_34ab3637
       field: dns.resolved_ip
       ignore_missing: true
       processor:
@@ -978,6 +1063,7 @@ processors:
             - remove:
                 field: _ingest._value
   - script:
+      tag: script_c8568aea
       description: Convert V4MAPPED addresses.
       lang: painless
       if: ctx.dns?.resolved_ip != null
@@ -1003,21 +1089,25 @@ processors:
           ]);
         }
   - registered_domain:
+      tag: registered_domain_dns_question_name_to_dns_question_24868ff9
       field: dns.question.name
       target_field: dns.question
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_related_hosts_c5d4edd1
       field: related.hosts
       value: "{{dns.question.name}}"
       allow_duplicates: false
       if: ctx.dns?.question?.name != null && ctx.dns?.question?.name != ""
   - remove:
+      tag: remove_dns_question_domain_610dad76
       description: Remove dns.question.domain because it is not part of ECS and is redundant with dns.question.name.
       field: dns.question.domain
       ignore_missing: true
       ignore_failure: true
   - foreach:
+      tag: foreach_dns_resolved_ip_066293db
       field: dns.resolved_ip
       ignore_missing: true
       processor:
@@ -1027,28 +1117,33 @@ processors:
           allow_duplicates: false
           ignore_failure: true
   - community_id:
+      tag: community_id_9c2f7277
       ignore_failure: true
       ignore_missing: false
 
 ## User fields
 
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_empty_value: true
       ignore_failure: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
@@ -1057,22 +1152,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
@@ -1081,12 +1180,14 @@ processors:
 ## Sysmon fields
 
   - rename:
+      tag: rename_winlog_event_data_QueryStatus_to_sysmon_dns_status_c310d5d2
       field: winlog.event_data.QueryStatus
       target_field: sysmon.dns.status
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.QueryStatus != null && ctx.winlog?.event_data?.QueryStatus != ""
   - script:
+      tag: script_06dfcee3
       description: Translate DNS Query status.
       lang: painless
       params:
@@ -1294,6 +1395,7 @@ processors:
           ctx.sysmon.dns.status = status;
         }
   - convert:
+      tag: convert_winlog_event_data_Archived_to_sysmon_file_archived_ba988912
       field: winlog.event_data.Archived
       target_field: sysmon.file.archived
       type: boolean
@@ -1301,6 +1403,7 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data?.Archived != null && ctx.winlog?.event_data?.Archived != ""
   - convert:
+      tag: convert_winlog_event_data_IsExecutable_to_sysmon_file_is_executable_0c28b197
       field: winlog.event_data.IsExecutable
       target_field: sysmon.file.is_executable
       type: boolean
@@ -1308,6 +1411,7 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data?.IsExecutable != null && ctx.winlog?.event_data?.IsExecutable != ""
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
@@ -1315,18 +1419,21 @@ processors:
 ## Related fields
 
   - append:
+      tag: append_related_user_0d94e1af
       field: related.user
       value: "{{user.name}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.user?.name != null && ctx.user.name != ""
   - append:
+      tag: append_related_ip_75c642a5
       field: related.ip
       value: "{{source.ip}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.source?.ip != null && ctx.source.ip != ""
   - append:
+      tag: append_related_ip_df9f8c82
       field: related.ip
       value: "{{destination.ip}}"
       ignore_failure: true
@@ -1336,6 +1443,7 @@ processors:
 ## Registry fields
 
   - script:
+      tag: script_cd7e1956
       description: Set registry fields.
       lang: painless
       if: |-
@@ -1431,6 +1539,7 @@ processors:
 
 ## Conformity
   - rename:
+      tag: rename_winlog_event_data_TargetProcessGuid_to_winlog_event_data_TargetProcessGUID_7c39f434
       field: winlog.event_data.TargetProcessGuid
       target_field: winlog.event_data.TargetProcessGUID
       if: ctx.winlog?.event_data?.TargetProcessGuid != null
@@ -1438,6 +1547,7 @@ processors:
 ## Cleanup
 
   - remove:
+      tag: remove_6bcaa69b
       field:
         - _temp
         - winlog.event_data.ProcessId
@@ -1469,6 +1579,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -1587,11 +1587,19 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -536,8 +536,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -535,11 +535,19 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for Windows Powershell events
 processors:
   - kv:
+      tag: kv_winlog_event_data_param2_to_winlog_event_data_1bba62f9
       description: Split Event 800 event data fields.
       field: winlog.event_data.param2
       target_field: winlog.event_data
@@ -11,6 +12,7 @@ processors:
       value_split: "="
       if: ctx.winlog?.event_id == "800"
   - script:
+      tag: script_2c51d005
       description: |-
         Split Events 4xx and 600 event data fields.
         Some events can contain multiline values containing also '\n', '\s', and '=' characters,
@@ -45,14 +47,17 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -66,42 +71,53 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_35704029
       field: event.type
       value: ["start"]
       if: ctx.event.code == "400"
   - set:
+      tag: set_event_type_ead6f56f
       field: event.type
       value: ["end"]
       if: ctx.event.code == "403"
   - set:
+      tag: set_event_type_e4a41200
       field: event.type
       value: ["info"]
       if: ctx.event?.type == null
   - convert:
+      tag: convert_winlog_event_data_SequenceNumber_to_event_sequence_9f3e8826
       field: winlog.event_data.SequenceNumber
       target_field: event.sequence
       type: long
       ignore_failure: true 
       ignore_missing: true
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true 
@@ -110,18 +126,21 @@ processors:
   ## Process fields.
 
   - rename:
+      tag: rename_winlog_event_data_HostId_to_process_entity_id_48bc4f37
       field: winlog.event_data.HostId
       target_field: process.entity_id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostId != ""
   - rename:
+      tag: rename_winlog_event_data_HostApplication_to_process_command_line_d4597d8e
       field: winlog.event_data.HostApplication
       target_field: process.command_line
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostApplication != ""
   - rename:
+      tag: rename_winlog_event_data_HostName_to_process_title_e6f2ccaa
       field: winlog.event_data.HostName
       target_field: process.title
       ignore_failure: true
@@ -131,23 +150,27 @@ processors:
   ## User fields.
 
   - split:
+      tag: split_winlog_event_data_UserId_to__temp_user_parts_2ddcfcb6
       field: winlog.event_data.UserId
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.UserId != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - append:
+      tag: append_related_user_54815ed0
       field: related.user
       value: "{{user.name}}"
       ignore_failure: true
@@ -156,22 +179,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
@@ -180,30 +207,35 @@ processors:
   ## PowerShell fields.
 
   - rename:
+      tag: rename_winlog_event_data_NewEngineState_to_powershell_engine_new_state_7bca7a1e
       field: winlog.event_data.NewEngineState
       target_field: powershell.engine.new_state
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.NewEngineState != ""
   - rename:
+      tag: rename_winlog_event_data_PreviousEngineState_to_powershell_engine_previous_state_47d03e95
       field: winlog.event_data.PreviousEngineState
       target_field: powershell.engine.previous_state
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.PreviousEngineState != ""
   - rename:
+      tag: rename_winlog_event_data_NewProviderState_to_powershell_provider_new_state_38528c47
       field: winlog.event_data.NewProviderState
       target_field: powershell.provider.new_state
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.NewProviderState != ""
   - rename:
+      tag: rename_winlog_event_data_ProviderName_to_powershell_provider_name_553c8d44
       field: winlog.event_data.ProviderName
       target_field: powershell.provider.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ProviderName != ""
   - convert:
+      tag: convert_winlog_event_data_DetailTotal_to_powershell_total_9ec908db
       field: winlog.event_data.DetailTotal
       target_field: powershell.total
       type: long
@@ -211,6 +243,7 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DetailTotal != ""
   - convert:
+      tag: convert_winlog_event_data_DetailSequence_to_powershell_sequence_d015a4c8
       field: winlog.event_data.DetailSequence
       target_field: powershell.sequence
       type: long
@@ -218,48 +251,56 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DetailSequence != ""
   - rename:
+      tag: rename_winlog_event_data_EngineVersion_to_powershell_engine_version_89690b88
       field: winlog.event_data.EngineVersion
       target_field: powershell.engine.version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.EngineVersion != ""
   - rename:
+      tag: rename_winlog_event_data_PipelineId_to_powershell_pipeline_id_f6cd8320
       field: winlog.event_data.PipelineId
       target_field: powershell.pipeline_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.PipelineId != ""
   - rename:
+      tag: rename_winlog_event_data_RunspaceId_to_powershell_runspace_id_127766ef
       field: winlog.event_data.RunspaceId
       target_field: powershell.runspace_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.RunspaceId != ""
   - rename:
+      tag: rename_winlog_event_data_HostVersion_to_powershell_process_executable_version_57db9eb2
       field: winlog.event_data.HostVersion
       target_field: powershell.process.executable_version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.HostVersion != ""
   - rename:
+      tag: rename_winlog_event_data_CommandLine_to_powershell_command_value_af88dcd0
       field: winlog.event_data.CommandLine
       target_field: powershell.command.value
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_CommandPath_to_powershell_command_path_59faaaae
       field: winlog.event_data.CommandPath
       target_field: powershell.command.path
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandPath != ""
   - rename:
+      tag: rename_winlog_event_data_CommandName_to_powershell_command_name_5f0b828e
       field: winlog.event_data.CommandName
       target_field: powershell.command.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandName != ""
   - rename:
+      tag: rename_winlog_event_data_CommandType_to_powershell_command_type_15a8cb69
       field: winlog.event_data.CommandType
       target_field: powershell.command.type
       ignore_failure: true
@@ -267,6 +308,7 @@ processors:
       if: ctx.winlog?.event_data?.CommandType != ""
 
   - split:
+      tag: split_winlog_event_data_param3_2773c881
       description: Split Event 800 command invocation details.
       field: winlog.event_data.param3
       separator: "\n"
@@ -274,6 +316,7 @@ processors:
       ignore_missing: true
       if: ctx.event.code == "800"
   - script:
+      tag: script_726ef306
       description: |-
         Parses all command invocation detail raw lines, and converts them to an object, based on their type.
          - for unexpectedly formatted ones: {value: "the raw line as it is"}
@@ -347,11 +390,13 @@ processors:
             }
         }
   - rename:
+      tag: rename__temp_details_to_powershell_command_invocation_details_b64d5930
       field: _temp.details
       target_field: powershell.command.invocation_details
       if: ctx._temp?.details != null && ctx._temp?.details.length > 0
 
   - script:
+      tag: script_8c91ea2d
       description: Implements Windows-like SplitCommandLine
       lang: painless
       if: ctx.process?.command_line != null && ctx.process.command_line != ""
@@ -431,6 +476,7 @@ processors:
         ctx.process.args_count = ctx.process.args.length;
  
   - script:
+      tag: script_3df7b466
       description: Adds file information.
       lang: painless
       if: ctx.winlog?.event_data?.ScriptName != null && ctx.winlog.event_data.ScriptName.length() > 1
@@ -450,6 +496,7 @@ processors:
             }
         }
   - rename:
+      tag: rename_winlog_event_data_ScriptName_to_file_path_d431a754
       field: winlog.event_data.ScriptName
       target_field: file.path
       ignore_failure: true
@@ -457,6 +504,7 @@ processors:
       if: ctx.winlog?.event_data?.ScriptName != ""
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
@@ -464,6 +512,7 @@ processors:
   ## Cleanup.
 
   - remove:
+      tag: remove_966d8acf
       field:
         - _temp
         - winlog.event_data.param1
@@ -478,6 +527,7 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -743,11 +743,19 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -744,8 +744,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for Windows Powershell/Operational events
 processors:
   - kv:
+      tag: kv_winlog_event_data_ContextInfo_to_winlog_event_data_25c6ca78
       description: Split Event 4103 event data fields.
       field: winlog.event_data.ContextInfo
       target_field: winlog.event_data
@@ -11,6 +12,7 @@ processors:
       value_split: "[:=]"
       if: ctx.winlog?.event_id == "4103"
   - script:
+      tag: script_51ecbf79
       description: Remove spaces from all event_data keys.
       lang: painless
       if: ctx.winlog?.event_data != null
@@ -25,14 +27,17 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -46,42 +51,53 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_category_dffe0229
       field: event.category
       value: ["process"]
   - set:
+      tag: set_event_type_737b2f2d
       field: event.type
       value: ["start"]
       if: ctx.event.code == "4105"
   - set:
+      tag: set_event_type_af54cfeb
       field: event.type
       value: ["end"]
       if: ctx.event.code == "4106"
   - set:
+      tag: set_event_type_e4a41200
       field: event.type
       value: ["info"]
       if: ctx.event?.type == null
   - convert:
+      tag: convert_winlog_event_data_SequenceNumber_to_event_sequence_9f3e8826
       field: winlog.event_data.SequenceNumber
       target_field: event.sequence
       type: long
       ignore_failure: true 
       ignore_missing: true
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true 
@@ -90,24 +106,28 @@ processors:
   ## Process fields.
 
   - rename:
+      tag: rename_winlog_event_data_HostID_to_process_entity_id_d763cef7
       field: winlog.event_data.HostID
       target_field: process.entity_id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostID != ""
   - rename:
+      tag: rename_winlog_event_data_HostApplication_to_process_command_line_d4597d8e
       field: winlog.event_data.HostApplication
       target_field: process.command_line
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostApplication != ""
   - rename:
+      tag: rename_winlog_event_data_HostName_to_process_title_e6f2ccaa
       field: winlog.event_data.HostName
       target_field: process.title
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.HostName != ""
   - set:
+      tag: set_process_pid_8e104e6e
       field: process.pid
       copy_from: winlog.process.pid
       ignore_failure: true
@@ -116,74 +136,87 @@ processors:
   ## User fields.
 
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_failure: true
       ignore_empty_value: true
   - set:
+      tag: set_user_domain_0d623826
       field: user.domain
       copy_from: winlog.user.domain
       ignore_failure: true
       ignore_empty_value: true
   - set:
+      tag: set_user_name_0f6a96c2
       field: user.name
       copy_from: winlog.user.name
       ignore_failure: true
       ignore_empty_value: true
   - append:
+      tag: append_related_user_54815ed0
       field: related.user
       value: "{{user.name}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.user?.name != null
   - append:
+      tag: append_related_hosts_6af32972
       field: related.hosts
       value: "{{user.domain}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.user?.domain != null
   - split:
+      tag: split_winlog_event_data_ConnectedUser_to__temp_connected_user_parts_234c40d8
       field: winlog.event_data.ConnectedUser
       target_field: "_temp.connected_user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.ConnectedUser != null
   - set:
+      tag: set_source_user_domain_0e800325
       field: source.user.domain
       value: "{{_temp.connected_user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.connected_user_parts != null && ctx._temp.connected_user_parts.size() == 2
   - set:
+      tag: set_source_user_name_cc3800e5
       field: source.user.name
       value: "{{_temp.connected_user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.connected_user_parts != null && ctx._temp.connected_user_parts.size() == 2
   - append:
+      tag: append_related_user_a59ec459
       field: related.user
       value: "{{source.user.name}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.source?.user?.name != null
   - rename:
+      tag: rename_user_domain_to_destination_user_domain_9f181953
       field: user.domain
       target_field: destination.user.domain
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.user != null
   - rename:
+      tag: rename_user_name_to_destination_user_name_9b06d685
       field: user.name
       target_field: destination.user.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.source?.user != null
   - set:
+      tag: set_user_domain_dc422317
       field: user.domain
       copy_from: source.user.domain
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.source?.user != null
   - set:
+      tag: set_user_name_462839cb
       field: user.name
       copy_from: source.user.name
       ignore_failure: true
@@ -192,22 +225,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
@@ -216,110 +253,129 @@ processors:
   ## PowerShell fields.
 
   - convert:
+      tag: convert_winlog_event_data_MessageNumber_to_powershell_sequence_9784f8c5
       field: winlog.event_data.MessageNumber
       target_field: powershell.sequence
       type: long
       ignore_failure: true 
       ignore_missing: true
   - convert:
+      tag: convert_winlog_event_data_MessageTotal_to_powershell_total_8148c255
       field: winlog.event_data.MessageTotal
       target_field: powershell.total
       type: long
       ignore_failure: true 
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_ShellID_to_powershell_id_594c4f11
       field: winlog.event_data.ShellID
       target_field: powershell.id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ShellID != ""
   - rename:
+      tag: rename_winlog_event_data_EngineVersion_to_powershell_engine_version_89690b88
       field: winlog.event_data.EngineVersion
       target_field: powershell.engine.version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.EngineVersion != ""
   - rename:
+      tag: rename_winlog_event_data_PipelineID_to_powershell_pipeline_id_5ca77720
       field: winlog.event_data.PipelineID
       target_field: powershell.pipeline_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.PipelineID != ""
   - rename:
+      tag: rename_winlog_event_data_RunspaceID_to_powershell_runspace_id_211147af
       field: winlog.event_data.RunspaceID
       target_field: powershell.runspace_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.RunspaceID != ""
   - rename:
+      tag: rename_winlog_event_data_RunspaceId_to_powershell_runspace_id_127766ef
       field: winlog.event_data.RunspaceId
       target_field: powershell.runspace_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.RunspaceId != ""
   - rename:
+      tag: rename_winlog_event_data_HostVersion_to_powershell_process_executable_version_57db9eb2
       field: winlog.event_data.HostVersion
       target_field: powershell.process.executable_version
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.HostVersion != ""
   - rename:
+      tag: rename_winlog_event_data_CommandLine_to_powershell_command_value_af88dcd0
       field: winlog.event_data.CommandLine
       target_field: powershell.command.value
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_CommandPath_to_powershell_command_path_59faaaae
       field: winlog.event_data.CommandPath
       target_field: powershell.command.path
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandPath != ""
   - rename:
+      tag: rename_winlog_event_data_CommandName_to_powershell_command_name_5f0b828e
       field: winlog.event_data.CommandName
       target_field: powershell.command.name
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandName != ""
   - rename:
+      tag: rename_winlog_event_data_CommandType_to_powershell_command_type_15a8cb69
       field: winlog.event_data.CommandType
       target_field: powershell.command.type
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.CommandType != ""
   - rename:
+      tag: rename_winlog_event_data_ScriptBlockId_to_powershell_file_script_block_id_153de20b
       field: winlog.event_data.ScriptBlockId
       target_field: powershell.file.script_block_id
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ScriptBlockId != ""
   - rename:
+      tag: rename_winlog_event_data_ScriptBlockText_to_powershell_file_script_block_text_740f3b05
       field: winlog.event_data.ScriptBlockText
       target_field: powershell.file.script_block_text
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.ScriptBlockText != ""
   - trim:
+      tag: trim_powershell_file_script_block_text_ac6bd654
       field: powershell.file.script_block_text
       ignore_missing: true
   - gsub:
+      tag: gsub_powershell_file_script_block_text_to__temp_script_block_no_space_0ad19ecf
       field: powershell.file.script_block_text
       target_field: _temp.script_block_no_space
       pattern: "\\s"
       replacement: ""
       ignore_missing: true
   - fingerprint:
+      tag: fingerprint_44d0ee03
       fields:
         - _temp.script_block_no_space
       target_field: powershell.file.script_block_hash
       ignore_missing: true
   - gsub:
+      tag: gsub_powershell_file_script_block_text_to__temp_script_block_no_signature_f0a2d6bd
       field: powershell.file.script_block_text
       target_field: _temp.script_block_no_signature
       pattern: "(?s)# SIG # Begin signature block.+"
       replacement: ""
       ignore_missing: true
   - script:
+      tag: script_12a4ac79
       lang: painless
       ignore_failure: true
       description: >
@@ -452,6 +508,7 @@ processors:
         ctx.powershell.file.script_block_unique_symbols = uniqueSymbols;
 
   - split:
+      tag: split_winlog_event_data_Payload_d3558e95
       description: Split Event 4103 command invocation details.
       field: winlog.event_data.Payload
       separator: "\n"
@@ -459,6 +516,7 @@ processors:
       ignore_missing: true
       if: ctx.event.code == "4103"
   - script:
+      tag: script_c30da396
       description: |-
         Parses all command invocation detail raw lines, and converts them to an object, based on their type.
          - for unexpectedly formatted ones: {value: "the raw line as it is"}
@@ -532,11 +590,13 @@ processors:
             }
         }
   - rename:
+      tag: rename__temp_details_to_powershell_command_invocation_details_b64d5930
       field: _temp.details
       target_field: powershell.command.invocation_details
       if: ctx._temp?.details != null && ctx._temp?.details.length > 0
 
   - script:
+      tag: script_8c91ea2d
       description: Implements Windows-like SplitCommandLine
       lang: painless
       if: ctx.process?.command_line != null && ctx.process.command_line != ""
@@ -616,12 +676,14 @@ processors:
         ctx.process.args_count = ctx.process.args.length;
  
   - rename:
+      tag: rename_winlog_event_data_Path_to_winlog_event_data_ScriptName_d0223d7a
       field: winlog.event_data.Path
       target_field: winlog.event_data.ScriptName
       ignore_failure: true
       ignore_missing: true
       if: ctx.winlog?.event_data?.Path != ""
   - script:
+      tag: script_3df7b466
       description: Adds file information.
       lang: painless
       if: ctx.winlog?.event_data?.ScriptName != null && ctx.winlog.event_data.ScriptName.length() > 1
@@ -641,6 +703,7 @@ processors:
             }
         }
   - rename:
+      tag: rename_winlog_event_data_ScriptName_to_file_path_d431a754
       field: winlog.event_data.ScriptName
       target_field: file.path
       ignore_failure: true
@@ -648,6 +711,7 @@ processors:
       if: ctx.winlog?.event_data?.ScriptName != ""
 
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
@@ -655,6 +719,7 @@ processors:
   ## Cleanup.
 
   - remove:
+      tag: remove_92e1ed50
       field:
         - _temp
         - winlog.event_data.SequenceNumber
@@ -670,6 +735,7 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -1588,8 +1588,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_a797062a
       field: error.message
       value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -1587,11 +1587,19 @@ processors:
       if: ctx.winlog?.event_data != null && ctx.winlog.event_data.size() == 0
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_a797062a
-      field: error.message
-      value: "{{{ _ingest.on_failure_message }}}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -4,14 +4,17 @@ processors:
 ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - script:
+      tag: script_9f489693
       description: Remove all empty values from event_data.
       lang: painless
       source: ctx.winlog?.event_data?.entrySet().removeIf(entry -> [null, "", "-", "{00000000-0000-0000-0000-000000000000}"].contains(entry.getValue()))
       if: ctx.winlog?.event_data != null
   - rename:
+      tag: rename_winlog_level_to_log_level_2deff502
       field: winlog.level
       target_field: log.level
       ignore_missing: true
@@ -26,14 +29,18 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_d2d52d0f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_2a78d052
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_3ea4cadf
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - date:
+      tag: date_winlog_event_data_UtcTime_5c157047
       field: winlog.event_data.UtcTime
       formats:
         - yyyy-MM-dd HH:mm:ss.SSS
@@ -42,9 +49,11 @@ processors:
       if: ctx.winlog?.event_data?.UtcTime != null
 
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
 
@@ -251,12 +260,14 @@ processors:
         def hm = new HashMap(params[ctx.event.code]);
         hm.forEach((k, v) -> ctx.event[k] = v);
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true 
       ignore_missing: true
 
   - rename:
+      tag: rename_winlog_event_data_ID_to_error_code_638ee276
       field: winlog.event_data.ID
       target_field: error.code
       ignore_failure: true
@@ -264,6 +275,7 @@ processors:
       if: ctx.event.code == "255" && ctx.winlog?.event_data?.ID != null && ctx.winlog?.event_data?.ID != ""
 
   - rename:
+      tag: rename_winlog_event_data_RuleName_to_rule_name_ff2226fa
       field: winlog.event_data.RuleName
       target_field: rule.name
       ignore_missing: true
@@ -272,6 +284,7 @@ processors:
 
 
   - rename:
+      tag: rename_winlog_event_data_Type_to_message_ca83af02
       field: winlog.event_data.Type
       target_field: message
       ignore_missing: true
@@ -279,12 +292,14 @@ processors:
       if: ctx.event.code == "25" && ctx.winlog?.event_data?.Type != null && ctx.winlog?.event_data?.Type != ""
 
   - rename:
+      tag: rename_winlog_event_data_Hash_to_winlog_event_data_Hashes_07892c03
       field: winlog.event_data.Hash
       target_field: winlog.event_data.Hashes
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Hash != null && ctx.winlog?.event_data?.Hash != ""
   - kv:
+      tag: kv_winlog_event_data_Hashes_to__temp_hashes_ec739711
       field: winlog.event_data.Hashes
       target_field: _temp.hashes
       field_split: ","
@@ -292,6 +307,7 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data?.Hashes != null
   - script:
+      tag: script_cefad630
       lang: painless
       if: ctx._temp?.hashes != null
       source: |-
@@ -330,23 +346,27 @@ processors:
 ## Process fields
 
   - rename:
+      tag: rename__temp_hashes_to_process_hash_f59425ad
       field: _temp.hashes
       target_field: process.hash
       if: |-
         ctx._temp?.hashes != null &&
         ["1", "23", "24", "25"].contains(ctx.event.code)
   - rename:
+      tag: rename_process_hash_imphash_to_process_pe_imphash_b5a09a6c
       field: process.hash.imphash
       target_field: process.pe.imphash
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_ProcessGuid_to_process_entity_id_6c4b3a26
       field: winlog.event_data.ProcessGuid
       target_field: process.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ProcessGuid != null && ctx.winlog?.event_data?.ProcessGuid != ""
   - convert:
+      tag: convert_winlog_event_data_ProcessId_to_process_pid_44fe6e1d
       field: winlog.event_data.ProcessId
       target_field: process.pid
       type: long
@@ -354,24 +374,28 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.ProcessId != null && ctx.winlog?.event_data?.ProcessId != ""
   - rename:
+      tag: rename_winlog_event_data_Image_to_process_executable_7d636c2a
       field: winlog.event_data.Image
       target_field: process.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Image != null && ctx.winlog?.event_data?.Image != ""
   - rename:
+      tag: rename_winlog_event_data_SourceProcessGuid_to_process_entity_id_c0ccaa87
       field: winlog.event_data.SourceProcessGuid
       target_field: process.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceProcessGuid != null && ctx.winlog?.event_data?.SourceProcessGuid != ""
   - rename:
+      tag: rename_winlog_event_data_SourceProcessGUID_to_process_entity_id_98f67f67
       field: winlog.event_data.SourceProcessGUID
       target_field: process.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceProcessGUID != null && ctx.winlog?.event_data?.SourceProcessGUID != ""
   - convert:
+      tag: convert_winlog_event_data_SourceProcessId_to_process_pid_43bab0b0
       field: winlog.event_data.SourceProcessId
       target_field: process.pid
       type: long
@@ -379,6 +403,7 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourceProcessId != null && ctx.winlog?.event_data?.SourceProcessId != ""
   - convert:
+      tag: convert_winlog_event_data_SourceThreadId_to_process_thread_id_5f0cb70b
       field: winlog.event_data.SourceThreadId
       target_field: process.thread.id
       type: long
@@ -386,36 +411,42 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourceThreadId != null && ctx.winlog?.event_data?.SourceThreadId != ""
   - rename:
+      tag: rename_winlog_event_data_SourceImage_to_process_executable_9fd80871
       field: winlog.event_data.SourceImage
       target_field: process.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceImage != null && ctx.winlog?.event_data?.SourceImage != ""
   - rename:
+      tag: rename_winlog_event_data_Destination_to_process_executable_0dd46f33
       field: winlog.event_data.Destination
       target_field: process.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Destination != null && ctx.winlog?.event_data?.Destination != ""
   - rename:
+      tag: rename_winlog_event_data_CommandLine_to_process_command_line_96e30e50
       field: winlog.event_data.CommandLine
       target_field: process.command_line
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.CommandLine != null && ctx.winlog?.event_data?.CommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_CurrentDirectory_to_process_working_directory_608b37f2
       field: winlog.event_data.CurrentDirectory
       target_field: process.working_directory
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.CurrentDirectory != null && ctx.winlog?.event_data?.CurrentDirectory != ""
   - rename:
+      tag: rename_winlog_event_data_ParentProcessGuid_to_process_parent_entity_id_2d954662
       field: winlog.event_data.ParentProcessGuid
       target_field: process.parent.entity_id
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ParentProcessGuid != null && ctx.winlog?.event_data?.ParentProcessGuid != ""
   - convert:
+      tag: convert_winlog_event_data_ParentProcessId_to_process_parent_pid_c780e8f3
       field: winlog.event_data.ParentProcessId
       target_field: process.parent.pid
       type: long
@@ -423,42 +454,49 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.ParentProcessId != null && ctx.winlog?.event_data?.ParentProcessId != ""
   - rename:
+      tag: rename_winlog_event_data_ParentImage_to_process_parent_executable_bacc688c
       field: winlog.event_data.ParentImage
       target_field: process.parent.executable
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ParentImage != null && ctx.winlog?.event_data?.ParentImage != ""
   - rename:
+      tag: rename_winlog_event_data_ParentCommandLine_to_process_parent_command_line_8601aa2e
       field: winlog.event_data.ParentCommandLine
       target_field: process.parent.command_line
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ParentCommandLine != null && ctx.winlog?.event_data?.ParentCommandLine != ""
   - rename:
+      tag: rename_winlog_event_data_OriginalFileName_to_process_pe_original_file_name_93afff9b
       field: winlog.event_data.OriginalFileName
       target_field: process.pe.original_file_name
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code != "7" && ctx.winlog?.event_data?.OriginalFileName != null && ctx.winlog?.event_data?.OriginalFileName != ""
   - set:
+      tag: set_process_pe_company_c2816db7
       field: process.pe.company
       copy_from: winlog.event_data.Company
       ignore_empty_value: true
       ignore_failure: true
       if: ctx.event.code != "7"
   - set:
+      tag: set_process_pe_description_6e39d255
       field: process.pe.description
       copy_from: winlog.event_data.Description
       ignore_empty_value: true
       ignore_failure: true
       if: ctx.event.code != "7"
   - set:
+      tag: set_process_pe_file_version_7e75767a
       field: process.pe.file_version
       copy_from: winlog.event_data.FileVersion
       ignore_empty_value: true
       ignore_failure: true
       if: ctx.event.code != "7"
   - set:
+      tag: set_process_pe_product_3e168e1f
       field: process.pe.product
       copy_from: winlog.event_data.Product
       ignore_empty_value: true
@@ -466,6 +504,7 @@ processors:
       if: ctx.event.code != "7"
 
   - script:
+      tag: script_85dfd5a9
       description: Implements Windows-like SplitCommandLine
       lang: painless
       if: |-
@@ -556,6 +595,7 @@ processors:
         }
 
   - script:
+      tag: script_f3024ab5
       description: Adds process name information.
       lang: painless
       if: |-
@@ -589,94 +629,111 @@ processors:
 ## File fields
 
   - set:
+      tag: set_file_hash_62c6ed89
       field: file.hash
       copy_from: _temp.hashes
       if: |-
         ctx._temp?.hashes != null &&
         ["6", "7", "15", "26", "29"].contains(ctx.event.code)
   - rename:
+      tag: rename_file_hash_imphash_to_file_pe_imphash_6baf0a60
       field: file.hash.imphash
       target_field: file.pe.imphash
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_TargetFilename_to_file_path_cea5fc4b
       field: winlog.event_data.TargetFilename
       target_field: file.path
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.TargetFilename != null && ctx.winlog?.event_data?.TargetFilename != ""
   - rename:
+      tag: rename_winlog_event_data_Device_to_file_path_dd9b02c1
       field: winlog.event_data.Device
       target_field: file.path
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Device != null && ctx.winlog?.event_data?.Device != ""
   - rename:
+      tag: rename_winlog_event_data_PipeName_to_file_name_fd128394
       field: winlog.event_data.PipeName
       target_field: file.name
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.PipeName != null && ctx.winlog?.event_data?.PipeName != ""
   - rename:
+      tag: rename_winlog_event_data_ImageLoaded_to_file_path_c8f42a6d
       field: winlog.event_data.ImageLoaded
       target_field: file.path
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.ImageLoaded != null && ctx.winlog?.event_data?.ImageLoaded != ""
   - set:
+      tag: set_file_code_signature_subject_name_cb55bafb
       field: file.code_signature.subject_name
       copy_from: winlog.event_data.Signature
       ignore_failure: true
       ignore_empty_value: true
   - set:
+      tag: set_file_code_signature_status_a66cac45
       field: file.code_signature.status
       copy_from: winlog.event_data.SignatureStatus
       ignore_failure: true
       ignore_empty_value: true
   - rename:
+      tag: rename_winlog_event_data_OriginalFileName_to_file_pe_original_file_name_869eb5cc
       field: winlog.event_data.OriginalFileName
       target_field: file.pe.original_file_name
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code == "7" && ctx.winlog?.event_data?.OriginalFileName != null && ctx.winlog?.event_data?.OriginalFileName != ""
   - set:
+      tag: set_file_pe_company_56e8dab0
       field: file.pe.company
       copy_from: winlog.event_data.Company
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_pe_description_b329982c
       field: file.pe.description
       copy_from: winlog.event_data.Description
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_pe_file_version_36bcbf21
       field: file.pe.file_version
       copy_from: winlog.event_data.FileVersion
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_pe_product_31604628
       field: file.pe.product
       copy_from: winlog.event_data.Product
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_file_code_signature_trusted_47d996ad
       field: file.code_signature.trusted
       value: true
       if: ctx.winlog?.event_data?.Signed != null && ctx.winlog.event_data.Signed == 'true'
   - set:
+      tag: set_file_code_signature_trusted_d3049f18
       field: file.code_signature.trusted
       value: false
       if: ctx.winlog?.event_data?.Signed != null && ctx.winlog.event_data.Signed != 'true'
   - set:
+      tag: set_file_code_signature_valid_4fccf922
       field: file.code_signature.valid
       value: true
       if: ctx.winlog?.event_data?.SignatureStatus != null && ctx.winlog?.event_data?.SignatureStatus == "Valid"
 
   - script:
+      tag: script_8bd0d8ed
       description: Adds file information.
       lang: painless
       if: ctx.file?.path != null && ctx.file.path.length() > 1
@@ -699,32 +756,38 @@ processors:
 ## DLL fields
 
   - set:
+      tag: set_dll_name_3629d056
       field: dll.name
       copy_from: file.name
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_dll_path_574a217e
       field: dll.path
       copy_from: file.path
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_dll_code_signature_subject_name_b00b038d
       field: dll.code_signature.subject_name
       copy_from: winlog.event_data.Signature
       ignore_failure: true
       ignore_empty_value: true
       if: ctx.event.code == "7"
   - set:
+      tag: set_dll_code_signature_trusted_df73491f
       field: dll.code_signature.trusted
       value: true
       if: ctx.event.code == "7" && ctx.winlog?.event_data?.Signed == 'true'
   - set:
+      tag: set_dll_code_signature_trusted_869bf1b0
       field: dll.code_signature.trusted
       value: false
       if: ctx.event.code == "7" && ctx.winlog?.event_data?.Signed != null && ctx.winlog?.event_data?.Signed == 'false'
   - script:
+      tag: script_f9d06e42
       description: Set dll.code_signature.status
       lang: painless
       if: ctx.event.code == "7"
@@ -737,16 +800,19 @@ processors:
           ctx.dll.code_signature.status = ctx.winlog.event_data.Signed;
         }
   - set:
+      tag: set_dll_hash_d3741256
       field: dll.hash
       copy_from: _temp.hashes
       if: |-
         ctx._temp?.hashes != null && ctx.event.code == "7"
   - rename:
+      tag: rename_dll_hash_imphash_to_dll_pe_imphash_f79a6c38
       field: dll.hash.imphash
       target_field: dll.pe.imphash
       ignore_failure: true
       ignore_missing: true
   - set:
+      tag: set_dll_pe_original_file_name_35d387dd
       field: dll.pe.original_file_name
       copy_from: file.pe.original_file_name
       ignore_failure: true
@@ -755,28 +821,33 @@ processors:
 ## Network, Destination, and Source fields
 
   - rename:
+      tag: rename_winlog_event_data_Protocol_to_network_transport_994bcb0d
       field: winlog.event_data.Protocol
       target_field: network.transport
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.Protocol != null && ctx.winlog?.event_data?.Protocol != ""
   - rename:
+      tag: rename_winlog_event_data_DestinationPortName_to_network_protocol_edf1f8a0
       field: winlog.event_data.DestinationPortName
       target_field: network.protocol
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code != "22" && ctx.winlog?.event_data?.DestinationPortName != null && ctx.winlog?.event_data?.DestinationPortName != ""
   - rename:
+      tag: rename_winlog_event_data_SourcePortName_to_network_protocol_f1ab163d
       field: winlog.event_data.SourcePortName
       target_field: network.protocol
       ignore_missing: true
       ignore_failure: true
       if: ctx.event.code != "22" && ctx.winlog?.event_data?.SourcePortName != null && ctx.winlog?.event_data?.SourcePortName != ""
   - set:
+      tag: set_network_protocol_3c708440
       field: network.protocol
       value: dns
       if: ctx.event.code == "22"
   - convert:
+      tag: convert_winlog_event_data_SourceIp_to_source_ip_a393b286
       field: winlog.event_data.SourceIp
       target_field: source.ip
       type: ip
@@ -784,12 +855,14 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourceIp != null && ctx.winlog?.event_data?.SourceIp != ""
   - rename:
+      tag: rename_winlog_event_data_SourceHostname_to_source_domain_820aedc9
       field: winlog.event_data.SourceHostname
       target_field: source.domain
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.SourceHostname != null && ctx.winlog?.event_data?.SourceHostname != ""
   - convert:
+      tag: convert_winlog_event_data_SourcePort_to_source_port_7e92f2af
       field: winlog.event_data.SourcePort
       target_field: source.port
       type: long
@@ -797,6 +870,7 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.SourcePort != null && ctx.winlog?.event_data?.SourcePort != ""
   - convert:
+      tag: convert_winlog_event_data_DestinationIp_to_destination_ip_187d4f90
       field: winlog.event_data.DestinationIp
       target_field: destination.ip
       type: ip
@@ -804,12 +878,14 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DestinationIp != null && ctx.winlog?.event_data?.DestinationIp != ""
   - rename:
+      tag: rename_winlog_event_data_DestinationHostname_to_destination_domain_7325d23b
       field: winlog.event_data.DestinationHostname
       target_field: destination.domain
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.DestinationHostname != null && ctx.winlog?.event_data?.DestinationHostname != ""
   - convert:
+      tag: convert_winlog_event_data_DestinationPort_to_destination_port_78f789f5
       field: winlog.event_data.DestinationPort
       target_field: destination.port
       type: long
@@ -817,28 +893,34 @@ processors:
       ignore_missing: true
       if: ctx.winlog?.event_data?.DestinationPort != null && ctx.winlog?.event_data?.DestinationPort != ""
   - rename:
+      tag: rename_winlog_event_data_QueryName_to_dns_question_name_3cd15691
       field: winlog.event_data.QueryName
       target_field: dns.question.name
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.QueryName != null && ctx.winlog?.event_data?.QueryName != ""
   - set:
+      tag: set_network_direction_00ba90c4
       field: network.direction
       value: egress
       if: ctx.winlog?.event_data?.Initiated != null && ctx.winlog?.event_data?.Initiated == "true"
   - set:
+      tag: set_network_direction_13b18f87
       field: network.direction
       value: ingress
       if: ctx.winlog?.event_data?.Initiated != null && ctx.winlog?.event_data?.Initiated == "false"
   - set:
+      tag: set_network_type_bbfc772a
       field: network.type
       value: ipv4
       if: ctx.winlog?.event_data?.SourceIsIpv6 != null && ctx.winlog?.event_data?.SourceIsIpv6 == "false"
   - set:
+      tag: set_network_type_73514339
       field: network.type
       value: ipv6
       if: ctx.winlog?.event_data?.SourceIsIpv6 != null && ctx.winlog?.event_data?.SourceIsIpv6 == "true"
   - script:
+      tag: script_1361f033
       description: |
         Splits the QueryResults field that contains the DNS responses.
         Example: "type:  5 f2.taboola.map.fastly.net;::ffff:151.101.66.2;::ffff:151.101.130.2;::ffff:151.101.194.2;::ffff:151.101.2.2;"
@@ -950,6 +1032,7 @@ processors:
           ctx.related.hosts = relatedHosts;
         }
   - foreach:
+      tag: foreach_dns_answers_3b0b739d
       field: dns.answers
       if: ctx.dns?.answers instanceof List
       ignore_failure: true
@@ -959,6 +1042,7 @@ processors:
           pattern: '^\[?::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(?:\](?::[0-9]+)?)?$'
           replacement: '$1'
   - foreach:
+      tag: foreach_dns_resolved_ip_0d1a1469
       field: dns.resolved_ip
       if: ctx.dns?.resolved_ip instanceof List
       ignore_failure: true
@@ -968,6 +1052,7 @@ processors:
           pattern: '^\[?::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(?:\](?::[0-9]+)?)?$'
           replacement: '$1'
   - foreach:
+      tag: foreach_dns_resolved_ip_34ab3637
       field: dns.resolved_ip
       ignore_missing: true
       processor:
@@ -978,6 +1063,7 @@ processors:
             - remove:
                 field: _ingest._value
   - script:
+      tag: script_c8568aea
       description: Convert V4MAPPED addresses.
       lang: painless
       if: ctx.dns?.resolved_ip != null
@@ -1003,21 +1089,25 @@ processors:
           ]);
         }
   - registered_domain:
+      tag: registered_domain_dns_question_name_to_dns_question_24868ff9
       field: dns.question.name
       target_field: dns.question
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_related_hosts_c5d4edd1
       field: related.hosts
       value: "{{dns.question.name}}"
       allow_duplicates: false
       if: ctx.dns?.question?.name != null && ctx.dns?.question?.name != ""
   - remove:
+      tag: remove_dns_question_domain_610dad76
       description: Remove dns.question.domain because it is not part of ECS and is redundant with dns.question.name.
       field: dns.question.domain
       ignore_missing: true
       ignore_failure: true
   - foreach:
+      tag: foreach_dns_resolved_ip_066293db
       field: dns.resolved_ip
       ignore_missing: true
       processor:
@@ -1027,28 +1117,33 @@ processors:
           allow_duplicates: false
           ignore_failure: true
   - community_id:
+      tag: community_id_9c2f7277
       ignore_failure: true
       ignore_missing: false
 
 ## User fields
 
   - set:
+      tag: set_user_id_0dabac40
       field: user.id
       copy_from: winlog.user.identifier
       ignore_empty_value: true
       ignore_failure: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
@@ -1057,22 +1152,26 @@ processors:
   # Get user details from the translate_sid processor enrichment
   # if they are available and we don't already have them.
   - rename:
+      tag: rename_winlog_event_data__MemberUserName_to_user_name_46f9020b
       field: winlog.event_data._MemberUserName
       target_field: user.name
       ignore_failure: true
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data__MemberDomain_to_user_domain_650026e2
       field: winlog.event_data._MemberDomain
       target_field: user.domain
       ignore_failure: true
       ignore_missing: true
   - append:
+      tag: append_user_roles_63374eff
       value: '{{{winlog.event_data._MemberAccountType}}}'
       field: user.roles
       ignore_failure: true
       allow_duplicates: false
       if: ctx.winlog?.event_data?._MemberAccountType != null
   - remove:
+      tag: remove_winlog_event_data__MemberAccountType_e41d8d2a
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
@@ -1081,12 +1180,14 @@ processors:
 ## Sysmon fields
 
   - rename:
+      tag: rename_winlog_event_data_QueryStatus_to_sysmon_dns_status_c310d5d2
       field: winlog.event_data.QueryStatus
       target_field: sysmon.dns.status
       ignore_missing: true
       ignore_failure: true
       if: ctx.winlog?.event_data?.QueryStatus != null && ctx.winlog?.event_data?.QueryStatus != ""
   - script:
+      tag: script_06dfcee3
       description: Translate DNS Query status.
       lang: painless
       params:
@@ -1294,6 +1395,7 @@ processors:
           ctx.sysmon.dns.status = status;
         }
   - convert:
+      tag: convert_winlog_event_data_Archived_to_sysmon_file_archived_ba988912
       field: winlog.event_data.Archived
       target_field: sysmon.file.archived
       type: boolean
@@ -1301,6 +1403,7 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data?.Archived != null && ctx.winlog?.event_data?.Archived != ""
   - convert:
+      tag: convert_winlog_event_data_IsExecutable_to_sysmon_file_is_executable_0c28b197
       field: winlog.event_data.IsExecutable
       target_field: sysmon.file.is_executable
       type: boolean
@@ -1308,6 +1411,7 @@ processors:
       ignore_failure: true
       if: ctx.winlog?.event_data?.IsExecutable != null && ctx.winlog?.event_data?.IsExecutable != ""
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
@@ -1315,18 +1419,21 @@ processors:
 ## Related fields
 
   - append:
+      tag: append_related_user_0d94e1af
       field: related.user
       value: "{{user.name}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.user?.name != null && ctx.user.name != ""
   - append:
+      tag: append_related_ip_75c642a5
       field: related.ip
       value: "{{source.ip}}"
       ignore_failure: true
       allow_duplicates: false
       if: ctx.source?.ip != null && ctx.source.ip != ""
   - append:
+      tag: append_related_ip_df9f8c82
       field: related.ip
       value: "{{destination.ip}}"
       ignore_failure: true
@@ -1336,6 +1443,7 @@ processors:
 ## Registry fields
 
   - script:
+      tag: script_cd7e1956
       description: Set registry fields.
       lang: painless
       if: |-
@@ -1431,6 +1539,7 @@ processors:
 
 ## Conformity
   - rename:
+      tag: rename_winlog_event_data_TargetProcessGuid_to_winlog_event_data_TargetProcessGUID_7c39f434
       field: winlog.event_data.TargetProcessGuid
       target_field: winlog.event_data.TargetProcessGUID
       if: ctx.winlog?.event_data?.TargetProcessGuid != null
@@ -1438,6 +1547,7 @@ processors:
 ## Cleanup
 
   - remove:
+      tag: remove_6bcaa69b
       field:
         - _temp
         - winlog.event_data.ProcessId
@@ -1469,6 +1579,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - remove:
+      tag: remove_winlog_event_data_af8c8256
       description: Remove empty event data.
       field: winlog.event_data
       ignore_missing: true

--- a/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
@@ -4,9 +4,11 @@ processors:
   ## ECS and Event fields.
 
   - set:
+      tag: set_ecs_version_f5923549
       field: ecs.version
       value: '8.17.0'
   - set:
+      tag: set_log_level_b08eee5f
       field: log.level
       copy_from: winlog.level
       ignore_empty_value: true
@@ -20,69 +22,87 @@ processors:
       if: ctx.winlog?.time_created != null
       on_failure:
         - remove:
+            tag: remove_winlog_time_created_1a30788f
             field: winlog.time_created
             ignore_failure: true
         - append:
+            tag: append_error_message_c5501840
             field: error.message
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
+            tag: fail_d347c61f
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - convert:
+      tag: convert_error_code_5bcb9be1
       field: error.code
       type: string
       ignore_missing: true
   - set:
+      tag: set_event_code_cdc75ed7
       field: event.code
       value: '{{winlog.event_id}}'
   - set:
+      tag: set_event_action_a656118f
       field: event.action
       value: antivirus-configuration-changed
       if: ctx.event?.code == "5007"
   - set:
+      tag: set_event_action_7a491a35
       field: event.action
       value: antivirus-updated
       if: ctx.event?.code == "2000"
   - set:
+      tag: set_event_action_4196c86c
       field: event.action
       value: file-uploaded
       if: ctx.event?.code == "2050"
   - set:
+      tag: set_event_action_914b2038
       field: event.action
       value: malware-detected
       if: ctx.event?.code == "1116" || ctx.event?.code == "1117"
   - set:
+      tag: set_event_action_13cab4fe
       field: event.action
       value: malware-quarantined
       if: ctx.event?.code == "1117" && ctx.winlog?.event_data?.Action_Name == "Quarantine"
   - set:
+      tag: set_event_category_0c3e8220
       field: event.category
       value: ["configuration"]
       if: ctx.event?.code == "5007"
   - set:
+      tag: set_event_category_fc038899
       field: event.category
       value: ["file"]
       if: ctx.event?.code == "2050"
   - set:
+      tag: set_event_category_b1393edb
       field: event.category
       value: ["malware"]
       if: ctx.event?.code == "1116" || ctx.event?.code == "1117"
   - set:
+      tag: set_event_category_ce8f0c9c
       field: event.category
       value: ["process"]
       override: false
       if: ctx.event?.category == null  
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_outcome_b8d5f939
       field: event.outcome
       value: success
       if: ctx.winlog?.event_data?.Error_Description == "The operation completed successfully. "
   - set:
+      tag: set_event_reference_97ca7590
       field: event.reference
       ignore_empty_value: true
       copy_from: winlog.event_data.FWLink
   - script:
+      tag: script_5e7000ea
       description: Set Event Types
       lang: painless
       source: |
@@ -111,11 +131,13 @@ processors:
           }
         }
   - set:
+      tag: set_destination_domain_d1cb382f
       field: destination.domain
       override: false
       ignore_empty_value: true
       copy_from: winlog.event_data.Destination
   - convert:
+      tag: convert_winlog_record_id_b6e33898
       field: winlog.record_id
       type: string
       ignore_failure: true
@@ -125,32 +147,38 @@ processors:
   ## User fields.
 
   - split:
+      tag: split_winlog_event_data_Detection_User_to__temp_user_parts_955276ec
       field: winlog.event_data.Detection_User
       separator: '\\'
       target_field: "_temp.user_parts"
       ignore_missing: true
   - split:
+      tag: split_winlog_event_data_User_to__temp_user_parts_56cb506e
       field: winlog.event_data.User
       target_field: "_temp.user_parts"
       separator: '\\'
       if: ctx.winlog?.event_data?.User != null
   - set:
+      tag: set_user_domain_6839aa32
       field: user.domain
       value: "{{_temp.user_parts.0}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - set:
+      tag: set_user_name_60c775be
       field: user.name
       value: "{{_temp.user_parts.1}}"
       ignore_failure: true
       ignore_empty_value: true
       if: ctx._temp?.user_parts != null && ctx._temp.user_parts.size() == 2
   - remove:
+      tag: remove__temp_58530347
       field: _temp
       ignore_missing: true
       if: ctx._temp != null
   - remove:
+      tag: remove_winlog_message_1ce338fe
       field: winlog.message
       ignore_missing: true
       if: ctx.winlog?.message != null
@@ -158,62 +186,73 @@ processors:
     ## File Fields
 
   - grok:
+      tag: grok_winlog_event_data_Path_835e508d
       field: winlog.event_data.Path
       patterns:
         - "file:_(?<file.path>[^;]+)(; process:_pid:%{NUMBER:process.pid})?"
         - "(?<file.path>[^;]+)(; process:_pid:%{NUMBER:process.pid})?"
       ignore_missing: true
   - split:
+      tag: split_winlog_event_data_Path_to_windows_defender_evidence_paths_31c6bfbc
       field: winlog.event_data.Path
       separator: ";"
       target_field: windows_defender.evidence_paths
       ignore_missing: true
       ignore_failure: true
   - trim:
+      tag: trim_windows_defender_evidence_paths_eb8ae3e8
       field: windows_defender.evidence_paths
       ignore_missing: true
       ignore_failure: true
   - gsub:
+      tag: gsub_windows_defender_evidence_paths_51ac9626
       field: windows_defender.evidence_paths
       pattern: "file:_"
       replacement: ""
       ignore_missing: true
       ignore_failure: true
   - gsub:
+      tag: gsub_windows_defender_evidence_paths_fd0fa843
       field: windows_defender.evidence_paths
       pattern: "process:_"
       replacement: ""
       ignore_missing: true
       ignore_failure: true
   - grok:
+      tag: grok_winlog_event_data_FileName_019ace8f
       field: winlog.event_data.FileName
       patterns:
         - 'file:_(?<file.path>[^;]+)(; process:_pid:%{NUMBER:process.pid})?'
         - '(?<file.path>[^;]+)(; process:_pid:%{NUMBER:process.pid})?'
       ignore_missing: true
   - set:
+      tag: set_file_path_f240f3f5
       field: "file.path"
       copy_from: "winlog.event_data.Path"
       override: false
       ignore_empty_value: true
   - set:
+      tag: set_file_path_9b8f50a7
       field: "file.path"
       override: false
       ignore_empty_value: true
       copy_from: "winlog.event_data.Filename"
   - grok:
+      tag: grok_file_path_2900363a
       field: file.path
       patterns:
         - '(?<file.name>([^\\\\]*$))'
       ignore_missing: true
       if: ctx.file?.name == null
   - grok:
+      tag: grok_file_name_7392b5d0
       field: file.name
       patterns:
         - '\.%{GREEDYDATA:file.extension}$'
       ignore_missing: true
       if: ctx.file?.name != null && ctx.file.name.contains('.')
   - set:
+      tag: set_file_hash_sha256_5793ac6c
       field: file.hash.sha256
       copy_from: winlog.event_data.Sha256
       override: false
@@ -223,24 +262,29 @@ processors:
       ## Process Fields
 
   - rename:
+      tag: rename_winlog_event_data_Target_Commandline_to_process_command_line_41ef4d7d
       field: winlog.event_data.Target_Commandline
       target_field: process.command_line
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_Parent_Commandline_to_process_parent_command_line_2e253974
       field: winlog.event_data.Parent_Commandline
       target_field: process.parent.command_line
       ignore_missing: true
   - rename:
+      tag: rename_winlog_event_data_Process_Name_to_process_executable_77c10411
       field: winlog.event_data.Process_Name
       target_field: process.executable
       ignore_missing: true
       if: ctx.process?.executable == null && ctx.event?.code != "1126"
   - rename:
+      tag: rename_winlog_event_data_Process_Name_to_process_name_10ea39af
       field: winlog.event_data.Process_Name
       target_field: process.name
       ignore_missing: true
       if: ctx.process?.name == null && ctx.event?.code == "1126"
   - grok:
+      tag: grok_process_executable_7381e630
       field: process.executable
       patterns:
         - '(?<process.name>([^\\]*$))'
@@ -249,6 +293,7 @@ processors:
 
       ## URL Fields
   - set:
+      tag: set_destination_domain_d1cb382f
       field: destination.domain
       override: false
       ignore_empty_value: true

--- a/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
@@ -300,11 +300,19 @@ processors:
       copy_from: winlog.event_data.Destination
 
 on_failure:
+  - append:
+      tag: append_error_message_2304b6c8
+      field: error.message
+      value: |-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
-      tag: append_error_message_4b65e074
-      field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+      tag: append_tags_d762b9c5
+      field: tags
+      value: preserve_original_event
+      allow_duplicates: false

--- a/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
@@ -293,7 +293,7 @@ processors:
 
       ## URL Fields
   - set:
-      tag: set_destination_domain_d1cb382f
+      tag: set_destination_domain_b6cf5ffd
       field: destination.domain
       override: false
       ignore_empty_value: true
@@ -301,8 +301,10 @@ processors:
 
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_4b65e074
       field: error.message
       value: "{{ _ingest.on_failure_message }}"

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 3.9.0
+version: 3.10.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[windows] Add tags to ingest pipeline processors

Used `elastic-package modify pipeline-tag` but avoided committing
non-tag changes (formatting, etc.).
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #17905