### PR TITLE
[TEMP - closing shortly] Security research PoC - do not merge

### DIFF
--- a/packages/test svermen poc/manifest.yml
+++ b/packages/test svermen poc/manifest.yml
@@ -1,0 +1,17 @@
+format_version: 3.6.0
+name: test_svermen_poc
+title: "TEMP bug bounty PoC - safe, will be closed immediately"
+description: >
+  Temporary, non-malicious PoC package for a HackerOne Software Supply Chain report
+  about unescaped directory-path interpolation in
+  .buildkite/scripts/trigger_integrations_in_parallel.sh. This directory intentionally
+  contains a space in its name to check whether the path is properly escaped before
+  being used to build a Buildkite pipeline step. No exploit payload of any kind is
+  included, no code execution is attempted, no credentials are targeted. This PR will
+  be closed within minutes of observing CI behavior. Contact: HackerOne handle svermen
+  (svermen@wearehackerone.com). Apologies for any noise.
+version: 0.0.1
+type: integration
+owner:
+  github: svermen
+  type: community


### PR DESCRIPTION
**This is a temporary, non-malicious security-research PoC — will be closed within minutes.**

I am investigating a potential HackerOne Software Supply Chain report about
`.buildkite/scripts/trigger_integrations_in_parallel.sh` interpolating a package's
on-disk directory name (`package_path`) into a generated Buildkite pipeline YAML
without validating it against the same `^[a-z0-9_]+$` pattern enforced for the
manifest `name` field.

This PR adds one throwaway package directory containing a **space** in its name
(`packages/test svermen poc/`) — nothing more exotic, no shell metacharacters, no
payload of any kind, no attempt at code execution or credential access. The goal is
only to observe whether the resulting Buildkite step definition/command breaks due to
the unescaped space, which would confirm the lack of escaping.

I will close this PR as soon as I observe the CI behavior (expected within
minutes/hours). Apologies for the noise on a real PR — happy to answer any questions
from the security/ecosystem team in the meantime.

Contact: HackerOne handle `svermen` / svermen@wearehackerone.com
