### PR TITLE
google_workspace: lengthen Gemini lag setting

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Lengthen Gemini lag setting to reduce missed events at polling window boundaries.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/20964
+      link: https://github.com/elastic/integrations/pull/21028
 - version: "3.8.0"
   changes:
     - description: Add `gmail_reports` data stream to collect Gmail activity events from the Google Reports API.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.1"
+  changes:
+    - description: Lengthen Gemini lag setting to reduce missed events at polling window boundaries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/20964
 - version: "3.8.0"
   changes:
     - description: Add `gmail_reports` data stream to collect Gmail activity events from the Google Reports API.

--- a/packages/google_workspace/data_stream/gemini/manifest.yml
+++ b/packages/google_workspace/data_stream/gemini/manifest.yml
@@ -34,7 +34,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 3m
+        default: 5m
       - name: batch_size
         type: integer
         title: Batch Size

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "3.8.0"
+version: "3.8.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
google_workspace: lengthen Gemini lag setting

Increase the default lag_time for the gemini data stream from 3m to
5m. Events near polling window boundaries were being skipped with the
shorter lag.

Fixes #20964
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #20964

