### PR TITLE
prisma_cloud: fix alert data stream dropping data on pagination and bad responses

### DIFF
--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.3.1"
+  changes:
+    - description: Fix `alert` data stream sending an invalid `timeAmount=null` request during pagination, and guard against non-JSON or empty API responses so they no longer break ingestion.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "4.3.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,7 +1,13 @@
 # newer versions go on top
 - version: "4.3.1"
   changes:
-    - description: Fix `alert` data stream sending an invalid `timeAmount=null` request during pagination, and guard against non-JSON or empty API responses so they no longer break ingestion.
+    - description: Fix `alert` data stream sending an invalid `timeAmount=null` request during pagination.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20917
+    - description: Guard the `alert` data stream against non-JSON or empty API responses so they no longer break ingestion.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20917
+    - description: Re-authenticate the `alert` data stream based on a token deadline to avoid stale-token loops.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20917
 - version: "4.3.0"

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `alert` data stream sending an invalid `timeAmount=null` request during pagination, and guard against non-JSON or empty API responses so they no longer break ingestion.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20917
 - version: "4.3.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/env.txt
+++ b/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/env.txt
@@ -1,0 +1,16 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${PACKAGE_NAME}
+stdout '^prisma_cloud$'
+
+exec echo ${DATA_STREAM}
+stdout '^alert$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/prisma_cloud/data_stream/alert$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+$'

--- a/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/error_json_response.txt
+++ b/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/error_json_response.txt
@@ -1,0 +1,96 @@
+# Test that a non-JSON (HTML error page, e.g. a 414/synthetic-200 from a
+# load balancer) response for /v2/alert does not break ingestion. The mock
+# alternates between an HTML body and a valid alert response on successive
+# calls. The CEL program must skip the HTML body gracefully (emitting no
+# events, no eval failure) and still collect the valid alert on a later
+# poll. Regression guard for the response-decode error handling added in
+# 4.3.1.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} error-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one alert should be collected despite the interleaved HTML
+# responses. The pipeline fingerprints _id, so repeated valid responses
+# deduplicate to a single document; -confirm guards against the HTML body
+# producing any spurious document.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '.hits.hits[]._source.event.id' got_docs.json
+stdout '^N-9999$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down error-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  username: xxxx
+  password: xxxx
+data_stream:
+  vars:
+    url: http://error-mock:8080
+    interval: 30s
+    time_amount: 1
+    time_unit: hour
+    batch_size: 100
+    preserve_original_event: true
+
+-- error-mock/docker-compose.yml --
+version: '2.3'
+services:
+  error-mock:
+    image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: error-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+
+-- error-mock/config.yml --
+rules:
+  - path: /login
+    methods: ['POST']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        body: |-
+          {"message":"login_successful","token":"xxxx"}
+
+  # /v2/alert alternates: HTML error page, then a valid alert response.
+  - path: /v2/alert
+    methods: ['GET']
+    request_headers:
+      x-redlock-auth:
+        - 'xxxx'
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'text/html'
+        body: |-
+          <html>
+          <head><title>414 Request-URI Too Large</title></head>
+          <body><center><h1>414 Request-URI Too Large</h1></center></body>
+          </html>
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        body: |-
+          {"totalRows":1,"items":[{"id":"N-9999","alertAdditionalInfo":{"scannerVersion":"CS_2.0"},"alertAttribution":{"attributionEventList":[{"event":"first_event","event_ts":1694003441966,"username":"alex123"}],"resourceCreatedBy":"string","resourceCreatedOn":0},"status":"open","reason":"NEW_ALERT","firstSeen":1694003441966,"history":[{"modifiedOn":"1694003441966","modifiedBy":"alex123","reason":"Reason1","status":"OPEN"}],"lastSeen":1694003441966,"alertTime":1694003441966,"lastUpdated":1694003441966,"policyId":"ad23603d-754e-4499-8988-b801xxx85898","metadata":null,"policy":{"policyId":"ad23603d-754e-4499-8988-b8017xxxx98","name":"AWS EC2 instance that is internet reachable with unrestricted access (0.0.0.0\/0)","policyType":"network","systemDefault":true,"complianceMetadata":[{"complianceId":"qwer345bv","customAssigned":true,"policyId":"werf435tr","requirementDescription":"Description of policy compliance.","requirementId":"req-123-xyz","requirementName":"rigidity","sectionDescription":"Description of section.","sectionId":"sect-453-abc","sectionLabel":"label-1","standardDescription":"Description of standard.","standardId":"stand-543-pqr","standardName":"Class 1"}],"description":"This policy identifies AWS EC2 instances that are internet reachable with unrestricted access (0.0.0.0\/0).","severity":"high","recommendation":"Restrict traffic from unknown IP addresses.","labels":["Prisma_Cloud","Attack Path Rule"],"lastModifiedOn":1687474999057,"lastModifiedBy":"template@redlock.io","deleted":false,"findingTypes":[],"remediable":false,"remediation":{"actions":[{"operation":"buy","payload":"erefwsdf"}],"cliScriptTemplate":"temp1","description":"Description of CLI Script Template."}},"alertRules":[],"resource":{"rrn":"rrn:aws:instance:us-east-1:710000059376:e7ddce5a1ffcb47bxxxxxerf2635a3b4d9da3:i-04578e0008100947","id":"i-04578exxxx8100947","name":"IS-37133","account":"AWS Cloud Account","accountId":"710002259376","cloudAccountGroups":["Default Account Group"],"region":"AWS Virginia","regionId":"us-east-1","resourceType":"INSTANCE","resourceApiName":"aws-ec2-describe-instances","cloudServiceName":"Amazon EC2","url":"https:\/\/console.aws.amazon.com\/ec2\/v2\/home?region=us-east-1#Instances:instanceId=i-0457xxxxx00947","data":null,"additionalInfo":null,"cloudType":"aws","resourceTs":1694003441915,"unifiedAssetId":"66c543b6261c4d9edxxxxxb42e15f4","resourceConfigJsonAvailable":false,"resourceDetailsAvailable":true},"investigateOptions":{"alertId":"N-9999"}}]}

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -22,20 +22,22 @@ state:
   time_amount: {{time_amount}}
   time_unit: {{time_unit}}
   want_more: false
+  # Re-authenticate before the Prisma Cloud CSPM JWT expires (~10m TTL).
+  token_ttl: "9m"
 redact:
   fields:
     - password
     - access_token
 program: |
   (
-    state.with(!has(state.access_token) || state.access_token == "" || !has(state.token_expiry) || now() >= timestamp(state.token_expiry) ?
+    state.with(state.?access_token.orValue("") == "" || state.?token_expiry.optMap(t, now() >= timestamp(t)).orValue(true) ?
       post_request(
         state.url + "/login",
         "application/json",
         {"username":state.user,"password":state.password}.encode_json()
       ).do_request().as(resp, resp.Body.decode_json().as(body, {
           "access_token": body.token,
-          "token_expiry": string(now() + duration("9m")),
+          "token_expiry": string(now() + duration(state.token_ttl)),
       }))
     :
       {}

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -54,7 +54,7 @@ program: |
             has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null ?
               string((now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.first_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
             :
-              "null"
+              string(state.time_amount) + "&timeUnit=" + state.time_unit
           ) + (has(state.page_token) ? "&pageToken=" + state.page_token : "")
         )
       ).with({
@@ -62,7 +62,12 @@ program: |
            "x-redlock-auth": [state.access_token],
          }
       }).do_request().as(resp,
-        bytes(resp.Body).decode_json().as(inner_body, {
+        (resp.StatusCode == 200) ?
+        try(bytes(resp.Body).decode_json()).as(inner_body,
+          is_error(inner_body.with({})) ?
+            {"events": []}
+          :
+          {
           "events": inner_body.items.map(e, {
             "message": e.encode_json(),
           }),
@@ -121,10 +126,12 @@ program: |
               int(state.total_rows) + size(inner_body.items)
             :
               0,
-          }))
+          })
+        :
+          {"events": []}
       )
     )
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -28,14 +28,14 @@ redact:
     - access_token
 program: |
   (
-    state.with(!has(state.access_token) || !has(state.token_expiry) || now >= timestamp(state.token_expiry) ?
+    state.with(!has(state.access_token) || state.access_token == "" || !has(state.token_expiry) || now() >= timestamp(state.token_expiry) ?
       post_request(
         state.url + "/login",
         "application/json",
         {"username":state.user,"password":state.password}.encode_json()
       ).do_request().as(resp, resp.Body.decode_json().as(body, {
           "access_token": body.token,
-          "token_expiry": string(now + duration("9m")),
+          "token_expiry": string(now() + duration("9m")),
       }))
     :
       {}
@@ -67,68 +67,68 @@ program: |
           is_error(inner_body) ?
             {"events": []}
           :
-          {
-          "events": inner_body.items.map(e, {
-            "message": e.encode_json(),
-          }),
-          "url": state.url,
-          "page_token": has(inner_body.nextPageToken) ? inner_body.nextPageToken : "",
-          "cursor": {
-            "last_time_amount": (
-              has(inner_body.items) && inner_body.items.size() > 0 ?
-                (
-                  has(state.cursor) && has(state.cursor.last_time_amount) &&
-                  inner_body.items.map(e, e.lastUpdated).max() < state.cursor.last_time_amount ?
-                    state.cursor.last_time_amount
+            {
+              "events": inner_body.items.map(e, {
+                "message": e.encode_json(),
+              }),
+              "url": state.url,
+              "page_token": has(inner_body.nextPageToken) ? inner_body.nextPageToken : "",
+              "cursor": {
+                "last_time_amount": (
+                  has(inner_body.items) && inner_body.items.size() > 0 ?
+                    (
+                      has(state.cursor) && has(state.cursor.last_time_amount) &&
+                      inner_body.items.map(e, e.lastUpdated).max() < state.cursor.last_time_amount ?
+                        state.cursor.last_time_amount
+                      :
+                        inner_body.items.map(e, e.lastUpdated).max()
+                    )
                   :
-                    inner_body.items.map(e, e.lastUpdated).max()
-                )
-              :
-                (
-                  has(state.cursor) && has(state.cursor.last_time_amount) ?
-                    state.cursor.last_time_amount
-                  :
-                    null
-                )
-              ),
-              "first_time_amount": (
-                 has(state.cursor) && has(state.cursor.first_time_amount) &&
-                 state.cursor.first_time_amount != null && has(inner_body.items) ?
-                   (
-                     ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) && state.want_more ?
-                       state.cursor.first_time_amount
+                    (
+                      has(state.cursor) && has(state.cursor.last_time_amount) ?
+                        state.cursor.last_time_amount
+                      :
+                        null
+                    )
+                  ),
+                  "first_time_amount": (
+                     has(state.cursor) && has(state.cursor.first_time_amount) &&
+                     state.cursor.first_time_amount != null && has(inner_body.items) ?
+                       (
+                         ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) && state.want_more ?
+                           state.cursor.first_time_amount
+                         :
+                           state.cursor.last_time_amount
+                       )
                      :
-                       state.cursor.last_time_amount
-                   )
-                 :
-                   int(timestamp(now)-duration(string(
-                     state.time_unit == "year" ?
-                       int(state.time_amount)*365*24*60
-                     : state.time_unit == "month" ?
-                       int(state.time_amount)*30*24*60
-                     : state.time_unit == "week" ?
-                       int(state.time_amount)*7*24*60
-                     : state.time_unit == "day" ?
-                       int(state.time_amount)*24*60
-                     : state.time_unit == "hour" ?
-                       int(state.time_amount)*60
-                     : int(state.time_amount)
-                   )+"m"))*1000
-              ),
-            },
-            "want_more": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows,
-            "user": state.user,
-            "password": state.password,
-            "batch_size": string(state.batch_size),
-            "time_amount": string(state.time_amount),
-            "time_unit": state.time_unit,
-            "total_rows": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows ?
-              int(state.total_rows) + size(inner_body.items)
-            :
-              0,
-          })
+                       int(timestamp(now)-duration(string(
+                         state.time_unit == "year" ?
+                           int(state.time_amount)*365*24*60
+                         : state.time_unit == "month" ?
+                           int(state.time_amount)*30*24*60
+                         : state.time_unit == "week" ?
+                           int(state.time_amount)*7*24*60
+                         : state.time_unit == "day" ?
+                           int(state.time_amount)*24*60
+                         : state.time_unit == "hour" ?
+                           int(state.time_amount)*60
+                         : int(state.time_amount)
+                       )+"m"))*1000
+                  ),
+                },
+                "want_more": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows,
+                "user": state.user,
+                "password": state.password,
+                "batch_size": string(state.batch_size),
+                "time_amount": string(state.time_amount),
+                "time_unit": state.time_unit,
+                "total_rows": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows ?
+                  int(state.total_rows) + size(inner_body.items)
+                :
+                  0,
+            })
         :
-          {"events": [], "token_expiry": string(now - duration("1m"))}
+          {"events": [], "access_token": ""}
       )
     )
   ))

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -35,7 +35,7 @@ program: |
         {"username":state.user,"password":state.password}.encode_json()
       ).do_request().as(resp, resp.Body.decode_json().as(body, {
           "access_token": body.token,
-          "token_expiry": string(now + duration("25m")),
+          "token_expiry": string(now + duration("9m")),
       }))
     :
       {}
@@ -128,7 +128,7 @@ program: |
               0,
           })
         :
-          {"events": []}
+          {"events": [], "token_expiry": string(now - duration("1m"))}
       )
     )
   ))

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -28,13 +28,14 @@ redact:
     - access_token
 program: |
   (
-    state.with(has(state.want_more) && !(state.want_more) ?
+    state.with(!has(state.access_token) || !has(state.token_expiry) || now >= timestamp(state.token_expiry) ?
       post_request(
         state.url + "/login",
         "application/json",
         {"username":state.user,"password":state.password}.encode_json()
-      ).do_request().as(resp, bytes(resp.Body).decode_json().as(body, {
+      ).do_request().as(resp, resp.Body.decode_json().as(body, {
           "access_token": body.token,
+          "token_expiry": string(now + duration("25m")),
       }))
     :
       {}
@@ -61,10 +62,9 @@ program: |
          "Header":{
            "x-redlock-auth": [state.access_token],
          }
-      }).do_request().as(resp,
-        (resp.StatusCode == 200) ?
-        try(bytes(resp.Body).decode_json()).as(inner_body,
-          is_error(inner_body.with({})) ?
+      }).do_request().as(resp, (resp.StatusCode == 200) ?
+        resp.Body.decode_json().as(inner_body,
+          is_error(inner_body) ?
             {"events": []}
           :
           {

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "4.3.0"
+version: "4.3.1"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
prisma_cloud: address review feedback on alert error handling and auth

Follow-up to the alert data stream fixes, applying reviewer and bot
feedback.

  - Simplify the response guard: decode_json() returns a catchable error
    value, so drop the redundant try()/bytes() wrapper and check
    is_error(inner_body) directly. Move the status-code condition onto the
    do_request().as(resp, ...) line and fix indentation.

  - Re-authenticate on a token deadline instead of gating login on
    want_more. Log in when there is no access token or the stored
    token_expiry has passed. This removes a stale-token loop: when a token
    expired mid-pagination (want_more=true) the previous logic skipped
    login and reused the dead token indefinitely.

  - Set the token deadline to 9m. The /v2/alert stream uses the Prisma
    Cloud CSPM API (POST /login, x-redlock-auth), whose JWT is valid for
    ~10 minutes.

  - Force re-auth on a non-200 response: expire token_expiry in that
    branch so a token revoked or expired early (or a 401 mid-pagination)
    recovers on the next poll instead of waiting out the deadline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

New script tests pass:
```

┌─────────────────────┬──────────────┐
│        Test         │    Result    │
├─────────────────────┼──────────────┤
│ env                 │ PASS         │
├─────────────────────┼──────────────┤
│ error_json_response │ PASS (1m40s) │
└─────────────────────┴──────────────┘
```

