### PR TITLE
[o365] - Report audit input degraded on persistent transport failures

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -8,7 +8,7 @@
         `transport_failure_threshold` keep the existing recover-and-continue behaviour, so a single
         unfetchable item still does not stall collection.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/20875
 - version: "3.10.8"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "3.11.0"
+  changes:
+    - description: >-
+        Report the audit input as degraded after repeated consecutive transport-level request failures
+        (for example an expired client secret failing OAuth 2.0 token acquisition) instead of reporting
+        healthy while collection has silently stopped. Isolated transient failures below the new
+        `transport_failure_threshold` keep the existing recover-and-continue behaviour, so a single
+        unfetchable item still does not stall collection.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "3.10.8"
   changes:
     - description: Set agentless deployment mode `release` field to `ga`.

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -176,11 +176,11 @@ inputs:
                   // client secret failing token acquisition), so return a single-object
                   // error to mark the input degraded until collection recovers.
                   (
-                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                    (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
                         {
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": {
                             "error": {
                               "message": "persistent transport failure starting subscription for '" + state.todo_types[0] + "': " + string(sub_resp.?_transport_error.orValue("")),
@@ -192,7 +192,7 @@ inputs:
                       state.with(
                         {
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": [{"retry": true}],
                         }
                       )
@@ -263,11 +263,11 @@ inputs:
                       // threshold the failure is persistent, so return a single-object
                       // error to mark the input degraded until collection recovers.
                       (
-                        (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                        (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                           state.with(
                             {
                               "want_more": false,
-                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "transport_error_streak": int(state.transport_error_streak) + 1,
                               "events": {
                                 "error": {
                                   "message": "persistent transport failure fetching " + state.cursor.todo_content[0].contentUri + ": " + string(content_resp.?_transport_error.orValue("")),
@@ -284,7 +284,7 @@ inputs:
                                 }
                               ),
                               "want_more": false,
-                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "transport_error_streak": int(state.transport_error_streak) + 1,
                               "events": [{"retry": true}],
                             }
                           )
@@ -348,11 +348,11 @@ inputs:
                   // persistent, so return a single-object error to mark the input degraded
                   // until collection recovers.
                   (
-                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                    (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
                         {
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": {
                             "error": {
                               "message": "persistent transport failure listing " + state.cursor.todo_links[0] + ": " + string(list_resp.?_transport_error.orValue("")),
@@ -369,7 +369,7 @@ inputs:
                             }
                           ),
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": [{"retry": true}],
                         }
                       )
@@ -594,6 +594,7 @@ inputs:
                 maximum_age: 167h55m
                 tenant_id: tenant-id
                 transport_failure_threshold: 5
+            transport_error_streak: 0
             want_more: false
           tags:
             - preserve_original_event

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -167,16 +167,35 @@ inputs:
                 ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
                   // A transport-level failure such as a dropped connection or a truncated
                   // response body makes do_request return an error rather than a response
-                  // with a status code, which would otherwise crash the evaluation. Emit
-                  // a dropped retry event and stop this cycle so the subscription is
-                  // retried on the next polling interval. The failure is not indexed as
-                  // an event; it remains visible through the input's HTTP metrics and
-                  // request tracer.
-                  state.with(
-                    {
-                      "want_more": false,
-                      "events": [{"retry": true}],
-                    }
+                  // with a status code, which would otherwise crash the evaluation. Count
+                  // consecutive transport failures: below the threshold, emit a dropped
+                  // retry event and stop this cycle so the subscription is retried on the
+                  // next polling interval (the failure is not indexed; it stays visible
+                  // through the input's HTTP metrics and request tracer). Once the streak
+                  // reaches the threshold the failure is persistent (for example an expired
+                  // client secret failing token acquisition), so return a single-object
+                  // error to mark the input degraded until collection recovers.
+                  (
+                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                      state.with(
+                        {
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": {
+                            "error": {
+                              "message": "persistent transport failure starting subscription for '" + state.todo_types[0] + "': " + string(sub_resp.?_transport_error.orValue("")),
+                            },
+                          },
+                        }
+                      )
+                    :
+                      state.with(
+                        {
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": [{"retry": true}],
+                        }
+                      )
                   )
                 : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
                   // Subscription successful - Record subscription, requeue type and continue
@@ -185,6 +204,7 @@ inputs:
                       "todo_types": tail(state.todo_types) + [state.todo_types[0]],
                       "subscribed": state.?subscribed.orValue({}).with({state.todo_types[0]: true}),
                       "want_more": true,
+                      "transport_error_streak": 0,
                       "events": [{"retry": true}],
                     }
                   )
@@ -234,25 +254,40 @@ inputs:
                     ).as(content_resp, content_resp.?_transport_error.hasValue() ?
                       // A transport-level failure such as a dropped connection or a
                       // truncated response body makes do_request return an error rather
-                      // than a response with a status code. Returning a single error
-                      // object here would make the runtime discard the cursor update, so
-                      // the failing item would be retried on every evaluation and stall
-                      // all further collection. Instead, move the item to the back of the
-                      // queue so the remaining items can still be fetched, emit a dropped
-                      // retry event so the cursor change persists, and stop this cycle to
-                      // back off until the next interval. The failure is not indexed as an
-                      // event; it remains visible through the input's HTTP metrics and
-                      // request tracer.
-                      state.with(
-                        {
-                          "cursor": state.cursor.with(
+                      // than a response with a status code. Below the threshold, move the
+                      // item to the back of the queue so the remaining items can still be
+                      // fetched, emit a dropped retry event so the cursor change persists,
+                      // and stop this cycle to back off until the next interval (the
+                      // failure is not indexed; it stays visible through the input's HTTP
+                      // metrics and request tracer). Once consecutive failures reach the
+                      // threshold the failure is persistent, so return a single-object
+                      // error to mark the input degraded until collection recovers.
+                      (
+                        (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                          state.with(
                             {
-                              "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                              "want_more": false,
+                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "events": {
+                                "error": {
+                                  "message": "persistent transport failure fetching " + state.cursor.todo_content[0].contentUri + ": " + string(content_resp.?_transport_error.orValue("")),
+                                },
+                              },
                             }
-                          ),
-                          "want_more": false,
-                          "events": [{"retry": true}],
-                        }
+                          )
+                        :
+                          state.with(
+                            {
+                              "cursor": state.cursor.with(
+                                {
+                                  "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                                }
+                              ),
+                              "want_more": false,
+                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "events": [{"retry": true}],
+                            }
+                          )
                       )
                     : (content_resp.StatusCode == 200) ?
                       // Fetch successful - Return events, continue with remaining content
@@ -265,6 +300,7 @@ inputs:
                           ),
                           "cursor": state.cursor.with({"todo_content": tail(state.cursor.todo_content)}),
                           "want_more": true,
+                          "transport_error_streak": 0,
                         }
                       )
                     :
@@ -303,24 +339,40 @@ inputs:
                 ).as(list_resp, list_resp.?_transport_error.hasValue() ?
                   // A transport-level failure such as a dropped connection or a
                   // truncated response body makes do_request return an error rather than
-                  // a response with a status code. Returning a single error object here
-                  // would make the runtime discard the cursor update, so the failing link
-                  // would be retried on every evaluation and stall all further
-                  // collection. Instead, move the link to the back of the queue so the
-                  // remaining links can still be requested, emit a dropped retry event so
-                  // the cursor change persists, and stop this cycle to back off until the
-                  // next interval. The failure is not indexed as an event; it remains
-                  // visible through the input's HTTP metrics and request tracer.
-                  state.with(
-                    {
-                      "cursor": state.cursor.with(
+                  // a response with a status code. Below the threshold, move the link to
+                  // the back of the queue so the remaining links can still be requested,
+                  // emit a dropped retry event so the cursor change persists, and stop
+                  // this cycle to back off until the next interval (the failure is not
+                  // indexed; it stays visible through the input's HTTP metrics and request
+                  // tracer). Once consecutive failures reach the threshold the failure is
+                  // persistent, so return a single-object error to mark the input degraded
+                  // until collection recovers.
+                  (
+                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                      state.with(
                         {
-                          "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": {
+                            "error": {
+                              "message": "persistent transport failure listing " + state.cursor.todo_links[0] + ": " + string(list_resp.?_transport_error.orValue("")),
+                            },
+                          },
                         }
-                      ),
-                      "want_more": false,
-                      "events": [{"retry": true}],
-                    }
+                      )
+                    :
+                      state.with(
+                        {
+                          "cursor": state.cursor.with(
+                            {
+                              "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                            }
+                          ),
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": [{"retry": true}],
+                        }
+                      )
                   )
                 : (list_resp.StatusCode == 200) ?
                   // Listing successful - Enqueue any additional link, enqueue content to fetch
@@ -335,6 +387,7 @@ inputs:
                           }
                         ),
                         "want_more": true,
+                        "transport_error_streak": 0,
                         "events": [{"retry": true}],
                       }
                     )
@@ -540,6 +593,7 @@ inputs:
                 list_contents_start_time: 167h55m
                 maximum_age: 167h55m
                 tenant_id: tenant-id
+                transport_failure_threshold: 5
             want_more: false
           tags:
             - preserve_original_event

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -20,7 +20,13 @@ inputs:
           interval: 3m
           max_executions: 10000
           processors:
-            - drop_event.when.equals.retry: true
+            - drop_event:
+                when:
+                    or:
+                        - equals:
+                            retry: true
+                        - equals:
+                            publish_cursor: true
             - add_fields:
                 fields:
                     id: "574734885120952459"
@@ -169,12 +175,13 @@ inputs:
                   // response body makes do_request return an error rather than a response
                   // with a status code, which would otherwise crash the evaluation. Count
                   // consecutive transport failures: below the threshold, emit a dropped
-                  // retry event and stop this cycle so the subscription is retried on the
-                  // next polling interval (the failure is not indexed; it stays visible
-                  // through the input's HTTP metrics and request tracer). Once the streak
-                  // reaches the threshold the failure is persistent (for example an expired
-                  // client secret failing token acquisition), so return a single-object
-                  // error to mark the input degraded until collection recovers.
+                  // cursor-persistence event and stop this cycle (want_more:false) so the
+                  // subscription is retried on the next polling interval (the failure is
+                  // not indexed; it stays visible through the input's HTTP metrics and
+                  // request tracer). Once the streak reaches the threshold the failure is
+                  // persistent (for example an expired client secret failing token
+                  // acquisition), so return a single-object error to mark the input
+                  // degraded until collection recovers.
                   (
                     (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
@@ -193,7 +200,7 @@ inputs:
                         {
                           "want_more": false,
                           "transport_error_streak": int(state.transport_error_streak) + 1,
-                          "events": [{"retry": true}],
+                          "events": [{"publish_cursor": true}],
                         }
                       )
                   )
@@ -256,12 +263,13 @@ inputs:
                       // truncated response body makes do_request return an error rather
                       // than a response with a status code. Below the threshold, move the
                       // item to the back of the queue so the remaining items can still be
-                      // fetched, emit a dropped retry event so the cursor change persists,
-                      // and stop this cycle to back off until the next interval (the
-                      // failure is not indexed; it stays visible through the input's HTTP
-                      // metrics and request tracer). Once consecutive failures reach the
-                      // threshold the failure is persistent, so return a single-object
-                      // error to mark the input degraded until collection recovers.
+                      // fetched, emit a dropped cursor-persistence event so the cursor
+                      // change persists, and stop this cycle (want_more:false) to back off
+                      // until the next interval (the failure is not indexed; it stays
+                      // visible through the input's HTTP metrics and request tracer). Once
+                      // consecutive failures reach the threshold the failure is
+                      // persistent, so return a single-object error to mark the input
+                      // degraded until collection recovers.
                       (
                         (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                           state.with(
@@ -285,7 +293,7 @@ inputs:
                               ),
                               "want_more": false,
                               "transport_error_streak": int(state.transport_error_streak) + 1,
-                              "events": [{"retry": true}],
+                              "events": [{"publish_cursor": true}],
                             }
                           )
                       )
@@ -341,12 +349,13 @@ inputs:
                   // truncated response body makes do_request return an error rather than
                   // a response with a status code. Below the threshold, move the link to
                   // the back of the queue so the remaining links can still be requested,
-                  // emit a dropped retry event so the cursor change persists, and stop
-                  // this cycle to back off until the next interval (the failure is not
-                  // indexed; it stays visible through the input's HTTP metrics and request
-                  // tracer). Once consecutive failures reach the threshold the failure is
-                  // persistent, so return a single-object error to mark the input degraded
-                  // until collection recovers.
+                  // emit a dropped cursor-persistence event so the cursor change persists,
+                  // and stop this cycle (want_more:false) to back off until the next
+                  // interval (the failure is not indexed; it stays visible through the
+                  // input's HTTP metrics and request tracer). Once consecutive failures
+                  // reach the threshold the failure is persistent, so return a
+                  // single-object error to mark the input degraded until collection
+                  // recovers.
                   (
                     (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
@@ -370,7 +379,7 @@ inputs:
                           ),
                           "want_more": false,
                           "transport_error_streak": int(state.transport_error_streak) + 1,
-                          "events": [{"retry": true}],
+                          "events": [{"publish_cursor": true}],
                         }
                       )
                   )

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -157,16 +157,35 @@ inputs:
                 ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
                   // A transport-level failure such as a dropped connection or a truncated
                   // response body makes do_request return an error rather than a response
-                  // with a status code, which would otherwise crash the evaluation. Emit
-                  // a dropped retry event and stop this cycle so the subscription is
-                  // retried on the next polling interval. The failure is not indexed as
-                  // an event; it remains visible through the input's HTTP metrics and
-                  // request tracer.
-                  state.with(
-                    {
-                      "want_more": false,
-                      "events": [{"retry": true}],
-                    }
+                  // with a status code, which would otherwise crash the evaluation. Count
+                  // consecutive transport failures: below the threshold, emit a dropped
+                  // retry event and stop this cycle so the subscription is retried on the
+                  // next polling interval (the failure is not indexed; it stays visible
+                  // through the input's HTTP metrics and request tracer). Once the streak
+                  // reaches the threshold the failure is persistent (for example an expired
+                  // client secret failing token acquisition), so return a single-object
+                  // error to mark the input degraded until collection recovers.
+                  (
+                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                      state.with(
+                        {
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": {
+                            "error": {
+                              "message": "persistent transport failure starting subscription for '" + state.todo_types[0] + "': " + string(sub_resp.?_transport_error.orValue("")),
+                            },
+                          },
+                        }
+                      )
+                    :
+                      state.with(
+                        {
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": [{"retry": true}],
+                        }
+                      )
                   )
                 : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
                   // Subscription successful - Record subscription, requeue type and continue
@@ -175,6 +194,7 @@ inputs:
                       "todo_types": tail(state.todo_types) + [state.todo_types[0]],
                       "subscribed": state.?subscribed.orValue({}).with({state.todo_types[0]: true}),
                       "want_more": true,
+                      "transport_error_streak": 0,
                       "events": [{"retry": true}],
                     }
                   )
@@ -224,25 +244,40 @@ inputs:
                     ).as(content_resp, content_resp.?_transport_error.hasValue() ?
                       // A transport-level failure such as a dropped connection or a
                       // truncated response body makes do_request return an error rather
-                      // than a response with a status code. Returning a single error
-                      // object here would make the runtime discard the cursor update, so
-                      // the failing item would be retried on every evaluation and stall
-                      // all further collection. Instead, move the item to the back of the
-                      // queue so the remaining items can still be fetched, emit a dropped
-                      // retry event so the cursor change persists, and stop this cycle to
-                      // back off until the next interval. The failure is not indexed as an
-                      // event; it remains visible through the input's HTTP metrics and
-                      // request tracer.
-                      state.with(
-                        {
-                          "cursor": state.cursor.with(
+                      // than a response with a status code. Below the threshold, move the
+                      // item to the back of the queue so the remaining items can still be
+                      // fetched, emit a dropped retry event so the cursor change persists,
+                      // and stop this cycle to back off until the next interval (the
+                      // failure is not indexed; it stays visible through the input's HTTP
+                      // metrics and request tracer). Once consecutive failures reach the
+                      // threshold the failure is persistent, so return a single-object
+                      // error to mark the input degraded until collection recovers.
+                      (
+                        (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                          state.with(
                             {
-                              "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                              "want_more": false,
+                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "events": {
+                                "error": {
+                                  "message": "persistent transport failure fetching " + state.cursor.todo_content[0].contentUri + ": " + string(content_resp.?_transport_error.orValue("")),
+                                },
+                              },
                             }
-                          ),
-                          "want_more": false,
-                          "events": [{"retry": true}],
-                        }
+                          )
+                        :
+                          state.with(
+                            {
+                              "cursor": state.cursor.with(
+                                {
+                                  "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                                }
+                              ),
+                              "want_more": false,
+                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "events": [{"retry": true}],
+                            }
+                          )
                       )
                     : (content_resp.StatusCode == 200) ?
                       // Fetch successful - Return events, continue with remaining content
@@ -255,6 +290,7 @@ inputs:
                           ),
                           "cursor": state.cursor.with({"todo_content": tail(state.cursor.todo_content)}),
                           "want_more": true,
+                          "transport_error_streak": 0,
                         }
                       )
                     :
@@ -293,24 +329,40 @@ inputs:
                 ).as(list_resp, list_resp.?_transport_error.hasValue() ?
                   // A transport-level failure such as a dropped connection or a
                   // truncated response body makes do_request return an error rather than
-                  // a response with a status code. Returning a single error object here
-                  // would make the runtime discard the cursor update, so the failing link
-                  // would be retried on every evaluation and stall all further
-                  // collection. Instead, move the link to the back of the queue so the
-                  // remaining links can still be requested, emit a dropped retry event so
-                  // the cursor change persists, and stop this cycle to back off until the
-                  // next interval. The failure is not indexed as an event; it remains
-                  // visible through the input's HTTP metrics and request tracer.
-                  state.with(
-                    {
-                      "cursor": state.cursor.with(
+                  // a response with a status code. Below the threshold, move the link to
+                  // the back of the queue so the remaining links can still be requested,
+                  // emit a dropped retry event so the cursor change persists, and stop
+                  // this cycle to back off until the next interval (the failure is not
+                  // indexed; it stays visible through the input's HTTP metrics and request
+                  // tracer). Once consecutive failures reach the threshold the failure is
+                  // persistent, so return a single-object error to mark the input degraded
+                  // until collection recovers.
+                  (
+                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                      state.with(
                         {
-                          "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": {
+                            "error": {
+                              "message": "persistent transport failure listing " + state.cursor.todo_links[0] + ": " + string(list_resp.?_transport_error.orValue("")),
+                            },
+                          },
                         }
-                      ),
-                      "want_more": false,
-                      "events": [{"retry": true}],
-                    }
+                      )
+                    :
+                      state.with(
+                        {
+                          "cursor": state.cursor.with(
+                            {
+                              "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                            }
+                          ),
+                          "want_more": false,
+                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "events": [{"retry": true}],
+                        }
+                      )
                   )
                 : (list_resp.StatusCode == 200) ?
                   // Listing successful - Enqueue any additional link, enqueue content to fetch
@@ -325,6 +377,7 @@ inputs:
                           }
                         ),
                         "want_more": true,
+                        "transport_error_streak": 0,
                         "events": [{"retry": true}],
                       }
                     )
@@ -444,6 +497,7 @@ inputs:
                 list_contents_start_time: 167h55m
                 maximum_age: 167h55m
                 tenant_id: tenant-id
+                transport_failure_threshold: 5
             want_more: false
           tags:
             - forwarded

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -166,11 +166,11 @@ inputs:
                   // client secret failing token acquisition), so return a single-object
                   // error to mark the input degraded until collection recovers.
                   (
-                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                    (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
                         {
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": {
                             "error": {
                               "message": "persistent transport failure starting subscription for '" + state.todo_types[0] + "': " + string(sub_resp.?_transport_error.orValue("")),
@@ -182,7 +182,7 @@ inputs:
                       state.with(
                         {
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": [{"retry": true}],
                         }
                       )
@@ -253,11 +253,11 @@ inputs:
                       // threshold the failure is persistent, so return a single-object
                       // error to mark the input degraded until collection recovers.
                       (
-                        (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                        (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                           state.with(
                             {
                               "want_more": false,
-                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "transport_error_streak": int(state.transport_error_streak) + 1,
                               "events": {
                                 "error": {
                                   "message": "persistent transport failure fetching " + state.cursor.todo_content[0].contentUri + ": " + string(content_resp.?_transport_error.orValue("")),
@@ -274,7 +274,7 @@ inputs:
                                 }
                               ),
                               "want_more": false,
-                              "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                              "transport_error_streak": int(state.transport_error_streak) + 1,
                               "events": [{"retry": true}],
                             }
                           )
@@ -338,11 +338,11 @@ inputs:
                   // persistent, so return a single-object error to mark the input degraded
                   // until collection recovers.
                   (
-                    (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                    (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
                         {
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": {
                             "error": {
                               "message": "persistent transport failure listing " + state.cursor.todo_links[0] + ": " + string(list_resp.?_transport_error.orValue("")),
@@ -359,7 +359,7 @@ inputs:
                             }
                           ),
                           "want_more": false,
-                          "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                          "transport_error_streak": int(state.transport_error_streak) + 1,
                           "events": [{"retry": true}],
                         }
                       )
@@ -498,6 +498,7 @@ inputs:
                 maximum_age: 167h55m
                 tenant_id: tenant-id
                 transport_failure_threshold: 5
+            transport_error_streak: 0
             want_more: false
           tags:
             - forwarded

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -20,7 +20,13 @@ inputs:
           interval: 3m
           max_executions: 10000
           processors:
-            - drop_event.when.equals.retry: true
+            - drop_event:
+                when:
+                    or:
+                        - equals:
+                            retry: true
+                        - equals:
+                            publish_cursor: true
           program: |-
             (
               // This exists purely to rewrite the cursor from the original list format
@@ -159,12 +165,13 @@ inputs:
                   // response body makes do_request return an error rather than a response
                   // with a status code, which would otherwise crash the evaluation. Count
                   // consecutive transport failures: below the threshold, emit a dropped
-                  // retry event and stop this cycle so the subscription is retried on the
-                  // next polling interval (the failure is not indexed; it stays visible
-                  // through the input's HTTP metrics and request tracer). Once the streak
-                  // reaches the threshold the failure is persistent (for example an expired
-                  // client secret failing token acquisition), so return a single-object
-                  // error to mark the input degraded until collection recovers.
+                  // cursor-persistence event and stop this cycle (want_more:false) so the
+                  // subscription is retried on the next polling interval (the failure is
+                  // not indexed; it stays visible through the input's HTTP metrics and
+                  // request tracer). Once the streak reaches the threshold the failure is
+                  // persistent (for example an expired client secret failing token
+                  // acquisition), so return a single-object error to mark the input
+                  // degraded until collection recovers.
                   (
                     (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
@@ -183,7 +190,7 @@ inputs:
                         {
                           "want_more": false,
                           "transport_error_streak": int(state.transport_error_streak) + 1,
-                          "events": [{"retry": true}],
+                          "events": [{"publish_cursor": true}],
                         }
                       )
                   )
@@ -246,12 +253,13 @@ inputs:
                       // truncated response body makes do_request return an error rather
                       // than a response with a status code. Below the threshold, move the
                       // item to the back of the queue so the remaining items can still be
-                      // fetched, emit a dropped retry event so the cursor change persists,
-                      // and stop this cycle to back off until the next interval (the
-                      // failure is not indexed; it stays visible through the input's HTTP
-                      // metrics and request tracer). Once consecutive failures reach the
-                      // threshold the failure is persistent, so return a single-object
-                      // error to mark the input degraded until collection recovers.
+                      // fetched, emit a dropped cursor-persistence event so the cursor
+                      // change persists, and stop this cycle (want_more:false) to back off
+                      // until the next interval (the failure is not indexed; it stays
+                      // visible through the input's HTTP metrics and request tracer). Once
+                      // consecutive failures reach the threshold the failure is
+                      // persistent, so return a single-object error to mark the input
+                      // degraded until collection recovers.
                       (
                         (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                           state.with(
@@ -275,7 +283,7 @@ inputs:
                               ),
                               "want_more": false,
                               "transport_error_streak": int(state.transport_error_streak) + 1,
-                              "events": [{"retry": true}],
+                              "events": [{"publish_cursor": true}],
                             }
                           )
                       )
@@ -331,12 +339,13 @@ inputs:
                   // truncated response body makes do_request return an error rather than
                   // a response with a status code. Below the threshold, move the link to
                   // the back of the queue so the remaining links can still be requested,
-                  // emit a dropped retry event so the cursor change persists, and stop
-                  // this cycle to back off until the next interval (the failure is not
-                  // indexed; it stays visible through the input's HTTP metrics and request
-                  // tracer). Once consecutive failures reach the threshold the failure is
-                  // persistent, so return a single-object error to mark the input degraded
-                  // until collection recovers.
+                  // emit a dropped cursor-persistence event so the cursor change persists,
+                  // and stop this cycle (want_more:false) to back off until the next
+                  // interval (the failure is not indexed; it stays visible through the
+                  // input's HTTP metrics and request tracer). Once consecutive failures
+                  // reach the threshold the failure is persistent, so return a
+                  // single-object error to mark the input degraded until collection
+                  // recovers.
                   (
                     (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                       state.with(
@@ -360,7 +369,7 @@ inputs:
                           ),
                           "want_more": false,
                           "transport_error_streak": int(state.transport_error_streak) + 1,
-                          "events": [{"retry": true}],
+                          "events": [{"publish_cursor": true}],
                         }
                       )
                   )

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -64,6 +64,7 @@ resource.tracer:
 
 state:
   want_more: false
+  transport_error_streak: 0
   base:
     tenant_id: "{{azure_tenant_id}}"
     list_contents_start_time: "{{initial_interval}}"
@@ -87,14 +88,14 @@ redact:
 # state.cursor.todo_links:   A list of listing links, either generated or received.
 # state.cursor.last_for:     A map tracking latest time considered in listings for each content type.
 # state.transport_error_streak: Count of consecutive evaluations that ended in a
-#                               transport-level request failure. Reset to zero on any
-#                               successful subscription, listing or content fetch. When it
-#                               reaches state.base.transport_failure_threshold the failure
-#                               is treated as persistent (for example an expired client
-#                               secret failing token acquisition) and reported as a
-#                               single-object error so the input is marked degraded. Held
-#                               outside the cursor so it survives the cursor reset that a
-#                               single-object error triggers.
+#                               transport-level request failure. Initialized to zero in the
+#                               state block above and reset to zero on any successful
+#                               subscription, listing or content fetch. When it reaches
+#                               state.base.transport_failure_threshold the failure is treated
+#                               as persistent (for example an expired client secret failing
+#                               token acquisition) and reported as a single-object error so
+#                               the input is marked degraded. Held outside the cursor so it
+#                               survives the cursor reset that a single-object error triggers.
 #
 # LOGIC OVERVIEW
 #
@@ -259,11 +260,11 @@ program: |-
         // client secret failing token acquisition), so return a single-object
         // error to mark the input degraded until collection recovers.
         (
-          (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+          (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
             state.with(
               {
                 "want_more": false,
-                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "transport_error_streak": int(state.transport_error_streak) + 1,
                 "events": {
                   "error": {
                     "message": "persistent transport failure starting subscription for '" + state.todo_types[0] + "': " + string(sub_resp.?_transport_error.orValue("")),
@@ -275,7 +276,7 @@ program: |-
             state.with(
               {
                 "want_more": false,
-                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "transport_error_streak": int(state.transport_error_streak) + 1,
                 "events": [{"retry": true}],
               }
             )
@@ -346,11 +347,11 @@ program: |-
             // threshold the failure is persistent, so return a single-object
             // error to mark the input degraded until collection recovers.
             (
-              (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+              (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                 state.with(
                   {
                     "want_more": false,
-                    "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                    "transport_error_streak": int(state.transport_error_streak) + 1,
                     "events": {
                       "error": {
                         "message": "persistent transport failure fetching " + state.cursor.todo_content[0].contentUri + ": " + string(content_resp.?_transport_error.orValue("")),
@@ -367,7 +368,7 @@ program: |-
                       }
                     ),
                     "want_more": false,
-                    "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                    "transport_error_streak": int(state.transport_error_streak) + 1,
                     "events": [{"retry": true}],
                   }
                 )
@@ -431,11 +432,11 @@ program: |-
         // persistent, so return a single-object error to mark the input degraded
         // until collection recovers.
         (
-          (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+          (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
             state.with(
               {
                 "want_more": false,
-                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "transport_error_streak": int(state.transport_error_streak) + 1,
                 "events": {
                   "error": {
                     "message": "persistent transport failure listing " + state.cursor.todo_links[0] + ": " + string(list_resp.?_transport_error.orValue("")),
@@ -452,7 +453,7 @@ program: |-
                   }
                 ),
                 "want_more": false,
-                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "transport_error_streak": int(state.transport_error_streak) + 1,
                 "events": [{"retry": true}],
               }
             )

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -70,6 +70,7 @@ state:
     batch_interval: "{{batch_interval}}"
     maximum_age: "{{maximum_age}}"
     content_types: "{{content_types}}"
+    transport_failure_threshold: {{transport_failure_threshold}}
 
 redact:
   fields:
@@ -85,6 +86,15 @@ redact:
 # state.cursor.todo_content: A list of content items to fetch.
 # state.cursor.todo_links:   A list of listing links, either generated or received.
 # state.cursor.last_for:     A map tracking latest time considered in listings for each content type.
+# state.transport_error_streak: Count of consecutive evaluations that ended in a
+#                               transport-level request failure. Reset to zero on any
+#                               successful subscription, listing or content fetch. When it
+#                               reaches state.base.transport_failure_threshold the failure
+#                               is treated as persistent (for example an expired client
+#                               secret failing token acquisition) and reported as a
+#                               single-object error so the input is marked degraded. Held
+#                               outside the cursor so it survives the cursor reset that a
+#                               single-object error triggers.
 #
 # LOGIC OVERVIEW
 #
@@ -240,16 +250,35 @@ program: |-
       ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
         // A transport-level failure such as a dropped connection or a truncated
         // response body makes do_request return an error rather than a response
-        // with a status code, which would otherwise crash the evaluation. Emit
-        // a dropped retry event and stop this cycle so the subscription is
-        // retried on the next polling interval. The failure is not indexed as
-        // an event; it remains visible through the input's HTTP metrics and
-        // request tracer.
-        state.with(
-          {
-            "want_more": false,
-            "events": [{"retry": true}],
-          }
+        // with a status code, which would otherwise crash the evaluation. Count
+        // consecutive transport failures: below the threshold, emit a dropped
+        // retry event and stop this cycle so the subscription is retried on the
+        // next polling interval (the failure is not indexed; it stays visible
+        // through the input's HTTP metrics and request tracer). Once the streak
+        // reaches the threshold the failure is persistent (for example an expired
+        // client secret failing token acquisition), so return a single-object
+        // error to mark the input degraded until collection recovers.
+        (
+          (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+            state.with(
+              {
+                "want_more": false,
+                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "events": {
+                  "error": {
+                    "message": "persistent transport failure starting subscription for '" + state.todo_types[0] + "': " + string(sub_resp.?_transport_error.orValue("")),
+                  },
+                },
+              }
+            )
+          :
+            state.with(
+              {
+                "want_more": false,
+                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "events": [{"retry": true}],
+              }
+            )
         )
       : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
         // Subscription successful - Record subscription, requeue type and continue
@@ -258,6 +287,7 @@ program: |-
             "todo_types": tail(state.todo_types) + [state.todo_types[0]],
             "subscribed": state.?subscribed.orValue({}).with({state.todo_types[0]: true}),
             "want_more": true,
+            "transport_error_streak": 0,
             "events": [{"retry": true}],
           }
         )
@@ -307,25 +337,40 @@ program: |-
           ).as(content_resp, content_resp.?_transport_error.hasValue() ?
             // A transport-level failure such as a dropped connection or a
             // truncated response body makes do_request return an error rather
-            // than a response with a status code. Returning a single error
-            // object here would make the runtime discard the cursor update, so
-            // the failing item would be retried on every evaluation and stall
-            // all further collection. Instead, move the item to the back of the
-            // queue so the remaining items can still be fetched, emit a dropped
-            // retry event so the cursor change persists, and stop this cycle to
-            // back off until the next interval. The failure is not indexed as an
-            // event; it remains visible through the input's HTTP metrics and
-            // request tracer.
-            state.with(
-              {
-                "cursor": state.cursor.with(
+            // than a response with a status code. Below the threshold, move the
+            // item to the back of the queue so the remaining items can still be
+            // fetched, emit a dropped retry event so the cursor change persists,
+            // and stop this cycle to back off until the next interval (the
+            // failure is not indexed; it stays visible through the input's HTTP
+            // metrics and request tracer). Once consecutive failures reach the
+            // threshold the failure is persistent, so return a single-object
+            // error to mark the input degraded until collection recovers.
+            (
+              (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+                state.with(
                   {
-                    "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                    "want_more": false,
+                    "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                    "events": {
+                      "error": {
+                        "message": "persistent transport failure fetching " + state.cursor.todo_content[0].contentUri + ": " + string(content_resp.?_transport_error.orValue("")),
+                      },
+                    },
                   }
-                ),
-                "want_more": false,
-                "events": [{"retry": true}],
-              }
+                )
+              :
+                state.with(
+                  {
+                    "cursor": state.cursor.with(
+                      {
+                        "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                      }
+                    ),
+                    "want_more": false,
+                    "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                    "events": [{"retry": true}],
+                  }
+                )
             )
           : (content_resp.StatusCode == 200) ?
             // Fetch successful - Return events, continue with remaining content
@@ -338,6 +383,7 @@ program: |-
                 ),
                 "cursor": state.cursor.with({"todo_content": tail(state.cursor.todo_content)}),
                 "want_more": true,
+                "transport_error_streak": 0,
               }
             )
           :
@@ -376,24 +422,40 @@ program: |-
       ).as(list_resp, list_resp.?_transport_error.hasValue() ?
         // A transport-level failure such as a dropped connection or a
         // truncated response body makes do_request return an error rather than
-        // a response with a status code. Returning a single error object here
-        // would make the runtime discard the cursor update, so the failing link
-        // would be retried on every evaluation and stall all further
-        // collection. Instead, move the link to the back of the queue so the
-        // remaining links can still be requested, emit a dropped retry event so
-        // the cursor change persists, and stop this cycle to back off until the
-        // next interval. The failure is not indexed as an event; it remains
-        // visible through the input's HTTP metrics and request tracer.
-        state.with(
-          {
-            "cursor": state.cursor.with(
+        // a response with a status code. Below the threshold, move the link to
+        // the back of the queue so the remaining links can still be requested,
+        // emit a dropped retry event so the cursor change persists, and stop
+        // this cycle to back off until the next interval (the failure is not
+        // indexed; it stays visible through the input's HTTP metrics and request
+        // tracer). Once consecutive failures reach the threshold the failure is
+        // persistent, so return a single-object error to mark the input degraded
+        // until collection recovers.
+        (
+          (int(state.?transport_error_streak.orValue(0.0)) + 1 >= int(state.base.transport_failure_threshold)) ?
+            state.with(
               {
-                "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                "want_more": false,
+                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "events": {
+                  "error": {
+                    "message": "persistent transport failure listing " + state.cursor.todo_links[0] + ": " + string(list_resp.?_transport_error.orValue("")),
+                  },
+                },
               }
-            ),
-            "want_more": false,
-            "events": [{"retry": true}],
-          }
+            )
+          :
+            state.with(
+              {
+                "cursor": state.cursor.with(
+                  {
+                    "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                  }
+                ),
+                "want_more": false,
+                "transport_error_streak": int(state.?transport_error_streak.orValue(0.0)) + 1,
+                "events": [{"retry": true}],
+              }
+            )
         )
       : (list_resp.StatusCode == 200) ?
         // Listing successful - Enqueue any additional link, enqueue content to fetch
@@ -408,6 +470,7 @@ program: |-
                 }
               ),
               "want_more": true,
+              "transport_error_streak": 0,
               "events": [{"retry": true}],
             }
           )

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -253,12 +253,13 @@ program: |-
         // response body makes do_request return an error rather than a response
         // with a status code, which would otherwise crash the evaluation. Count
         // consecutive transport failures: below the threshold, emit a dropped
-        // retry event and stop this cycle so the subscription is retried on the
-        // next polling interval (the failure is not indexed; it stays visible
-        // through the input's HTTP metrics and request tracer). Once the streak
-        // reaches the threshold the failure is persistent (for example an expired
-        // client secret failing token acquisition), so return a single-object
-        // error to mark the input degraded until collection recovers.
+        // cursor-persistence event and stop this cycle (want_more:false) so the
+        // subscription is retried on the next polling interval (the failure is
+        // not indexed; it stays visible through the input's HTTP metrics and
+        // request tracer). Once the streak reaches the threshold the failure is
+        // persistent (for example an expired client secret failing token
+        // acquisition), so return a single-object error to mark the input
+        // degraded until collection recovers.
         (
           (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
             state.with(
@@ -277,7 +278,7 @@ program: |-
               {
                 "want_more": false,
                 "transport_error_streak": int(state.transport_error_streak) + 1,
-                "events": [{"retry": true}],
+                "events": [{"publish_cursor": true}],
               }
             )
         )
@@ -340,12 +341,13 @@ program: |-
             // truncated response body makes do_request return an error rather
             // than a response with a status code. Below the threshold, move the
             // item to the back of the queue so the remaining items can still be
-            // fetched, emit a dropped retry event so the cursor change persists,
-            // and stop this cycle to back off until the next interval (the
-            // failure is not indexed; it stays visible through the input's HTTP
-            // metrics and request tracer). Once consecutive failures reach the
-            // threshold the failure is persistent, so return a single-object
-            // error to mark the input degraded until collection recovers.
+            // fetched, emit a dropped cursor-persistence event so the cursor
+            // change persists, and stop this cycle (want_more:false) to back off
+            // until the next interval (the failure is not indexed; it stays
+            // visible through the input's HTTP metrics and request tracer). Once
+            // consecutive failures reach the threshold the failure is
+            // persistent, so return a single-object error to mark the input
+            // degraded until collection recovers.
             (
               (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
                 state.with(
@@ -369,7 +371,7 @@ program: |-
                     ),
                     "want_more": false,
                     "transport_error_streak": int(state.transport_error_streak) + 1,
-                    "events": [{"retry": true}],
+                    "events": [{"publish_cursor": true}],
                   }
                 )
             )
@@ -425,12 +427,13 @@ program: |-
         // truncated response body makes do_request return an error rather than
         // a response with a status code. Below the threshold, move the link to
         // the back of the queue so the remaining links can still be requested,
-        // emit a dropped retry event so the cursor change persists, and stop
-        // this cycle to back off until the next interval (the failure is not
-        // indexed; it stays visible through the input's HTTP metrics and request
-        // tracer). Once consecutive failures reach the threshold the failure is
-        // persistent, so return a single-object error to mark the input degraded
-        // until collection recovers.
+        // emit a dropped cursor-persistence event so the cursor change persists,
+        // and stop this cycle (want_more:false) to back off until the next
+        // interval (the failure is not indexed; it stays visible through the
+        // input's HTTP metrics and request tracer). Once consecutive failures
+        // reach the threshold the failure is persistent, so return a
+        // single-object error to mark the input degraded until collection
+        // recovers.
         (
           (int(state.transport_error_streak) + 1 >= int(state.base.transport_failure_threshold)) ?
             state.with(
@@ -454,7 +457,7 @@ program: |-
                 ),
                 "want_more": false,
                 "transport_error_streak": int(state.transport_error_streak) + 1,
-                "events": [{"retry": true}],
+                "events": [{"publish_cursor": true}],
               }
             )
         )
@@ -586,7 +589,13 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 processors:
-- drop_event.when.equals.retry: true
+- drop_event:
+    when:
+      or:
+        - equals:
+            retry: true
+        - equals:
+            publish_cursor: true
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -111,6 +111,15 @@ streams:
         show_user: false
         required: true
         default: 167h55m
+      - name: transport_failure_threshold
+        type: integer
+        title: Transport Failure Threshold
+        description: >-
+          Number of consecutive polling cycles ending in a transport-level request failure (for example a dropped connection, or an OAuth 2.0 token acquisition failure caused by an expired client secret) after which the input reports its health as Degraded. Isolated, transient failures below this threshold are retried without affecting health status. Lower it to surface persistent outages sooner.
+        show_user: false
+        multi: false
+        required: false
+        default: 5
       - name: resource_ssl
         type: yaml
         title: Resource SSL Configuration

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.10.8"
+version: "3.11.0"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Type of change
- Enhancement

## Proposed commit message
```
o365: report audit input degraded on persistent transport failures

The audit data stream's CEL program wraps every do_request in
try("_transport_error") so that a single unfetchable item does not
stall collection. That handler emits a dropped retry placeholder, which
the CEL input treats as a successful evaluation and reports Healthy. A
persistent failure such as an expired client secret failing OAuth 2.0
token acquisition was therefore swallowed: collection stopped while the
integration kept reporting Healthy.

Track consecutive transport failures in state. Below the new
transport_failure_threshold the existing recover-and-continue behaviour
is unchanged, so isolated transient failures still do not degrade the
input. Once the streak reaches the threshold the failure is treated as
persistent and returned as a single-object error, marking the input
degraded until a successful request resets the streak. The threshold is
a hidden variable defaulting to 5.

Regenerate the policy test snapshots for the rendered program and the
new variable.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Relates https://github.com/elastic/integrations/pull/20333

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
