### PR TITLE
gcs-mock-service: fix bucket created once per file instead of once per bucket

### DIFF
--- a/packages/cloudflare_logpush/data_stream/access_request/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/access_request/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/audit/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/audit/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/casb/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/casb/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/device_posture/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/device_posture/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/dns/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/dns/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/email_security_alerts/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/email_security_alerts/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/firewall_event/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/gateway_http/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/gateway_network/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/http_request/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/http_request/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/magic_ids/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/nel_report/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/nel_report/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/network_analytics/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/network_session/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/network_session/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/page_shield_events/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/page_shield_events/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/cloudflare_logpush/data_stream/workers_trace/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/netskope/data_stream/transaction/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/netskope/data_stream/transaction/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)

--- a/packages/symantec_endpoint_security/data_stream/event/_dev/deploy/docker/gcs-mock-service/main.go
+++ b/packages/symantec_endpoint_security/data_stream/event/_dev/deploy/docker/gcs-mock-service/main.go
@@ -86,13 +86,13 @@ func readManifest(path string) (*Manifest, error) {
 // processManifest creates buckets and uploads objects as specified in the manifest.
 func processManifest(manifest *Manifest) error {
 	for bucketName, bucket := range manifest.Buckets {
+		if err := createBucket(bucketName); err != nil {
+			return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
+		}
 		for _, file := range bucket.Files {
 			fmt.Printf("preloading data for bucket: %s | path: %s | content-type: %s...\n",
 				bucketName, file.Path, file.ContentType)
 
-			if err := createBucket(bucketName); err != nil {
-				return fmt.Errorf("failed to create bucket '%s': %w", bucketName, err)
-			}
 			data, err := os.ReadFile(file.Path)
 			if err != nil {
 				return fmt.Errorf("failed to read bucket data file '%s': %w", file.Path, err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
gcs-mock-service: fix bucket created once per file instead of once per bucket

processManifest called createBucket inside the per-file loop, so any
bucket configured with more than one file would fail on the second file
with "bucket already exists" and exit with code 1. Move the call outside
the inner loop so the bucket is created once per bucket entry.
```

> [!NOTE]
> No changelogs since this is not user-facing.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #20455

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
