### PR TITLE
[system]: fixes include_xml regression on winlog security

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.23.3"
+  changes:
+    - description: Fix regression in winlog security datastream, hard-coding include_xml to true
+      type: bugfix
+      link: 
 - version: "2.23.2"
   changes:
     - description: Normalize leading whitespace in sudo invoking usernames for the auth data stream while preserving support for unpadded messages.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,7 +1,7 @@
 # later versions go on top
 - version: "2.23.3"
   changes:
-    - description: Fix regression in winlog security datastream, hard-coding include_xml to true
+    - description: Fix regression in winlog security data stream where include_xml was always enabled (restore preserve_original_event gating)
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20941
 - version: "2.23.2"

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix regression in winlog security datastream, hard-coding include_xml to true
       type: bugfix
-      link: 
+      link: https://github.com/elastic/integrations/pull/20941
 - version: "2.23.2"
   changes:
     - description: Normalize leading whitespace in sudo invoking usernames for the auth data stream while preserving support for unpadded messages.

--- a/packages/system/data_stream/security/_dev/test/policy/test-custom-processors.expected
+++ b/packages/system/data_stream/security/_dev/test/policy/test-custom-processors.expected
@@ -11,7 +11,6 @@ inputs:
           data_stream:
             dataset: system.security
           ignore_older: 72h
-          include_xml: true
           name: Security
           processors:
             - decode_xml:

--- a/packages/system/data_stream/security/_dev/test/policy/test-default.expected
+++ b/packages/system/data_stream/security/_dev/test/policy/test-default.expected
@@ -10,7 +10,6 @@ inputs:
           data_stream:
             dataset: system.security
           ignore_older: 72h
-          include_xml: true
           name: Security
           processors:
             - decode_xml:

--- a/packages/system/data_stream/security/_dev/test/policy/test-preserve-original-event.expected
+++ b/packages/system/data_stream/security/_dev/test/policy/test-preserve-original-event.expected
@@ -1,0 +1,58 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: system
+      name: test-preserve-original-event-system
+      streams:
+        - condition: ${host.platform} == 'windows'
+          data_stream:
+            dataset: system.security
+          ignore_older: 72h
+          include_xml: true
+          name: Security
+          processors:
+            - decode_xml:
+                field: winlog.event_data.TaskContent
+                ignore_failure: true
+                ignore_missing: true
+                target_field: winlog._tmp.scheduled_task.task_content
+                to_lower: true
+                when:
+                    and:
+                        - has_fields:
+                            - winlog.event_data.TaskContent
+                        - equals:
+                            winlog.provider_name: Microsoft-Windows-Security-Auditing
+            - decode_xml:
+                field: winlog.event_data.TaskContentNew
+                ignore_failure: true
+                ignore_missing: true
+                target_field: winlog._tmp.scheduled_task.task_content_new
+                to_lower: true
+                when:
+                    and:
+                        - has_fields:
+                            - winlog.event_data.TaskContentNew
+                        - equals:
+                            winlog.provider_name: Microsoft-Windows-Security-Auditing
+          tags:
+            - preserve_original_event
+      type: winlog
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-system.security-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/packages/system/data_stream/security/_dev/test/policy/test-preserve-original-event.yml
+++ b/packages/system/data_stream/security/_dev/test/policy/test-preserve-original-event.yml
@@ -1,0 +1,3 @@
+data_stream:
+  vars:
+    preserve_original_event: true

--- a/packages/system/data_stream/security/agent/stream/winlog.yml.hbs
+++ b/packages/system/data_stream/security/agent/stream/winlog.yml.hbs
@@ -9,6 +9,9 @@ ignore_older: {{ignore_older}}
 {{#if language}}
 language: {{language}}
 {{/if}}
+{{#if preserve_original_event}}
+include_xml: true
+{{/if}}
 tags:
 {{#each tags as |tag i|}}
   - {{tag}}
@@ -19,7 +22,6 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-include_xml: true
 processors:
 - decode_xml:
     when:

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.23.2"
+version: "2.23.3"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## Proposed commit message

Fixes a regression that prevents the system security datastream to exclude xml parsing, see https://github.com/elastic/integrations/issues/20940

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

## How to test this PR locally

I could not test this locally, as I don't have a Windows machine to test. 

## Related issues

- Closes #20940