### PR TITLE
[infoblox_nios] Fix NIOS 9 named log parsing

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.2.0"
   changes:
-    - description: Fix `dns.question.*` extraction for NIOS 9 `named` log lines: accept the logging-category prefix on notify, zone-transfer and DNSSEC validation patterns; allow the EDNS Client Subnet suffix on `queries` lines; normalise `dns.question.name` to lower case (DNS names are case-insensitive).
+    - description: Fix `dns.question.*` extraction for NIOS 9 `named` log lines by accepting the logging-category prefix on notify, zone-transfer and DNSSEC validation patterns; allow the EDNS Client Subnet suffix on `queries` lines; normalise `dns.question.name` to lower case (DNS names are case-insensitive).
       type: bugfix
       link: https://github.com/elastic/integrations/pull/21004
     - description: Add `infoblox_nios.log.dns.ecs_client_subnet.*`, `failure_reason`, `query_context`, `action` and `transfer.*` fields for the NIOS 9 `query-errors`, `security` and `xfer-in` categories, and set an ECS-valid `event.outcome` and `dns.response_code` from them.

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Fix `dns.question.*` extraction for NIOS 9 `named` log lines: accept the logging-category prefix on notify, zone-transfer and DNSSEC validation patterns; allow the EDNS Client Subnet suffix on `queries` lines; normalise `dns.question.name` to lower case (DNS names are case-insensitive).
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21004
+    - description: Add `infoblox_nios.log.dns.ecs_client_subnet.*`, `failure_reason`, `query_context`, `action` and `transfer.*` fields for the NIOS 9 `query-errors`, `security` and `xfer-in` categories, and set an ECS-valid `event.outcome` and `dns.response_code` from them.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/21004
 - version: "2.1.2"
   changes:
     - description: Reorder the `pipeline_dns` grok alternatives so high-volume client query and response lines are matched before lower-volume administrative events, reducing average per-document ingest time. Parsed output is unchanged.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2025-04-18T05:02:05.000Z",
+            "@timestamp": "2026-04-18T05:02:05.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-81-14-6C"
@@ -11,7 +11,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-04-18T05:02:05.000Z",
+                "created": "2026-04-18T05:02:05.000Z",
                 "original": "<30>Apr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via eth3"
             },
             "host": {
@@ -55,7 +55,7 @@
             ]
         },
         {
-            "@timestamp": "2025-04-18T05:02:05.000Z",
+            "@timestamp": "2026-04-18T05:02:05.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-81-14-6C"
@@ -65,7 +65,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-04-18T05:02:05.000Z",
+                "created": "2026-04-18T05:02:05.000Z",
                 "original": "<30>Apr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via 192.168.0.2"
             },
             "host": {
@@ -108,7 +108,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "mac": "00-50-56-83-6C-A0"
             },
@@ -117,7 +117,7 @@
             },
             "event": {
                 "action": "dhcpdiscover",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDISCOVER from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID a76ecf84 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -164,7 +164,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "mac": "00-50-56-83-6C-A0"
             },
@@ -173,7 +173,7 @@
             },
             "event": {
                 "action": "dhcpdiscover",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain 10.0.0.1 dhcpd[7024]: DHCPDISCOVER from 00:50:56:83:6c:a0 via eth3 TransID b5e92c59 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -224,7 +224,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "mac": "00-50-56-83-D0-F6"
             },
@@ -233,7 +233,7 @@
             },
             "event": {
                 "action": "dhcpdiscover",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 10.0.0.1 dhcpd[2750]: DHCPDISCOVER from 00:50:56:83:d0:f6 via eth1 TransID 6214ab45: network 10.50.0.0/20: no free leases"
             },
             "host": {
@@ -283,7 +283,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "mac": "00-50-56-83-6C-A0"
             },
@@ -292,7 +292,7 @@
             },
             "event": {
                 "action": "dhcpdiscover",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPDISCOVER from 00:50:56:83:6c:a0 via eth3 TransID 748f30ab"
             },
             "host": {
@@ -336,7 +336,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "mac": "00-00-00-00-00-00"
             },
@@ -345,7 +345,7 @@
             },
             "event": {
                 "action": "dhcpdiscover",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPDISCOVER from 00:00:00:00:00:00 (h000000000000) via 192.168.0.2 TransID 01000000"
             },
             "host": {
@@ -390,7 +390,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -400,7 +400,7 @@
             },
             "event": {
                 "action": "dhcpoffer",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPOFFER on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 119 offered-duration 1800 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -460,7 +460,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -470,7 +470,7 @@
             },
             "event": {
                 "action": "dhcpoffer",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPOFFER on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 120 offered-duration 1800"
             },
             "host": {
@@ -529,7 +529,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-31T15:30:05.000Z",
+            "@timestamp": "2026-03-31T15:30:05.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "26-9A-76-87-8A-06"
@@ -539,7 +539,7 @@
             },
             "event": {
                 "action": "dhcpoffer",
-                "created": "2025-03-31T15:30:05.000Z",
+                "created": "2026-03-31T15:30:05.000Z",
                 "original": "<30>Mar 31 15:30:05 10.0.0.1 dhcpd[15752]: DHCPOFFER on 192.168.0.4 to 26:9a:76:87:8a:06 via eth2 relay 192.168.0.3 lease-duration 1795 uid 01:26:9a:76:87:8a:06"
             },
             "host": {
@@ -595,7 +595,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-00-00-00-00-00"
@@ -605,7 +605,7 @@
             },
             "event": {
                 "action": "dhcpoffer",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPOFFER on 192.168.0.4 to 00:00:00:00:00:00 via eth1 relay 192.168.0.3 lease-duration 43137 offered-duration 43200"
             },
             "host": {
@@ -663,7 +663,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "CC-BB-CC-DD-EE-FF"
@@ -673,7 +673,7 @@
             },
             "event": {
                 "action": "dhcpoffer",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPOFFER on 192.168.0.4 to cc:bb:cc:dd:ee:ff via eth1 relay 192.168.0.3 lease-duration 120"
             },
             "host": {
@@ -728,7 +728,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -738,7 +738,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 54737448 uid 01:00:50:56:83:6c:a0 (RENEW)"
             },
             "host": {
@@ -795,7 +795,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -805,7 +805,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 8767dc3c uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -859,7 +859,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -869,7 +869,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[4495]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 54ade258 uid 01:00:50:56:83:6c:a0 (RENEW)"
             },
             "host": {
@@ -922,7 +922,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -932,7 +932,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[4495]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 TransID a18a70a0 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -980,7 +980,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-D3-83"
@@ -990,7 +990,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[25637]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:d3:83 via eth1 TransID 3ca1e0b7: unknown lease 192.168.0.4."
             },
             "host": {
@@ -1044,7 +1044,7 @@
             ]
         },
         {
-            "@timestamp": "2025-04-06T10:13:31.000Z",
+            "@timestamp": "2026-04-06T10:13:31.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1054,7 +1054,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-04-06T10:13:31.000Z",
+                "created": "2026-04-06T10:13:31.000Z",
                 "original": "<30>Apr  6 10:13:31 infoblox.localdomain dhcpd[22730]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 542900fa uid 01:00:50:56:83:6c:a0: database update failed"
             },
             "host": {
@@ -1107,7 +1107,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1117,7 +1117,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 via eth3 TransID 748f30ab"
             },
             "host": {
@@ -1168,7 +1168,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-96-03"
@@ -1178,7 +1178,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[30827]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:96:03 via eth1 TransID 9cf7c9e9: ignored (not authoritative)."
             },
             "host": {
@@ -1228,7 +1228,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1238,7 +1238,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 TransID 2d422d0c"
             },
             "host": {
@@ -1285,7 +1285,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-31T15:30:06.000Z",
+            "@timestamp": "2026-03-31T15:30:06.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "9A-DF-6E-F6-1F-23"
@@ -1295,7 +1295,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-31T15:30:06.000Z",
+                "created": "2026-03-31T15:30:06.000Z",
                 "original": "<30>Mar 31 15:30:06 10.0.0.1 dhcpd[15752]: DHCPREQUEST for 192.168.0.4 from 9a:df:6e:f6:1f:23 via 172.26.0.1 TransID 15ca711f uid 01:9a:df:6e:f6:1f:23 (RENEW)"
             },
             "host": {
@@ -1343,7 +1343,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-00-00-00-00-00"
@@ -1353,7 +1353,7 @@
             },
             "event": {
                 "action": "dhcprequest",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:00:00:00:00:00 via 192.168.0.3 TransID 01000000 (RENEW)"
             },
             "host": {
@@ -1404,7 +1404,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1414,7 +1414,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[17530]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800 (RENEW) uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -1472,7 +1472,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1482,7 +1482,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -1539,7 +1539,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:07:57.000Z",
+            "@timestamp": "2026-07-12T15:07:57.000Z",
             "client": {
                 "as": {
                     "number": 35908
@@ -1561,7 +1561,7 @@
             },
             "event": {
                 "action": "dhcpoffer",
-                "created": "2025-07-12T15:07:57.000Z",
+                "created": "2026-07-12T15:07:57.000Z",
                 "original": "<30>Jul 12 15:07:57 67.43.156.0 dhcpd[8061]: DHCPOFFER on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 40977 offered-duration 43200 uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
@@ -1618,7 +1618,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1628,7 +1628,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800"
             },
             "host": {
@@ -1684,7 +1684,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "9A-DF-6E-F6-1F-23"
@@ -1694,7 +1694,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 10.0.0.1 dhcpd[15752]: DHCPACK on 192.168.0.4 to 9a:df:6e:f6:1f:23 via eth2 relay 192.168.0.3 lease-duration 7257600 (RENEW) uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
@@ -1751,7 +1751,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-00-00-00-00-00"
@@ -1761,7 +1761,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPACK on 192.168.0.4 to 00:00:00:00:00:00 (h000000000000) via eth1 relay 192.168.0.3 lease-duration 43200 (RENEW)"
             },
             "host": {
@@ -1819,7 +1819,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:10:48.000Z",
+            "@timestamp": "2026-07-12T15:10:48.000Z",
             "client": {
                 "as": {
                     "number": 35908
@@ -1841,7 +1841,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-07-12T15:10:48.000Z",
+                "created": "2026-07-12T15:10:48.000Z",
                 "original": "<30>Jul 12 15:10:48 67.43.156.0 dhcpd[13468]: DHCPACK on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 7257600 (RENEW)"
             },
             "host": {
@@ -1895,7 +1895,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "CC-BB-CC-DD-EE-FF"
@@ -1905,7 +1905,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPACK on 192.168.0.4 to cc:bb:cc:dd:ee:ff via eth1 relay 192.168.0.3 lease-duration 43200"
             },
             "host": {
@@ -1960,7 +1960,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -1970,7 +1970,7 @@
             },
             "event": {
                 "action": "dhcprelease",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPRELEASE of 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 (found) TransID 0286f3d0 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
@@ -2023,7 +2023,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -2033,7 +2033,7 @@
             },
             "event": {
                 "action": "dhcprelease",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPRELEASE of 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 (not found) TransID 665fd9f1"
             },
             "host": {
@@ -2083,7 +2083,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-6C-A0"
@@ -2093,7 +2093,7 @@
             },
             "event": {
                 "action": "dhcpexpire",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPEXPIRE on 192.168.0.4 to 00:50:56:83:6c:a0"
             },
             "host": {
@@ -2130,7 +2130,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-18T13:35:15.000Z",
+            "@timestamp": "2026-03-18T13:35:15.000Z",
             "client": {
                 "ip": "192.168.0.4"
             },
@@ -2139,7 +2139,7 @@
             },
             "event": {
                 "action": "dhcpinform",
-                "created": "2025-03-18T13:35:15.000Z",
+                "created": "2026-03-18T13:35:15.000Z",
                 "original": "<30>Mar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 5713b740"
             },
             "host": {
@@ -2183,7 +2183,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-18T13:35:15.000Z",
+            "@timestamp": "2026-03-18T13:35:15.000Z",
             "client": {
                 "ip": "192.168.0.4"
             },
@@ -2192,7 +2192,7 @@
             },
             "event": {
                 "action": "dhcpinform",
-                "created": "2025-03-18T13:35:15.000Z",
+                "created": "2026-03-18T13:35:15.000Z",
                 "original": "<30>Mar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via eth2 TransID 5713b740"
             },
             "host": {
@@ -2239,7 +2239,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4"
             },
@@ -2248,7 +2248,7 @@
             },
             "event": {
                 "action": "dhcpinform",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 78563412: not authoritative for subnet 10.0.0.0"
             },
             "host": {
@@ -2295,7 +2295,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-18T11:44:52.000Z",
+            "@timestamp": "2026-03-18T11:44:52.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "34-29-8F-71-B8-99"
@@ -2305,7 +2305,7 @@
             },
             "event": {
                 "action": "dhcpdecline",
-                "created": "2025-03-18T11:44:52.000Z",
+                "created": "2026-03-18T11:44:52.000Z",
                 "original": "<30>Mar 18 11:44:52 10.0.0.1 dhcpd[32243]: DHCPDECLINE of 192.168.0.4 from 34:29:8f:71:b8:99 via 10.10.4.1 TransID 00000000: not found"
             },
             "host": {
@@ -2352,7 +2352,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-07T08:32:59.000Z",
+            "@timestamp": "2026-03-07T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-C0-DD-07-18-E2"
@@ -2362,7 +2362,7 @@
             },
             "event": {
                 "action": "dhcpdecline",
-                "created": "2025-03-07T08:32:59.000Z",
+                "created": "2026-03-07T08:32:59.000Z",
                 "original": "<30>Mar 7 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPDECLINE of 192.168.0.4 from 00:c0:dd:07:18:e2 via 192.168.0.2: abandoned\\n"
             },
             "host": {
@@ -2408,7 +2408,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "F4-30-B9-17-AB-0E"
@@ -2418,7 +2418,7 @@
             },
             "event": {
                 "action": "dhcpnak",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPNAK on 192.168.0.4 to f4:30:b9:17:ab:0e via 192.168.0.2"
             },
             "host": {
@@ -2461,7 +2461,7 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "client": {
                 "ip": "192.168.0.4"
             },
@@ -2470,7 +2470,7 @@
             },
             "event": {
                 "action": "dhcpleasequery",
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPLEASEQUERY from 192.168.0.4: LEASEQUERY not allowed, query ignored"
             },
             "host": {
@@ -2512,12 +2512,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDISCOVER some text"
             },
             "host": {
@@ -2554,12 +2554,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPOFFER some text"
             },
             "host": {
@@ -2596,12 +2596,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPREQUEST some text"
             },
             "host": {
@@ -2638,12 +2638,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPACK some text"
             },
             "host": {
@@ -2680,12 +2680,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPRELEASE some text"
             },
             "host": {
@@ -2722,12 +2722,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPEXPIRE some text"
             },
             "host": {
@@ -2764,12 +2764,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPINFORM some text"
             },
             "host": {
@@ -2806,12 +2806,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDECLINE some text"
             },
             "host": {
@@ -2848,12 +2848,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPNAK some text"
             },
             "host": {
@@ -2890,12 +2890,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPLEASEQUERY some text"
             },
             "host": {
@@ -2932,12 +2932,12 @@
             ]
         },
         {
-            "@timestamp": "2025-03-27T08:32:59.000Z",
+            "@timestamp": "2026-03-27T08:32:59.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2025-03-27T08:32:59.000Z",
+                "created": "2026-03-27T08:32:59.000Z",
                 "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: some text"
             },
             "host": {
@@ -2974,7 +2974,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:55:55.000Z",
+            "@timestamp": "2026-07-12T15:55:55.000Z",
             "client": {
                 "geo": {
                     "continent_name": "Europe",
@@ -2993,7 +2993,7 @@
             },
             "event": {
                 "action": "encapsulated solicit",
-                "created": "2025-07-12T15:55:55.000Z",
+                "created": "2026-07-12T15:55:55.000Z",
                 "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulated Solicit message from 2a02:cf40:: port 547 from client DUID 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23, transaction ID 0x698AD400"
             },
             "host": {
@@ -3034,7 +3034,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:55:55.000Z",
+            "@timestamp": "2026-07-12T15:55:55.000Z",
             "client": {
                 "geo": {
                     "continent_name": "Europe",
@@ -3052,7 +3052,7 @@
             },
             "event": {
                 "action": "advertise na",
-                "created": "2025-07-12T15:55:55.000Z",
+                "created": "2026-07-12T15:55:55.000Z",
                 "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Advertise NA: address 2a02:cf40:: to client with duid 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23 iaid = -1620146908 valid for 43200 seconds"
             },
             "host": {
@@ -3094,7 +3094,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:55:55.000Z",
+            "@timestamp": "2026-07-12T15:55:55.000Z",
             "client": {
                 "geo": {
                     "continent_name": "Europe",
@@ -3113,7 +3113,7 @@
             },
             "event": {
                 "action": "relay-forward",
-                "created": "2025-07-12T15:55:55.000Z",
+                "created": "2026-07-12T15:55:55.000Z",
                 "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Relay-forward message from 2a02:cf40:: port 547, link address 2a02:cf40::1, peer address 2a02:cf40::2"
             },
             "host": {
@@ -3156,7 +3156,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:55:55.000Z",
+            "@timestamp": "2026-07-12T15:55:55.000Z",
             "client": {
                 "geo": {
                     "continent_name": "Europe",
@@ -3175,7 +3175,7 @@
             },
             "event": {
                 "action": "encapsulating advertise",
-                "created": "2025-07-12T15:55:55.000Z",
+                "created": "2026-07-12T15:55:55.000Z",
                 "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulating Advertise message to send to 2a02:cf40:: port 547"
             },
             "host": {
@@ -3212,7 +3212,7 @@
             ]
         },
         {
-            "@timestamp": "2025-07-12T15:55:55.000Z",
+            "@timestamp": "2026-07-12T15:55:55.000Z",
             "client": {
                 "geo": {
                     "continent_name": "Europe",
@@ -3231,7 +3231,7 @@
             },
             "event": {
                 "action": "sending relay-reply",
-                "created": "2025-07-12T15:55:55.000Z",
+                "created": "2026-07-12T15:55:55.000Z",
                 "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Sending Relay-reply message to 2a02:cf40:: port 547"
             },
             "host": {
@@ -3268,7 +3268,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-28T09:25:49.000Z",
+            "@timestamp": "2026-09-28T09:25:49.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "00-50-56-83-96-03"
@@ -3278,7 +3278,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-09-28T09:25:49.000Z",
+                "created": "2026-09-28T09:25:49.000Z",
                 "original": "<30>Sep 28 09:25:49 infoblox.localdomain 10.0.0.1 dhcpd[25691]: DHCPACK on 192.168.0.4 to 00:50:56:83:96:03 via eth2 relay 192.168.0.4 lease-duration 3600 uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
@@ -3337,7 +3337,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-30T11:27:26.000Z",
+            "@timestamp": "2026-09-30T11:27:26.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "CE-93-30-8E-DB-AC"
@@ -3347,7 +3347,7 @@
             },
             "event": {
                 "action": "release",
-                "created": "2025-09-30T11:27:26.000Z",
+                "created": "2026-09-30T11:27:26.000Z",
                 "original": "<30>Sep 30 11:27:26 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: RELEASE on 192.168.0.4 to ce:93:30:8e:db:ac"
             },
             "host": {
@@ -3388,7 +3388,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-30T11:30:55.000Z",
+            "@timestamp": "2026-09-30T11:30:55.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "9C-AD-97-7A-FD-33"
@@ -3398,7 +3398,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-09-30T11:30:55.000Z",
+                "created": "2026-09-30T11:30:55.000Z",
                 "original": "<30>Sep 30 11:30:55 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK to 192.168.0.4 (9c:ad:97:7a:fd:33) via eth2"
             },
             "host": {
@@ -3446,7 +3446,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-30T11:33:03.000Z",
+            "@timestamp": "2026-09-30T11:33:03.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "4A-34-BF-D2-78-24"
@@ -3456,7 +3456,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-09-30T11:33:03.000Z",
+                "created": "2026-09-30T11:33:03.000Z",
                 "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 via eth2 relay 67.43.156.0 lease-duration 900 uid 01:4a:34:bf:d2:78:24"
             },
             "host": {
@@ -3516,7 +3516,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-30T11:33:03.000Z",
+            "@timestamp": "2026-09-30T11:33:03.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "4A-34-BF-D2-78-24"
@@ -3526,7 +3526,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-09-30T11:33:03.000Z",
+                "created": "2026-09-30T11:33:03.000Z",
                 "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 (my-iPhone) via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW) uid 01:4a:34:bf:d2:78:24"
             },
             "host": {
@@ -3592,7 +3592,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-30T11:33:03.000Z",
+            "@timestamp": "2026-09-30T11:33:03.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "4A-34-BF-D2-78-24"
@@ -3602,7 +3602,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-09-30T11:33:03.000Z",
+                "created": "2026-09-30T11:33:03.000Z",
                 "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW) uid 01:4a:34:bf:d2:78:24"
             },
             "host": {
@@ -3666,7 +3666,7 @@
             ]
         },
         {
-            "@timestamp": "2025-09-30T11:33:03.000Z",
+            "@timestamp": "2026-09-30T11:33:03.000Z",
             "client": {
                 "ip": "192.168.0.4",
                 "mac": "4A-34-BF-D2-78-24"
@@ -3676,7 +3676,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-09-30T11:33:03.000Z",
+                "created": "2026-09-30T11:33:03.000Z",
                 "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 (my-iPhone) via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW)"
             },
             "host": {
@@ -3741,7 +3741,7 @@
             ]
         },
         {
-            "@timestamp": "2025-05-31T13:21:52.000Z",
+            "@timestamp": "2026-05-31T13:21:52.000Z",
             "client": {
                 "ip": "10.71.68.10"
             },
@@ -3750,7 +3750,7 @@
             },
             "event": {
                 "action": "reverse_map_update",
-                "created": "2025-05-31T13:21:52.000Z",
+                "created": "2026-05-31T13:21:52.000Z",
                 "original": "<131>May 31 13:21:52 10.54.17.251 dhcpd[1122]: Reverse map update for 10.71.68.10 abandoned because of non-retryable failure: REFUSED",
                 "outcome": "failure"
             },
@@ -3788,13 +3788,13 @@
             ]
         },
         {
-            "@timestamp": "2025-05-31T13:21:52.000Z",
+            "@timestamp": "2026-05-31T13:21:52.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
                 "action": "add_forward_map",
-                "created": "2025-05-31T13:21:52.000Z",
+                "created": "2026-05-31T13:21:52.000Z",
                 "original": "<131>May 31 13:21:52 10.54.17.251 dhcpd[1122]: Unable to add forward map from PRinter12345.domain.subdomain.subsubdomain to 10.71.68.10 by server 127.0.0.1#53: REFUSED",
                 "outcome": "failure"
             },
@@ -3839,7 +3839,7 @@
             ]
         },
         {
-            "@timestamp": "2025-12-30T12:57:22.000Z",
+            "@timestamp": "2026-12-30T12:57:22.000Z",
             "client": {
                 "geo": {
                     "city_name": "London",
@@ -3861,7 +3861,7 @@
             },
             "event": {
                 "action": "dhcpack",
-                "created": "2025-12-30T12:57:22.000Z",
+                "created": "2026-12-30T12:57:22.000Z",
                 "original": "<30>Dec 30 12:57:22  myns.mydom.ltd 81.2.69.192 dhcpd[25033]: DHCPACK on 81.2.69.142 to 8e:cd:d9:ff:ff:ff via eth2 relay 81.2.69.144 lease-duration 7257537 offered-duration 7257579 (RENEW)"
             },
             "host": {

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log
@@ -39,6 +39,8 @@
 <30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f8710ec5968 81.2.69.144#38594 (198.51.100.149.in-addr.arpa): query failed (failure) for 198.51.100.149.in-addr.arpa/IN/PTR at query.c:12064
 <30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230d48968 175.16.199.1#36404 (Www.eXaMple.cH): query (cache) 'Www.eXaMple.cH/A/IN' denied
 <30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230e2f968 89.160.20.112#55610 (checkip.example.com): view 1: query (cache) 'checkip.example.com/AAAA/IN' denied
+<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230d48968 89.160.20.112#36404 (allowed.example.com): query (cache) 'allowed.example.com/A/IN' approved
+<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f8692d47168 89.160.20.128#42985 (noecs.example.com): query: noecs.example.com IN A -E(0)C (192.168.0.3) [ECS]
 <30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: xfer-in: transfer of 'sub.example.com/IN' from 192.168.0.1#53: Transfer completed: 2 messages, 702 records, 20630 bytes, 0.004 secs (5157500 bytes/sec) (serial 2218142)
 <30>Mar  9 23:59:59 infoblox.localdomain named[1142237]: xfer-in: transfer of 'sub1.example.com/IN' from 192.168.0.1#53: failed while receiving responses: REFUSED
 <30>Mar  9 23:59:59 infoblox.localdomain named[1122512]: xfer-in: transfer of '203.0.113.in-addr.arpa/IN' from 192.168.0.1#53: Transfer status: success
@@ -46,3 +48,5 @@
 <30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: notify: zone 2.0.192.in-addr.arpa/IN: sending notifies (serial 5818988)
 <30>Mar  9 23:59:59 infoblox.localdomain named[950271]: notify: client @0x7f869d88d968 2001:db8::53#42578: received notify for zone '2.0.192.in-addr.arpa'
 <30>Mar  9 23:59:59 infoblox.localdomain named[950271]: dnssec:   validating in-addr.arpa/SOA: got insecure response; parent indicates it should be secure
+<30>Mar  9 23:59:59 infoblox.localdomain named[7741]: notify: zone sub.example.com/IN/internal: notify from 192.168.0.1#53: zone is up to date
+<30>Mar  9 23:59:59 infoblox.localdomain named[7741]: notify: zone sub.example.com/IN/external: sending notifies (serial 1000001)

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log
@@ -31,3 +31,18 @@
 <30>Mar 11 23:51:31 infoblox.localdomain named[17742]: queries: client @0x7f1dd4114af0 192.168.0.6#40100 (mail.example.org): view default: query: mail.example.org IN MX + (192.168.0.1)
 <30>Mar 11 23:51:31 infoblox.localdomain named[28468]: CEF:0|Infoblox|NIOS|8.6.2-49634-e88e9df276a8|RPZ-QNAME|PASSTHRU|7|app=DNS dst=192.168.0.1 src=192.168.0.9 spt=51999 view=_default qtype=AAAA msg="rpz QNAME PASSTHRU rewrite ok.example.com [AAAA] via ok.example.com.rpz1.com" CAT=RPZ
 <30>Mar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.7#51200 TCP: query: multi.example.com IN A response: NOERROR +ED multi.example.com 300 IN A 192.168.0.20; multi.example.com 300 IN A 192.168.0.21;
+<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f86a7acb968 2001:db8::1#42302 (cloud.example.com): query: cloud.example.com IN AAAA -E(0)D (192.168.0.1) [ECS 89.160.20.112/24/0]
+<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f871f37d168 89.160.20.112#39512 (idlb-vip.example.com): view default: query: idlb-vip.example.com IN AAAA -E(0)DC (192.168.0.2) [ECS 81.2.69.144/24/0]
+<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f8692d47168 89.160.20.128#42985 (git.example.com): query: git.example.com IN A -E(0)C (192.168.0.3) [ECS 67.43.156.0]
+<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f86a85cf968 89.160.20.112#55590 (captive.example.com): query failed (REFUSED) for captive.example.com/IN/A at query.c:9090
+<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f870d223168 89.160.20.128#25083 (203.0.113.158.dnsbl.example.net): query failed (timed out) for 203.0.113.158.dnsbl.example.net/IN/A at query.c:12064
+<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f8710ec5968 81.2.69.144#38594 (198.51.100.149.in-addr.arpa): query failed (failure) for 198.51.100.149.in-addr.arpa/IN/PTR at query.c:12064
+<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230d48968 175.16.199.1#36404 (Www.eXaMple.cH): query (cache) 'Www.eXaMple.cH/A/IN' denied
+<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230e2f968 89.160.20.112#55610 (checkip.example.com): view 1: query (cache) 'checkip.example.com/AAAA/IN' denied
+<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: xfer-in: transfer of 'sub.example.com/IN' from 192.168.0.1#53: Transfer completed: 2 messages, 702 records, 20630 bytes, 0.004 secs (5157500 bytes/sec) (serial 2218142)
+<30>Mar  9 23:59:59 infoblox.localdomain named[1142237]: xfer-in: transfer of 'sub1.example.com/IN' from 192.168.0.1#53: failed while receiving responses: REFUSED
+<30>Mar  9 23:59:59 infoblox.localdomain named[1122512]: xfer-in: transfer of '203.0.113.in-addr.arpa/IN' from 192.168.0.1#53: Transfer status: success
+<30>Mar  9 23:59:59 infoblox.localdomain named[1123246]: xfer-in: transfer of 'mysub.example.com/IN' from 192.168.0.1#53: Transfer status: IXFR failed
+<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: notify: zone 2.0.192.in-addr.arpa/IN: sending notifies (serial 5818988)
+<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: notify: client @0x7f869d88d968 2001:db8::53#42578: received notify for zone '2.0.192.in-addr.arpa'
+<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: dnssec:   validating in-addr.arpa/SOA: got insecure response; parent indicates it should be secure

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -397,12 +397,24 @@
                 "ip": "192.168.0.1",
                 "port": 59735
             },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "config.nos-avg.cz",
+                    "registered_domain": "nos-avg.cz",
+                    "subdomain": "config",
+                    "top_level_domain": "cz",
+                    "type": "TXT"
+                },
+                "response_code": "REFUSED"
+            },
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
                 "created": "2026-03-09T23:59:59.000Z",
-                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: client @0x7f1dd4114af0 192.168.0.1#59735 (config.nos-avg.cz): query failed (REFUSED) for config.nos-avg.cz/IN/TXT at query.c:10288"
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: client @0x7f1dd4114af0 192.168.0.1#59735 (config.nos-avg.cz): query failed (REFUSED) for config.nos-avg.cz/IN/TXT at query.c:10288",
+                "outcome": "failure"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -410,6 +422,7 @@
             "infoblox_nios": {
                 "log": {
                     "dns": {
+                        "failure_reason": "REFUSED",
                         "message": "(REFUSED) for config.nos-avg.cz/IN/TXT at query.c:10288"
                     },
                     "service_name": "named",
@@ -430,6 +443,7 @@
             },
             "related": {
                 "hosts": [
+                    "config.nos-avg.cz",
                     "infoblox.localdomain"
                 ],
                 "ip": [
@@ -797,6 +811,13 @@
                 "ip": "192.168.0.1",
                 "port": 46982
             },
+            "dns": {
+                "question": {
+                    "name": "local_14.com",
+                    "registered_domain": "local_14.com",
+                    "top_level_domain": "com"
+                }
+            },
             "ecs": {
                 "version": "8.11.0"
             },
@@ -831,6 +852,7 @@
             },
             "related": {
                 "hosts": [
+                    "local_14.com",
                     "infoblox.localdomain"
                 ],
                 "ip": [
@@ -860,7 +882,8 @@
             },
             "event": {
                 "created": "2026-03-11T23:51:31.000Z",
-                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer status: success"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer status: success",
+                "outcome": "success"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -868,7 +891,10 @@
             "infoblox_nios": {
                 "log": {
                     "dns": {
-                        "message": "Transfer status: success"
+                        "message": "Transfer status: success",
+                        "transfer": {
+                            "status": "success"
+                        }
                     },
                     "service_name": "named",
                     "type": "DNS"
@@ -918,7 +944,8 @@
             },
             "event": {
                 "created": "2026-03-11T23:51:31.000Z",
-                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer completed: 1 messages, 9 records, 326 bytes, 0.001 secs (326000 bytes/sec)"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer completed: 1 messages, 9 records, 326 bytes, 0.001 secs (326000 bytes/sec)",
+                "outcome": "success"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -926,7 +953,10 @@
             "infoblox_nios": {
                 "log": {
                     "dns": {
-                        "message": "Transfer completed: 1 messages, 9 records, 326 bytes, 0.001 secs (326000 bytes/sec)"
+                        "message": "Transfer completed: 1 messages, 9 records, 326 bytes, 0.001 secs (326000 bytes/sec)",
+                        "transfer": {
+                            "status": "completed"
+                        }
                     },
                     "service_name": "named",
                     "type": "DNS"
@@ -1410,12 +1440,24 @@
                 "ip": "192.168.1.90",
                 "port": 64727
             },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "ocsp.digicert.com",
+                    "registered_domain": "digicert.com",
+                    "subdomain": "ocsp",
+                    "top_level_domain": "com",
+                    "type": "A"
+                },
+                "response_code": "REFUSED"
+            },
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
                 "created": "2026-04-14T16:16:05.000Z",
-                "original": "<30>Apr 14 16:16:05 10.50.1.227 named[2588]: query-errors: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query failed (REFUSED) for ocsp.digicert.com/IN/A at query.c:10288"
+                "original": "<30>Apr 14 16:16:05 10.50.1.227 named[2588]: query-errors: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query failed (REFUSED) for ocsp.digicert.com/IN/A at query.c:10288",
+                "outcome": "failure"
             },
             "host": {
                 "ip": [
@@ -1426,6 +1468,7 @@
                 "log": {
                     "dns": {
                         "category": "query-errors",
+                        "failure_reason": "REFUSED",
                         "message": "(REFUSED) for ocsp.digicert.com/IN/A at query.c:10288"
                     },
                     "service_name": "named",
@@ -1445,6 +1488,9 @@
                 "pid": 2588
             },
             "related": {
+                "hosts": [
+                    "ocsp.digicert.com"
+                ],
                 "ip": [
                     "192.168.1.90",
                     "10.50.1.227"
@@ -2934,6 +2980,1118 @@
                 "ip": [
                     "192.168.0.21",
                     "192.168.0.7"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 65551,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Greenwich",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.47687,
+                        "lon": -4.1E-4
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "2001:db8::1",
+                "port": 42302
+            },
+            "dns": {
+                "header_flags": [
+                    "DO"
+                ],
+                "question": {
+                    "class": "IN",
+                    "name": "cloud.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "cloud",
+                    "top_level_domain": "com",
+                    "type": "AAAA"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f86a7acb968 2001:db8::1#42302 (cloud.example.com): query: cloud.example.com IN AAAA -E(0)D (192.168.0.1) [ECS 89.160.20.112/24/0]"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "queries",
+                        "ecs_client_subnet": {
+                            "ip": "89.160.20.112",
+                            "prefix_length": 24,
+                            "scope_prefix_length": 0
+                        },
+                        "header_flags": "-E(0)D"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "queries: client @0x7f86a7acb968 2001:db8::1#42302 (cloud.example.com): query: cloud.example.com IN AAAA -E(0)D (192.168.0.1) [ECS 89.160.20.112/24/0]",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 17742
+            },
+            "related": {
+                "hosts": [
+                    "cloud.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "2001:db8::1",
+                    "192.168.0.1",
+                    "89.160.20.112"
+                ]
+            },
+            "server": {
+                "ip": "192.168.0.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 39512
+            },
+            "dns": {
+                "header_flags": [
+                    "CD",
+                    "DO"
+                ],
+                "question": {
+                    "class": "IN",
+                    "name": "idlb-vip.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "idlb-vip",
+                    "top_level_domain": "com",
+                    "type": "AAAA"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f871f37d168 89.160.20.112#39512 (idlb-vip.example.com): view default: query: idlb-vip.example.com IN AAAA -E(0)DC (192.168.0.2) [ECS 81.2.69.144/24/0]"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "queries",
+                        "ecs_client_subnet": {
+                            "ip": "81.2.69.144",
+                            "prefix_length": 24,
+                            "scope_prefix_length": 0
+                        },
+                        "header_flags": "-E(0)DC"
+                    },
+                    "service_name": "named",
+                    "type": "DNS",
+                    "view": "default"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "queries: client @0x7f871f37d168 89.160.20.112#39512 (idlb-vip.example.com): view default: query: idlb-vip.example.com IN AAAA -E(0)DC (192.168.0.2) [ECS 81.2.69.144/24/0]",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 17742
+            },
+            "related": {
+                "hosts": [
+                    "idlb-vip.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.112",
+                    "192.168.0.2",
+                    "81.2.69.144"
+                ]
+            },
+            "server": {
+                "ip": "192.168.0.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 42985
+            },
+            "dns": {
+                "header_flags": [
+                    "CD"
+                ],
+                "question": {
+                    "class": "IN",
+                    "name": "git.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "git",
+                    "top_level_domain": "com",
+                    "type": "A"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f8692d47168 89.160.20.128#42985 (git.example.com): query: git.example.com IN A -E(0)C (192.168.0.3) [ECS 67.43.156.0]"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "queries",
+                        "ecs_client_subnet": {
+                            "ip": "67.43.156.0"
+                        },
+                        "header_flags": "-E(0)C"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "queries: client @0x7f8692d47168 89.160.20.128#42985 (git.example.com): query: git.example.com IN A -E(0)C (192.168.0.3) [ECS 67.43.156.0]",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 17742
+            },
+            "related": {
+                "hosts": [
+                    "git.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.128",
+                    "192.168.0.3",
+                    "67.43.156.0"
+                ]
+            },
+            "server": {
+                "ip": "192.168.0.3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 55590
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "captive.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "captive",
+                    "top_level_domain": "com",
+                    "type": "A"
+                },
+                "response_code": "REFUSED"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f86a85cf968 89.160.20.112#55590 (captive.example.com): query failed (REFUSED) for captive.example.com/IN/A at query.c:9090",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "query-errors",
+                        "failure_reason": "REFUSED",
+                        "message": "(REFUSED) for captive.example.com/IN/A at query.c:9090"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "query-errors: client @0x7f86a85cf968 89.160.20.112#55590 (captive.example.com): query failed (REFUSED) for captive.example.com/IN/A at query.c:9090",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 950271
+            },
+            "related": {
+                "hosts": [
+                    "captive.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.112"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 25083
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "203.0.113.158.dnsbl.example.net",
+                    "registered_domain": "example.net",
+                    "subdomain": "203.0.113.158.dnsbl",
+                    "top_level_domain": "net",
+                    "type": "A"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f870d223168 89.160.20.128#25083 (203.0.113.158.dnsbl.example.net): query failed (timed out) for 203.0.113.158.dnsbl.example.net/IN/A at query.c:12064",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "query-errors",
+                        "failure_reason": "timed out",
+                        "message": "(timed out) for 203.0.113.158.dnsbl.example.net/IN/A at query.c:12064"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "query-errors: client @0x7f870d223168 89.160.20.128#25083 (203.0.113.158.dnsbl.example.net): query failed (timed out) for 203.0.113.158.dnsbl.example.net/IN/A at query.c:12064",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 950271
+            },
+            "related": {
+                "hosts": [
+                    "203.0.113.158.dnsbl.example.net",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.128"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "port": 38594
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "198.51.100.149.in-addr.arpa",
+                    "registered_domain": "149.in-addr.arpa",
+                    "subdomain": "198.51.100",
+                    "top_level_domain": "in-addr.arpa",
+                    "type": "PTR"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: query-errors: client @0x7f8710ec5968 81.2.69.144#38594 (198.51.100.149.in-addr.arpa): query failed (failure) for 198.51.100.149.in-addr.arpa/IN/PTR at query.c:12064",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "query-errors",
+                        "failure_reason": "failure",
+                        "message": "(failure) for 198.51.100.149.in-addr.arpa/IN/PTR at query.c:12064"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "query-errors: client @0x7f8710ec5968 81.2.69.144#38594 (198.51.100.149.in-addr.arpa): query failed (failure) for 198.51.100.149.in-addr.arpa/IN/PTR at query.c:12064",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 950271
+            },
+            "related": {
+                "hosts": [
+                    "198.51.100.149.in-addr.arpa",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "geo": {
+                    "city_name": "Changchun",
+                    "continent_name": "Asia",
+                    "country_iso_code": "CN",
+                    "country_name": "China",
+                    "location": {
+                        "lat": 43.88,
+                        "lon": 125.3228
+                    },
+                    "region_iso_code": "CN-22",
+                    "region_name": "Jilin Sheng"
+                },
+                "ip": "175.16.199.1",
+                "port": 36404
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "www.example.ch",
+                    "registered_domain": "example.ch",
+                    "subdomain": "www",
+                    "top_level_domain": "ch",
+                    "type": "A"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230d48968 175.16.199.1#36404 (Www.eXaMple.cH): query (cache) 'Www.eXaMple.cH/A/IN' denied",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "action": "denied",
+                        "category": "security",
+                        "message": "(Www.eXaMple.cH): query (cache) 'Www.eXaMple.cH/A/IN' denied",
+                        "query_context": "cache"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "security: client @0x7fc230d48968 175.16.199.1#36404 (Www.eXaMple.cH): query (cache) 'Www.eXaMple.cH/A/IN' denied",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1116488
+            },
+            "related": {
+                "hosts": [
+                    "www.example.ch",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "175.16.199.1"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 55610
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "checkip.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "checkip",
+                    "top_level_domain": "com",
+                    "type": "AAAA"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230e2f968 89.160.20.112#55610 (checkip.example.com): view 1: query (cache) 'checkip.example.com/AAAA/IN' denied",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "action": "denied",
+                        "category": "security",
+                        "message": "(checkip.example.com): view 1: query (cache) 'checkip.example.com/AAAA/IN' denied",
+                        "query_context": "cache"
+                    },
+                    "service_name": "named",
+                    "type": "DNS",
+                    "view": "1"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "security: client @0x7fc230e2f968 89.160.20.112#55610 (checkip.example.com): view 1: query (cache) 'checkip.example.com/AAAA/IN' denied",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1116488
+            },
+            "related": {
+                "hosts": [
+                    "checkip.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.112"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "ip": "192.168.0.1",
+                "port": 53
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "sub.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "sub",
+                    "top_level_domain": "com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: xfer-in: transfer of 'sub.example.com/IN' from 192.168.0.1#53: Transfer completed: 2 messages, 702 records, 20630 bytes, 0.004 secs (5157500 bytes/sec) (serial 2218142)",
+                "outcome": "success"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "xfer-in",
+                        "message": "Transfer completed: 2 messages, 702 records, 20630 bytes, 0.004 secs (5157500 bytes/sec) (serial 2218142)",
+                        "transfer": {
+                            "status": "completed"
+                        }
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "xfer-in: transfer of 'sub.example.com/IN' from 192.168.0.1#53: Transfer completed: 2 messages, 702 records, 20630 bytes, 0.004 secs (5157500 bytes/sec) (serial 2218142)",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1116488
+            },
+            "related": {
+                "hosts": [
+                    "sub.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "192.168.0.1"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "ip": "192.168.0.1",
+                "port": 53
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "sub1.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "sub1",
+                    "top_level_domain": "com"
+                },
+                "response_code": "REFUSED"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1142237]: xfer-in: transfer of 'sub1.example.com/IN' from 192.168.0.1#53: failed while receiving responses: REFUSED",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "xfer-in",
+                        "message": "failed while receiving responses: REFUSED",
+                        "transfer": {
+                            "stage": "failed",
+                            "status": "REFUSED"
+                        }
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "xfer-in: transfer of 'sub1.example.com/IN' from 192.168.0.1#53: failed while receiving responses: REFUSED",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1142237
+            },
+            "related": {
+                "hosts": [
+                    "sub1.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "192.168.0.1"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "ip": "192.168.0.1",
+                "port": 53
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "203.0.113.in-addr.arpa",
+                    "registered_domain": "113.in-addr.arpa",
+                    "subdomain": "203.0",
+                    "top_level_domain": "in-addr.arpa"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1122512]: xfer-in: transfer of '203.0.113.in-addr.arpa/IN' from 192.168.0.1#53: Transfer status: success",
+                "outcome": "success"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "xfer-in",
+                        "message": "Transfer status: success",
+                        "transfer": {
+                            "status": "success"
+                        }
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "xfer-in: transfer of '203.0.113.in-addr.arpa/IN' from 192.168.0.1#53: Transfer status: success",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1122512
+            },
+            "related": {
+                "hosts": [
+                    "203.0.113.in-addr.arpa",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "192.168.0.1"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "ip": "192.168.0.1",
+                "port": 53
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "mysub.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "mysub",
+                    "top_level_domain": "com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1123246]: xfer-in: transfer of 'mysub.example.com/IN' from 192.168.0.1#53: Transfer status: IXFR failed",
+                "outcome": "failure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "xfer-in",
+                        "message": "Transfer status: IXFR failed",
+                        "transfer": {
+                            "status": "IXFR failed"
+                        }
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "xfer-in: transfer of 'mysub.example.com/IN' from 192.168.0.1#53: Transfer status: IXFR failed",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1123246
+            },
+            "related": {
+                "hosts": [
+                    "mysub.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "192.168.0.1"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "2.0.192.in-addr.arpa",
+                    "registered_domain": "192.in-addr.arpa",
+                    "subdomain": "2.0",
+                    "top_level_domain": "in-addr.arpa"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: notify: zone 2.0.192.in-addr.arpa/IN: sending notifies (serial 5818988)"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "notify",
+                        "message": "sending notifies (serial 5818988)"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "notify: zone 2.0.192.in-addr.arpa/IN: sending notifies (serial 5818988)",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1116488
+            },
+            "related": {
+                "hosts": [
+                    "2.0.192.in-addr.arpa",
+                    "infoblox.localdomain"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 65551,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Greenwich",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.47687,
+                        "lon": -4.1E-4
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "2001:db8::53",
+                "port": 42578
+            },
+            "dns": {
+                "question": {
+                    "name": "2.0.192.in-addr.arpa",
+                    "registered_domain": "192.in-addr.arpa",
+                    "subdomain": "2.0",
+                    "top_level_domain": "in-addr.arpa"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: notify: client @0x7f869d88d968 2001:db8::53#42578: received notify for zone '2.0.192.in-addr.arpa'"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "notify",
+                        "message": "received notify for zone '2.0.192.in-addr.arpa'"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "notify: client @0x7f869d88d968 2001:db8::53#42578: received notify for zone '2.0.192.in-addr.arpa'",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 950271
+            },
+            "related": {
+                "hosts": [
+                    "2.0.192.in-addr.arpa",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "2001:db8::53"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "dns": {
+                "question": {
+                    "name": "in-addr.arpa",
+                    "top_level_domain": "in-addr.arpa",
+                    "type": "SOA"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[950271]: dnssec:   validating in-addr.arpa/SOA: got insecure response; parent indicates it should be secure"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "dnssec",
+                        "message": "got insecure response; parent indicates it should be secure"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "dnssec:   validating in-addr.arpa/SOA: got insecure response; parent indicates it should be secure",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 950271
+            },
+            "related": {
+                "hosts": [
+                    "in-addr.arpa",
+                    "infoblox.localdomain"
                 ]
             },
             "tags": [

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -3662,6 +3662,174 @@
         {
             "@timestamp": "2026-03-09T23:59:59.000Z",
             "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "port": 36404
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "allowed.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "allowed",
+                    "top_level_domain": "com",
+                    "type": "A"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[1116488]: security: client @0x7fc230d48968 89.160.20.112#36404 (allowed.example.com): query (cache) 'allowed.example.com/A/IN' approved",
+                "outcome": "success"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "action": "approved",
+                        "category": "security",
+                        "message": "(allowed.example.com): query (cache) 'allowed.example.com/A/IN' approved",
+                        "query_context": "cache"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "security: client @0x7fc230d48968 89.160.20.112#36404 (allowed.example.com): query (cache) 'allowed.example.com/A/IN' approved",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 1116488
+            },
+            "related": {
+                "hosts": [
+                    "allowed.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.112"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 42985
+            },
+            "dns": {
+                "header_flags": [
+                    "CD"
+                ],
+                "question": {
+                    "class": "IN",
+                    "name": "noecs.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "noecs",
+                    "top_level_domain": "com",
+                    "type": "A"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: queries: client @0x7f8692d47168 89.160.20.128#42985 (noecs.example.com): query: noecs.example.com IN A -E(0)C (192.168.0.3) [ECS]"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "queries",
+                        "header_flags": "-E(0)C"
+                    },
+                    "service_name": "named",
+                    "type": "DNS"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "queries: client @0x7f8692d47168 89.160.20.128#42985 (noecs.example.com): query: noecs.example.com IN A -E(0)C (192.168.0.3) [ECS]",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 17742
+            },
+            "related": {
+                "hosts": [
+                    "noecs.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "89.160.20.128",
+                    "192.168.0.3"
+                ]
+            },
+            "server": {
+                "ip": "192.168.0.3"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
                 "ip": "192.168.0.1",
                 "port": 53
             },
@@ -4091,6 +4259,121 @@
             "related": {
                 "hosts": [
                     "in-addr.arpa",
+                    "infoblox.localdomain"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "client": {
+                "ip": "192.168.0.1",
+                "port": 53
+            },
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "sub.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "sub",
+                    "top_level_domain": "com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[7741]: notify: zone sub.example.com/IN/internal: notify from 192.168.0.1#53: zone is up to date"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "notify",
+                        "message": "zone is up to date"
+                    },
+                    "service_name": "named",
+                    "type": "DNS",
+                    "view": "internal"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "notify: zone sub.example.com/IN/internal: notify from 192.168.0.1#53: zone is up to date",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 7741
+            },
+            "related": {
+                "hosts": [
+                    "sub.example.com",
+                    "infoblox.localdomain"
+                ],
+                "ip": [
+                    "192.168.0.1"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-03-09T23:59:59.000Z",
+            "dns": {
+                "question": {
+                    "class": "IN",
+                    "name": "sub.example.com",
+                    "registered_domain": "example.com",
+                    "subdomain": "sub",
+                    "top_level_domain": "com"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "created": "2026-03-09T23:59:59.000Z",
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[7741]: notify: zone sub.example.com/IN/external: sending notifies (serial 1000001)"
+            },
+            "host": {
+                "domain": "infoblox.localdomain"
+            },
+            "infoblox_nios": {
+                "log": {
+                    "dns": {
+                        "category": "notify",
+                        "message": "sending notifies (serial 1000001)"
+                    },
+                    "service_name": "named",
+                    "type": "DNS",
+                    "view": "external"
+                }
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30
+                }
+            },
+            "message": "notify: zone sub.example.com/IN/external: sending notifies (serial 1000001)",
+            "network": {
+                "protocol": "dns"
+            },
+            "process": {
+                "pid": 7741
+            },
+            "related": {
+                "hosts": [
+                    "sub.example.com",
                     "infoblox.localdomain"
                 ]
             },

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -13,13 +13,14 @@ processors:
       # timestamp-prefixed ones, which start with GREEDYDATA and are costlier to reject.
       # Keep the relative order within each overlapping group when editing this list.
       patterns:
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA}\\): %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} %{DATA:infoblox_nios.log.dns.header_flags} \\(%{IP:server.ip}\\)$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA}\\): %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} %{DATA:infoblox_nios.log.dns.header_flags} \\(%{IP:server.ip}\\)(?:\\s*%{ECS_CLIENT_SUBNET})?$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
-        - "^zone %{DATA:dns.question.name}/%{DATA:dns.question.class}: notify from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}' from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^validating %{DATA:dns.question.name}/%{WORD:dns.question.type}: %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*zone %{DATA:dns.question.name}/%{DATA:dns.question.class}: notify from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*zone %{DATA:dns.question.name}/%{DATA:dns.question.class}: %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}' from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*validating %{DATA:dns.question.name}/%{WORD:dns.question.type}: %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} updating zone '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA}\\): %{VIEW}?query failed %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA:infoblox_nios.log.dns.before_query}\\): rewriting query name %{DATA} to '%{DATA:infoblox_nios.log.dns.after_query}', type %{DATA:dns.question.type}$"
@@ -30,6 +31,7 @@ processors:
       pattern_definitions:
         CLIENT: 'client (?:%{DATA} )?%{IP:client.ip}#%{NUMBER:client.port:long}:?'
         VIEW: 'view %{DATA:infoblox_nios.log.view}: '
+        ECS_CLIENT_SUBNET: '\[ECS(?: %{IP:infoblox_nios.log.dns.ecs_client_subnet.ip}(?:/%{NUMBER:infoblox_nios.log.dns.ecs_client_subnet.prefix_length:long}(?:/%{NUMBER:infoblox_nios.log.dns.ecs_client_subnet.scope_prefix_length:long})?)?)?\]'
   - date:
       field: _tmp.timestamp
       target_field: _tmp.timestamp
@@ -137,6 +139,48 @@ processors:
       # starts with a double quote before the quotes are stripped, so this condition must
       # stay after that gsub, and the gsub must keep running for non-RPZ messages too.
       if: ctx.infoblox_nios?.log?.dns?.message != null && ctx.infoblox_nios.log.dns.message.startsWith('rpz ')
+  - grok:
+      field: infoblox_nios.log.dns.message
+      tag: grok_dns_query_error_message
+      patterns:
+        - "^\\(%{DATA:infoblox_nios.log.dns.failure_reason}\\) for %{NOTSPACE:dns.question.name}/%{DATA:dns.question.class}/%{WORD:dns.question.type} at %{GREEDYDATA}$"
+      if: >-
+        ctx.infoblox_nios?.log?.dns?.message != null &&
+        ctx.infoblox_nios.log.dns.message.startsWith('(') && ctx.infoblox_nios.log.dns.message.contains(') for ')
+      ignore_failure: true
+  - grok:
+      field: infoblox_nios.log.dns.message
+      tag: grok_dns_security_message
+      patterns:
+        - "^\\(%{DATA}\\): %{VIEW}?query (?:\\(%{DATA:infoblox_nios.log.dns.query_context}\\) )?'%{NOTSPACE:dns.question.name}/%{WORD:dns.question.type}/%{DATA:dns.question.class}' %{WORD:infoblox_nios.log.dns.action}$"
+      pattern_definitions:
+        VIEW: 'view %{DATA:infoblox_nios.log.view}: '
+      if: >-
+        ctx.infoblox_nios?.log?.dns?.message != null &&
+        (ctx.infoblox_nios.log.dns.message.endsWith(' denied') || ctx.infoblox_nios.log.dns.message.endsWith(' approved'))
+      ignore_failure: true
+  - grok:
+      field: infoblox_nios.log.dns.message
+      tag: grok_dns_transfer_message
+      patterns:
+        - "^Transfer status: %{GREEDYDATA:infoblox_nios.log.dns.transfer.status}$"
+        - "^Transfer %{WORD:infoblox_nios.log.dns.transfer.status}:%{GREEDYDATA}$"
+        - "^%{DATA:infoblox_nios.log.dns.transfer.stage} while receiving responses: %{GREEDYDATA:infoblox_nios.log.dns.transfer.status}$"
+      if: >-
+        ctx.infoblox_nios?.log?.dns?.message != null &&
+        (ctx.infoblox_nios.log.dns.message.startsWith('Transfer ') || ctx.infoblox_nios.log.dns.message.contains(' while receiving responses: '))
+      ignore_failure: true
+  - grok:
+      field: infoblox_nios.log.dns.message
+      tag: grok_dns_received_notify_message
+      patterns:
+        - "^received notify for zone '%{DATA:dns.question.name}'$"
+      if: ctx.infoblox_nios?.log?.dns?.message != null && ctx.infoblox_nios.log.dns.message.startsWith('received notify for zone ')
+      ignore_failure: true
+  - lowercase:
+      field: dns.question.name
+      tag: lowercase_dns_question_name
+      ignore_missing: true
   - convert:
       field: dns.answers.ttl
       type: long
@@ -228,6 +272,28 @@ processors:
       if: ctx.server?.ip != null
       allow_duplicates: false
       ignore_failure: true
+  - convert:
+      field: infoblox_nios.log.dns.ecs_client_subnet.ip
+      tag: convert_ecs_client_subnet_ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - remove:
+            field: infoblox_nios.log.dns.ecs_client_subnet.ip
+            ignore_missing: true
+        - append:
+            field: error.message
+            value: >-
+              Processor '{{{ _ingest.on_failure_processor_type }}}'
+              {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+              {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: related.ip
+      tag: append_ecs_client_subnet_ip_to_related
+      value: '{{{infoblox_nios.log.dns.ecs_client_subnet.ip}}}'
+      if: ctx.infoblox_nios?.log?.dns?.ecs_client_subnet?.ip != null
+      allow_duplicates: false
+      ignore_failure: true
   - foreach:
       field: dns.answers.name
       if: ctx.dns?.answers?.name != null
@@ -275,6 +341,72 @@ processors:
           ctx.put('dns', hm);
         }
         ctx.dns.put('header_flags', hf);
+  - set:
+      field: event.outcome
+      value: failure
+      tag: set_event_outcome_query_failed
+      if: ctx.infoblox_nios?.log?.dns?.failure_reason != null
+  - set:
+      field: event.outcome
+      value: failure
+      tag: set_event_outcome_denied
+      if: ctx.infoblox_nios?.log?.dns?.action == 'denied'
+  - set:
+      field: event.outcome
+      value: success
+      tag: set_event_outcome_approved
+      if: ctx.infoblox_nios?.log?.dns?.action == 'approved'
+  - script:
+      lang: painless
+      tag: script_event_outcome_transfer
+      description: Derive an ECS-valid event.outcome from the raw BIND zone-transfer status.
+      if: ctx.infoblox_nios?.log?.dns?.transfer?.status != null
+      source: |
+        def status = ctx.infoblox_nios.log.dns.transfer.status.toLowerCase();
+        def ok = status == 'success' || status == 'completed';
+        if (ctx.event == null) {
+          ctx.event = new HashMap();
+        }
+        ctx.event.outcome = ok ? 'success' : 'failure';
+  - script:
+      lang: painless
+      tag: script_dns_response_code_from_failure
+      description: >-
+        Promote the raw BIND failure token to dns.response_code, but only when it really is
+        a DNS RCODE. BIND also reports internal results such as `timed out` or `failure`,
+        which must not leak into dns.response_code.
+      if: >-
+        ctx.dns?.response_code == null &&
+        (ctx.infoblox_nios?.log?.dns?.failure_reason != null || ctx.infoblox_nios?.log?.dns?.transfer?.status != null)
+      params:
+        rcodes:
+          - NOERROR
+          - FORMERR
+          - SERVFAIL
+          - NXDOMAIN
+          - NOTIMP
+          - REFUSED
+          - YXDOMAIN
+          - YXRRSET
+          - NXRRSET
+          - NOTAUTH
+          - NOTZONE
+      source: |
+        def dnsLog = ctx.infoblox_nios?.log?.dns;
+        if (dnsLog == null) {
+          return;
+        }
+        def candidate = dnsLog.failure_reason;
+        if (candidate == null && dnsLog.transfer != null) {
+          candidate = dnsLog.transfer.status;
+        }
+        if (candidate == null || !params.rcodes.contains(candidate)) {
+          return;
+        }
+        if (ctx.dns == null) {
+          ctx.dns = new HashMap();
+        }
+        ctx.dns.response_code = candidate;
   - registered_domain:
       field: "dns.question.name"
       target_field: "dns.question"

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -17,14 +17,14 @@ processors:
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*zone %{DATA:dns.question.name}/%{DATA:dns.question.class}: notify from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*zone %{DATA:dns.question.name}/%{DATA:dns.question.class}: %{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}' from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*zone %{DATA:dns.question.name}/%{WORD:dns.question.class}(?:/%{NOTSPACE:infoblox_nios.log.view})?: notify from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*zone %{DATA:dns.question.name}/%{WORD:dns.question.class}(?:/%{NOTSPACE:infoblox_nios.log.view})?: %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*transfer of '%{DATA:dns.question.name}/%{WORD:dns.question.class}(?:/%{NOTSPACE:infoblox_nios.log.view})?' from %{IP:client.ip}#%{NUMBER:client.port:long}:? %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*validating %{DATA:dns.question.name}/%{WORD:dns.question.type}: %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} updating zone '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA}\\): %{VIEW}?query failed %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA:infoblox_nios.log.dns.before_query}\\): rewriting query name %{DATA} to '%{DATA:infoblox_nios.log.dns.after_query}', type %{DATA:dns.question.type}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA}\\): transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA}\\): transfer of '%{DATA:dns.question.name}/%{WORD:dns.question.class}(?:/%{NOTSPACE:infoblox_nios.log.view})?': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*CEF:0\\|Infoblox\\|NIOS\\|%{GREEDYDATA:infoblox_nios.log.dns.version}\\|RPZ-%{DATA:dns.answers.type}\\|%{DATA:infoblox_nios.log.dns.answers_policy}\\|\\d+\\|app=DNS dst=%{IP:server.ip} src=%{IP:client.ip} spt=%{NUMBER:client.port:long} view=%{DATA:infoblox_nios.log.dns.view_name} qtype=%{WORD:dns.question.type} msg=%{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.dns.message}$"
@@ -391,6 +391,14 @@ processors:
           - NXRRSET
           - NOTAUTH
           - NOTZONE
+          - BADVERS
+          - BADKEY
+          - BADTIME
+          - BADMODE
+          - BADNAME
+          - BADALG
+          - BADTRUNC
+          - BADCOOKIE
       source: |
         def dnsLog = ctx.infoblox_nios?.log?.dns;
         if (dnsLog == null) {
@@ -400,7 +408,11 @@ processors:
         if (candidate == null && dnsLog.transfer != null) {
           candidate = dnsLog.transfer.status;
         }
-        if (candidate == null || !params.rcodes.contains(candidate)) {
+        if (candidate == null) {
+          return;
+        }
+        candidate = candidate.toUpperCase();
+        if (!params.rcodes.contains(candidate)) {
           return;
         }
         if (ctx.dns == null) {

--- a/packages/infoblox_nios/data_stream/log/fields/fields.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/fields.yml
@@ -149,7 +149,7 @@
           type: text
         - name: failure_reason
           type: keyword
-          description: Reason BIND reported for a failed query, verbatim. Usually a DNS RCODE such as `REFUSED`, but may be an internal result such as `timed out` or `failure`.
+          description: Reason BIND reported for a failed query, verbatim. Usually a DNS RCODE such as `REFUSED`, but can be an internal result such as `timed out` or `failure`.
         - name: message
           type: text
         - name: query_context

--- a/packages/infoblox_nios/data_stream/log/fields/fields.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/fields.yml
@@ -121,6 +121,9 @@
     - name: dns
       type: group
       fields:
+        - name: action
+          type: keyword
+          description: Decision BIND logged for the query under the security category, for example `denied` or `approved`.
         - name: after_query
           type: text
         - name: answers_policy
@@ -129,10 +132,39 @@
           type: text
         - name: category
           type: text
+        - name: ecs_client_subnet
+          type: group
+          description: EDNS Client Subnet (ECS) option, as defined in RFC 7871, reported on a query log line. Not related to the Elastic Common Schema.
+          fields:
+            - name: ip
+              type: ip
+              description: Client subnet address carried in the EDNS Client Subnet option.
+            - name: prefix_length
+              type: long
+              description: Source prefix length of the EDNS Client Subnet option, in bits.
+            - name: scope_prefix_length
+              type: long
+              description: Scope prefix length of the EDNS Client Subnet option, in bits.
         - name: failed_message
           type: text
+        - name: failure_reason
+          type: keyword
+          description: Reason BIND reported for a failed query, verbatim. Usually a DNS RCODE such as `REFUSED`, but may be an internal result such as `timed out` or `failure`.
         - name: message
           type: text
+        - name: query_context
+          type: keyword
+          description: Source BIND answered the query from when logging a security decision, for example `cache`.
+        - name: transfer
+          type: group
+          description: Details of a zone transfer reported under the xfer-in category.
+          fields:
+            - name: stage
+              type: keyword
+              description: Stage of the zone transfer that BIND reported a failure in, for example `failed` in `failed while receiving responses`.
+            - name: status
+              type: keyword
+              description: Status BIND reported for the zone transfer, verbatim, for example `success`, `completed`, `IXFR failed` or `REFUSED`.
         - name: view_name
           type: text
         - name: version

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -290,7 +290,7 @@ An example event for `log` looks as following:
 | infoblox_nios.log.dns.ecs_client_subnet.prefix_length | Source prefix length of the EDNS Client Subnet option, in bits. | long |
 | infoblox_nios.log.dns.ecs_client_subnet.scope_prefix_length | Scope prefix length of the EDNS Client Subnet option, in bits. | long |
 | infoblox_nios.log.dns.failed_message |  | text |
-| infoblox_nios.log.dns.failure_reason | Reason BIND reported for a failed query, verbatim. Usually a DNS RCODE such as `REFUSED`, but may be an internal result such as `timed out` or `failure`. | keyword |
+| infoblox_nios.log.dns.failure_reason | Reason BIND reported for a failed query, verbatim. Usually a DNS RCODE such as `REFUSED`, but can be an internal result such as `timed out` or `failure`. | keyword |
 | infoblox_nios.log.dns.header_flags |  | keyword |
 | infoblox_nios.log.dns.message |  | text |
 | infoblox_nios.log.dns.query_context | Source BIND answered the query from when logging a security decision, for example `cache`. | keyword |

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -281,13 +281,19 @@ An example event for `log` looks as following:
 | infoblox_nios.log.dhcp.trans_id |  | keyword |
 | infoblox_nios.log.dhcp.uid |  | keyword |
 | infoblox_nios.log.dhcp.validation_second |  | long |
+| infoblox_nios.log.dns.action | Decision BIND logged for the query under the security category, for example `denied` or `approved`. | keyword |
 | infoblox_nios.log.dns.after_query |  | text |
 | infoblox_nios.log.dns.answers_policy |  | text |
 | infoblox_nios.log.dns.before_query |  | text |
 | infoblox_nios.log.dns.category |  | text |
+| infoblox_nios.log.dns.ecs_client_subnet.ip | Client subnet address carried in the EDNS Client Subnet option. | ip |
+| infoblox_nios.log.dns.ecs_client_subnet.prefix_length | Source prefix length of the EDNS Client Subnet option, in bits. | long |
+| infoblox_nios.log.dns.ecs_client_subnet.scope_prefix_length | Scope prefix length of the EDNS Client Subnet option, in bits. | long |
 | infoblox_nios.log.dns.failed_message |  | text |
+| infoblox_nios.log.dns.failure_reason | Reason BIND reported for a failed query, verbatim. Usually a DNS RCODE such as `REFUSED`, but may be an internal result such as `timed out` or `failure`. | keyword |
 | infoblox_nios.log.dns.header_flags |  | keyword |
 | infoblox_nios.log.dns.message |  | text |
+| infoblox_nios.log.dns.query_context | Source BIND answered the query from when logging a security decision, for example `cache`. | keyword |
 | infoblox_nios.log.dns.rpz.action |  | keyword |
 | infoblox_nios.log.dns.rpz.domain |  | keyword |
 | infoblox_nios.log.dns.rpz.domain_rewrite |  | keyword |
@@ -295,6 +301,8 @@ An example event for `log` looks as following:
 | infoblox_nios.log.dns.rpz.query_class_rewrite |  | keyword |
 | infoblox_nios.log.dns.rpz.rule_type |  | keyword |
 | infoblox_nios.log.dns.rpz.type |  | keyword |
+| infoblox_nios.log.dns.transfer.stage | Stage of the zone transfer that BIND reported a failure in, for example `failed` in `failed while receiving responses`. | keyword |
+| infoblox_nios.log.dns.transfer.status | Status BIND reported for the zone transfer, verbatim, for example `success`, `completed`, `IXFR failed` or `REFUSED`. | keyword |
 | infoblox_nios.log.dns.version |  | text |
 | infoblox_nios.log.dns.view_name |  | text |
 | infoblox_nios.log.service_name |  | keyword |

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "2.1.2"
+version: "2.2.0"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change: Bug, Enhancement -->

## Proposed commit message

```
[infoblox_nios] Fix NIOS 9 named log parsing

NIOS 9 prefixes named log lines with a logging-category token
(e.g. `queries:`, `security:`). The notify, zone-transfer, and
DNSSEC-validation grok patterns lacked that prefix, silently
dropping dns.question.* fields. A trailing EDNS Client Subnet
suffix on `queries` lines had the same effect: those lines fell
through to the catch-all alternative, which kept client.ip and the
raw message but none of dns.question.*.

Fix both by accepting the optional category prefix on all affected
patterns and adding an ECS_CLIENT_SUBNET pattern definition for
the suffix. Normalise dns.question.name to lowercase after
extraction (DNS names are case-insensitive, and resolvers may
0x20-encode them, which BIND logs verbatim).

Bound dns.question.class to a single token on the zone and
zone-transfer patterns, and capture the optional BIND view into
infoblox_nios.log.view. Previously a multi-view deployment logging
`zone name/class/view:` put `IN/internal` into the ECS
dns.question.class field.

Parse the message tail for query-errors, security, xfer-in, and
notify categories to extract failure_reason, action, query_context,
and transfer status. Derive ECS event.outcome and dns.response_code
from those values; raw BIND tokens stay in infoblox_nios.log.dns.*.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) _(no dashboard changes)_

## Author's Checklist

- [x] Pipeline unit tests updated (`test-dns.log` and `test-dns.log-expected.json`) to cover new NIOS 9 log lines for all four categories
- [x] New fields documented in `fields/fields.yml` and `docs/README.md`
- [x] Each new grok processor tagged and gated with a cheap prefix/suffix condition to avoid hot-path regressions
- [x] `event.outcome` and `dns.response_code` are only set when there is enough information; DNS-specific RCODE strings are allow-listed to prevent internal BIND status tokens from leaking into `dns.response_code`

## How to test this PR locally

```bash
# From the repo root, with elastic-package available:
cd packages/infoblox_nios
elastic-package test pipeline --data-streams log
```

The `test-dns.log` file contains representative NIOS 9 lines for each new category. Compare the rendered output against `test-dns.log-expected.json`.

To smoke-test against a real stack:

1. Configure Infoblox NIOS 9 to forward named logs via syslog.
2. Enable one or more of the `queries`, `query-errors`, `security`, `xfer-in`, and `notify` categories in the BIND logging configuration.
3. Ingest a sample via the infoblox_nios integration and confirm that `dns.question.*`, `event.outcome`, and `dns.response_code` are populated correctly.

## Related issues

- Closes #16636 
- Closes #16626 

## Screenshots
