### PR TITLE
[aws_mq] Enable Identity Federation for agentless deployments

### DIFF
--- a/packages/aws_mq/changelog.yml
+++ b/packages/aws_mq/changelog.yml
@@ -1,7 +1,10 @@
 # newer versions go on top
 - version: "2.0.0"
   changes:
-    - description: Enable Identity Federation (Cloud Connectors) for Amazon MQ metrics and log data streams. Adds var_groups credential selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, and Shared Credentials options. Bumps kibana and agent version floors to ^9.6.0 (required for use_cloud_connectors support). Major version bump frees the 1.x namespace for a backport branch serving users on older stacks.
+    - description: Raise the minimum required Kibana and Elastic Agent versions to 9.6.0, needed for Identity Federation (`use_cloud_connectors`) support. Deployments on older stacks cannot upgrade to 2.x; the 1.x line is reserved for backports serving older stacks.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/20817
+    - description: Enable Identity Federation (Cloud Connectors) for Amazon MQ metrics and log data streams. Adds var_groups credential selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, and Shared Credentials options.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/20817
 - version: "1.0.0"

--- a/packages/aws_mq/changelog.yml
+++ b/packages/aws_mq/changelog.yml
@@ -1,3 +1,9 @@
+# newer versions go on top
+- version: "2.0.0"
+  changes:
+    - description: Enable Identity Federation (Cloud Connectors) for Amazon MQ metrics and log data streams. Adds var_groups credential selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, and Shared Credentials options. Bumps kibana and agent version floors to ^9.6.0 (required for use_cloud_connectors support). Major version bump frees the 1.x namespace for a backport branch serving users on older stacks.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/aws_mq/changelog.yml
+++ b/packages/aws_mq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Identity Federation (Cloud Connectors) for Amazon MQ metrics and log data streams. Adds var_groups credential selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, and Shared Credentials options. Bumps kibana and agent version floors to ^9.6.0 (required for use_cloud_connectors support). Major version bump frees the 1.x namespace for a backport branch serving users on older stacks.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20817
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/aws_mq/data_stream/activemq_audit_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
@@ -1,0 +1,39 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws_mq
+      name: test-aws-cloudwatch-agentless-cloud-connector-aws_mq
+      streams:
+        - data_stream:
+            dataset: aws_mq.activemq_audit_logs
+          default_region: us-east-1
+          log_group_name_prefix: /aws/amazonmq/broker
+          number_of_workers: 1
+          publisher_pipeline.disable_host: true
+          region_name: us-east-1
+          role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          start_position: beginning
+          tags:
+            - forwarded
+            - aws_mq-activemq-audit-logs
+          use_cloud_connectors: true
+      type: aws-cloudwatch
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws_mq.activemq_audit_logs-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws_mq/data_stream/activemq_audit_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
@@ -7,7 +7,8 @@ inputs:
             name: aws_mq
       name: test-aws-cloudwatch-agentless-cloud-connector-aws_mq
       streams:
-        - data_stream:
+        - api_sleep: 200ms
+          data_stream:
             dataset: aws_mq.activemq_audit_logs
           default_region: us-east-1
           log_group_name_prefix: /aws/amazonmq/broker
@@ -15,6 +16,7 @@ inputs:
           publisher_pipeline.disable_host: true
           region_name: us-east-1
           role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          scan_frequency: 1m
           start_position: beginning
           tags:
             - forwarded

--- a/packages/aws_mq/data_stream/activemq_audit_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.yml
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.yml
@@ -1,0 +1,10 @@
+input: aws-cloudwatch
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    log_group_name_prefix: /aws/amazonmq/broker
+    region_name: us-east-1
+    number_of_workers: 1

--- a/packages/aws_mq/data_stream/activemq_audit_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -84,6 +84,9 @@ session_token: {{session_token}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/aws_mq/data_stream/activemq_audit_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_mq/data_stream/activemq_audit_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,30 +2,37 @@
 description: Pipeline for ActiveMQ audit logs in AmazonMQ.
 processors:
   - set:
+      tag: set_1
       field: event.ingested
       value: "{{{_ingest.timestamp}}}"
       ignore_empty_value: true
       ignore_failure: true
   - rename:
+      tag: rename_2
       field: message
       target_field: event.original
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_3
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
+      tag: set_4
       field: ecs.version
       value: 8.11.0
   - set:
+      tag: set_5
       field: cloud.service.name
       value: amazonmq_activemq
   - set:
+      tag: set_6
       field: cloud.provider
       value: aws
   - grok:
+      tag: grok_7
       field: event.original
       pattern_definitions:
         NOPIPEGREEDYDATA: "(\\n|(?! \\|).)*"
@@ -35,6 +42,7 @@ processors:
       ignore_missing: true
       ignore_failure: false
   - script:
+      tag: script_8
       if: "ctx.log?.level != null"
       lang: painless
       source: >-
@@ -45,6 +53,7 @@ processors:
           ctx.event.type = ["info"];
         }
   - script:
+      tag: script_9
       description: Drops null/empty values recursively
       lang: painless
       ignore_failure: true
@@ -64,11 +73,13 @@ processors:
         drop(ctx);
 on_failure:
   - set:
+      tag: set_on_failure_1
       field: event.kind
       value: pipeline_error
   - set:
+      tag: set_on_failure_2
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}' in pipeline {{{ _ingest.pipeline }}}

--- a/packages/aws_mq/data_stream/activemq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/activemq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
@@ -7,7 +7,8 @@ inputs:
             name: aws_mq
       name: test-aws-cloudwatch-agentless-cloud-connector-aws_mq
       streams:
-        - data_stream:
+        - api_sleep: 200ms
+          data_stream:
             dataset: aws_mq.activemq_general_logs
           default_region: us-east-1
           log_group_name_prefix: /aws/amazonmq/broker
@@ -15,6 +16,7 @@ inputs:
           publisher_pipeline.disable_host: true
           region_name: us-east-1
           role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          scan_frequency: 1m
           start_position: beginning
           tags:
             - forwarded

--- a/packages/aws_mq/data_stream/activemq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/activemq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
@@ -1,0 +1,39 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws_mq
+      name: test-aws-cloudwatch-agentless-cloud-connector-aws_mq
+      streams:
+        - data_stream:
+            dataset: aws_mq.activemq_general_logs
+          default_region: us-east-1
+          log_group_name_prefix: /aws/amazonmq/broker
+          number_of_workers: 1
+          publisher_pipeline.disable_host: true
+          region_name: us-east-1
+          role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          start_position: beginning
+          tags:
+            - forwarded
+            - aws_mq-activemq-general-logs
+          use_cloud_connectors: true
+      type: aws-cloudwatch
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws_mq.activemq_general_logs-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws_mq/data_stream/activemq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.yml
+++ b/packages/aws_mq/data_stream/activemq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.yml
@@ -1,0 +1,10 @@
+input: aws-cloudwatch
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    log_group_name_prefix: /aws/amazonmq/broker
+    region_name: us-east-1
+    number_of_workers: 1

--- a/packages/aws_mq/data_stream/activemq_general_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_mq/data_stream/activemq_general_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -84,6 +84,9 @@ session_token: {{session_token}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/aws_mq/data_stream/activemq_general_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_mq/data_stream/activemq_general_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,25 +2,31 @@
 description: Pipeline for ActiveMQ general logs in AmazonMQ.
 processors:
   - rename:
+      tag: rename_1
       field: message
       target_field: event.original
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_2
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
+      tag: set_3
       field: ecs.version
       value: 8.11.0
   - set:
+      tag: set_4
       field: cloud.service.name
       value: amazonmq_activemq
   - set:
+      tag: set_5
       field: cloud.provider
       value: aws
   - grok:
+      tag: grok_6
       field: event.original
       pattern_definitions:
         GREEDYMULTILINE: "(.|\\n|\\t)*"
@@ -31,20 +37,24 @@ processors:
         - "%{TIMESTAMP_DATA:timestamp}%{SPACE}\\|%{SPACE}%{LOGLEVEL:log.level}%{SPACE}\\|%{SPACE}%{NOPIPEGREEDYDATA:message}%{SPACE}\\|%{SPACE}%{NOPIPEGREEDYDATA:activemq.log.caller}%{SPACE}\\|%{SPACE}%{THREAD_NAME:activemq.log.thread}%{SPACE}%{GREEDYMULTILINE:error.stack_trace}"
       ignore_missing: true
   - date:
+      tag: date_7
       if: "ctx.event.timezone == null"
       field: timestamp
       target_field: "@timestamp"
       formats: ["yyyy-MM-dd HH:mm:ss,SSS"]
   - date:
+      tag: date_8
       if: "ctx.event.timezone != null"
       field: timestamp
       target_field: "@timestamp"
       timezone: "{{{ event.timezone }}}"
       formats: ["yyyy-MM-dd HH:mm:ss,SSS"]
   - remove:
+      tag: remove_9
       field:
         - timestamp
   - script:
+      tag: script_10
       if: "ctx.log?.level != null"
       lang: painless
       source: >-
@@ -55,6 +65,7 @@ processors:
           ctx.event.type = ["info"];
         }
   - script:
+      tag: script_11
       description: Drops null/empty values recursively
       lang: painless
       ignore_failure: true
@@ -74,11 +85,13 @@ processors:
         drop(ctx);
 on_failure:
   - set:
+      tag: set_on_failure_1
       field: event.kind
       value: pipeline_error
   - set:
+      tag: set_on_failure_2
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}' in pipeline {{{ _ingest.pipeline }}}

--- a/packages/aws_mq/data_stream/activemq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/activemq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
@@ -1,0 +1,92 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws_mq
+      name: test-metrics-agentless-cloud-connector-aws_mq
+      streams:
+        - data_stream:
+            dataset: aws_mq.activemq_metrics
+          default_region: us-east-1
+          metrics:
+            - name:
+                - AmqpMaximumConnections
+                - MqttMaximumConnections
+                - OpenwireMaximumConnections
+                - StompMaximumConnections
+                - WsMaximumConnections
+                - CurrentConnectionsCount
+                - EstablishedConnectionsCount
+                - InactiveDurableTopicSubscribersCount
+                - JournalFilesForFastRecovery
+                - JournalFilesForFullRecovery
+                - NetworkConnectorConnectionCount
+                - NetworkIn
+                - NetworkOut
+                - OpenTransactionCount
+                - TotalConsumerCount
+                - TotalMessageCount
+                - TotalProducerCount
+                - VolumeReadOps
+                - VolumeWriteOps
+                - ConsumerCount
+                - ReceiveCount
+                - ProducerCount
+                - QueueSize
+                - TotalEnqueueCount
+                - TotalDequeueCount
+              namespace: AWS/AmazonMQ
+              statistic:
+                - Maximum
+            - name:
+                - BurstBalance
+                - CpuCreditBalance
+              namespace: AWS/AmazonMQ
+              statistic:
+                - Minimum
+            - name:
+                - CpuUtilization
+                - HeapUsage
+                - JobSchedulerStorePercentUsage
+                - StorePercentUsage
+                - TempPercentUsage
+                - EnqueueTime
+                - MemoryUsage
+                - BurstBalance
+              namespace: AWS/AmazonMQ
+              statistic:
+                - Average
+            - name:
+                - EnqueueCount
+                - ExpiredCount
+                - DequeueCount
+                - DispatchCount
+                - InFlightCount
+              namespace: AWS/AmazonMQ
+              statistic:
+                - Sum
+          metricsets:
+            - cloudwatch
+          period: 5m
+          role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          tags_filter: null
+          use_cloud_connectors: true
+      type: aws/metrics
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - metrics-aws_mq.activemq_metrics-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws_mq/data_stream/activemq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/activemq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
@@ -10,6 +10,7 @@ inputs:
         - data_stream:
             dataset: aws_mq.activemq_metrics
           default_region: us-east-1
+          include_linked_accounts: true
           metrics:
             - name:
                 - AmqpMaximumConnections

--- a/packages/aws_mq/data_stream/activemq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.yml
+++ b/packages/aws_mq/data_stream/activemq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.yml
@@ -1,0 +1,7 @@
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    period: 5m

--- a/packages/aws_mq/data_stream/activemq_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws_mq/data_stream/activemq_metrics/agent/stream/stream.yml.hbs
@@ -27,6 +27,9 @@ shared_credential_file: {{shared_credential_file}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if default_region}}
 default_region: {{default_region}}
 {{/if}}

--- a/packages/aws_mq/data_stream/activemq_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_mq/data_stream/activemq_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -2,15 +2,18 @@
 description: Pipeline of ActiveMQ metrics
 processors:
   - dot_expander:
+      tag: dot_expander_1
       field: "*"
       ignore_failure: true
   - drop:
+      tag: drop_2
       description: "To drop the documents having RabbitMQ metrics"
       if: >
         ctx.aws?.amazonmq?.metrics?.size() == 1 &&
         ctx.aws.amazonmq.metrics.ConsumerCount?.max != null
       ignore_failure: true
   - rename:
+      tag: rename_3
       field: "aws.amazonmq.metrics"
       target_field: "aws.amazonmq.metrics.activemq.broker"
       ignore_missing: true
@@ -18,6 +21,7 @@ processors:
         ctx.aws?.dimensions?.Broker != null &&
         (ctx.aws?.dimensions?.Topic == null && ctx.aws?.dimensions?.Queue == null )
   - rename:
+      tag: rename_4
       field: "aws.amazonmq.metrics"
       target_field: "aws.amazonmq.metrics.activemq.destination"
       ignore_missing: true
@@ -27,12 +31,15 @@ processors:
 
 on_failure:
   - set:
+      tag: set_on_failure_1
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_on_failure_2
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - set:
+      tag: set_on_failure_3
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
@@ -1,0 +1,43 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws_mq
+      name: test-aws-cloudwatch-agentless-cloud-connector-aws_mq
+      streams:
+        - data_stream:
+            dataset: aws_mq.rabbitmq_general_logs
+          default_region: us-east-1
+          log_group_name_prefix: /aws/amazonmq/broker
+          multiline:
+            match: after
+            negate: true
+            pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}'
+          number_of_workers: 1
+          publisher_pipeline.disable_host: true
+          region_name: us-east-1
+          role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          start_position: beginning
+          tags:
+            - forwarded
+            - aws_mq-rabbitmq-general-logs
+          use_cloud_connectors: true
+      type: aws-cloudwatch
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws_mq.rabbitmq_general_logs-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.expected
@@ -7,18 +7,16 @@ inputs:
             name: aws_mq
       name: test-aws-cloudwatch-agentless-cloud-connector-aws_mq
       streams:
-        - data_stream:
+        - api_sleep: 200ms
+          data_stream:
             dataset: aws_mq.rabbitmq_general_logs
           default_region: us-east-1
           log_group_name_prefix: /aws/amazonmq/broker
-          multiline:
-            match: after
-            negate: true
-            pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}'
           number_of_workers: 1
           publisher_pipeline.disable_host: true
           region_name: us-east-1
           role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          scan_frequency: 1m
           start_position: beginning
           tags:
             - forwarded

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/_dev/test/policy/test-aws-cloudwatch-agentless-cloud-connector.yml
@@ -1,0 +1,10 @@
+input: aws-cloudwatch
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    log_group_name_prefix: /aws/amazonmq/broker
+    region_name: us-east-1
+    number_of_workers: 1

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/agent/stream/aws-cloudwatch.yml.hbs
@@ -84,6 +84,9 @@ session_token: {{session_token}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if proxy_url }}
 proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/aws_mq/data_stream/rabbitmq_general_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_general_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,25 +2,31 @@
 description: Pipeline for RabbitMQ general logs in AmazonMQ.
 processors:
   - rename:
+      tag: rename_1
       field: message
       target_field: event.original
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_2
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
+      tag: set_3
       field: ecs.version
       value: 8.11.0
   - set:
+      tag: set_4
       field: cloud.service.name
       value: amazonmq_rabbitmq
   - set:
+      tag: set_5
       field: cloud.provider
       value: aws
   - grok:
+      tag: grok_6
       field: event.original
       pattern_definitions:
         GREEDYMULTILINE: "(.|\n)*"
@@ -30,12 +36,14 @@ processors:
         %{GREEDYMULTILINE:message}"
       ignore_missing: true
   - date:
+      tag: date_7
       if: "ctx.event.timezone == null"
       field: timestamp
       target_field: "@timestamp"
       formats:
       - yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
   - date:
+      tag: date_8
       if: "ctx.event.timezone != null"
       field: "timestamp"
       target_field: "@timestamp"
@@ -43,9 +51,11 @@ processors:
       formats:
       - yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
   - remove:
+      tag: remove_9
       field:
         - timestamp
   - script:
+      tag: script_10
       if: "ctx.log?.level != null"
       lang: painless
       source: >-
@@ -56,6 +66,7 @@ processors:
           ctx.event.type = ["info"];
         }
   - script:
+      tag: script_11
       description: Drops null/empty values recursively
       lang: painless
       ignore_failure: true
@@ -75,11 +86,13 @@ processors:
         drop(ctx);
 on_failure:
   - set:
+      tag: set_on_failure_1
       field: event.kind
       value: pipeline_error
   - set:
+      tag: set_on_failure_2
       field: error.message
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}' in pipeline {{{ _ingest.pipeline }}}

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
@@ -1,0 +1,63 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.6.0
+            name: aws_mq
+      name: test-metrics-agentless-cloud-connector-aws_mq
+      streams:
+        - data_stream:
+            dataset: aws_mq.rabbitmq_metrics
+          default_region: us-east-1
+          metrics:
+            - name:
+                - ExchangeCount
+                - QueueCount
+                - ConnectionCount
+                - ChannelCount
+                - ConsumerCount
+                - MessageCount
+                - MessageReadyCount
+                - MessageUnacknowledgedCount
+                - PublishRate
+                - ConfirmRate
+                - AckRate
+                - SystemCpuUtilization
+                - RabbitMQMemLimit
+                - RabbitMQMemUsed
+                - RabbitMQDiskFreeLimit
+                - RabbitMQFdUsed
+                - RabbitMQIOReadAverageTime
+                - RabbitMQIOWriteAverageTime
+              namespace: AWS/AmazonMQ
+              statistic:
+                - Maximum
+            - name:
+                - RabbitMQDiskFree
+              namespace: AWS/AmazonMQ
+              statistic:
+                - Minimum
+          metricsets:
+            - cloudwatch
+          period: 5m
+          role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+          tags_filter: null
+          use_cloud_connectors: true
+      type: aws/metrics
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - metrics-aws_mq.rabbitmq_metrics-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.expected
@@ -10,6 +10,7 @@ inputs:
         - data_stream:
             dataset: aws_mq.rabbitmq_metrics
           default_region: us-east-1
+          include_linked_accounts: true
           metrics:
             - name:
                 - ExchangeCount

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/_dev/test/policy/test-metrics-agentless-cloud-connector.yml
@@ -1,0 +1,7 @@
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticAmazonMQReadOnly
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    period: 5m

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/agent/stream/stream.yml.hbs
@@ -27,6 +27,9 @@ shared_credential_file: {{shared_credential_file}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if default_region}}
 default_region: {{default_region}}
 {{/if}}

--- a/packages/aws_mq/data_stream/rabbitmq_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_mq/data_stream/rabbitmq_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -2,15 +2,18 @@
 description: Pipeline of RabbitMQ metrics
 processors:
   - dot_expander:
+      tag: dot_expander_1
       field: "*"
       ignore_failure: true
   - drop:
+      tag: drop_2
       description: "To drop the documents having RabbitMQ metrics"
       if: >
         ctx.aws?.amazonmq?.metrics?.size() == 1 &&
         ctx.aws.amazonmq.metrics.ConsumerCount?.max != null
       ignore_failure: true
   - rename:
+      tag: rename_3
       field: "aws.amazonmq.metrics"
       target_field: "aws.amazonmq.metrics.rabbitmq.broker"
       ignore_missing: true
@@ -18,6 +21,7 @@ processors:
         ctx.aws?.dimensions?.Broker != null &&
         (ctx.aws?.dimensions?.Node == null && ctx.aws?.dimensions?.Queue == null )
   - rename:
+      tag: rename_4
       field: "aws.amazonmq.metrics"
       target_field: "aws.amazonmq.metrics.rabbitmq.node"
       ignore_missing: true
@@ -25,6 +29,7 @@ processors:
         ctx.aws?.dimensions?.Broker != null &&
         (ctx.aws?.dimensions?.Node != null )
   - rename:
+      tag: rename_5
       field: "aws.amazonmq.metrics"
       target_field: "aws.amazonmq.metrics.rabbitmq.queue"
       ignore_missing: true
@@ -34,12 +39,15 @@ processors:
 
 on_failure:
   - set:
+      tag: set_on_failure_1
       field: event.kind
       value: pipeline_error
   - append:
+      tag: append_on_failure_2
       field: tags
       value: preserve_original_event
       allow_duplicates: false
   - set:
+      tag: set_on_failure_3
       field: error.message
       value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/aws_mq/manifest.yml
+++ b/packages/aws_mq/manifest.yml
@@ -145,9 +145,25 @@ policy_templates:
       - type: aws/metrics
         title: Collect Amazon MQ metrics
         description: Collect Amazon MQ metrics using AWS CloudWatch.
+        provider_permissions:
+          - provider: aws
+            description: CloudWatch metrics read access for Amazon MQ monitoring.
+            permissions:
+              - name: cloudwatch:GetMetricData
+              - name: cloudwatch:ListMetrics
+              - name: tag:GetResources
       - type: aws-cloudwatch
         title: Collect Amazon MQ Logs from CloudWatch
         description: Collect Amazon MQ logs from CloudWatch with Elastic Agent.
+        provider_permissions:
+          - provider: aws
+            description: CloudWatch Logs read access for Amazon MQ log collection.
+            permissions:
+              - name: logs:DescribeLogGroups
+              - name: logs:DescribeLogStreams
+              - name: logs:FilterLogEvents
+              - name: logs:GetLogEvents
+              - name: logs:GetLogGroupFields
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/aws_mq/manifest.yml
+++ b/packages/aws_mq/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.3.1
+format_version: 3.6.4
 name: aws_mq
 title: "Amazon MQ"
-version: "1.0.0"
+version: "2.0.0"
 description: "Collect Amazon MQ metrics and logs with Elastic Agent"
 type: integration
 categories:
@@ -11,9 +11,12 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.16.5 || ^9.0.0"
+    version: "^9.6.0"
   elastic:
     subscription: "basic"
+  # auth.aws.use_cloud_connectors (Identity Federation) requires Elastic Agent 9.6.0+.
+  agent:
+    version: "^9.6.0"
 screenshots:
   - src: /img/amazonmq-activemq-dashboard.png
     title: ActiveMQ overview dashboard
@@ -28,17 +31,6 @@ icons:
     title: Amazon MQ logo
     size: 32x32
     type: image/svg+xml
-policy_templates:
-  - name: amazon_mq
-    title: Amazon MQ
-    description: Collect Amazon MQ metrics and logs
-    inputs:
-      - type: aws/metrics
-        title: Collect Amazon MQ metrics
-        description: Collect Amazon MQ metrics using AWS CloudWatch.
-      - type: aws-cloudwatch
-        title: Collect Amazon MQ Logs from CloudWatch
-        description: Collect Amazon MQ logs from CloudWatch with Elastic Agent.
 vars:
   - name: shared_credential_file
     type: text
@@ -80,6 +72,12 @@ vars:
     multi: false
     required: false
     show_user: false
+  - name: supports_identity_federation
+    type: bool
+    title: Supports Identity Federation
+    multi: false
+    required: false
+    show_user: false
   - name: endpoint
     type: text
     title: Endpoint
@@ -103,6 +101,53 @@ vars:
     required: false
     show_user: false
     description: URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>
+var_groups:
+  - name: credential_type
+    required: true
+    title: Setup Access
+    selector_title: Preferred method
+    options:
+      - name: identity_federation
+        title: Identity Federation
+        vars: [role_arn, supports_identity_federation]
+        hide_in_deployment_modes: [default]
+        provider: aws
+        iac_template_url: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-federated-identity-aws-9.6.0.yml
+      - name: direct_access_key
+        title: Direct Access Keys
+        vars: [access_key_id, secret_access_key]
+      - name: temporary_access_key
+        title: Temporary Access Keys
+        vars: [access_key_id, secret_access_key, session_token]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role
+        title: Assume Role
+        vars: [role_arn]
+        hide_in_deployment_modes: [agentless]
+      - name: shared_credentials
+        title: Shared Credentials
+        vars: [shared_credential_file, credential_profile_name]
+        hide_in_deployment_modes: [agentless]
+policy_templates:
+  - name: amazon_mq
+    title: Amazon MQ
+    description: Collect Amazon MQ metrics and logs
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: observability
+        division: engineering
+        team: obs-infraobs-integrations
+    inputs:
+      - type: aws/metrics
+        title: Collect Amazon MQ metrics
+        description: Collect Amazon MQ metrics using AWS CloudWatch.
+      - type: aws-cloudwatch
+        title: Collect Amazon MQ Logs from CloudWatch
+        description: Collect Amazon MQ logs from CloudWatch with Elastic Agent.
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic


### PR DESCRIPTION
## Proposed commit message

Enable Identity Federation (Cloud Connectors) for the Amazon MQ integration.

Adds `var_groups` with a credential selector (Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, Shared Credentials), enables agentless deployment mode, and wires `use_cloud_connectors` into all five stream templates. Bumps `format_version` to 3.6.4 and `kibana`/`agent` floors to `^9.6.0` (required for `use_cloud_connectors`). Fixes pipeline processor tag and `on_failure` hygiene surfaced by the format_version bump.

**Major version bump (`1.0.0` → `2.0.0`)** frees the `1.x` namespace for `backport-aws_mq-1.x`, which will carry patch/minor fixes for users on stacks below `^9.6.0`. See elastic/ingest-dev#8788 for the branching strategy.

Part of elastic/ingest-dev#8812.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs. *(E2E validation pending)*
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition)
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) *(no dashboards added or changed)*

## Author's Checklist

- [ ] `backport-aws_mq-1.x` branch created on elastic/integrations from the last `1.0.0` release commit
- [ ] CODEOWNERS sign-off from `@elastic/obs-infraobs-integrations` on the major version bump + Kibana floor change
- [ ] E2E: activemq_metrics and rabbitmq_metrics validated via Identity Federation
- [ ] E2E: activemq_audit_logs, activemq_general_logs, rabbitmq_general_logs validated via Identity Federation
- [ ] CFT permissions already covered by `ElasticAwsMetrics` and `ElasticAwsCloudwatchLogs` in elastic/cloudbeat#8030

## Related

- elastic/ingest-dev#8812 (per-package federation rollout)
- elastic/ingest-dev#8788 (branching strategy)
- elastic/cloudbeat#8030 (CFT — permissions already covered)
- elastic/integrations#20893 (1.x backport branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
