### PR TITLE
[Wiz] Set CDR transform destination indices to 3 primary shards

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.8.0"
+  changes:
+    - description: Set the `latest_cdr_vulnerabilities` and `latest_cdr_misconfigurations` transform destination indices to 3 primary shards to avoid shard-size warnings at scale. The destination indices are re-created (`-v3` and `-v4` respectively).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "4.7.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set the `latest_cdr_vulnerabilities` and `latest_cdr_misconfigurations` transform destination indices to 3 primary shards to avoid shard-size warnings at scale. The destination indices are re-created (`-v3` and `-v4` respectively).
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21016
 - version: "4.7.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/wiz/elasticsearch/transform/latest_cdr_misconfigurations/manifest.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_misconfigurations/manifest.yml
@@ -1,0 +1,5 @@
+start: true
+destination_index_template:
+  settings:
+    index:
+      number_of_shards: 3

--- a/packages/wiz/elasticsearch/transform/latest_cdr_misconfigurations/transform.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_misconfigurations/transform.yml
@@ -15,7 +15,7 @@ source:
               - data_frozen
               - data_cold
 dest:
-  index: "security_solution-wiz.misconfiguration_latest-v3"
+  index: "security_solution-wiz.misconfiguration_latest-v4"
   aliases:
     - alias: "security_solution-wiz.misconfiguration_latest"
       move_on_creation: true
@@ -40,4 +40,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0

--- a/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/manifest.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/manifest.yml
@@ -1,0 +1,5 @@
+start: true
+destination_index_template:
+  settings:
+    index:
+      number_of_shards: 3

--- a/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/transform.yml
+++ b/packages/wiz/elasticsearch/transform/latest_cdr_vulnerabilities/transform.yml
@@ -15,7 +15,7 @@ source:
               - data_frozen
               - data_cold
 dest:
-  index: "security_solution-wiz.vulnerability_latest-v2"
+  index: "security_solution-wiz.vulnerability_latest-v3"
   aliases:
     - alias: "security_solution-wiz.vulnerability_latest"
       move_on_creation: true
@@ -42,4 +42,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: wiz
 title: Wiz
-version: "4.7.0"
+version: "4.8.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message
wiz: set CDR transform destination indices to 3 primary shards

The `latest_cdr_vulnerabilities` and `latest_cdr_misconfigurations` Wiz transforms write to destination indices that are created with a single primary shard, because neither transform shipped a `manifest.yml` with a `destination_index_template`. At scale this trips Elasticsearch shard-size warnings.

This standardises both CDR "latest" transforms on `number_of_shards: 3`, a reasonable static middle-ground (\~25 GB/shard at the reported 76 GB) that clears the warning for realistic index sizes without over-sharding small deployments.

Because `number_of_shards` is an immutable, create-time index setting, adding a `destination_index_template` and bumping `fleet_transform_version` alone is not enough: on upgrade Fleet reinstalls the transform but keeps the existing destination index, so an already-created 1-shard index would not be re-sharded. To make the new shard count take effect for existing customers, the destination index `-vN` suffix is bumped so a fresh index is created from the updated template, the transform repopulates it, and the `move_on_creation: true` alias moves onto the new index.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] Confirm the new `-v3` / `-v4` destination indices are created with 3 primary shards.
- [x] Confirm the `security_solution-wiz.{vulnerability,misconfiguration}_latest` aliases point at the new indices after install/upgrade.

## How to test this PR locally

1. Build/install the package: `elastic-package check` then `elastic-package install` (from `packages/wiz`).
2. Verify the shard count on the new destination indices:
   - `GET security_solution-wiz.vulnerability_latest-v3/_settings` → `index.number_of_shards: 3`
   - `GET security_solution-wiz.misconfiguration_latest-v4/_settings` → `index.number_of_shards: 3`
3. Verify the aliases resolve to the new indices:
   - `GET security_solution-wiz.vulnerability_latest/_alias`
   - `GET security_solution-wiz.misconfiguration_latest/_alias`
4. Confirm both transforms start and populate the new destination indices.

## Related issues

- Closes [#20820](https://github.com/elastic/integrations/issues/20820)