### PR TITLE
[FIM] Use link panel for dashboard navigation

### DIFF
--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Use links panel in Dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20921
 - version: "1.17.1"
   changes:
     - description: Transfer package ownership to elastic/security-service-integrations.

--- a/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
@@ -3,8 +3,148 @@
         "controlGroupInput": {
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"1493457d-79d9-47e6-ba81-8741d24ecff6\":{\"order\":6,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.name\",\"title\":\"Agent name\",\"id\":\"1493457d-79d9-47e6-ba81-8741d24ecff6\",\"enhancements\":{}}},\"69968e76-1a2d-46cc-85f8-16cc08091b4d\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"69968e76-1a2d-46cc-85f8-16cc08091b4d\",\"fieldName\":\"event.action\",\"title\":\"Action\",\"enhancements\":{}}},\"2e332616-cbb4-4b36-8b40-b8e73cf5e12d\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"2e332616-cbb4-4b36-8b40-b8e73cf5e12d\",\"fieldName\":\"file.hash.sha1\",\"title\":\"SHA1\",\"enhancements\":{}}},\"2e1f7a9a-9603-452d-a303-948334f86026\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"2e1f7a9a-9603-452d-a303-948334f86026\",\"fieldName\":\"file.path\",\"title\":\"File path\",\"enhancements\":{}}},\"1eb33bc0-80e1-4b97-b20d-98c09d6b2667\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"1eb33bc0-80e1-4b97-b20d-98c09d6b2667\",\"fieldName\":\"host.os.platform\",\"title\":\"Host platform\",\"enhancements\":{}}},\"63c1b88d-be1e-47ae-8b04-24b0c40f6c59\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"63c1b88d-be1e-47ae-8b04-24b0c40f6c59\",\"fieldName\":\"host.os.name\",\"title\":\"Hostname\",\"enhancements\":{}}},\"f696824e-7a6e-4a76-9eb4-1867d467232d\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"f696824e-7a6e-4a76-9eb4-1867d467232d\",\"fieldName\":\"file.owner\",\"title\":\"File owner\",\"enhancements\":{}}}}"
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "1493457d-79d9-47e6-ba81-8741d24ecff6": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "agent.name",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Agent name"
+                    },
+                    "grow": true,
+                    "order": 6,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "1eb33bc0-80e1-4b97-b20d-98c09d6b2667": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "host.os.platform",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Host platform"
+                    },
+                    "grow": true,
+                    "order": 4,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "2e1f7a9a-9603-452d-a303-948334f86026": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "file.path",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "File path"
+                    },
+                    "grow": true,
+                    "order": 0,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "2e332616-cbb4-4b36-8b40-b8e73cf5e12d": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "file.hash.sha1",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "SHA1"
+                    },
+                    "grow": true,
+                    "order": 3,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "63c1b88d-be1e-47ae-8b04-24b0c40f6c59": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "host.os.name",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Hostname"
+                    },
+                    "grow": true,
+                    "order": 5,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "69968e76-1a2d-46cc-85f8-16cc08091b4d": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "event.action",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "Action"
+                    },
+                    "grow": true,
+                    "order": 2,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "f696824e-7a6e-4a76-9eb4-1867d467232d": {
+                    "explicitInput": {
+                        "dataViewId": "logs-*",
+                        "exclude": false,
+                        "existsSelected": false,
+                        "fieldName": "file.owner",
+                        "searchTechnique": "prefix",
+                        "selectedOptions": [],
+                        "sort": {
+                            "by": "_count",
+                            "direction": "desc"
+                        },
+                        "title": "File owner"
+                    },
+                    "grow": true,
+                    "order": 1,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                }
+            },
+            "showApplySelections": false
         },
         "description": "Events collected by the File Integrity Monitoring integration.",
         "kibanaSavedObjectMeta": {
@@ -24,45 +164,6 @@
             "useMargins": true
         },
         "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**File Integrity Monitoring**\n\n**[Events](/app/dashboards#/view/fim-97c782f0-4291-11ee-a0f4-51818a115e85)**  \n\n**Overview**\n\nThis dashboard provides information about the File Integrity Monitoring events collected.  \n\nThe FIM integration sends events when a file is changed (created, updated, or deleted) in realtime. At startup this integration will perform an initial scan of the configured files and directories to generate baseline data for the monitored paths and detect changes since the last time it was run. It uses locally persisted data in order to only send events for new or modified files.\n\nThis integration is compatible with Linux, Windows and macOS platforms.\n\nMore information at the [**Integration Page**](/app/integrations/detail/fim/overview).",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 39,
-                    "i": "1d4f74c6-35f0-42db-8592-362faed90dbe",
-                    "w": 8,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "1d4f74c6-35f0-42db-8592-362faed90dbe",
-                "title": "Table of contents",
-                "type": "visualization",
-                "version": "8.7.1"
-            },
             {
                 "embeddableConfig": {
                     "attributes": {
@@ -200,19 +301,19 @@
                         "visualizationType": "lnsPie"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "title": "[Logs FIM] Top actions over monitored files",
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 12,
                     "i": "17459f03-e774-4ca8-b17c-cbe1c2196437",
                     "w": 20,
                     "x": 8,
-                    "y": 0
+                    "y": 4
                 },
                 "panelIndex": "17459f03-e774-4ca8-b17c-cbe1c2196437",
-                "title": "[Logs FIM] Top actions over monitored files",
-                "type": "lens",
-                "version": "8.7.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -348,19 +449,19 @@
                         "visualizationType": "lnsPie"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "title": "[Logs FIM] Top platforms",
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 12,
                     "i": "2bb7d4a5-64e6-4e1b-ac71-7096e0702142",
                     "w": 20,
                     "x": 28,
-                    "y": 0
+                    "y": 4
                 },
                 "panelIndex": "2bb7d4a5-64e6-4e1b-ac71-7096e0702142",
-                "title": "[Logs FIM] Top platforms",
-                "type": "lens",
-                "version": "8.7.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -488,19 +589,19 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "title": "[Logs FIM] Top files",
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 12,
                     "i": "ef42409b-48f1-46d3-9c36-219137e54dba",
                     "w": 20,
                     "x": 8,
-                    "y": 12
+                    "y": 16
                 },
                 "panelIndex": "ef42409b-48f1-46d3-9c36-219137e54dba",
-                "title": "[Logs FIM] Top files",
-                "type": "lens",
-                "version": "8.7.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -629,19 +730,19 @@
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "title": "[Logs FIM] Top file owners",
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 12,
                     "i": "903ce2be-2885-45b7-b65d-c2d2bcab3f2b",
                     "w": 20,
                     "x": 28,
-                    "y": 12
+                    "y": 16
                 },
                 "panelIndex": "903ce2be-2885-45b7-b65d-c2d2bcab3f2b",
-                "title": "[Logs FIM] Top file owners",
-                "type": "lens",
-                "version": "8.7.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -847,47 +948,80 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false
+                    "hidePanelTitles": false,
+                    "title": "[Logs FIM] Events over time (Created vs Deleted vs Modified)",
+                    "type": "lens"
                 },
                 "gridData": {
                     "h": 15,
                     "i": "8a2459e5-fd93-4efc-9d6e-39928b9ce5e4",
                     "w": 40,
                     "x": 8,
-                    "y": 24
+                    "y": 28
                 },
                 "panelIndex": "8a2459e5-fd93-4efc-9d6e-39928b9ce5e4",
-                "title": "[Logs FIM] Events over time (Created vs Deleted vs Modified)",
-                "type": "lens",
-                "version": "8.7.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {}
+                    "enhancements": {},
+                    "savedObjectId": "fim-6c045e50-4295-11ee-a0f4-51818a115e85"
                 },
                 "gridData": {
                     "h": 23,
                     "i": "7969a555-0794-4dcc-98c4-a1435b7d787a",
                     "w": 48,
                     "x": 0,
-                    "y": 39
+                    "y": 43
                 },
                 "panelIndex": "7969a555-0794-4dcc-98c4-a1435b7d787a",
-                "panelRefName": "panel_7969a555-0794-4dcc-98c4-a1435b7d787a",
-                "type": "search",
-                "version": "8.7.1"
+                "type": "search"
+            },
+            {
+                "embeddableConfig": {
+                    "content": "**Overview**\n\nThis dashboard provides information about the File Integrity Monitoring events collected.  \n\nThe FIM integration sends events when a file is changed (created, updated, or deleted) in realtime. At startup this integration will perform an initial scan of the configured files and directories to generate baseline data for the monitored paths and detect changes since the last time it was run. It uses locally persisted data in order to only send events for new or modified files.\n\nThis integration is compatible with Linux, Windows and macOS platforms.\n\nMore information at the [**Integration Page**](/app/integrations/detail/fim/overview)."
+                },
+                "gridData": {
+                    "h": 39,
+                    "i": "f11751f2-9689-4594-8122-ddade8d40d8f",
+                    "w": 8,
+                    "x": 0,
+                    "y": 4
+                },
+                "panelIndex": "f11751f2-9689-4594-8122-ddade8d40d8f",
+                "type": "DASHBOARD_MARKDOWN"
+            },
+            {
+                "embeddableConfig": {
+                    "layout": "horizontal",
+                    "links": [
+                        {
+                            "destinationRefName": "link_8b2f7e85-3b32-42bb-8812-ee18001f32d1_dashboard",
+                            "id": "8b2f7e85-3b32-42bb-8812-ee18001f32d1",
+                            "label": "Events ",
+                            "order": 0,
+                            "type": "dashboardLink"
+                        }
+                    ]
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "b21b9704-5a34-4ee9-9d67-bde8b2b4e477",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "b21b9704-5a34-4ee9-9d67-bde8b2b4e477",
+                "type": "links"
             }
         ],
         "timeRestore": false,
         "title": "[Logs FIM] Events overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-08-24T16:36:42.102Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2026-08-27T05:24:28.970Z",
     "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
     "references": [
         {
             "id": "logs-*",
@@ -941,12 +1075,17 @@
         },
         {
             "id": "fim-6c045e50-4295-11ee-a0f4-51818a115e85",
-            "name": "7969a555-0794-4dcc-98c4-a1435b7d787a:panel_7969a555-0794-4dcc-98c4-a1435b7d787a",
+            "name": "7969a555-0794-4dcc-98c4-a1435b7d787a:savedObjectRef",
             "type": "search"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_1493457d-79d9-47e6-ba81-8741d24ecff6:optionsListDataView",
+            "name": "controlGroup_2e1f7a9a-9603-452d-a303-948334f86026:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "controlGroup_f696824e-7a6e-4a76-9eb4-1867d467232d:optionsListDataView",
             "type": "index-pattern"
         },
         {
@@ -961,11 +1100,6 @@
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_2e1f7a9a-9603-452d-a303-948334f86026:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "controlGroup_1eb33bc0-80e1-4b97-b20d-98c09d6b2667:optionsListDataView",
             "type": "index-pattern"
         },
@@ -976,9 +1110,15 @@
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_f696824e-7a6e-4a76-9eb4-1867d467232d:optionsListDataView",
+            "name": "controlGroup_1493457d-79d9-47e6-ba81-8741d24ecff6:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
+            "name": "b21b9704-5a34-4ee9-9d67-bde8b2b4e477:link_8b2f7e85-3b32-42bb-8812-ee18001f32d1_dashboard",
+            "type": "dashboard"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "10.3.0"
 }

--- a/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
@@ -998,7 +998,7 @@
                         {
                             "destinationRefName": "link_8b2f7e85-3b32-42bb-8812-ee18001f32d1_dashboard",
                             "id": "8b2f7e85-3b32-42bb-8812-ee18001f32d1",
-                            "label": "Events ",
+                            "label": "Events",
                             "order": 0,
                             "type": "dashboardLink"
                         }
@@ -1020,7 +1020,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-08-27T05:24:28.970Z",
+    "created_at": "2026-08-31T09:08:10.942Z",
     "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
     "references": [
         {

--- a/packages/fim/kibana/search/fim-6c045e50-4295-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/search/fim-6c045e50-4295-11ee-a0f4-51818a115e85.json
@@ -82,7 +82,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-08-26T10:37:57.806Z",
+    "created_at": "2026-08-31T09:07:56.611Z",
     "id": "fim-6c045e50-4295-11ee-a0f4-51818a115e85",
     "references": [
         {

--- a/packages/fim/kibana/search/fim-6c045e50-4295-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/search/fim-6c045e50-4295-11ee-a0f4-51818a115e85.json
@@ -49,16 +49,41 @@
                 "desc"
             ]
         ],
+        "tabs": [
+            {
+                "attributes": {
+                    "columns": [
+                        "file.path",
+                        "file.hash.sha1",
+                        "event.action",
+                        "host.hostname"
+                    ],
+                    "grid": {},
+                    "hideChart": false,
+                    "isTextBasedQuery": false,
+                    "kibanaSavedObjectMeta": {
+                        "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":\"FIM\",\"disabled\":false,\"field\":\"data_stream.dataset\",\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index\",\"key\":\"data_stream.dataset\",\"negate\":false,\"params\":{\"query\":\"fim.event\"},\"type\":\"phrase\"},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"fim.event\"}}}],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+                    },
+                    "sort": [
+                        [
+                            "@timestamp",
+                            "desc"
+                        ]
+                    ],
+                    "timeRestore": false,
+                    "usesAdHocDataView": false
+                },
+                "id": "8aea6f98-e91f-40a5-ab1a-6bb0200c6131",
+                "label": "Untitled"
+            }
+        ],
         "timeRestore": false,
         "title": "Latest FIM events",
         "usesAdHocDataView": false
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-08-24T15:46:42.486Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2026-08-26T10:37:57.806Z",
     "id": "fim-6c045e50-4295-11ee-a0f4-51818a115e85",
-    "migrationVersion": {
-        "search": "8.0.0"
-    },
     "references": [
         {
             "id": "logs-*",
@@ -71,5 +96,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "search"
+    "type": "search",
+    "typeMigrationVersion": "10.9.0"
 }

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: fim
 title: "File Integrity Monitoring"
-version: "1.17.1"
+version: "1.18.0"
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Enhancement

## Proposed commit message
```
Fim: Migrate dashboard links to links panels

Update dashboard navigation from markdown links to link panel.
```
## Checklist

- [X] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #15868 

## Screenshots
Before:
<img width="700" height="358" alt="image" src="https://github.com/user-attachments/assets/ac7099f3-086e-4c39-9fa8-eb7419e23c0c" />

After:
<img width="1410" height="873" alt="image" src="https://github.com/user-attachments/assets/2ca59b2f-faaa-4574-b6db-b00174fa06f6" />
