### PR TITLE
Use links panels in the system audit integration

### DIFF
--- a/packages/system_audit/changelog.yml
+++ b/packages/system_audit/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use the links panel in the dashboards
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20856
 - version: "1.11.1"
   changes:
     - description: Transfer package ownership to elastic/security-service-integrations.

--- a/packages/system_audit/changelog.yml
+++ b/packages/system_audit/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.2"
+  changes:
+    - description: Use the links panel in the dashboards
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.11.1"
   changes:
     - description: Transfer package ownership to elastic/security-service-integrations.

--- a/packages/system_audit/changelog.yml
+++ b/packages/system_audit/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.11.2"
   changes:
-    - description: Use the links panel in the dashboards
+    - description: Use the links panel in the dashboards.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20856
 - version: "1.11.1"

--- a/packages/system_audit/kibana/dashboard/system_audit-137c52f0-286a-11e9-9d21-0be348776e6c.json
+++ b/packages/system_audit/kibana/dashboard/system_audit-137c52f0-286a-11e9-9d21-0be348776e6c.json
@@ -37,26 +37,25 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                    "attributes": {
+                        "title": "links",
+                        "layout": "horizontal",
+                        "links": [
+                            {
+                                "label": "System Overview",
+                                "type": "dashboardLink",
+                                "id": "system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90",
+                                "order": 0,
+                                "destinationRefName": "link_system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90_dashboard"
+                            },
+                            {
+                                "label": "Packages",
+                                "type": "dashboardLink",
+                                "id": "system_audit-137c52f0-286a-11e9-9d21-0be348776e6c",
+                                "order": 1,
+                                "destinationRefName": "link_system_audit-137c52f0-286a-11e9-9d21-0be348776e6c_dashboard"
                             }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**Dashboards**: [System Overview](#/dashboard/system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90) | **[Packages](#/dashboard/system_audit-137c52f0-286a-11e9-9d21-0be348776e6c)**",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
+                        ]
                     }
                 },
                 "gridData": {
@@ -68,8 +67,7 @@
                 },
                 "panelIndex": "bf77ed0a-b695-4aad-8c25-9c12d11902f0",
                 "title": "Dashboard Links [System Audit]",
-                "type": "visualization",
-                "version": "8.7.1"
+                "type": "links"
             },
             {
                 "embeddableConfig": {
@@ -1177,6 +1175,16 @@
             "id": "logs-*",
             "name": "6545e047-42b2-4d65-84c3-29d892d6d35d:4923e269-0e73-4067-ae5a-b6ede668a019",
             "type": "index-pattern"
+        },
+        {
+            "name": "bf77ed0a-b695-4aad-8c25-9c12d11902f0:link_system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90_dashboard",
+            "type": "dashboard",
+            "id": "system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90"
+        },
+        {
+            "name": "bf77ed0a-b695-4aad-8c25-9c12d11902f0:link_system_audit-137c52f0-286a-11e9-9d21-0be348776e6c_dashboard",
+            "type": "dashboard",
+            "id": "system_audit-137c52f0-286a-11e9-9d21-0be348776e6c"
         }
     ],
     "type": "dashboard"

--- a/packages/system_audit/kibana/dashboard/system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90.json
+++ b/packages/system_audit/kibana/dashboard/system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90.json
@@ -348,25 +348,25 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                    "attributes": {
+                        "title": "links",
+                        "layout": "horizontal",
+                        "links": [
+                            {
+                                "label": "System Overview",
+                                "type": "dashboardLink",
+                                "id": "system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90",
+                                "order": 0,
+                                "destinationRefName": "link_system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90_dashboard"
+                            },
+                            {
+                                "label": "Packages",
+                                "type": "dashboardLink",
+                                "id": "system_audit-137c52f0-286a-11e9-9d21-0be348776e6c",
+                                "order": 1,
+                                "destinationRefName": "link_system_audit-137c52f0-286a-11e9-9d21-0be348776e6c_dashboard"
                             }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**Dashboards**: **[System Overview](#/dashboard/system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90)** | [Packages](#/dashboard/system_audit-137c52f0-286a-11e9-9d21-0be348776e6c)",
-                            "openLinksInNewTab": false
-                        },
-                        "type": "markdown",
-                        "uiState": {}
+                        ]
                     }
                 },
                 "gridData": {
@@ -378,8 +378,7 @@
                 },
                 "panelIndex": "1bf0e900-2d1c-4665-82d4-a65d0148eea0",
                 "title": "Dashboard Links [System Audit]",
-                "type": "visualization",
-                "version": "8.7.1"
+                "type": "links"
             }
         ],
         "timeRestore": false,
@@ -417,6 +416,16 @@
             "id": "logs-*",
             "name": "2:5acbc0ec-4aa7-43b9-8ad0-3edf38291e98",
             "type": "index-pattern"
+        },
+        {
+            "name": "1bf0e900-2d1c-4665-82d4-a65d0148eea0:link_system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90_dashboard",
+            "type": "dashboard",
+            "id": "system_audit-2be46cb0-27f2-11e9-89af-fd12d59dac90"
+        },
+        {
+            "name": "1bf0e900-2d1c-4665-82d4-a65d0148eea0:link_system_audit-137c52f0-286a-11e9-9d21-0be348776e6c_dashboard",
+            "type": "dashboard",
+            "id": "system_audit-137c52f0-286a-11e9-9d21-0be348776e6c"
         }
     ],
     "type": "dashboard"

--- a/packages/system_audit/manifest.yml
+++ b/packages/system_audit/manifest.yml
@@ -3,7 +3,7 @@ name: system_audit
 title: System Audit
 description: Collect various logs & metrics from System Audit modules with Elastic Agent.
 type: integration
-version: "1.11.1"
+version: "1.11.2"
 conditions:
   kibana:
     version: '^8.7.1 || ^9.0.0'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
This enables a links panel for the Servicenow integration

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- #13630

## Screenshots

Before
<img width="1271" height="1113" alt="Screenshot 2026-08-21 at 13 41 43" src="https://github.com/user-attachments/assets/22d14d52-1311-474d-a25d-228c0d0a8d19" />
After
<img width="1271" height="1113" alt="Screenshot 2026-08-21 at 13 37 22" src="https://github.com/user-attachments/assets/56adf685-2cf7-46cf-95c7-c2e343b1aba8" />
