### PR TITLE
[cato_networks] Surface account errorString as input error

### DIFF
--- a/packages/cato_networks/changelog.yml
+++ b/packages/cato_networks/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: '0.1.3'
+  changes:
+    - description: Fix the `event` input silently succeeding when the Cato Networks API returns a non-null `accounts.errorString` with HTTP 200. The input now surfaces this as an input error so Fleet reports the stream as unhealthy.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20959
 - version: '0.1.2'
   changes:
     - description: Set agentless deployment mode `release` field to `beta`.

--- a/packages/cato_networks/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/cato_networks/data_stream/event/agent/stream/cel.yml.hbs
@@ -67,24 +67,36 @@ program: |
         resp.Body.decode_json().as(body,
           // in case of rate limit and wrong API key, StatusCode will be 200 and eventsFeed will be null
           (body.?data.eventsFeed.orValue(null) != null) ?
-            {
-              "events": (body.data.eventsFeed.?accounts.orValue(null) != null) ?
-                body.data.eventsFeed.accounts.map(account, (account.?records.orValue(null) != null) ?
-                  account.records.map(record,
-                    {
-                      "message": record.fieldsMap.encode_json(),
-                    }
-                  )
-                :
-                  []
-                ).flatten()
+            (body.data.eventsFeed.?accounts.orValue([]).filter(account, account.?errorString.orValue("") != "").map(account, account.errorString)).as(account_errors,
+              (size(account_errors) > 0) ?
+                {
+                  "events": {
+                    "error": {
+                      "message": "POST " + state.url.trim_right("/") + "/api/v1/graphql2" + ": " + account_errors.join("; "),
+                    },
+                  },
+                  "want_more": false,
+                }
               :
-                [],
-              "cursor": {
-                ?"marker": body.?data.eventsFeed.marker,
-              },
-              "want_more": body.data.eventsFeed.fetchedCount >= state.max_page_limit,
-            }
+                {
+                  "events": (body.data.eventsFeed.?accounts.orValue(null) != null) ?
+                    body.data.eventsFeed.accounts.map(account, (account.?records.orValue(null) != null) ?
+                      account.records.map(record,
+                        {
+                          "message": record.fieldsMap.encode_json(),
+                        }
+                      )
+                    :
+                      []
+                    ).flatten()
+                  :
+                    [],
+                  "cursor": {
+                    ?"marker": body.?data.eventsFeed.marker,
+                  },
+                  "want_more": body.data.eventsFeed.fetchedCount >= state.max_page_limit,
+                }
+            )
           :
             {
               "events": {

--- a/packages/cato_networks/manifest.yml
+++ b/packages/cato_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.2
 name: cato_networks
 title: Cato Networks
-version: 0.1.2
+version: 0.1.3
 description: Collect logs from Cato Networks with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
Surface account errorString as input error

The `event` CEL program only checked whether `eventsFeed` was null,
ignoring per-account `errorString` values returned by the API with
HTTP 200 (e.g. "event feed is disabled for account"). This left the
input silently reporting a healthy, empty poll instead of surfacing
the failure, hiding data loss from Fleet.

Check `accounts[].errorString` and emit an `events.error` when any
account reports one, matching the existing error-handling branches
in the same program. Bump package version to 0.1.3 and add a
changelog entry.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Confirm the `audit` data stream is correctly left unchanged (the Cato API's `AuditFeedAccountRecords` type has no `errorString` field, unlike `EventsFeedAccountRecords`)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. Run the existing system tests to confirm no regression on the success path:
   ```
   elastic-package test system --data-streams event -v
   ```
2. To exercise the new error path locally, add a mock server rule (in `_dev/deploy/docker/files/config.yml`) that returns `data.eventsFeed.accounts[].errorString` set to a non-empty string with HTTP 200, and a matching `data_stream/event/_dev/test/system/test-*.yml` config pointing at it with `account_ids` matching that rule and `assert.hit_count: 0`. Confirm the CEL input surfaces an `events.error` (visible via the request tracer or agent debug logs) instead of a silent, healthy empty poll.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/20947

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
