### PR TITLE
[endace] Add tags to ingest pipeline processors

### DIFF
--- a/packages/endace/changelog.yml
+++ b/packages/endace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Add tags to ingest pipeline processors.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20808
 - version: "0.2.0"
   changes:
     - description: Preserve event.original on pipeline error.

--- a/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/compatibility.yml
+++ b/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/compatibility.yml
@@ -13,6 +13,7 @@ processors:
       target_field: network_traffic.status
       ignore_missing: true
   - rename:
+      tag: rename_process_ppid_to_process_parent_pid_efedbd92
       field: process.ppid
       target_field: process.parent.pid
       ignore_missing: true

--- a/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/compatibility.yml
+++ b/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/compatibility.yml
@@ -29,13 +29,16 @@ processors:
 
 on_failure:
   - append:
+      tag: append_error_message_9319ae1f
       field: error.message
       value: |-
           Processor "{{{ _ingest.on_failure_processor_type }}}" with tag "{{{ _ingest.on_failure_processor_tag }}}" in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags_d762b9c5
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/default.yml
@@ -118,13 +118,16 @@ processors:
 
 on_failure:
   - append:
+      tag: append_error_message_9319ae1f
       field: error.message
       value: |-
           Processor "{{{ _ingest.on_failure_processor_type }}}" with tag "{{{ _ingest.on_failure_processor_tag }}}" in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags_d762b9c5
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/endace.yml
+++ b/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/endace.yml
@@ -82,15 +82,18 @@ processors:
 
 on_failure:
   - append:
+      tag: append_error_message_106c936e
       field: error.message
       description: "Error Message"
       value: |-
           Processor "{{{ _ingest.on_failure_processor_type }}}" with tag "{{{ _ingest.on_failure_processor_tag }}}" in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_event_kind_5feba029
       field: event.kind
       description: "Event Kind"
       value: pipeline_error
   - append:
+      tag: append_tags_d762b9c5
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/geoip.yml
+++ b/packages/endace/data_stream/flow/elasticsearch/ingest_pipeline/geoip.yml
@@ -103,13 +103,16 @@ processors:
 
 on_failure:
   - append:
+      tag: append_error_message_1fd9793d
       field: error.message
       value: |-
         Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_tags_d762b9c5
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/endace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/endace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -142,9 +142,11 @@ processors:
       if: ctx.error?.message != null
 on_failure:
   - set:
+      tag: set_event_kind_f51b77ad
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_error_message_ec34c92a
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -152,6 +154,7 @@ on_failure:
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
   - append:
+      tag: append_tags_d762b9c5
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/endace/data_stream/log/elasticsearch/ingest_pipeline/endace-netflow.yml
+++ b/packages/endace/data_stream/log/elasticsearch/ingest_pipeline/endace-netflow.yml
@@ -82,6 +82,7 @@ processors:
 
 on_failure:
   - append:
+      tag: append_error_message_ec34c92a
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
@@ -89,10 +90,12 @@ on_failure:
         {{/_ingest.on_failure_processor_tag}}in pipeline '{{{ _ingest.pipeline }}}'
         failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
+      tag: set_event_kind_5feba029
       field: event.kind
       description: "Event Kind"
       value: pipeline_error
   - append:
+      tag: append_tags_d762b9c5
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/endace/manifest.yml
+++ b/packages/endace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: endace
 title: "Endace"
-version: 0.2.0
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: "This Endace integration configures Network Packet Capture for flow generation and adds a pivot field to your Endace platform."


### PR DESCRIPTION
## Proposed commit message

```
[endace] Add tags to ingest pipeline processors

Used `elastic-package modify pipeline-tag` but avoided committing
non-tag changes (formatting, etc.).
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #17905