### PR TITLE
[backports] allow maintain role in backport workflow permission checks

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -68,10 +68,10 @@ jobs:
         run: |
           PERMISSION=$(gh api "repos/$REPOSITORY/collaborators/$ACTOR/permission" \
             --jq '.permission' 2>/dev/null || echo "none")
-          if [[ "$PERMISSION" == "write" || "$PERMISSION" == "admin" ]]; then
+          if [[ "$PERMISSION" == "write" || "$PERMISSION" == "maintain" || "$PERMISSION" == "admin" ]]; then
             echo "permitted=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Actor $ACTOR lacks write/admin permission ($PERMISSION) — skipping"
+            echo "Actor $ACTOR lacks write/maintain/admin permission ($PERMISSION) — skipping"
           fi
 
       - name: Resolve merge SHA and PR metadata

--- a/.github/workflows/sync-backport-changelog.yml
+++ b/.github/workflows/sync-backport-changelog.yml
@@ -78,10 +78,10 @@ jobs:
         run: |
           PERMISSION=$(gh api "repos/$REPOSITORY/collaborators/$ACTOR/permission" \
             --jq '.permission' 2>/dev/null || echo "none")
-          if [[ "$PERMISSION" == "write" || "$PERMISSION" == "admin" ]]; then
+          if [[ "$PERMISSION" == "write" || "$PERMISSION" == "maintain" || "$PERMISSION" == "admin" ]]; then
             echo "permitted=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Actor $ACTOR lacks write/admin permission ($PERMISSION) — skipping"
+            echo "Actor $ACTOR lacks write/maintain/admin permission ($PERMISSION) — skipping"
           fi
 
       - name: Resolve PR metadata


### PR DESCRIPTION
<!-- Label: Enhancement -->

## Proposed commit message

```
chore: allow maintain role in backport workflow permission checks

The actor permission gate in `auto-backport` and `sync-backport-changelog`
workflows only accepted `write` and `admin` roles, inadvertently excluding
users with the `maintain` role.

GitHub's `maintain` role grants push access and the ability to manage PRs,
making it appropriate for triggering backport automation. This change adds
`maintain` to the accepted permission levels in both workflows.
```

## Author's Checklist

- [x] Verified that `maintain` permission level includes push access in GitHub's permission model
- [x] Both affected workflows (`auto-backport.yml`, `sync-backport-changelog.yml`) updated consistently

## Related issues

- Relates https://github.com/elastic/integrations/issues/19016

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).