### PR TITLE
[system/security] - Drop empty process.args token from trailing whitespace

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.23.1"
+  changes:
+    - description: Fix `process.args` and `process.args_count` in the `system.security` Windows Event ID 4688 pipeline by discarding empty tokens produced by trailing or repeated whitespace in the command line.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/00000
 - version: "2.23.0"
   changes:
     - description: Set `event.kind` to `event` for `system.syslog` records collected through the log input, matching the journald pipeline so all syslog events carry a consistent ECS event categorization.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `process.args` and `process.args_count` in the `system.security` Windows Event ID 4688 pipeline by discarding empty tokens produced by trailing or repeated whitespace in the command line.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/00000
+      link: https://github.com/elastic/integrations/pull/20907
 - version: "2.23.0"
   changes:
     - description: Set `event.kind` to `event` for `system.syslog` records collected through the log input, matching the journald pipeline so all syslog events carry a consistent ECS event categorization.

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-4698-scheduled-task-created.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-4698-scheduled-task-created.json-expected.json
@@ -78,8 +78,8 @@
                     },
                     "triggers": [
                         {
-                            "enabled": true,
                             "definition": "v=1|type=time|enabled=true|interval=PT1740S|duration=P9999D|stop_at_duration_end=false",
+                            "enabled": true,
                             "repetition": {
                                 "duration": "P9999D",
                                 "interval": "PT1740S",

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2019-4688-process-created.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2019-4688-process-created.json
@@ -66,6 +66,70 @@
                 "type": "filebeat",
                 "version": "8.0.0"
             }
+        },
+        {
+            "@timestamp": "2021-04-15T19:05:10.100Z",
+            "winlog": {
+                "process": {
+                    "pid": 4,
+                    "thread": {
+                        "id": 6120
+                    }
+                },
+                "record_id": 5011,
+                "level": "information",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "outcome": "success",
+                "computer_name": "WORKSTATION01",
+                "keywords": [
+                    "Audit Success"
+                ],
+                "opcode": "Info",
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "version": 2,
+                "time_created": "2021-04-15T19:05:10.050Z",
+                "channel": "Security",
+                "event_id": 4688,
+                "event_data": {
+                    "SubjectDomainName": "TESTDOMAIN",
+                    "SubjectLogonId": "0x3a1f2",
+                    "TargetDomainName": "-",
+                    "MandatoryLabel": "S-1-16-8192",
+                    "SubjectUserSid": "S-1-5-21-1111111111-2222222222-3333333333-1001",
+                    "NewProcessId": "0x5a9c",
+                    "TokenElevationType": "%%1936",
+                    "ProcessId": "0x49d0",
+                    "CommandLine": "\"C:\\Windows\\System32\\notepad.exe\" ",
+                    "TargetUserName": "-",
+                    "SubjectUserName": "testuser",
+                    "TargetUserSid": "S-1-0-0",
+                    "TargetLogonId": "0x0",
+                    "ParentProcessName": "C:\\Windows\\explorer.exe",
+                    "NewProcessName": "C:\\Windows\\System32\\notepad.exe"
+                }
+            },
+            "event": {
+                "kind": "event",
+                "code": 4688,
+                "provider": "Microsoft-Windows-Security-Auditing",
+                "outcome": "success"
+            },
+            "log": {
+                "level": "information"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "WORKSTATION01"
+            },
+            "agent": {
+                "ephemeral_id": "a1b2c3d4-0000-1111-2222-333344445555",
+                "id": "6f7e8d9c-1234-5678-9abc-def012345678",
+                "name": "WORKSTATION01",
+                "type": "filebeat",
+                "version": "8.0.0"
+            }
         }
     ]
 }

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2019-4688-process-created.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2019-4688-process-created.json-expected.json
@@ -101,6 +101,103 @@
                 "time_created": "2019-11-14T17:10:15.151Z",
                 "version": 2
             }
+        },
+        {
+            "@timestamp": "2021-04-15T19:05:10.050Z",
+            "agent": {
+                "ephemeral_id": "a1b2c3d4-0000-1111-2222-333344445555",
+                "id": "6f7e8d9c-1234-5678-9abc-def012345678",
+                "name": "WORKSTATION01",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "created-process",
+                "category": [
+                    "process"
+                ],
+                "code": "4688",
+                "kind": "event",
+                "outcome": "success",
+                "provider": "Microsoft-Windows-Security-Auditing",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "name": "WORKSTATION01"
+            },
+            "log": {
+                "level": "information"
+            },
+            "process": {
+                "args": [
+                    "\"C:\\Windows\\System32\\notepad.exe\""
+                ],
+                "args_count": 1,
+                "command_line": "\"C:\\Windows\\System32\\notepad.exe\" ",
+                "executable": "C:\\Windows\\System32\\notepad.exe",
+                "name": "notepad.exe",
+                "parent": {
+                    "executable": "C:\\Windows\\explorer.exe",
+                    "name": "explorer.exe",
+                    "pid": 18896
+                },
+                "pid": 23196
+            },
+            "related": {
+                "user": [
+                    "testuser"
+                ]
+            },
+            "user": {
+                "domain": "TESTDOMAIN",
+                "effective": {
+                    "id": "S-1-0-0"
+                },
+                "id": "S-1-5-21-1111111111-2222222222-3333333333-1001",
+                "name": "testuser"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "WORKSTATION01",
+                "event_data": {
+                    "CommandLine": "\"C:\\Windows\\System32\\notepad.exe\" ",
+                    "MandatoryLabel": "S-1-16-8192",
+                    "ProcessId": "0x49d0",
+                    "SubjectDomainName": "TESTDOMAIN",
+                    "SubjectLogonId": "0x3a1f2",
+                    "SubjectUserName": "testuser",
+                    "SubjectUserSid": "S-1-5-21-1111111111-2222222222-3333333333-1001",
+                    "TargetLogonId": "0x0",
+                    "TargetUserSid": "S-1-0-0",
+                    "TokenElevationType": "%%1936"
+                },
+                "event_id": "4688",
+                "keywords": [
+                    "Audit Success"
+                ],
+                "level": "information",
+                "logon": {
+                    "id": "0x3a1f2"
+                },
+                "opcode": "Info",
+                "outcome": "success",
+                "process": {
+                    "pid": 4,
+                    "thread": {
+                        "id": 6120
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5011",
+                "time_created": "2021-04-15T19:05:10.050Z",
+                "version": 2
+            }
         }
     ]
 }

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -4342,10 +4342,12 @@ processors:
               }
             }
             if (Character.isWhitespace(ctx.winlog.event_data.CommandLine.charAt(i)) && !in_quote) {
-              al.add(ctx.winlog.event_data.CommandLine.substring(start, end));
+              if (end > start) {
+                al.add(ctx.winlog.event_data.CommandLine.substring(start, end));
+              }
               start = i + 1;
             }
-            if (i == ctx.winlog.event_data.CommandLine.length() - 1) {
+            if (i == ctx.winlog.event_data.CommandLine.length() - 1 && start <= end) {
               al.add(ctx.winlog.event_data.CommandLine.substring(start, end + 1));
             }
           }

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.23.0"
+version: "2.23.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
system.security: drop empty process.args token from trailing whitespace

The Event ID 4688 command-line tokenizer split winlog.event_data.CommandLine
on whitespace but never discarded empty tokens. Windows records a no-argument
process launch with a trailing space after the quoted executable path, so the
final space produced a spurious empty-string element in process.args and
inflated process.args_count by one (e.g. "...\notepad.exe" with a trailing
space yielded args_count 2 instead of 1). Consecutive spaces between real
arguments had the same effect.

Skip empty tokens both when splitting on whitespace and when emitting the
final token, so process.args and process.args_count reflect the actual
argument list. Add a pipeline test case for a no-argument launch with a
trailing space.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
