### PR TITLE
[cisco_asa] Restrict 315011 unquoted username pattern.

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.16"
+  changes:
+    - description: Restrict the 315011 unquoted username pattern to the standard username character class.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20840
 - version: "2.45.15"
   changes:
     - description: Fix parse_315011 grok pattern to support double-quoted SSH usernames containing spaces and apostrophes.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -199,3 +199,4 @@ Jun 26 18:04:40 198.51.100.10 %ASA-6-113005: AAA user authorization Rejected : r
 Apr 27 02:03:03 dev01: %ASA-6-611101: User authentication succeeded: Uname: alice.johnson
 Apr 27 02:03:03 dev01: %ASA-6-611102: User authentication failed: Uname: alice.johnson
 <166>Jun 27 2026 10:00:24: %ASA-6-113015: AAA user authentication Rejected : reason = User was not found : local database : user = alice.johnson
+<166>CHI-ASAv-UG %ASA-6-315011: SSH session from 203.0.113.20 on interface inside for user "" terminated normally

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -14019,6 +14019,92 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "cisco": {
+                "asa": {
+                    "source_interface": "inside"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "ssh-session-ended",
+                "category": [
+                    "network"
+                ],
+                "code": "315011",
+                "kind": "event",
+                "original": "<166>CHI-ASAv-UG %ASA-6-315011: SSH session from 203.0.113.20 on interface inside for user \"\" terminated normally",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "CHI-ASAv-UG"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "CHI-ASAv-UG",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "CHI-ASAv-UG"
+                ],
+                "ip": [
+                    "203.0.113.20"
+                ]
+            },
+            "source": {
+                "as": {
+                    "number": 64502,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Madrid",
+                    "continent_name": "Europe",
+                    "country_iso_code": "ES",
+                    "country_name": "Spain",
+                    "location": {
+                        "lat": 40.41639,
+                        "lon": -3.7025
+                    },
+                    "region_iso_code": "ES-M",
+                    "region_name": "Madrid"
+                },
+                "ip": "203.0.113.20",
+                "user": {
+                    "name": ""
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -698,8 +698,9 @@ processors:
         - 'SSH session from (?:%{IP:source.ip} )?on interface %{NOTSPACE:_temp_.cisco.source_interface} for user %{CISCO_USER} disconnected by SSH server, reason: %{GREEDYDATA:event.reason}'
         - 'SSH session from (?:%{IP:source.ip} )?on interface %{NOTSPACE:_temp_.cisco.source_interface} for user %{CISCO_USER} terminated normally'
       pattern_definitions:
-        NOTQUOTE: '[^"]*?'
-        CISCO_USER: '(?:\"(?:\*{5}|(?<source.user.name>[^\"]+))\"|(?:\*{5}|%{NOTQUOTE:source.user.name}))'
+        USERNAME: "[a-zA-Z0-9._'-]+"
+        QUOTEDUSER: '[^"]*'
+        CISCO_USER: '(?:"(?:\*{5}|%{QUOTEDUSER:source.user.name})"|\*{5}|%{USERNAME:source.user.name})'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '322001'"
       tag: parse_322001

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.15"
+version: "2.45.16"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Follow-up to #20667.

## Problem

#20667 fixed quoted 315011 usernames containing spaces and apostrophes. Its unquoted fallback is `NOTQUOTE: '[^"]*?'`, which matches anything except a double quote — spaces, `:`, `,`, `(`, `)`, `\`, `@`, and the empty string.

Cisco never quotes the unquoted form, so this branch only ever sees plain usernames. Making it a catch-all means any unrecognised 315011 shape is silently captured as a username instead of failing to `on_failure`. Verified against a live stack:

| message | on `main` today |
|---|---|
| `… for user admin on channel 0 terminated normally` | `source.user.name = "admin on channel 0"` |
| `… for user  terminated normally` (double space) | `source.user.name = ""` |

The PR's own "Reviewer concerns" section flagged this and it went in unresolved.

## Change

```yaml
      pattern_definitions:
        USERNAME: "[a-zA-Z0-9._'-]+"
        QUOTEDUSER: '[^"]*'
        CISCO_USER: '(?:"(?:\*{5}|%{QUOTEDUSER:source.user.name})"|\*{5}|%{USERNAME:source.user.name})'
```

- The permissive form stays where it is safe — **inside** the quotes, delimited on both sides. That part of #20667 was right, and it matches how 605004/605005 already treat quoted usernames (`dissect` on `for user "%{source.user.name}"`, i.e. everything up to the closing quote).
- The unquoted branch drops back to the `USERNAME` override that **ten** other processors in this pipeline already share — stock `USERNAME` plus the apostrophe. 315011 was the only processor still inheriting the stock pattern, which is why the apostrophe half of #20667's bug existed here and nowhere else.
- `QUOTEDUSER` is `[^"]*`, not `[^"]+`, so `for user ""` yields `""` — matching how 605004 already handles the same input (there is an existing `for user ""` fixture expecting `source.user.name: ""`).

Also replaces the raw `(?<source.user.name>…)` named capture with `%{PATTERN:field}`, the form used everywhere else in this ~3,300-line file. That capture works correctly — this is style only.

## Verification

`elastic-package test pipeline` — 34/34 passing. Every pre-existing 315011 fixture parses **identically**; the only expected-output change is the added fixture.

Checked on a live stack via `_ingest/pipeline/_simulate`, old pattern vs new, across all 315011 fixtures plus probes:

| message | #20667 | this PR |
|---|---|---|
| `for user USER_1 disconnected…` | `USER_1` | `USER_1` |
| `for user "user-test" terminated normally.` | `user-test` | `user-test` |
| `for user "*****"` / `for user *****` | masked | masked |
| `for user "jsmith"…` (no source IP) | `jsmith` | `jsmith` |
| `for user "Lab1's User" disconnected…` | `Lab1's User` | `Lab1's User` |
| `for user "Lab1 User" terminated normally` | `Lab1 User` | `Lab1 User` |
| `for user O'Brien disconnected…` | `O'Brien` | `O'Brien` |
| `for user ""` | parse failure | `""` ← new fixture |
| `for user admin on channel 0 terminated normally` | `admin on channel 0` | on_failure |
| `for user  terminated normally` | `""` | on_failure |

## Out of scope

Cisco documents a third 315011 variant — `… for user "x" terminated`, without `normally` — which neither #20667 nor this PR handles. Left alone deliberately to keep this single-concern; happy to add it here if reviewers prefer.

---
_This pull request is drafted by :robot: Claude Code/Opus 5 under my supervision._
