### PR TITLE
[google_workspace] Lengthen login lag setting

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.7.1"
+  changes:
+    - description: Lengthen login lag setting.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20910
 - version: "3.7.0"
   changes:
     - description: Add Gemini in Workspace Apps data stream to collect generative AI usage activity via the Admin Reports API.

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -23,7 +23,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 3m
+        default: 30m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "3.7.0"
+version: "3.7.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
## Proposed commit message

```
[google_workspace] Lengthen login lag setting

Lengthen the default lag setting for the login data stream from 3 mins
to 30 mins. It was 3 hours until the the recent change #19780. The 30
minute value is the result of detailed testing and reconciliation
against a live account.

In March 2021[1] Google consolidated account-change events (password,
recovery info, 2SV, Advanced Protection, email forwarding) into the
Login application.

Now the Login audit application as a whole contains nine event types
with very different lag characteristics (see lag times[2] and event
reference[3]):

**Near real time (couple of minutes)**
`login` (`login_success`, `login_failure`, `login_challenge`,
`login_verification`, `logout`, `risky_sensitive_action_*`).

**Tens of minutes**
`2sv_change`, `password_change`, `recovery_info_change`,
`titanium_change`, `email_forwarding_change`.

**Not documented; detection-driven**
`account_warning`, `attack_warning`, `blocked_sender_change`.

Although login events only need a couple of minutes, the other event
types in the login application need longer.

[1]: https://workspaceupdates.googleblog.com/2021/03/login-related-events-consolidated-within-admin-console.html
[2]: https://support.google.com/a/answer/7061566
[3]: https://developers.google.com/admin-sdk/reports/v1/appendix/activity/login
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #19780