### PR TITLE
aws: Add Instance/Pod IAM Role option to Setup Access selector

### DIFF
--- a/packages/aws/_dev/build/docs/README.md
+++ b/packages/aws/_dev/build/docs/README.md
@@ -86,13 +86,17 @@ Before using the AWS integration you will need:
 ### AWS Credentials
 
 AWS credentials are required for running AWS integrations.
-There are a few ways to provide AWS credentials:
+In the integration policy, the **Setup Access** section has a **Preferred method** selector.
+Pick the option that matches how you want to authenticate; only the fields that option needs are shown, and those fields are required.
 
-* Use access keys directly
-* Use temporary security credentials
-* Use a shared credentials file
-* Use an IAM role Amazon Resource Name (ARN)
-* Use an EC2 instance's IAM Role
+| Preferred method | Fields | Details |
+|---|---|---|
+| Direct Access Keys | `access_key_id`, `secret_access_key` | [Use access keys directly](#use-access-keys-directly) |
+| Temporary Access Keys | `access_key_id`, `secret_access_key`, `session_token` | [Use temporary security credentials](#use-temporary-security-credentials) |
+| Shared Credentials | `shared_credential_file`, `credential_profile_name` | [Use a shared credentials file](#use-a-shared-credentials-file) |
+| Assume Role | `role_arn` | [Use an IAM role Amazon Resource Name (ARN)](#use-an-iam-role-amazon-resource-name-arn) |
+| Instance or Pod IAM Role | none | [Use an EC2 instance's or pod's IAM Role](#use-an-ec2-instances-or-pods-iam-role) |
+| Identity Federation | Federated identity (agentless only) | Cloud Connectors; shown only for Elastic-managed (agentless) deployments |
 
 #### Use access keys directly
 
@@ -156,26 +160,20 @@ Instead, when you assume a role it provides you with temporary security credenti
 IAM role ARN can be used to specify which AWS IAM role to assume to generate temporary credentials.
 For more details, refer to [AssumeRole API documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
-To use an IAM role ARN, you need to provide either a [credential profile](#use-a-shared-credentials-file) or
-[access keys](#use-access-keys-directly) along with the `role_arn` advanced option.
-`role_arn` is used to specify which AWS IAM role to assume for generating temporary credentials.
+Select the **Assume Role** method and provide `role_arn`, the IAM role to assume for generating temporary credentials.
+The credentials used to call `AssumeRole` come from the AWS SDK default credential chain on the host running Elastic Agent
+(environment variables, the default shared credentials profile, or the EC2 instance profile / pod role).
 
-Note: If `role_arn` is given, the package will check if access keys are given.
-If they are not given, the package will check for a credential profile name.
-If neither is given, the default credential profile will be used. 
+Note: **Assume Role** always calls `AssumeRole` on the given `role_arn`. If you only want to use the role that is
+already attached to the EC2 instance or pod, use the **Instance or Pod IAM Role** method instead and leave `role_arn` unset.
 
-#### Use an EC2 instance's IAM Role
+#### Use an EC2 instance's or pod's IAM Role
 
 When Elastic Agent runs on an EC2 instance that has an IAM role attached via an instance profile, it can automatically authenticate to AWS services using a temporary access key pair and session token provided by the Instance Metadata Service (IMDS). For more details, refer to [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
+The same applies to Elastic Agent running in Kubernetes on Amazon EKS with [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) or [IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 
-To use the IAM role attached to the EC2 instance, leave all of the following options empty:
-
-* `access_key_id`
-* `secret_access_key`
-* `session_token`
-* `credential_profile_name`
-* `shared_credential_file`
-* `role_arn`
+To use the IAM role attached to the EC2 instance or pod, select the **Instance or Pod IAM Role** method under **Setup Access**.
+No credential fields are shown or required; Elastic Agent resolves credentials through the AWS SDK default credential chain.
 
 ### AWS Permissions
 

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "8.1.2"
+  changes:
+    - description: Add an `Instance or Pod IAM Role` option to the `Setup Access` selector so Elastic Agent can authenticate with the AWS SDK default credential chain (EC2 instance profile, EKS Pod Identity or IRSA) without entering access keys or a Role ARN. Since 7.0.0 every option required at least one credential field, which made this documented path impossible to save.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "8.1.1"
   changes:
     - description: Lower the minimum supported Elastic Agent version from 9.6.0 to 9.4.0. The required capabilities (auth.aws for CEL/HTTPJSON inputs and libbeat Cloud Connectors on the current ExternalID contract) all ship in Elastic Agent 9.4.0.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add an `Instance or Pod IAM Role` option to the `Setup Access` selector so Elastic Agent can authenticate with the AWS SDK default credential chain (EC2 instance profile, EKS Pod Identity or IRSA) without entering access keys or a Role ARN. Since 7.0.0 every option required at least one credential field, which made this documented path impossible to save.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21025
 - version: "8.1.1"
   changes:
     - description: Lower the minimum supported Elastic Agent version from 9.6.0 to 9.4.0. The required capabilities (auth.aws for CEL/HTTPJSON inputs and libbeat Cloud Connectors on the current ExternalID contract) all ship in Elastic Agent 9.4.0.

--- a/packages/aws/docs/README.md
+++ b/packages/aws/docs/README.md
@@ -86,13 +86,17 @@ Before using the AWS integration you will need:
 ### AWS Credentials
 
 AWS credentials are required for running AWS integrations.
-There are a few ways to provide AWS credentials:
+In the integration policy, the **Setup Access** section has a **Preferred method** selector.
+Pick the option that matches how you want to authenticate; only the fields that option needs are shown, and those fields are required.
 
-* Use access keys directly
-* Use temporary security credentials
-* Use a shared credentials file
-* Use an IAM role Amazon Resource Name (ARN)
-* Use an EC2 instance's IAM Role
+| Preferred method | Fields | Details |
+|---|---|---|
+| Direct Access Keys | `access_key_id`, `secret_access_key` | [Use access keys directly](#use-access-keys-directly) |
+| Temporary Access Keys | `access_key_id`, `secret_access_key`, `session_token` | [Use temporary security credentials](#use-temporary-security-credentials) |
+| Shared Credentials | `shared_credential_file`, `credential_profile_name` | [Use a shared credentials file](#use-a-shared-credentials-file) |
+| Assume Role | `role_arn` | [Use an IAM role Amazon Resource Name (ARN)](#use-an-iam-role-amazon-resource-name-arn) |
+| Instance or Pod IAM Role | none | [Use an EC2 instance's or pod's IAM Role](#use-an-ec2-instances-or-pods-iam-role) |
+| Identity Federation | Federated identity (agentless only) | Cloud Connectors; shown only for Elastic-managed (agentless) deployments |
 
 #### Use access keys directly
 
@@ -156,26 +160,20 @@ Instead, when you assume a role it provides you with temporary security credenti
 IAM role ARN can be used to specify which AWS IAM role to assume to generate temporary credentials.
 For more details, refer to [AssumeRole API documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
-To use an IAM role ARN, you need to provide either a [credential profile](#use-a-shared-credentials-file) or
-[access keys](#use-access-keys-directly) along with the `role_arn` advanced option.
-`role_arn` is used to specify which AWS IAM role to assume for generating temporary credentials.
+Select the **Assume Role** method and provide `role_arn`, the IAM role to assume for generating temporary credentials.
+The credentials used to call `AssumeRole` come from the AWS SDK default credential chain on the host running Elastic Agent
+(environment variables, the default shared credentials profile, or the EC2 instance profile / pod role).
 
-Note: If `role_arn` is given, the package will check if access keys are given.
-If they are not given, the package will check for a credential profile name.
-If neither is given, the default credential profile will be used. 
+Note: **Assume Role** always calls `AssumeRole` on the given `role_arn`. If you only want to use the role that is
+already attached to the EC2 instance or pod, use the **Instance or Pod IAM Role** method instead and leave `role_arn` unset.
 
-#### Use an EC2 instance's IAM Role
+#### Use an EC2 instance's or pod's IAM Role
 
 When Elastic Agent runs on an EC2 instance that has an IAM role attached via an instance profile, it can automatically authenticate to AWS services using a temporary access key pair and session token provided by the Instance Metadata Service (IMDS). For more details, refer to [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
+The same applies to Elastic Agent running in Kubernetes on Amazon EKS with [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) or [IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 
-To use the IAM role attached to the EC2 instance, leave all of the following options empty:
-
-* `access_key_id`
-* `secret_access_key`
-* `session_token`
-* `credential_profile_name`
-* `shared_credential_file`
-* `role_arn`
+To use the IAM role attached to the EC2 instance or pod, select the **Instance or Pod IAM Role** method under **Setup Access**.
+No credential fields are shown or required; Elastic Agent resolves credentials through the AWS SDK default credential chain.
 
 ### AWS Permissions
 

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.4
 name: aws
 title: AWS
-version: 8.1.1
+version: 8.1.2
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -137,6 +137,11 @@ var_groups:
       - name: shared_credentials
         title: Shared Credentials
         vars: [shared_credential_file, credential_profile_name]
+        hide_in_deployment_modes: [agentless]
+      - name: default_credentials
+        title: Instance or Pod IAM Role
+        description: Use the IAM role attached to the EC2 instance profile or Kubernetes pod (EKS Pod Identity or IRSA). Credentials are discovered by the AWS SDK default credential chain, so no fields are required.
+        vars: []
         hide_in_deployment_modes: [agentless]
 policy_templates:
   - name: awshealth


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws: Add Instance/Pod IAM Role option to Setup Access selector

Add a default_credentials var_group option (displayed as "Instance or Pod IAM Role") with no
required fields, so Elastic Agent can authenticate using the AWS SDK default credential chain
(EC2 instance profile, EKS Pod Identity, IRSA) without entering access keys or a Role ARN.
This restores the documented capability that was blocked when the credential_type var_group
became required with all-var options in 7.0.0 (#19828).

Update the credentials documentation to clarify the Setup Access selector, explain each option's
purpose, and distinguish "Assume Role" (assumes a specified role) from "Instance/Pod IAM Role"
(uses the role attached to the host).
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

### Existing option unchanged
<img width="850" height="722" alt="Screenshot 2026-09-02 at 11 25 06 PM" src="https://github.com/user-attachments/assets/bc21a805-7170-482a-ba54-5b53bfef53ab" />

### New option
<img width="850" height="722" alt="Screenshot 2026-09-02 at 11 25 23 PM" src="https://github.com/user-attachments/assets/a4524026-acf6-4b9e-a56c-08791cd2f925" />



