### PR TITLE
[kubernetes_otel] Add missing controlGroupInput to dashboards

### DIFF
--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f.json
@@ -630,7 +630,7 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "Deployments ranked by availability (lowest first). Click a deployment name to drill into deployment details, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = available replicas ÷ desired replicas. Available and desired replica counts are latest values. Container restarts = sum across all pods and containers over the selected time range.",
+                    "description": "Deployments ranked by availability (lowest first). Click a deployment name to drill into deployment details, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = available replicas \u00f7 desired replicas. Available and desired replica counts are latest values. Container restarts = sum across all pods and containers over the selected time range.",
                     "drilldowns": [
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
@@ -1513,7 +1513,7 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "DaemonSets ranked by misscheduled node count (highest first). Click a DaemonSet name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = ready ÷ desired. All counts reflect the latest collected values.",
+                    "description": "DaemonSets ranked by misscheduled node count (highest first). Click a DaemonSet name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = ready \u00f7 desired. All counts reflect the latest collected values.",
                     "drilldowns": [
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
@@ -2354,7 +2354,7 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "Jobs ranked by failed pods (highest first), then by remaining completions. Click a Job name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Completion = successful ÷ desired pods. All pod counts reflect the latest collected values.",
+                    "description": "Jobs ranked by failed pods (highest first), then by remaining completions. Click a Job name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Completion = successful \u00f7 desired pods. All pod counts reflect the latest collected values.",
                     "drilldowns": [
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
@@ -2742,7 +2742,19 @@
         "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Workloads"
+        "title": "[Kubernetes OTel] Workloads",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-06-17T05:39:44.087Z",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
@@ -3363,7 +3363,19 @@
         "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Pod Detail"
+        "title": "[Kubernetes OTel] Pod Detail",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-06-17T05:41:43.358Z",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13.json
@@ -4740,7 +4740,19 @@
         "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Cluster Detail"
+        "title": "[Kubernetes OTel] Cluster Detail",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-06-02T15:08:40.798Z",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb.json
@@ -5504,7 +5504,19 @@
         "timeFrom": "now-1h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Overview"
+        "title": "[Kubernetes OTel] Overview",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-06-04T11:33:38.224Z",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -4210,7 +4210,19 @@
         "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Deployment Detail"
+        "title": "[Kubernetes OTel] Deployment Detail",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-06-17T05:44:16.016Z",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
@@ -2379,7 +2379,19 @@
         "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Pods"
+        "title": "[Kubernetes OTel] Pods",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-06-17T05:41:43.200Z",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e.json
@@ -1840,7 +1840,19 @@
         "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
-        "title": "[Kubernetes OTel] Clusters"
+        "title": "[Kubernetes OTel] Clusters",
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {},
+            "showApplySelections": false
+        }
     },
     "coreMigrationVersion": "8.8.0",
     "created_at": "2026-05-27T07:59:30.171Z",


### PR DESCRIPTION
## Summary

Seven dashboards in the \`kubernetes_otel\` package were missing the \`controlGroupInput\` attribute. Kibana's dashboard telemetry task calls \`JSON.parse()\` on \`controlGroupInput?.panelsJSON\` for every dashboard. When \`controlGroupInput\` is absent, the optional-chain evaluates to \`undefined\` and \`JSON.parse(undefined)\` throws, producing this warning in Kibana logs once per affected dashboard per daily telemetry run:

\`\`\`
[WARN][plugins.dashboard] Unable to parse panelsJSON for telemetry collection
\`\`\`

This PR adds the standard empty \`controlGroupInput\` block (matching the format already used by the other dashboards in this package that have no controls: Node Detail, Namespace Detail, Namespaces, Nodes).

A companion fix to guard the Kibana telemetry code defensively: https://github.com/elastic/kibana/pull/286668

## Affected dashboards

- \`[Kubernetes OTel] Overview\`
- \`[Kubernetes OTel] Workloads\`
- \`[Kubernetes OTel] Pods\`
- \`[Kubernetes OTel] Clusters\`
- \`[Kubernetes OTel] Pod Detail\`
- \`[Kubernetes OTel] Deployment Detail\`
- \`[Kubernetes OTel] Cluster Detail\`

## Test plan

- [ ] Install the updated package in Kibana and trigger the dashboard telemetry task — no \`Unable to parse panelsJSON\` warnings should appear for these dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)