### PR TITLE
Add owners for the OpenTelemetry input packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -247,7 +247,7 @@
 /packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
 /packages/elastic_security @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/elasticapm_input_otel @elastic/obs-intake-services
+/packages/elasticapm_input_otel @elastic/obs-ds-intake-services
 /packages/elasticsearch @elastic/stack-monitoring
 /packages/aws_elb_otel @elastic/obs-infraobs-integrations
 /packages/ece @elastic/stack-monitoring
@@ -349,7 +349,7 @@
 /packages/ironscales @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/island_browser @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/istio @elastic/obs-ds-hosted-services
-/packages/jaeger_input_otel @elastic/obs-intake-services
+/packages/jaeger_input_otel @elastic/obs-ds-intake-services
 /packages/jamf_compliance_reporter @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/jamf_pro @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/jamf_protect @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -362,7 +362,7 @@
 /packages/jupiter_one @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/kafka @elastic/obs-infraobs-integrations
 /packages/kafka_connect @elastic/obs-infraobs-integrations
-/packages/kafka_input_otel @elastic/obs-intake-services
+/packages/kafka_input_otel @elastic/obs-ds-intake-services
 /packages/kafka_log @elastic/obs-infraobs-integrations
 /packages/kafka_otel @elastic/obs-infraobs-integrations
 /packages/keeper_security_siem_integration @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -444,7 +444,7 @@
 /packages/osquery @elastic/security-service-integrations
 /packages/osquery_manager @elastic/security-defend-workflows
 /packages/otel_collector_internal_telemetry @elastic/obs-signals-metrics-team
-/packages/otlp_input_otel @elastic/obs-intake-services
+/packages/otlp_input_otel @elastic/obs-ds-intake-services
 /packages/pad @elastic/threat-research-and-detection-engineering @elastic/kibana-management
 /packages/panw @elastic/integration-experience
 /packages/panw_cortex_xdr @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -635,7 +635,7 @@
 /packages/zeek @elastic/integration-experience
 /packages/zerofox @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/zeronetworks @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/zipkin_input_otel @elastic/obs-intake-services
+/packages/zipkin_input_otel @elastic/obs-ds-intake-services
 /packages/zookeeper @elastic/obs-infraobs-integrations
 /packages/zookeeper_otel @elastic/obs-infraobs-integrations
 /packages/zoom @elastic/security-service-integrations @elastic/sit-crest-contractors

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /packages/anthropic @elastic/integration-experience
 /packages/anthropic_metrics @elastic/obs-infraobs-integrations
 /packages/apache @elastic/obs-infraobs-integrations
-/packages/apache_input_otel @elastic/ecosystem
+/packages/apache_input_otel @elastic/obs-infraobs-integrations
 /packages/apache_otel @elastic/obs-infraobs-integrations
 /packages/apache_spark @elastic/obs-infraobs-integrations
 /packages/apache_tomcat @elastic/obs-infraobs-integrations
@@ -239,7 +239,7 @@
 /packages/dga @elastic/threat-research-and-detection-engineering
 /packages/digital_guardian @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/docker @elastic/obs-ds-hosted-services
-/packages/docker_input_otel @elastic/ecosystem
+/packages/docker_input_otel @elastic/obs-signals-metrics-team
 /packages/docker_otel @elastic/obs-ds-hosted-services
 /packages/doppel @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/doppler @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -247,7 +247,7 @@
 /packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
 /packages/elastic_security @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/elasticapm_input_otel @elastic/ecosystem
+/packages/elasticapm_input_otel @elastic/obs-intake-services
 /packages/elasticsearch @elastic/stack-monitoring
 /packages/aws_elb_otel @elastic/obs-infraobs-integrations
 /packages/ece @elastic/stack-monitoring
@@ -325,17 +325,17 @@
 /packages/haproxy_otel @elastic/obs-infraobs-integrations
 /packages/hashicorp_vault @elastic/integration-experience
 /packages/hid_bravura_monitor @elastic/security-service-integrations
-/packages/hostmetrics_input_otel @elastic/obs-infraobs-integrations
+/packages/hostmetrics_input_otel @elastic/obs-signals-metrics-team
 /packages/hpe_aruba_cx @elastic/integration-experience
 /packages/hta @elastic/threat-research-and-detection-engineering
 /packages/http_endpoint @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/httpcheck_otel @elastic/ecosystem
+/packages/httpcheck_otel @elastic/obs-signals-logs-team
 /packages/httpjson @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/ibm_qradar @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/ibmmq @elastic/obs-infraobs-integrations
 /packages/ibmmq_otel @elastic/obs-infraobs-integrations
 /packages/iis @elastic/obs-infraobs-integrations
-/packages/iis_input_otel @elastic/ecosystem
+/packages/iis_input_otel @elastic/obs-infraobs-integrations
 /packages/iis_otel @elastic/obs-infraobs-integrations
 /packages/imperva @elastic/integration-experience
 /packages/imperva_cloud_waf @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -349,7 +349,7 @@
 /packages/ironscales @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/island_browser @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/istio @elastic/obs-ds-hosted-services
-/packages/jaeger_input_otel @elastic/ecosystem
+/packages/jaeger_input_otel @elastic/obs-intake-services
 /packages/jamf_compliance_reporter @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/jamf_pro @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/jamf_protect @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -362,14 +362,14 @@
 /packages/jupiter_one @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/kafka @elastic/obs-infraobs-integrations
 /packages/kafka_connect @elastic/obs-infraobs-integrations
-/packages/kafka_input_otel @elastic/ecosystem
+/packages/kafka_input_otel @elastic/obs-intake-services
 /packages/kafka_log @elastic/obs-infraobs-integrations
 /packages/kafka_otel @elastic/obs-infraobs-integrations
 /packages/keeper_security_siem_integration @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/keycloak @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/kibana @elastic/stack-monitoring
 /packages/kolide @elastic/integration-experience
-/packages/kubeletstats_input_otel @elastic/ecosystem
+/packages/kubeletstats_input_otel @elastic/obs-signals-metrics-team
 /packages/kubernetes @elastic/obs-ds-hosted-services
 /packages/kubernetes/kibana @elastic/obs-ds-hosted-services
 /packages/kubernetes_otel @elastic/obs-infraobs-integrations
@@ -405,7 +405,7 @@
 /packages/mysql @elastic/obs-infraobs-integrations
 /packages/mysql_enterprise @elastic/security-service-integrations
 /packages/mysql_otel @elastic/obs-infraobs-integrations
-/packages/mysql_input_otel @elastic/ecosystem
+/packages/mysql_input_otel @elastic/obs-infraobs-integrations
 /packages/nagios_xi @elastic/obs-infraobs-integrations
 /packages/nats @elastic/obs-infraobs-integrations
 /packages/neon_cyber @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -444,7 +444,7 @@
 /packages/osquery @elastic/security-service-integrations
 /packages/osquery_manager @elastic/security-defend-workflows
 /packages/otel_collector_internal_telemetry @elastic/obs-signals-metrics-team
-/packages/otlp_input_otel @elastic/ecosystem
+/packages/otlp_input_otel @elastic/obs-intake-services
 /packages/pad @elastic/threat-research-and-detection-engineering @elastic/kibana-management
 /packages/panw @elastic/integration-experience
 /packages/panw_cortex_xdr @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -467,8 +467,8 @@
 /packages/prometheus/data_stream/query @elastic/obs-infraobs-integrations
 /packages/prometheus/data_stream/remote_write @elastic/obs-ds-hosted-services
 /packages/prometheus_input @elastic/obs-infraobs-integrations
-/packages/prometheus_input_otel @elastic/ecosystem
-/packages/prometheus_input_otel_raw @elastic/ecosystem
+/packages/prometheus_input_otel @elastic/obs-infraobs-integrations
+/packages/prometheus_input_otel_raw @elastic/obs-infraobs-integrations
 /packages/proofpoint_essentials @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/proofpoint_itm @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/proofpoint_on_demand @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -485,7 +485,7 @@
 /packages/radware @elastic/integration-experience
 /packages/rapid7_insightvm @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/redis @elastic/obs-infraobs-integrations
-/packages/redis_input_otel @elastic/ecosystem
+/packages/redis_input_otel @elastic/obs-infraobs-integrations
 /packages/redis_otel @elastic/obs-infraobs-integrations
 /packages/redisenterprise @elastic/obs-infraobs-integrations
 /packages/redisenterprise_otel @elastic/obs-infraobs-integrations
@@ -508,7 +508,7 @@
 /packages/spring_boot @elastic/obs-infraobs-integrations
 /packages/spycloud @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/sql_input @elastic/obs-infraobs-integrations
-/packages/sql_server_input_otel @elastic/ecosystem
+/packages/sql_server_input_otel @elastic/obs-infraobs-integrations
 /packages/squid @elastic/integration-experience
 /packages/supabase @elastic/obs-infraobs-integrations
 /packages/stan @elastic/obs-infraobs-integrations
@@ -635,7 +635,7 @@
 /packages/zeek @elastic/integration-experience
 /packages/zerofox @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/zeronetworks @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/zipkin_input_otel @elastic/ecosystem
+/packages/zipkin_input_otel @elastic/obs-intake-services
 /packages/zookeeper @elastic/obs-infraobs-integrations
 /packages/zookeeper_otel @elastic/obs-infraobs-integrations
 /packages/zoom @elastic/security-service-integrations @elastic/sit-crest-contractors

--- a/packages/apache_input_otel/manifest.yml
+++ b/packages/apache_input_otel/manifest.yml
@@ -107,5 +107,5 @@ policy_templates:
         description: Override the server name used for TLS verification.
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/docker_input_otel/manifest.yml
+++ b/packages/docker_input_otel/manifest.yml
@@ -88,5 +88,5 @@ policy_templates:
         required: false
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-signals-metrics-team
   type: elastic

--- a/packages/elasticapm_input_otel/manifest.yml
+++ b/packages/elasticapm_input_otel/manifest.yml
@@ -82,5 +82,5 @@ policy_templates:
         default: generic
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-intake-services
   type: elastic

--- a/packages/elasticapm_input_otel/manifest.yml
+++ b/packages/elasticapm_input_otel/manifest.yml
@@ -82,5 +82,5 @@ policy_templates:
         default: generic
         show_user: false
 owner:
-  github: elastic/obs-intake-services
+  github: elastic/obs-ds-intake-services
   type: elastic

--- a/packages/hostmetrics_input_otel/manifest.yml
+++ b/packages/hostmetrics_input_otel/manifest.yml
@@ -127,5 +127,5 @@ policy_templates:
             os.type:
               enabled: true
 owner:
-  github: elastic/obs-infraobs-integrations
+  github: elastic/obs-signals-metrics-team
   type: elastic

--- a/packages/httpcheck_otel/manifest.yml
+++ b/packages/httpcheck_otel/manifest.yml
@@ -64,5 +64,5 @@ policy_templates:
         required: false
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-signals-logs-team
   type: elastic

--- a/packages/iis_input_otel/manifest.yml
+++ b/packages/iis_input_otel/manifest.yml
@@ -42,5 +42,5 @@ policy_templates:
         default: 1s
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/jaeger_input_otel/manifest.yml
+++ b/packages/jaeger_input_otel/manifest.yml
@@ -137,5 +137,5 @@ policy_templates:
         description: Path to the CA certificate file for verifying client certificates (mTLS).
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-intake-services
   type: elastic

--- a/packages/jaeger_input_otel/manifest.yml
+++ b/packages/jaeger_input_otel/manifest.yml
@@ -137,5 +137,5 @@ policy_templates:
         description: Path to the CA certificate file for verifying client certificates (mTLS).
         show_user: false
 owner:
-  github: elastic/obs-intake-services
+  github: elastic/obs-ds-intake-services
   type: elastic

--- a/packages/kafka_input_otel/manifest.yml
+++ b/packages/kafka_input_otel/manifest.yml
@@ -483,5 +483,5 @@ policy_templates:
         required: false
         show_user: false
 owner:
-  github: elastic/obs-intake-services
+  github: elastic/obs-ds-intake-services
   type: elastic

--- a/packages/kafka_input_otel/manifest.yml
+++ b/packages/kafka_input_otel/manifest.yml
@@ -483,5 +483,5 @@ policy_templates:
         required: false
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-intake-services
   type: elastic

--- a/packages/kubeletstats_input_otel/manifest.yml
+++ b/packages/kubeletstats_input_otel/manifest.yml
@@ -173,5 +173,5 @@ policy_templates:
         show_user: false
         default: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-signals-metrics-team
   type: elastic

--- a/packages/mysql_input_otel/manifest.yml
+++ b/packages/mysql_input_otel/manifest.yml
@@ -252,5 +252,5 @@ policy_templates:
           mysql.max_used_connections:
             enabled: true
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/otlp_input_otel/manifest.yml
+++ b/packages/otlp_input_otel/manifest.yml
@@ -175,5 +175,5 @@ policy_templates:
         show_user: false
         default: generic
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-intake-services
   type: elastic

--- a/packages/otlp_input_otel/manifest.yml
+++ b/packages/otlp_input_otel/manifest.yml
@@ -175,5 +175,5 @@ policy_templates:
         show_user: false
         default: generic
 owner:
-  github: elastic/obs-intake-services
+  github: elastic/obs-ds-intake-services
   type: elastic

--- a/packages/prometheus_input_otel/manifest.yml
+++ b/packages/prometheus_input_otel/manifest.yml
@@ -142,5 +142,5 @@ policy_templates:
         description: Bearer token sent as Authorization Bearer credentials. Ignored when Username is set.
         show_user: true
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/prometheus_input_otel_raw/manifest.yml
+++ b/packages/prometheus_input_otel_raw/manifest.yml
@@ -48,5 +48,5 @@ policy_templates:
           ```
         show_user: true
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/redis_input_otel/manifest.yml
+++ b/packages/redis_input_otel/manifest.yml
@@ -163,5 +163,5 @@ policy_templates:
         default: 1s
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/sql_server_input_otel/manifest.yml
+++ b/packages/sql_server_input_otel/manifest.yml
@@ -171,5 +171,5 @@ policy_templates:
         required: false
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/zipkin_input_otel/manifest.yml
+++ b/packages/zipkin_input_otel/manifest.yml
@@ -106,5 +106,5 @@ policy_templates:
         default: false
         show_user: false
 owner:
-  github: elastic/obs-intake-services
+  github: elastic/obs-ds-intake-services
   type: elastic

--- a/packages/zipkin_input_otel/manifest.yml
+++ b/packages/zipkin_input_otel/manifest.yml
@@ -106,5 +106,5 @@ policy_templates:
         default: false
         show_user: false
 owner:
-  github: elastic/ecosystem
+  github: elastic/obs-intake-services
   type: elastic


### PR DESCRIPTION
Add owners to the OTEL input packages. 
The ownership is decided as per the respective receiver owners of the OTel input package. 

| Package | Receiver | Category | Team |
|---------|----------|----------|------|
| `apache_input_otel` | apachereceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `aws_cloudwatch_input_otel` | awscloudwatchreceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `docker_input_otel` | dockerstatsreceiver | Signals / metrics | `@elastic/obs-signals-metrics-team` |
| `elasticapm_input_otel` | elasticapm (connector) | Streams / managed inputs | `@elastic/obs-ds-intake-services` |
| `hostmetrics_input_otel` | hostmetricsreceiver | Signals / metrics | `@elastic/obs-signals-metrics-team` |
| `httpcheck_otel` | httpcheckreceiver | Signals / logs | `@elastic/obs-signals-logs-team` |
| `iis_input_otel` | iisreceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `jaeger_input_otel` | jaegerreceiver | Streams / managed inputs | `@elastic/obs-ds-intake-services` |
| `kafka_input_otel` | kafkareceiver | Streams / managed inputs | `@elastic/obs-ds-intake-services` |
| `kubeletstats_input_otel` | kubeletstatsreceiver | Signals / metrics | `@elastic/obs-signals-metrics-team` |
| `mysql_input_otel` | mysqlreceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `nginx_input_otel` | nginxreceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `otlp_input_otel` | otlpreceiver | Streams / managed inputs | `@elastic/obs-ds-intake-services` |
| `prometheus_input_otel` | prometheusreceiver (guided) | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `prometheus_input_otel_raw` | prometheusreceiver (raw/BYO config) | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `redis_input_otel` | redisreceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `sql_server_input_otel` | sqlserverreceiver | Signals / integrations | `@elastic/obs-infraobs-integrations` |
| `statsd_input_otel` | statsdreceiver | Streams / agent framework | `@elastic/ecosystem` |
| `zipkin_input_otel` | zipkinreceiver | Streams / managed inputs | `@elastic/obs-ds-intake-services` |