### PR TITLE
[sublime_security] Restrict event expansion settings to SQS collection mode

### DIFF
--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.1"
+  changes:
+    - description: Apply expand_event_list_from_field and content_type only to the SQS collection mode in the audit and message_event data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20968
 - version: "1.15.0"
   changes:
     - description: Remove unused agentless tag cleanup from the email_message data stream.

--- a/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -39,9 +39,9 @@ max_number_of_messages: {{max_number_of_messages}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
-
 expand_event_list_from_field: events
 content_type: application/json
+
 {{/if}}
 
 {{! allows number of workers to be configured for SQS queue and S3 buckets}}

--- a/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -40,6 +40,8 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+expand_event_list_from_field: events
+content_type: application/json
 {{/if}}
 
 {{! allows number of workers to be configured for SQS queue and S3 buckets}}
@@ -47,8 +49,6 @@ file_selectors:
 number_of_workers: {{number_of_workers}}
 {{/if}}
 
-expand_event_list_from_field: events
-content_type: application/json
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
 {{/if}}

--- a/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
@@ -39,9 +39,9 @@ max_number_of_messages: {{max_number_of_messages}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
-
 expand_event_list_from_field: events
 content_type: application/json
+
 {{/if}}
 
 {{! allows number of workers to be configured for SQS queue and S3 buckets}}

--- a/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/sublime_security/data_stream/message_event/agent/stream/aws-s3.yml.hbs
@@ -40,6 +40,8 @@ file_selectors:
 {{file_selectors}}
 {{/if}}
 
+expand_event_list_from_field: events
+content_type: application/json
 {{/if}}
 
 {{! allows number of workers to be configured for SQS queue and S3 buckets}}
@@ -47,8 +49,6 @@ file_selectors:
 number_of_workers: {{number_of_workers}}
 {{/if}}
 
-expand_event_list_from_field: events
-content_type: application/json
 {{#if access_key_id}}
 access_key_id: {{access_key_id}}
 {{/if}}

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: sublime_security
 title: Sublime Security
-version: "1.15.0"
+version: "1.15.1"
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!--
Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Issue is that the sublime security s3 export will export files in JSONL format, not JSON files with an "events" key as the existing code suggests. This causes the following errors, which causes ingest to fail:
```
failed processing S3 event for object key "sublime_platform_message_events/2026/08/28/004549Z-KMUHHK.jsonl" ...
expand_event_list_from_field key <events> is not in event
failed processing S3 event for object key "sublime_platform_audit_log/2026/08/28/004549Z-JOHLLY.jsonl" ...
expand_event_list_from_field key <events> is not in event
```

## Proposed commit message

Move `expand_event_list_from_field` and `content_type` inside the SQS branch of the `audit` and `message_event` aws-s3 stream templates so direct S3 bucket collection is not configured with SQS-only options.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) (no dashboards changed).

## Author's Checklist

- [x] Verify agentless (direct S3) deployments render without `expand_event_list_from_field`/`content_type`.

## How to test this PR locally

Render the `audit` and `message_event` aws-s3 stream in both collection modes (e.g. via `elastic-package build`) and confirm `expand_event_list_from_field: events` and `content_type: application/json` only appear when SQS collection is selected. Run `elastic-package test` in `packages/sublime_security` for system tests.

## Related issues

-

## Screenshots

N/A
