### PR TITLE
[ess_billing] Fix billing stream cursor stall on not-yet-elapsed day

### DIFF
--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.2"
+  changes:
+    - description: Prevent the billing data stream from stalling by not advancing the cursor when the current day's window has not yet elapsed.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/19548
 - version: "1.9.1"
   changes:
     - description: Clarify that billing data covers all Elastic Cloud products—Hosted, Serverless, and cloud connected usage.

--- a/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
+++ b/packages/ess_billing/data_stream/billing/agent/stream/cel.yml.hbs
@@ -80,7 +80,7 @@ program: |-
           ).as(req, (req.to > now) ?
             {
               "events": [],
-              "cursor": { "last_to": req.to },
+              "cursor": { "last_to": req.from },
               "want_more": false,
             }
           :
@@ -158,7 +158,7 @@ program: |-
         {
           "events": [],
           "cursor": {
-            "last_to": req.to,
+            "last_to": req.from,
           },
           "want_more": false,
         }

--- a/packages/ess_billing/manifest.yml
+++ b/packages/ess_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ess_billing
 title: "Elasticsearch Service Billing"
-version: "1.9.1"
+version: "1.9.2"
 source:
   license: "Elastic-2.0"
 description: "Collect billing metrics for your Elastic Cloud organization, including Hosted, Serverless, and cloud connected usage"


### PR DESCRIPTION
## Proposed commit message

The ess_billing billing input collects one day of billing at a time. It saves a bookmark called `cursor.last_to` for the last day it collected.

When the next day is not finished yet (`req.to > now`), the program is right to skip the fetch and send no events. But it also moved the bookmark forward to `req.to`, which is a future day.

Because the skip path sends no events, Filebeat never saves that future bookmark to disk. The problem is that the in-memory bookmark keeps moving forward. On the next run it reads that future bookmark, the day is still not finished, so it skips again. It never calls the billing API again. The input still shows HEALTHY, but it makes 0 GET calls and sends 0 events until the process is restarted. This is also why a restart brings data back: the restart drops the future in-memory bookmark and reloads the last saved one.

This change keeps the bookmark at `req.from` on the skip path, so it stays on the last finished day. Both paths are updated (with tags and without tags). The next run then collects the day that has now finished. The normal fetch paths are not changed and still move the bookmark to `req.to`.

Without this fix the integration stops sending data silently. Billing dashboards go stale, and only a restart brings the data back for a while.

## Scope

This fixes the silent stall (#19548). The separate agentless cursor-persistence problem (#19639) and the restart re-backfill / duplicate problem (#19549) are not addressed here and stay open.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] Change is limited to the two `(req.to > now)` skip branches. The normal fetch paths still move `last_to` to `req.to`.
- [x] Verified the actual CEL program behavior by running the extracted program through the same CEL engine and libraries the agent uses, with a mock billing API and a controlled clock. The old code stays stuck (0 GET, 0 events every day) once the bookmark reaches the current day. The new code holds the bookmark and resumes fetching the next day, for both the with-tags and without-tags paths.

## How to test this PR locally

1. `cd packages/ess_billing`
2. `elastic-package lint` (the existing dashboard `SVR00002` warnings are not related to this change).
3. `elastic-package test pipeline --data-streams billing`
4. `elastic-package test system --data-streams billing`

All three pass. The system test covers the normal ingest path and confirms this change does not break it.

Behavior check (with `interval: 24h`, `lookbehind: 365`, bookmark on day D, process started on day D):

- Before: day D skips and the bookmark moves to D+1. Day D+1 skips and moves to D+2. It never fetches again.
- After: day D skips and the bookmark stays on D. Day D+1 fetches day D. Day D+2 fetches day D+1. It catches up and stays current.

The existing system test (`lookbehind: 2`, expects 20 hits) is not affected because its runs never take the skip path.

## Related issues

- Closes #19548