### PR TITLE
[Backport] Add backport-aws-7.1 entry for aws package

### DIFF
--- a/.backports.yml
+++ b/.backports.yml
@@ -27,6 +27,13 @@ backports:
     archived: true
     remove_other_packages: true
   - package: aws
+    branch: backport-aws-7.1
+    base_version: "7.1.1"
+    base_commit: "d3ca77ff4c"
+    maintained_until: null
+    archived: false
+    remove_other_packages: true
+  - package: aws
     branch: backport-aws-6.x
     base_version: "6.21.0"
     base_commit: "913b779a20"


### PR DESCRIPTION
## Proposed commit message

```
[Backport] Add backport-aws-7.1 entry for aws package

Add a new entry in `.backports.yml` for the `aws` package backport branch
`backport-aws-7.1`, based on version 7.1.1 (commit d3ca77ff4c).

aws 7.1.1 is the last release installable on Kibana 9.4.x and 9.5.x
(`kibana.version: ^9.4.0`); 7.2.0 and later require Kibana ^9.6.0. A
branch at 7.1.1 is needed to ship the fix for the `Setup Access`
selector, which since 7.0.0 offers no option for authenticating with
the EC2 instance profile / pod IAM role (elastic/integrations#21025), to
users who cannot yet upgrade to 9.6.

The branch is active (`archived: false`) and strips all other packages
(`remove_other_packages: true`), consistent with the backport-aws-6.x
entry.
```

## Why a 7.1 branch

| aws version | `kibana.version` | Installable on Kibana 9.5.x |
|---|---|---|
| 6.21.0 (`backport-aws-6.x`) | `^8.19.4 \|\| ^9.2.1` | yes, but predates `var_groups`, so not affected |
| 7.0.0 – 7.1.1 | `^9.4.0` | yes, affected |
| 7.2.0 – 8.1.1 (main) | `^9.6.0` | no |

The fix on `main` (a `default_credentials` option with `vars: []` in the `credential_type` var_group) will ship as 8.1.2 and can never be installed on 9.4/9.5. A 7.1.2 release from this branch is the only way to reach those users.

## Author's Checklist

- [x] `base_version` matches the package version at the point the branch diverged from main (7.1.1).
- [x] `base_commit` is the exact commit on main that published 7.1.1: `d3ca77ff4c` (resolved with `./dev/scripts/get_release_commit.sh -p aws -v 7.1.1`).
- [x] `maintained_until` is `null`; can be set to the Kibana 9.5 end-of-support date if preferred.
- [x] `archived: false` — branch is active and should receive backports.
- [x] `remove_other_packages: true` — only the `aws` package is kept on the branch.

## How to test this PR locally

No local testing required. CI validates the `.backports.yml` entry (inventory check) and dry-runs the backport branch creation. After merge, the `backport-aws-7.1` branch is created automatically by CI.

## Related issues

- https://github.com/elastic/integrations/pull/21025
- Follow-up: fix PR against `backport-aws-7.1` releasing aws 7.1.2, then a changelog sync PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
