### PR TITLE
Transfer cloud-services package ownership to siem-conduit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -210,9 +210,9 @@
 /packages/claroty_xdome @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/claude_code @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/claude_cowork @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/cloud_asset_inventory @elastic/cloud-services
-/packages/cloud_defend @elastic/cloud-services
-/packages/cloud_security_posture @elastic/cloud-services
+/packages/cloud_asset_inventory @elastic/siem-conduit
+/packages/cloud_defend @elastic/siem-conduit
+/packages/cloud_security_posture @elastic/siem-conduit
 /packages/cloudflare @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cloudflare_logpush @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cockroachdb @elastic/obs-infraobs-integrations
@@ -605,7 +605,7 @@
 /packages/varonis @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/vectra_detect @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/vectra_rux @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/verifier_otel @elastic/cloud-services
+/packages/verifier_otel @elastic/siem-conduit
 /packages/vercel @elastic/obs-infraobs-integrations
 /packages/vercel_otel @elastic/obs-infraobs-integrations
 /packages/vsphere @elastic/obs-infraobs-integrations

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -13,7 +13,7 @@
   changes:
     - description: Transfer package ownership to the elastic/siem-conduit team.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR_NUMBER
+      link: https://github.com/elastic/integrations/pull/20832
 - version: "1.7.1"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -9,6 +9,11 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.7.2"
+  changes:
+    - description: Transfer package ownership to the elastic/siem-conduit team.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR_NUMBER
 - version: "1.7.1"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.7.1"
+version: "1.7.2"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"
@@ -39,7 +39,7 @@ policy_templates:
         release: beta
         organization: security
         division: engineering
-        team: cloud-services
+        team: siem-conduit
     multiple: true
     icons:
       - src: /img/logo_cloud_security_posture.svg
@@ -127,5 +127,5 @@ policy_templates:
       - security
       - cloud
 owner:
-  github: elastic/cloud-services
+  github: elastic/siem-conduit
   type: elastic

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Transfer package ownership to the elastic/siem-conduit team.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR_NUMBER
+      link: https://github.com/elastic/integrations/pull/20832
 - version: "1.4.1-beta"
   changes:
     - description: Improve documentation. Properly mark integration as beta.

--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.2-beta"
+  changes:
+    - description: Transfer package ownership to the elastic/siem-conduit team.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR_NUMBER
 - version: "1.4.1-beta"
   changes:
     - description: Improve documentation. Properly mark integration as beta.

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_defend
 title: "Defend for Containers (BETA)"
-version: 1.4.1-beta
+version: 1.4.2-beta
 source:
   license: "Elastic-2.0"
 description: "Elastic Defend for Containers (BETA) provides cloud-native runtime protections for containerized environments."
@@ -65,4 +65,4 @@ policy_templates:
                     actions: [alert]
 owner:
   type: elastic
-  github: elastic/cloud-services
+  github: elastic/siem-conduit

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -24,7 +24,7 @@
   changes:
     - description: Transfer package ownership to the elastic/siem-conduit team.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR_NUMBER
+      link: https://github.com/elastic/integrations/pull/20832
 - version: "3.5.0"
   changes:
     - description: Release version 3.5.0

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -20,6 +20,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.5.1"
+  changes:
+    - description: Transfer package ownership to the elastic/siem-conduit team.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR_NUMBER
 - version: "3.5.0"
   changes:
     - description: Release version 3.5.0

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.5.0"
+version: "3.5.1"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -125,7 +125,7 @@ policy_templates:
         release: ga
         organization: security
         division: engineering
-        team: cloud-services
+        team: siem-conduit
     inputs:
       - type: cloudbeat/cis_aws
         title: Amazon Web Services
@@ -239,5 +239,5 @@ policy_templates:
             description: Template URL to Cloud Formation Quick Create Stack
             default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cnvm-9.2.0.yml&stackName=Elastic-Vulnerability-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
 owner:
-  github: elastic/cloud-services
+  github: elastic/siem-conduit
   type: elastic

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Transfer package ownership to the elastic/siem-conduit team.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/PR_NUMBER
+      link: https://github.com/elastic/integrations/pull/20832
 - version: "0.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Transfer package ownership to the elastic/siem-conduit team.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/PR_NUMBER
 - version: "0.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: verifier_otel
 title: "Permission Verifier"
-version: 0.1.0
+version: 0.1.1
 source:
   license: "Elastic-2.0"
 description: "Verify identity federation based integration permissions and report results to Elasticsearch using the Verifier receiver of the OTel Collector."
@@ -36,7 +36,7 @@ policy_templates:
         release: beta
         organization: security
         division: engineering
-        team: cloud-services
+        team: siem-conduit
     vars:
       - name: identity_federation_id
         type: text
@@ -190,5 +190,5 @@ policy_templates:
         required: false
         show_user: true
 owner:
-  github: elastic/cloud-services
+  github: elastic/siem-conduit
   type: elastic


### PR DESCRIPTION
## Summary

Transfers ownership of the packages previously owned by `@elastic/cloud-services` to `@elastic/siem-conduit`.

Changes for each affected package:
- Update `CODEOWNERS` entry.
- Update `owner.github` in `manifest.yml`.
- Update the agentless deployment `team:` field in `manifest.yml` (where present).
- Bump version and add a changelog entry.

Affected packages:
- `cloud_asset_inventory` (1.7.1 → 1.7.2)
- `cloud_defend` (1.4.1-beta → 1.4.2-beta)
- `cloud_security_posture` (3.5.0 → 3.5.1)
- `verifier_otel` (0.1.0 → 0.1.1)

## Test plan

- [ ] CI passes (CODEOWNERS check, changelog/version validation).
