### PR TITLE
Add apt retry option to Dockerfiles to fix intermittent network failures

### DIFF
--- a/packages/activemq/_dev/deploy/docker/Dockerfile
+++ b/packages/activemq/_dev/deploy/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV ACTIVEMQ_STOMP=61613 ACTIVEMQ_REST=8161
 
 RUN set -x && \
     mkdir -p /opt && \
-    apt-get update && \
+    apt-get -o Acquire::Retries=3 update && \
     apt-get install netcat-openbsd -y
 
 RUN curl --fail https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz -o $ACTIVEMQ-bin.tar.gz

--- a/packages/apache/_dev/deploy/docker/Dockerfile
+++ b/packages/apache/_dev/deploy/docker/Dockerfile
@@ -4,6 +4,6 @@ FROM httpd:$SERVICE_VERSION
 RUN sed -i 's/deb.debian/archive.debian/' /etc/apt/sources.list && \
     sed -i 's/security.debian/archive.debian/' /etc/apt/sources.list && \
     sed -i "/buster-updates/d" /etc/apt/sources.list
-RUN apt-get update && apt-get install -y curl
+RUN apt-get -o Acquire::Retries=3 update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/packages/apache_input_otel/_dev/deploy/docker/Dockerfile
+++ b/packages/apache_input_otel/_dev/deploy/docker/Dockerfile
@@ -4,6 +4,6 @@ FROM httpd:$SERVICE_VERSION
 RUN sed -i 's/deb.debian/archive.debian/' /etc/apt/sources.list && \
     sed -i 's/security.debian/archive.debian/' /etc/apt/sources.list && \
     sed -i "/buster-updates/d" /etc/apt/sources.list
-RUN apt-get update && apt-get install -y curl
+RUN apt-get -o Acquire::Retries=3 update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:8080/server-status?auto
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/packages/cassandra/_dev/deploy/docker/Dockerfile
+++ b/packages/cassandra/_dev/deploy/docker/Dockerfile
@@ -11,7 +11,7 @@ ENV CASSANDRA_LIB=/var/lib/cassandra
 
 RUN set -eux; \
     savedAptMark="$(apt-mark showmanual)"; \
-    apt-get update; \
+    apt-get -o Acquire::Retries=3 update; \
     apt-get install -y --no-install-recommends wget \
     &&  wget http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/${JOLOKIA_VERSION}/jolokia-jvm-${JOLOKIA_VERSION}-agent.jar -O jolokia-jvm-${JOLOKIA_VERSION}-agent.jar
 

--- a/packages/haproxy/_dev/deploy/docker/Dockerfile
+++ b/packages/haproxy/_dev/deploy/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG HAPROXY_VERSION=3.2
 FROM haproxy:${HAPROXY_VERSION}
 USER root
-RUN apt-get update && apt-get install -y netcat-openbsd
+RUN apt-get -o Acquire::Retries=3 update && apt-get install -y netcat-openbsd
 
 HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 14567 && nc -z localhost 14570
 

--- a/packages/iptables/_dev/deploy/docker/Dockerfile
+++ b/packages/iptables/_dev/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
 
-RUN apt-get update \
-      && apt install -y systemd-journal-remote \
+RUN apt-get -o Acquire::Retries=3 update \
+      && apt-get install -y systemd-journal-remote \
       && rm -rf /var/lib/apt/lists/*

--- a/packages/journald/_dev/deploy/docker/Dockerfile
+++ b/packages/journald/_dev/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
 
-RUN apt-get update \
-      && apt install -y systemd-journal-remote \
+RUN apt-get -o Acquire::Retries=3 update \
+      && apt-get install -y systemd-journal-remote \
       && rm -rf /var/lib/apt/lists/*

--- a/packages/kafka/_dev/deploy/docker/Dockerfile-java8
+++ b/packages/kafka/_dev/deploy/docker/Dockerfile-java8
@@ -14,7 +14,7 @@ ENV TERM=linux
 RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
     && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list \
     && sed -i '/stretch-updates/d' /etc/apt/sources.list \
-    && apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat-openbsd dnsutils procps
+    && apt-get -o Acquire::Retries=3 update && apt-get install -y curl openjdk-8-jre-headless netcat-openbsd dnsutils procps
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && \
     curl -J -L -s -f -o - https://github.com/kadwanev/retry/releases/download/1.0.1/retry-1.0.1.tar.gz | tar xfz - -C /usr/local/bin && \

--- a/packages/kafka/_dev/deploy/docker/Dockerfile-zookeeper
+++ b/packages/kafka/_dev/deploy/docker/Dockerfile-zookeeper
@@ -14,7 +14,7 @@ ENV TERM=linux
 RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
     && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list \
     && sed -i '/stretch-updates/d' /etc/apt/sources.list \
-    && apt-get update && apt-get upgrade -y && apt-get install -y curl openjdk-8-jre-headless netcat-openbsd dnsutils procps
+    && apt-get -o Acquire::Retries=3 update && apt-get upgrade -y && apt-get install -y curl openjdk-8-jre-headless netcat-openbsd dnsutils procps
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && \
     curl -J -L -s -f -o - https://github.com/kadwanev/retry/releases/download/1.0.1/retry-1.0.1.tar.gz | tar xfz - -C /usr/local/bin && \

--- a/packages/nginx/_dev/deploy/docker/Dockerfile
+++ b/packages/nginx/_dev/deploy/docker/Dockerfile
@@ -6,6 +6,6 @@ RUN if [ "${NGINX_SERVICE_VERSION}" = "1.19.5" ]; then \
       sed -i 's/security.debian/archive.debian/' /etc/apt/sources.list && \
       sed -i "/buster-updates/d" /etc/apt/sources.list; \
     fi && \
-    apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+    apt-get -o Acquire::Retries=3 update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost/server-status
 COPY ./nginx.conf /etc/nginx/

--- a/packages/nginx_input_otel/_dev/deploy/docker/Dockerfile
+++ b/packages/nginx_input_otel/_dev/deploy/docker/Dockerfile
@@ -4,6 +4,6 @@ FROM nginx:${SERVICE_VERSION}
 RUN sed -i 's/deb.debian/archive.debian/' /etc/apt/sources.list && \
     sed -i 's/security.debian/archive.debian/' /etc/apt/sources.list && \
     sed -i "/buster-updates/d" /etc/apt/sources.list
-RUN apt-get update && apt-get install -y curl
+RUN apt-get -o Acquire::Retries=3 update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost/server-status
 COPY ./nginx.conf /etc/nginx/

--- a/packages/php_fpm/_dev/deploy/docker/files/Dockerfile
+++ b/packages/php_fpm/_dev/deploy/docker/files/Dockerfile
@@ -7,7 +7,7 @@ RUN echo >> /opt/bitnami/php/etc/php-fpm.d/www.conf &&\
 
 # Following command installs nginx
 
-RUN apt-get update -y &&\
+RUN apt-get -o Acquire::Retries=3 update -y &&\
     apt-get upgrade -y &&\
     apt-get install nginx -y
 

--- a/packages/rabbitmq/_dev/deploy/docker/Dockerfile
+++ b/packages/rabbitmq/_dev/deploy/docker/Dockerfile
@@ -18,7 +18,7 @@ COPY entrypoint.d/simulate_queue_connection.py entrypoint.d/entrypoint.sh entryp
 RUN /usr/local/bin/fix_debian_stretch_apt.sh
 
 # Install Python 3 and pika for consumer simulation
-RUN apt-get update && apt-get install -y python3 python3-pika
+RUN apt-get -o Acquire::Retries=3 update && apt-get install -y python3 python3-pika
 
 # Set entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/system/_dev/deploy/docker/Dockerfile
+++ b/packages/system/_dev/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
 
-RUN apt-get update \
-      && apt install -y systemd-journal-remote \
+RUN apt-get -o Acquire::Retries=3 update \
+      && apt-get install -y systemd-journal-remote \
       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

There have been rare, intermittent, failures when fetching apt packages, which causes failing tests and CI jobs.

This adds the apt built-in retry  mechanism with `-o Acquire::Retries=3` to all `apt-get update` calls across affected packages, to attempt to prevent these CI failures. Also switches `apt install` to `apt-get install`, which is the recommended command for non-interactive use.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #15774
- Closes #15779

