### PR TITLE
[elasticsearch] Decode querylog NDJSON on the Agent

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Decode querylog NDJSON on the Agent so events parse when the x-pack destination template overrides the Fleet ingest pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/20985
 - version: "1.22.0"
   changes:
     - description: Add security_stats data stream to collect per-node Document Level Security (DLS) bitset cache metrics from the Security Stats API (requires Elasticsearch 9.2+).

--- a/packages/elasticsearch/data_stream/querylog/agent/stream/log.yml.hbs
+++ b/packages/elasticsearch/data_stream/querylog/agent/stream/log.yml.hbs
@@ -11,3 +11,10 @@ condition: {{ condition }}
 {{/if}}
 allow_deprecated_use: true
 exclude_files: [".gz$"]
+processors:
+  - decode_json_fields:
+      fields: ["message"]
+      target: ""
+      overwrite_keys: true
+      expand_keys: true
+      add_error_key: true

--- a/packages/elasticsearch/data_stream/querylog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/elasticsearch/data_stream/querylog/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,5 @@
 ---
-description: Pipeline for parsing elasticsearch query logs.
+description: Pipeline for elasticsearch query logs. JSON expansion happens on the Agent when possible.
 processors:
   - set:
       field: event.ingested

--- a/packages/elasticsearch/data_stream/querylog/elasticsearch/ingest_pipeline/pipeline-json.yml
+++ b/packages/elasticsearch/data_stream/querylog/elasticsearch/ingest_pipeline/pipeline-json.yml
@@ -1,5 +1,5 @@
 ---
-description: Pipeline for parsing Elasticsearch query log lines as JSON (NDJSON).
+description: Fallback JSON expansion for query log lines that the shipper did not already decode.
 on_failure:
   - set:
       field: error.message
@@ -9,6 +9,7 @@ processors:
       field: message
       target_field: _ecs_json_message
       ignore_missing: true
+      if: ctx.elasticsearch?.querylog == null && ctx.message instanceof String
   - json:
       field: _ecs_json_message
       add_to_root: true

--- a/packages/elasticsearch/data_stream/querylog/manifest.yml
+++ b/packages/elasticsearch/data_stream/querylog/manifest.yml
@@ -19,4 +19,4 @@ streams:
         show_user: false
     template_path: log.yml.hbs
     title: Query logs
-    description: Collect Elasticsearch query logs (NDJSON) using log input. Override `paths` on macOS or Windows to match your install (same defaults as the Filebeat `elasticsearch` querylog fileset).
+    description: Collect Elasticsearch query logs (NDJSON) using log input. Lines are expanded on the Agent. Override `paths` on macOS or Windows to match your install (same defaults as the Filebeat `elasticsearch` querylog fileset).

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.22.0
+version: 1.22.1
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

Query log files are already ECS JSON. Filebeat expands them with `filestream` + `ndjson`. The integration Agent stream was a plain `logfile` input, so parsing depended on `pipeline-json.yml` via the Fleet `default_pipeline`. That template (priority 200) loses to x-pack `logs-elasticsearch.querylog@template` (priority 240 after elastic/elasticsearch#158188). Events stayed as a JSON string in `message` and the dashboard was empty.

This expands NDJSON on the Agent (`decode_json_fields` + `expand_keys`), matching Filebeat. The ingest pipeline stays as a fallback for raw `message` lines (pipeline tests still cover that).

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## How to test this PR locally

```
cd packages/elasticsearch
elastic-package test pipeline --data-streams querylog
elastic-package test system --data-streams querylog
```

On a 9.4+ cluster with `elasticsearch.querylog.enabled: true` and this package installed, documents in `logs-elasticsearch.querylog-*` should have `elasticsearch.querylog.type` populated even when `logs-elasticsearch.querylog@template` is the matching index template.

## Related issues

- Closes #20985
- Relates https://github.com/elastic/sdh-elasticsearch/issues/10223
- Relates https://github.com/elastic/elasticsearch/pull/158188