### PR TITLE
[nozomi_networks] surface query errors returned in HTTP 200 responses

### DIFF
--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Surface Nozomi query errors returned in HTTP 200 responses instead of silently collecting no data.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/20871
+      link: https://github.com/elastic/integrations/pull/20936
 - version: "0.4.1"
   changes:
     - description: Fix pipeline errors on string epoch uptime values, non-numeric variable values, and comma-separated audit IP addresses.

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.2"
+  changes:
+    - description: Surface Nozomi query errors returned in HTTP 200 responses instead of silently collecting no data.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20871
 - version: "0.4.1"
   changes:
     - description: Fix pipeline errors on string epoch uptime values, non-numeric variable values, and comma-separated audit IP addresses.

--- a/packages/nozomi_networks/data_stream/alert/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/alert/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^alert$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/alert$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/alert/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/alert/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the alert data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.alert != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/alert/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/asset/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/asset/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^asset$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/asset$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/asset/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/asset/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the asset data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.asset != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/asset/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/audit/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/audit/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^audit$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/audit$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/audit/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/audit/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the audit data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.audit != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/audit/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/health/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/health/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^health$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/health$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/health/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/health/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the health data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.health != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/health/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/health/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/node/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/node/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^node$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/node$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/node/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/node/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the node data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.node != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/node/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/node/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/node_cve/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/node_cve/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^node_cve$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/node_cve$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/node_cve/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/node_cve/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the node_cve data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.node_cve != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/node_cve/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/node_cve/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/session/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/session/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^session$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/session$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/session/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/session/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the session data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.session != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/session/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/session/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].last_activity_time)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].last_activity_time)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/data_stream/variable/_dev/test/scripts/env.txt
+++ b/packages/nozomi_networks/data_stream/variable/_dev/test/scripts/env.txt
@@ -1,0 +1,25 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${CONFIG_ROOT}
+stdout '/\.elastic-package$'
+
+exec echo ${CONFIG_PROFILES}
+stdout '/\.elastic-package/profiles$'
+
+exec echo ${PACKAGE_NAME}
+stdout '^nozomi_networks$'
+
+exec echo ${PACKAGE_ROOT}
+stdout '/packages/nozomi_networks$'
+
+exec echo ${DATA_STREAM}
+stdout '^variable$'
+
+exec echo ${DATA_STREAM_ROOT}
+stdout '/packages/nozomi_networks/data_stream/variable$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+
+exec echo ${PREVIOUS_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'

--- a/packages/nozomi_networks/data_stream/variable/_dev/test/scripts/query_api_error.txt
+++ b/packages/nozomi_networks/data_stream/variable/_dev/test/scripts/query_api_error.txt
@@ -1,0 +1,76 @@
+# Test that the variable data stream surfaces a Nozomi query error returned
+# inside an HTTP 200 response body instead of silently collecting no data.
+#
+# Nozomi returns {"error":"...","result":[]} with status 200 when a query
+# field is unsupported. The CEL program must emit an error event and set
+# want_more=false so the failure is visible.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Exactly one error event; confirm window guards against silent empty polls
+# producing nothing and against duplicate error events on the next interval.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 1 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.error.message // empty] | flatten | .[]' got_docs.json
+stdout 'Nozomi query rejected: Syntax not supported \(record_created_at\)'
+
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.variable != null)] | length' got_docs.json
+stdout '^0$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Any query to the open API returns HTTP 200 with an error body.
+  # Nozomi uses this pattern for unsupported query fields (e.g. CMC).
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"Syntax not supported (record_created_at)","result":[],"header":[],"total":0}

--- a/packages/nozomi_networks/data_stream/variable/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/variable/agent/stream/cel.yml.hbs
@@ -41,21 +41,32 @@ program: |
             "Authorization": ["Basic " + base64(state.username + ":" + state.password)],
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
-          resp.Body.decode_json().as(body, {
-            "events": body.result.map(e, {
-              "message": e.encode_json(),
-            }),
-            "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
-            "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
-            "start_time": start_time,
-            "cursor": {
-              ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
-                optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
-              :
-                state.?cursor.last_timestamp
-            },
-          }
-        )
+          resp.Body.decode_json().as(body,
+            body.?error.orValue("") != "" ?
+              {
+                "events": {
+                  "error": {
+                    "message": "Nozomi query rejected: " + body.error,
+                  },
+                },
+                "want_more": false,
+              }
+            :
+              {
+                "events": body.result.map(e, {
+                  "message": e.encode_json(),
+                }),
+                "want_more": body.?result.hasValue() && size(body.result) >= state.batch_size,
+                "page": body.?result.hasValue() && size(body.result) >= state.batch_size ? int(state.?page.orValue(1)) + 1 : 1,
+                "start_time": start_time,
+                "cursor": {
+                  ?"last_timestamp": has(body.result) && size(body.result) > 0 ?
+                    optional.of(string(int(body.result[size(body.result) - 1].record_created_at)))
+                  :
+                    state.?cursor.last_timestamp
+                },
+              }
+            )
       :
         {
           "events": {

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.4.1
+version: 0.4.2
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
[nozomi_networks] surface query errors returned in HTTP 200 responses

Nozomi returns query failures such as "Syntax not supported (...)" with
HTTP 200 and an error field in the JSON body. The CEL programs only
checked StatusCode == 200 and treated empty result arrays as success,
so collection failed silently. Detect a non-empty body.error on 200 and
emit an error event with want_more false across all eight data streams.
Also fix indentation of the success branch in the new ternary so both
arms align.

```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
**Added script tests pass.**

```
--- Test results for package: nozomi_networks - START ---
╭─────────────────┬─────────────┬───────────┬─────────────────┬────────┬─────────────────╮
│ PACKAGE         │ DATA STREAM │ TEST TYPE │ TEST NAME       │ RESULT │    TIME ELAPSED │
├─────────────────┼─────────────┼───────────┼─────────────────┼────────┼─────────────────┤
│ nozomi_networks │ node        │ script    │ query_api_error │ PASS   │ 1m12.035494125s │
╰─────────────────┴─────────────┴───────────┴─────────────────┴────────┴─────────────────╯
--- Test results for package: nozomi_networks - END   ---
Done
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/20935
