### PR TITLE
prisma_cloud: switch alert collection to POST body pagination

### DIFF
--- a/packages/prisma_cloud/_dev/deploy/docker/files/config.yml
+++ b/packages/prisma_cloud/_dev/deploy/docker/files/config.yml
@@ -9,7 +9,7 @@ rules:
         body: |
           {"message":"login_successful","token":"xxxx","customerNames":[{"customerName":"Company (Tech Partner Only) - 84706136261xxxxxx32","prismaId":"1121575xxxx8690944","tosAccepted":true}]}
   - path: /v2/alert
-    methods: ['GET']
+    methods: ['POST']
     request_headers:
       x-redlock-auth:
         - 'xxxx'

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `alert` data stream pagination by switching `/v2/alert` collection to `POST` with the query and `pageToken` in the request body. The previous `GET` approach put the large `pageToken` in the URL, causing HTTP 414 errors and dropped alerts on paginated responses.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20978
 - version: "4.3.1"
   changes:
     - description: Fix `alert` data stream sending an invalid `timeAmount=null` request during pagination.

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.3.2"
+  changes:
+    - description: Fix `alert` data stream pagination by switching `/v2/alert` collection to `POST` with the query and `pageToken` in the request body. The previous `GET` approach put the large `pageToken` in the URL, causing HTTP 414 errors and dropped alerts on paginated responses.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "4.3.1"
   changes:
     - description: Fix `alert` data stream sending an invalid `timeAmount=null` request during pagination.

--- a/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/error_json_response.txt
+++ b/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/error_json_response.txt
@@ -74,7 +74,7 @@ rules:
 
   # /v2/alert alternates: HTML error page, then a valid alert response.
   - path: /v2/alert
-    methods: ['GET']
+    methods: ['POST']
     request_headers:
       x-redlock-auth:
         - 'xxxx'

--- a/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/pagination.txt
+++ b/packages/prisma_cloud/data_stream/alert/_dev/test/scripts/pagination.txt
@@ -1,0 +1,91 @@
+# Test that alerts spanning multiple pages are all collected. The mock
+# returns a first page with a nextPageToken and a second page without one.
+# The CEL program must POST to /v2/alert, follow the pageToken in the request
+# body (not the URL), and collect alerts from every page. Regression guard for
+# the pageToken pagination fix (switch GET query-string pagination -> POST body
+# pagination), which previously dropped paged data (414 / empty pages).
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} page-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# All three alerts across the two pages should be collected. The pipeline
+# fingerprints _id, so re-collection on later polls deduplicates to three
+# documents; -confirm guards against duplicates or missed pages.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 3 -confirm 15s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+exec jq -r '[.hits.hits[]._source.event.id] | sort | join(",")' got_docs.json
+stdout '^P-1,P-2,P-3$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down page-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  username: xxxx
+  password: xxxx
+data_stream:
+  vars:
+    url: http://page-mock:8080
+    interval: 30s
+    time_amount: 1
+    time_unit: hour
+    batch_size: 2
+    preserve_original_event: true
+
+-- page-mock/docker-compose.yml --
+version: '2.3'
+services:
+  page-mock:
+    image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: page-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+
+-- page-mock/config.yml --
+rules:
+  - path: /login
+    methods: ['POST']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        body: |-
+          {"message":"login_successful","token":"xxxx"}
+
+  # /v2/alert (POST): page 1 carries a nextPageToken, page 2 does not.
+  - path: /v2/alert
+    methods: ['POST']
+    request_headers:
+      x-redlock-auth:
+        - 'xxxx'
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        body: |-
+          {"totalRows": 3, "items": [{"id": "P-1", "alertAdditionalInfo": {"scannerVersion": "CS_2.0"}, "alertAttribution": {"attributionEventList": [{"event": "first_event", "event_ts": 1694003441966, "username": "alex123"}], "resourceCreatedBy": "string", "resourceCreatedOn": 0}, "status": "open", "reason": "NEW_ALERT", "firstSeen": 1694003441966, "history": [{"modifiedOn": "1694003441966", "modifiedBy": "alex123", "reason": "Reason1", "status": "OPEN"}], "lastSeen": 1694003441966, "alertTime": 1694003441966, "lastUpdated": 1694003441000, "policyId": "ad23603d-754e-4499-8988-b801xxx85898", "metadata": null, "policy": {"policyId": "ad23603d-754e-4499-8988-b8017xxxx98", "name": "AWS EC2 instance that is internet reachable with unrestricted access (0.0.0.0/0)", "policyType": "network", "systemDefault": true, "complianceMetadata": [{"complianceId": "qwer345bv", "customAssigned": true, "policyId": "werf435tr", "requirementDescription": "Description of policy compliance.", "requirementId": "req-123-xyz", "requirementName": "rigidity", "sectionDescription": "Description of section.", "sectionId": "sect-453-abc", "sectionLabel": "label-1", "standardDescription": "Description of standard.", "standardId": "stand-543-pqr", "standardName": "Class 1"}], "description": "This policy identifies AWS EC2 instances that are internet reachable with unrestricted access (0.0.0.0/0).", "severity": "high", "recommendation": "Restrict traffic from unknown IP addresses.", "labels": ["Prisma_Cloud", "Attack Path Rule"], "lastModifiedOn": 1687474999057, "lastModifiedBy": "template@redlock.io", "deleted": false, "findingTypes": [], "remediable": false, "remediation": {"actions": [{"operation": "buy", "payload": "erefwsdf"}], "cliScriptTemplate": "temp1", "description": "Description of CLI Script Template."}}, "alertRules": [], "resource": {"rrn": "rrn:aws:instance:us-east-1:710000059376:e7ddce5a1ffcb47bxxxxxerf2635a3b4d9da3:i-04578e0008100947", "id": "i-04578exxxx8100947", "name": "IS-37133", "account": "AWS Cloud Account", "accountId": "710002259376", "cloudAccountGroups": ["Default Account Group"], "region": "AWS Virginia", "regionId": "us-east-1", "resourceType": "INSTANCE", "resourceApiName": "aws-ec2-describe-instances", "cloudServiceName": "Amazon EC2", "url": "https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:instanceId=i-0457xxxxx00947", "data": null, "additionalInfo": null, "cloudType": "aws", "resourceTs": 1694003441915, "unifiedAssetId": "66c543b6261c4d9edxxxxxb42e15f4", "resourceConfigJsonAvailable": false, "resourceDetailsAvailable": true}, "investigateOptions": {"alertId": "P-1"}}, {"id": "P-2", "alertAdditionalInfo": {"scannerVersion": "CS_2.0"}, "alertAttribution": {"attributionEventList": [{"event": "first_event", "event_ts": 1694003441966, "username": "alex123"}], "resourceCreatedBy": "string", "resourceCreatedOn": 0}, "status": "open", "reason": "NEW_ALERT", "firstSeen": 1694003441966, "history": [{"modifiedOn": "1694003441966", "modifiedBy": "alex123", "reason": "Reason1", "status": "OPEN"}], "lastSeen": 1694003441966, "alertTime": 1694003441966, "lastUpdated": 1694003442000, "policyId": "ad23603d-754e-4499-8988-b801xxx85898", "metadata": null, "policy": {"policyId": "ad23603d-754e-4499-8988-b8017xxxx98", "name": "AWS EC2 instance that is internet reachable with unrestricted access (0.0.0.0/0)", "policyType": "network", "systemDefault": true, "complianceMetadata": [{"complianceId": "qwer345bv", "customAssigned": true, "policyId": "werf435tr", "requirementDescription": "Description of policy compliance.", "requirementId": "req-123-xyz", "requirementName": "rigidity", "sectionDescription": "Description of section.", "sectionId": "sect-453-abc", "sectionLabel": "label-1", "standardDescription": "Description of standard.", "standardId": "stand-543-pqr", "standardName": "Class 1"}], "description": "This policy identifies AWS EC2 instances that are internet reachable with unrestricted access (0.0.0.0/0).", "severity": "high", "recommendation": "Restrict traffic from unknown IP addresses.", "labels": ["Prisma_Cloud", "Attack Path Rule"], "lastModifiedOn": 1687474999057, "lastModifiedBy": "template@redlock.io", "deleted": false, "findingTypes": [], "remediable": false, "remediation": {"actions": [{"operation": "buy", "payload": "erefwsdf"}], "cliScriptTemplate": "temp1", "description": "Description of CLI Script Template."}}, "alertRules": [], "resource": {"rrn": "rrn:aws:instance:us-east-1:710000059376:e7ddce5a1ffcb47bxxxxxerf2635a3b4d9da3:i-04578e0008100947", "id": "i-04578exxxx8100947", "name": "IS-37133", "account": "AWS Cloud Account", "accountId": "710002259376", "cloudAccountGroups": ["Default Account Group"], "region": "AWS Virginia", "regionId": "us-east-1", "resourceType": "INSTANCE", "resourceApiName": "aws-ec2-describe-instances", "cloudServiceName": "Amazon EC2", "url": "https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:instanceId=i-0457xxxxx00947", "data": null, "additionalInfo": null, "cloudType": "aws", "resourceTs": 1694003441915, "unifiedAssetId": "66c543b6261c4d9edxxxxxb42e15f4", "resourceConfigJsonAvailable": false, "resourceDetailsAvailable": true}, "investigateOptions": {"alertId": "P-2"}}], "nextPageToken": "PAGE2TOKEN"}
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        body: |-
+          {"totalRows": 3, "items": [{"id": "P-3", "alertAdditionalInfo": {"scannerVersion": "CS_2.0"}, "alertAttribution": {"attributionEventList": [{"event": "first_event", "event_ts": 1694003441966, "username": "alex123"}], "resourceCreatedBy": "string", "resourceCreatedOn": 0}, "status": "open", "reason": "NEW_ALERT", "firstSeen": 1694003441966, "history": [{"modifiedOn": "1694003441966", "modifiedBy": "alex123", "reason": "Reason1", "status": "OPEN"}], "lastSeen": 1694003441966, "alertTime": 1694003441966, "lastUpdated": 1694003443000, "policyId": "ad23603d-754e-4499-8988-b801xxx85898", "metadata": null, "policy": {"policyId": "ad23603d-754e-4499-8988-b8017xxxx98", "name": "AWS EC2 instance that is internet reachable with unrestricted access (0.0.0.0/0)", "policyType": "network", "systemDefault": true, "complianceMetadata": [{"complianceId": "qwer345bv", "customAssigned": true, "policyId": "werf435tr", "requirementDescription": "Description of policy compliance.", "requirementId": "req-123-xyz", "requirementName": "rigidity", "sectionDescription": "Description of section.", "sectionId": "sect-453-abc", "sectionLabel": "label-1", "standardDescription": "Description of standard.", "standardId": "stand-543-pqr", "standardName": "Class 1"}], "description": "This policy identifies AWS EC2 instances that are internet reachable with unrestricted access (0.0.0.0/0).", "severity": "high", "recommendation": "Restrict traffic from unknown IP addresses.", "labels": ["Prisma_Cloud", "Attack Path Rule"], "lastModifiedOn": 1687474999057, "lastModifiedBy": "template@redlock.io", "deleted": false, "findingTypes": [], "remediable": false, "remediation": {"actions": [{"operation": "buy", "payload": "erefwsdf"}], "cliScriptTemplate": "temp1", "description": "Description of CLI Script Template."}}, "alertRules": [], "resource": {"rrn": "rrn:aws:instance:us-east-1:710000059376:e7ddce5a1ffcb47bxxxxxerf2635a3b4d9da3:i-04578e0008100947", "id": "i-04578exxxx8100947", "name": "IS-37133", "account": "AWS Cloud Account", "accountId": "710002259376", "cloudAccountGroups": ["Default Account Group"], "region": "AWS Virginia", "regionId": "us-east-1", "resourceType": "INSTANCE", "resourceApiName": "aws-ec2-describe-instances", "cloudServiceName": "Amazon EC2", "url": "https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:instanceId=i-0457xxxxx00947", "data": null, "additionalInfo": null, "cloudType": "aws", "resourceTs": 1694003441915, "unifiedAssetId": "66c543b6261c4d9edxxxxxb42e15f4", "resourceConfigJsonAvailable": false, "resourceDetailsAvailable": true}, "investigateOptions": {"alertId": "P-3"}}]}

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -18,10 +18,8 @@ state:
   user: {{username}}
   password: {{password}}
   batch_size: {{batch_size}}
-  total_rows: 0
   time_amount: {{time_amount}}
   time_unit: {{time_unit}}
-  want_more: false
   # Re-authenticate before the Prisma Cloud CSPM JWT expires (~10m TTL).
   token_ttl: "9m"
 redact:
@@ -42,28 +40,28 @@ program: |
     :
       {}
     ).as(state, state.with(
-      request("GET", state.url + "/v2/alert?timeType=relative&detailed=true&limit=" + string(state.batch_size) + "&timeAmount=" +
+      request("POST", state.url + "/v2/alert",
         (
-          has(state.want_more) && !(state.want_more) ?
-          (
-            has(state.cursor) && has(state.cursor.last_time_amount) &&
-            state.cursor.last_time_amount != null ?
-             string((now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
+          state.?page_token.orValue("") != "" ?
+            {"pageToken": state.page_token}
           :
-             string(state.time_amount) + "&timeUnit=" + state.time_unit
-          )
-        :
-          (
-            has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null ?
-              string((now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.first_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
-            :
-              string(state.time_amount) + "&timeUnit=" + state.time_unit
-          ) + (has(state.page_token) ? "&pageToken=" + state.page_token : "")
-        )
+            {
+              "detailed": true,
+              "limit": int(state.batch_size),
+              "timeRange": {
+                "type": "relative",
+                "value": has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null ?
+                  {"amount": (now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1, "unit": "minute"}
+                :
+                  {"amount": int(state.time_amount), "unit": state.time_unit},
+              },
+            }
+        ).encode_json()
       ).with({
-         "Header":{
-           "x-redlock-auth": [state.access_token],
-         }
+        "Header": {
+          "Content-Type": ["application/json"],
+          "x-redlock-auth": [state.access_token],
+        }
       }).do_request().as(resp, (resp.StatusCode == 200) ?
         resp.Body.decode_json().as(inner_body,
           is_error(inner_body) ?
@@ -74,66 +72,31 @@ program: |
                 "message": e.encode_json(),
               }),
               "url": state.url,
-              "page_token": has(inner_body.nextPageToken) ? inner_body.nextPageToken : "",
+              "page_token": inner_body.?nextPageToken.orValue(""),
               "cursor": {
-                "last_time_amount": (
-                  has(inner_body.items) && inner_body.items.size() > 0 ?
-                    (
-                      has(state.cursor) && has(state.cursor.last_time_amount) &&
-                      inner_body.items.map(e, e.lastUpdated).max() < state.cursor.last_time_amount ?
-                        state.cursor.last_time_amount
-                      :
-                        inner_body.items.map(e, e.lastUpdated).max()
-                    )
-                  :
-                    (
-                      has(state.cursor) && has(state.cursor.last_time_amount) ?
-                        state.cursor.last_time_amount
-                      :
-                        null
-                    )
-                  ),
-                  "first_time_amount": (
-                     has(state.cursor) && has(state.cursor.first_time_amount) &&
-                     state.cursor.first_time_amount != null && has(inner_body.items) ?
-                       (
-                         ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) && state.want_more ?
-                           state.cursor.first_time_amount
-                         :
-                           state.cursor.last_time_amount
-                       )
-                     :
-                       int(timestamp(now)-duration(string(
-                         state.time_unit == "year" ?
-                           int(state.time_amount)*365*24*60
-                         : state.time_unit == "month" ?
-                           int(state.time_amount)*30*24*60
-                         : state.time_unit == "week" ?
-                           int(state.time_amount)*7*24*60
-                         : state.time_unit == "day" ?
-                           int(state.time_amount)*24*60
-                         : state.time_unit == "hour" ?
-                           int(state.time_amount)*60
-                         : int(state.time_amount)
-                       )+"m"))*1000
-                  ),
-                },
-                "want_more": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows,
-                "user": state.user,
-                "password": state.password,
-                "batch_size": string(state.batch_size),
-                "time_amount": string(state.time_amount),
-                "time_unit": state.time_unit,
-                "total_rows": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows ?
-                  int(state.total_rows) + size(inner_body.items)
+                "last_time_amount": has(inner_body.items) && inner_body.items.size() > 0 ?
+                  (
+                    has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null &&
+                    state.cursor.last_time_amount > inner_body.items.map(e, e.lastUpdated).max() ?
+                      state.cursor.last_time_amount
+                    :
+                      inner_body.items.map(e, e.lastUpdated).max()
+                  )
                 :
-                  0,
+                  state.?cursor.last_time_amount.orValue(null),
+              },
+              "want_more": inner_body.?nextPageToken.orValue("") != "",
+              "user": state.user,
+              "password": state.password,
+              "batch_size": string(state.batch_size),
+              "time_amount": string(state.time_amount),
+              "time_unit": state.time_unit,
             })
         :
-          {"events": [], "access_token": ""}
+          {"events": [], "access_token": "", "page_token": ""}
       )
-    )
-  ))
+    ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -50,7 +50,7 @@ program: |
               "limit": int(state.batch_size),
               "timeRange": {
                 "type": "relative",
-                "value": has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null ?
+                "value": state.?cursor.last_time_amount.orValue(null) != null ?
                   {"amount": (now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1, "unit": "minute"}
                 :
                   {"amount": int(state.time_amount), "unit": state.time_unit},
@@ -68,19 +68,19 @@ program: |
             {"events": []}
           :
             {
-              "events": inner_body.items.map(e, {
+              "events": inner_body.?items.orValue([]).map(e, {
                 "message": e.encode_json(),
               }),
               "url": state.url,
               "page_token": inner_body.?nextPageToken.orValue(""),
               "cursor": {
-                "last_time_amount": has(inner_body.items) && inner_body.items.size() > 0 ?
-                  (
-                    has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null &&
-                    state.cursor.last_time_amount > inner_body.items.map(e, e.lastUpdated).max() ?
+                "last_time_amount": inner_body.?items.orValue([]).size() > 0 ?
+                  inner_body.items.map(e, e.lastUpdated).max().as(max_updated,
+                    state.?cursor.last_time_amount.orValue(null) != null &&
+                    state.cursor.last_time_amount > max_updated ?
                       state.cursor.last_time_amount
                     :
-                      inner_body.items.map(e, e.lastUpdated).max()
+                      max_updated
                   )
                 :
                   state.?cursor.last_time_amount.orValue(null),

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -51,7 +51,7 @@ program: |
               "timeRange": {
                 "type": "relative",
                 "value": has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null ?
-                  {"amount": (now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1, "unit": "minute"}
+                  {"amount": (now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1, "unit": "minute"}
                 :
                   {"amount": int(state.time_amount), "unit": state.time_unit},
               },

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "4.3.1"
+version: "4.3.2"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
prisma_cloud: switch alert collection to POST body pagination

The alert data stream paginated /v2/alert with a GET, carrying the
pageToken in the URL query string. Prisma's nextPageToken encodes the
full original query and can reach ~43kB, producing request URIs that
exceed server limits (HTTP 414) so paginated data was never collected.
Where the token did fit, the request also re-sent a freshly computed
relative time window alongside the token, conflicting with the absolute
time range embedded in it, and Prisma returned empty pages. The 4.3.1
non-JSON guard masked both failures as silent empty results.

Rework collection to the documented POST /v2/alert form:

  - The first request of a poll sends the query in the JSON body
    (detailed, limit, and a relative timeRange derived from the cursor
    or the configured initial window).

  - Subsequent pages send only {"pageToken": <nextPageToken>} in the
    body; the token carries the query, so there is no URL length limit,
    no encoding corruption, and no conflicting time parameters.

  - Pagination is driven by nextPageToken presence, removing the
    first_time_amount and total_rows accounting that existed only to
    rebuild time windows for GET pagination.

  - A non-200 response now also clears page_token so a rejected or
    stale token restarts pagination from the cursor window on the next
    poll instead of retrying the same token indefinitely, as seen in
    customer diagnostics where a 43kB token was retried every minute.

Update the system test and error_json_response script test mocks to
POST, and add a pagination script test that serves two pages via body
pageToken and asserts alerts from both pages are indexed.

Validated with mito against multi-page, non-JSON, empty-body, 401, and
stale-token mocks, and with elastic-package build, lint, test system,
and test script (env, error_json_response, pagination all pass).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
