### PR TITLE
[greenhouse] Drop scalar performer.meta values that conflict with object mapping

### DIFF
--- a/packages/greenhouse/changelog.yml
+++ b/packages/greenhouse/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Drop scalar performer.meta values that conflict with the object mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/20642
 - version: "0.2.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/greenhouse/changelog.yml
+++ b/packages/greenhouse/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Drop scalar performer.meta values that conflict with the object mapping.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/20642
+      link: https://github.com/elastic/integrations/pull/21012
 - version: "0.2.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/greenhouse/data_stream/audit/_dev/test/pipeline/test-audit-events.json
+++ b/packages/greenhouse/data_stream/audit/_dev/test/pipeline/test-audit-events.json
@@ -14,6 +14,9 @@
         },
         {
             "message": "{\"request\":{\"id\":\"3456cID\",\"type\":\"jobs#destroy\"},\"performer\":{\"meta\":{\"name\":\"HR Manager\",\"username\":\"hr.manager@omniva-corp.com\"},\"id\":55555,\"ip_address\":\"172.16.0.100\",\"type\":\"user\"},\"organization_id\":456,\"event\":{\"meta\":{\"name\":[\"Software Engineer\",null]},\"target_type\":\"Job\",\"target_id\":789,\"type\":\"data_change_destroy\"},\"event_time\":\"2023-06-04T08:15:30.500Z\"}"
+        },
+        {
+            "message": "{\"event\":{\"meta\":{\"id\":12345},\"target_id\":\"12345\",\"target_type\":\"Example\",\"type\":\"data_change_create\"},\"event_time\":\"2026-08-10T17:13:22.060Z\",\"organization_id\":1234,\"performer\":{\"id\":null,\"ip_address\":\"192.0.2.1\",\"meta\":\"Not Found\",\"type\":\"user\"},\"request\":{\"id\":\"sanitized-request-id\",\"type\":\"example-request\"}}"
         }
     ]
 }

--- a/packages/greenhouse/data_stream/audit/_dev/test/pipeline/test-audit-events.json-expected.json
+++ b/packages/greenhouse/data_stream/audit/_dev/test/pipeline/test-audit-events.json-expected.json
@@ -337,6 +337,60 @@
                 "full_name": "HR Manager",
                 "id": "55555"
             }
+        },
+        {
+            "@timestamp": "2026-08-10T17:13:22.060Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "data_change_create",
+                "category": [
+                    "configuration",
+                    "iam"
+                ],
+                "id": "sanitized-request-id",
+                "kind": "event",
+                "original": "{\"event\":{\"meta\":{\"id\":12345},\"target_id\":\"12345\",\"target_type\":\"Example\",\"type\":\"data_change_create\"},\"event_time\":\"2026-08-10T17:13:22.060Z\",\"organization_id\":1234,\"performer\":{\"id\":null,\"ip_address\":\"192.0.2.1\",\"meta\":\"Not Found\",\"type\":\"user\"},\"request\":{\"id\":\"sanitized-request-id\",\"type\":\"example-request\"}}",
+                "type": [
+                    "creation"
+                ]
+            },
+            "greenhouse": {
+                "audit": {
+                    "event": {
+                        "meta": {
+                            "id": 12345
+                        },
+                        "target_id": "12345",
+                        "target_type": "Example",
+                        "type": "data_change_create"
+                    },
+                    "performer": {
+                        "type": "user"
+                    },
+                    "request": {
+                        "id": "sanitized-request-id",
+                        "type": "example-request"
+                    }
+                }
+            },
+            "organization": {
+                "id": "1234"
+            },
+            "related": {
+                "ip": [
+                    "192.0.2.1"
+                ]
+            },
+            "source": {
+                "ip": "192.0.2.1"
+            },
+            "tags": [
+                "preserve_original_event",
+                "forwarded",
+                "greenhouse-audit"
+            ]
         }
     ]
 }

--- a/packages/greenhouse/data_stream/audit/_dev/test/pipeline/test-audit-events.json-expected.json
+++ b/packages/greenhouse/data_stream/audit/_dev/test/pipeline/test-audit-events.json-expected.json
@@ -384,6 +384,24 @@
                 ]
             },
             "source": {
+                "as": {
+                    "number": 64500,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Las Vegas",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 36.17497,
+                        "lon": -115.13722
+                    },
+                    "region_iso_code": "US-NV",
+                    "region_name": "Nevada"
+                },
                 "ip": "192.0.2.1"
             },
             "tags": [

--- a/packages/greenhouse/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/greenhouse/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -42,6 +42,12 @@ processors:
       field: json
       target_field: greenhouse.audit
       ignore_missing: true
+  - remove:
+      tag: remove_non_object_performer_meta_9f2a6c4d
+      description: Remove non-object performer.meta values that conflict with the integration mapping
+      field: greenhouse.audit.performer.meta
+      ignore_missing: true
+      if: ctx.greenhouse?.audit?.performer?.meta != null && !(ctx.greenhouse.audit.performer.meta instanceof Map)
 
   # Timestamp
   - date:

--- a/packages/greenhouse/manifest.yml
+++ b/packages/greenhouse/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: greenhouse
 title: "Greenhouse"
-version: "0.2.0"
+version: "0.2.1"
 description: Collect audit logs from Greenhouse ATS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Drop scalar performer.meta values that conflict with object mapping

Greenhouse Audit Log API sometimes returns `performer.meta` as a scalar string (`"Not Found"`) instead of an object. The field is mapped as a group, so Elasticsearch rejects those documents with `document_parsing_exception`. Drop non-object `performer.meta` values in the ingest pipeline and keep the original payload in `event.original`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## How to test this PR locally

```bash
cd packages/greenhouse
elastic-package test pipeline -v --data-streams audit
```

## Related issues

- Closes #20642