### PR TITLE
cisco_ise: remove broken cts-environment-version convert

### DIFF
--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.15"
+  changes:
+    - description: Remove broken convert processor for cisco_av_pair.cts-environment-version in Passed Authentications pipeline. The processor referenced a stale hyphenated field path and was a silent no-op since the Nov 2024 av-pair refactor; the field remains a keyword string per mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.32.14"
   changes:
     - description: Add null check for script_parse_av_pairs processor.

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove broken convert processor for cisco_av_pair.cts-environment-version in Passed Authentications pipeline. The processor referenced a stale hyphenated field path and was a silent no-op since the Nov 2024 av-pair refactor; the field remains a keyword string per mapping.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21021
 - version: "1.32.14"
   changes:
     - description: Add null check for script_parse_av_pairs processor.

--- a/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_passed_authentications.yml
+++ b/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_passed_authentications.yml
@@ -347,21 +347,6 @@ processors:
             tag: remove_cisco_ise_log_cisco_av_pair_coa-push_19d8e2e6
             field: cisco_ise.log.cisco_av_pair.coa-push
   - convert:
-      tag: convert_cisco_ise_log_cisco-av-pair_cts-environment-version_to_cisco_ise_log_cisco-av-pair_cts-environment-version_0f389da9
-      field: cisco_ise.log.cisco-av-pair.cts-environment-version
-      target_field: cisco_ise.log.cisco-av-pair.cts-environment-version
-      type: long
-      ignore_missing: true
-      on_failure:
-        - append:
-            tag: append_error_message_dc791e7c
-            field: error.message
-            value: '{{{_ingest.on_failure_message}}}'
-        - remove:
-            tag: remove_cisco_ise_log_cisco_av_pair_cts-environment-version_bca00b12
-            field: cisco_ise.log.cisco_av_pair.cts-environment-version
-            ignore_missing: true
-  - convert:
       tag: convert_cisco_ise_log_log_details_ClientLatency_to_cisco_ise_log_client_latency_108a319b
       field: cisco_ise.log.log_details.ClientLatency
       target_field: cisco_ise.log.client.latency

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ise
 title: Cisco ISE
-version: "1.32.14"
+version: "1.32.15"
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
cisco_ise: remove broken cts-environment-version convert

The Passed Authentications convert processor referenced
cisco_ise.log.cisco-av-pair.cts-environment-version, a stale
hyphenated path left over from the Nov 2024 av-pair refactor.
script_parse_av_pairs stores values under cisco_av_pair, so the
convert was a silent no-op (ignore_missing: true).

Remove the processor rather than fixing the path and keeping
type: long. The field is mapped as keyword, has been ingested as
a string since the refactor, and cts-environment-version is a
version identifier, not a quantity.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
