### PR TITLE
[system] Populate event.action for Linux IAM auth events and sudo systemctl

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.23.5"
+  changes:
+    - description: Populate `event.action` for Linux useradd/userdel/groupadd/groupdel auth events, extract `group.name` from gshadow/group file lines, and set `service.name` plus `event.action` for sudo systemctl start/stop/restart commands.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/20851
 - version: "2.23.4"
   changes:
     - description: Include Windows Security event 6272 in subject-field ECS mapping (SubjectUserSid, SubjectUserName, SubjectDomainName) like other audited events.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Populate `event.action` for Linux useradd/userdel/groupadd/groupdel auth events, extract `group.name` from gshadow/group file lines, and set `service.name` plus `event.action` for sudo systemctl start/stop/restart commands.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/20851
+      link: https://github.com/elastic/integrations/pull/21042
 - version: "2.23.4"
   changes:
     - description: Include Windows Security event 6272 in subject-field ECS mapping (SubjectUserSid, SubjectUserName, SubjectDomainName) like other audited events.

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
@@ -13,6 +13,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],
@@ -790,6 +791,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -924,6 +926,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-deleted",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
@@ -13,6 +13,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],
@@ -766,6 +767,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -894,6 +896,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-deleted",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-rhel79.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-rhel79.log-expected.json
@@ -6,6 +6,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],
@@ -49,6 +50,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-deleted",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
@@ -2316,6 +2316,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -2327,6 +2328,10 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "id": "1003",
+                "name": "tsg"
             },
             "host": {
                 "hostname": "precise32"
@@ -2354,6 +2359,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -2365,6 +2371,9 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "name": "tsg"
             },
             "host": {
                 "hostname": "precise32"
@@ -2392,6 +2401,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -2434,6 +2444,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],
@@ -4642,6 +4653,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -4653,6 +4665,10 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "id": "111",
+                "name": "mysql"
             },
             "host": {
                 "hostname": "precise32"
@@ -4680,6 +4696,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -4691,6 +4708,9 @@
                     "group",
                     "creation"
                 ]
+            },
+            "group": {
+                "name": "mysql"
             },
             "host": {
                 "hostname": "precise32"
@@ -4718,6 +4738,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -4760,6 +4781,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth.log-expected.json
@@ -468,6 +468,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-created",
                 "category": [
                     "iam"
                 ],
@@ -510,6 +511,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
@@ -51,6 +51,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-deleted",
                 "category": [
                     "iam"
                 ],
@@ -104,6 +105,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-created",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log
@@ -1,0 +1,12 @@
+2026-08-14T10:55:26.000000+00:00 host01 useradd[3823271]: new user: name=testuser, UID=16004, GID=16004, home=/home/testuser, shell=/bin/bash
+2026-08-20T10:08:02.000000+00:00 host01 userdel[2848204]: delete user 'testuser1'
+2026-08-20T10:07:04.000000+00:00 host01 groupadd[2846675]: new group: name=testgroup, GID=16005
+2026-08-20T10:08:25.000000+00:00 host01 groupdel[2849001]: group 'testgroup' removed
+2026-08-20T09:59:53.000000+00:00 host01 useradd[2827781]: new group: name=testuser1, GID=16004
+2026-08-20T10:08:02.000000+00:00 host01 userdel[2848204]: removed group 'testuser1' owned by 'testuser1'
+2026-07-29T16:04:11.000000+00:00 host01 userdel[5845]: removed group 'testsiemlog' owned by 'testsiemlog'
+2026-08-14T11:03:49.000000+00:00 host01 sudo[3843970]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog
+2026-07-29T16:04:56.000000+00:00 host01 sudo[3843971]: testuser : TTY=pts/2 ; PWD=/home/testuser ; USER=root ; COMMAND=/bin/systemctl start rsyslog
+2026-08-20T10:07:03.000000+00:00 host01 groupadd[2846675]: group added to /etc/gshadow: name=testgroup
+2026-08-20T10:08:24.000000+00:00 host01 groupdel[2849001]: group 'testgroup' removed from /etc/gshadow
+2026-08-14T11:04:10.000000+00:00 host01 sudo[3843972]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog.service

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log
@@ -10,3 +10,5 @@
 2026-08-20T10:07:03.000000+00:00 host01 groupadd[2846675]: group added to /etc/gshadow: name=testgroup
 2026-08-20T10:08:24.000000+00:00 host01 groupdel[2849001]: group 'testgroup' removed from /etc/gshadow
 2026-08-14T11:04:10.000000+00:00 host01 sudo[3843972]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog.service
+2026-08-14T11:04:20.000000+00:00 host01 sudo[3843973]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl start --no-block rsyslog
+2026-08-14T11:04:30.000000+00:00 host01 sudo[3843974]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl --user stop --now rsyslog

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-config.yml
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-config.yml
@@ -1,0 +1,4 @@
+fields:
+  input.type: log
+dynamic_fields:
+  "event.ingested": "^.*$"

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-config.yml
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-config.yml
@@ -1,4 +1,2 @@
 fields:
   input.type: log
-dynamic_fields:
-  "event.ingested": "^.*$"

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-expected.json
@@ -1,0 +1,579 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-08-14T10:55:26.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "user-created",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-14T10:55:26.000000+00:00 host01 useradd[3823271]: new user: name=testuser, UID=16004, GID=16004, home=/home/testuser, shell=/bin/bash",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "creation"
+                ]
+            },
+            "group": {
+                "id": "16004"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "new user: name=testuser, UID=16004, GID=16004, home=/home/testuser, shell=/bin/bash",
+            "process": {
+                "name": "useradd",
+                "pid": 3823271
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "testuser"
+                ]
+            },
+            "system": {
+                "auth": {
+                    "useradd": {
+                        "home": "/home/testuser",
+                        "shell": "/bin/bash"
+                    }
+                }
+            },
+            "user": {
+                "id": "16004",
+                "name": "testuser",
+                "target": {
+                    "id": "16004",
+                    "name": "testuser"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T10:08:02.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "user-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T10:08:02.000000+00:00 host01 userdel[2848204]: delete user 'testuser1'",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "deletion"
+                ]
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "delete user 'testuser1'",
+            "process": {
+                "name": "userdel",
+                "pid": 2848204
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "testuser1"
+                ]
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "name": "testuser1",
+                "target": {
+                    "name": "testuser1"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T10:07:04.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-created",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T10:07:04.000000+00:00 host01 groupadd[2846675]: new group: name=testgroup, GID=16005",
+                "outcome": "success",
+                "type": [
+                    "group",
+                    "creation"
+                ]
+            },
+            "group": {
+                "id": "16005",
+                "name": "testgroup"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "new group: name=testgroup, GID=16005",
+            "process": {
+                "name": "groupadd",
+                "pid": 2846675
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T10:08:25.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T10:08:25.000000+00:00 host01 groupdel[2849001]: group 'testgroup' removed",
+                "outcome": "success",
+                "type": [
+                    "group",
+                    "deletion"
+                ]
+            },
+            "group": {
+                "name": "testgroup"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "group 'testgroup' removed",
+            "process": {
+                "name": "groupdel",
+                "pid": 2849001
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T09:59:53.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-created",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T09:59:53.000000+00:00 host01 useradd[2827781]: new group: name=testuser1, GID=16004",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "creation"
+                ]
+            },
+            "group": {
+                "id": "16004",
+                "name": "testuser1"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "new group: name=testuser1, GID=16004",
+            "process": {
+                "name": "useradd",
+                "pid": 2827781
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T10:08:02.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T10:08:02.000000+00:00 host01 userdel[2848204]: removed group 'testuser1' owned by 'testuser1'",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "deletion"
+                ]
+            },
+            "group": {
+                "name": "testuser1"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "removed group 'testuser1' owned by 'testuser1'",
+            "process": {
+                "name": "userdel",
+                "pid": 2848204
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "testuser1"
+                ]
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "target": {
+                    "name": "testuser1"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-07-29T16:04:11.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-07-29T16:04:11.000000+00:00 host01 userdel[5845]: removed group 'testsiemlog' owned by 'testsiemlog'",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "deletion"
+                ]
+            },
+            "group": {
+                "name": "testsiemlog"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "removed group 'testsiemlog' owned by 'testsiemlog'",
+            "process": {
+                "name": "userdel",
+                "pid": 5845
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "testsiemlog"
+                ]
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "target": {
+                    "name": "testsiemlog"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-08-14T11:03:49.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-stop",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "2026-08-14T11:03:49.000000+00:00 host01 sudo[3843970]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog",
+            "process": {
+                "name": "sudo",
+                "pid": 3843970
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "root"
+                ]
+            },
+            "service": {
+                "name": "rsyslog"
+            },
+            "system": {
+                "auth": {
+                    "sudo": {
+                        "command": "/bin/systemctl stop rsyslog",
+                        "pwd": "/home",
+                        "tty": "pts/2",
+                        "user": "root"
+                    }
+                }
+            },
+            "user": {
+                "effective": {
+                    "name": "root"
+                },
+                "name": "root"
+            }
+        },
+        {
+            "@timestamp": "2026-07-29T16:04:56.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-start",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "2026-07-29T16:04:56.000000+00:00 host01 sudo[3843971]: testuser : TTY=pts/2 ; PWD=/home/testuser ; USER=root ; COMMAND=/bin/systemctl start rsyslog",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "testuser : TTY=pts/2 ; PWD=/home/testuser ; USER=root ; COMMAND=/bin/systemctl start rsyslog",
+            "process": {
+                "name": "sudo",
+                "pid": 3843971
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "testuser",
+                    "root"
+                ]
+            },
+            "service": {
+                "name": "rsyslog"
+            },
+            "system": {
+                "auth": {
+                    "sudo": {
+                        "command": "/bin/systemctl start rsyslog",
+                        "pwd": "/home/testuser",
+                        "tty": "pts/2",
+                        "user": "root"
+                    }
+                }
+            },
+            "user": {
+                "effective": {
+                    "name": "root"
+                },
+                "name": "testuser"
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T10:07:03.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-created",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T10:07:03.000000+00:00 host01 groupadd[2846675]: group added to /etc/gshadow: name=testgroup",
+                "outcome": "success",
+                "type": [
+                    "group",
+                    "creation"
+                ]
+            },
+            "group": {
+                "name": "testgroup"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "group added to /etc/gshadow: name=testgroup",
+            "process": {
+                "name": "groupadd",
+                "pid": 2846675
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-08-20T10:08:24.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "group-deleted",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-08-20T10:08:24.000000+00:00 host01 groupdel[2849001]: group 'testgroup' removed from /etc/gshadow",
+                "outcome": "success",
+                "type": [
+                    "group",
+                    "deletion"
+                ]
+            },
+            "group": {
+                "name": "testgroup"
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "group 'testgroup' removed from /etc/gshadow",
+            "process": {
+                "name": "groupdel",
+                "pid": 2849001
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
+        },
+        {
+            "@timestamp": "2026-08-14T11:04:10.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-stop",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "2026-08-14T11:04:10.000000+00:00 host01 sudo[3843972]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog.service",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog.service",
+            "process": {
+                "name": "sudo",
+                "pid": 3843972
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "root"
+                ]
+            },
+            "service": {
+                "name": "rsyslog"
+            },
+            "system": {
+                "auth": {
+                    "sudo": {
+                        "command": "/bin/systemctl stop rsyslog.service",
+                        "pwd": "/home",
+                        "tty": "pts/2",
+                        "user": "root"
+                    }
+                }
+            },
+            "user": {
+                "effective": {
+                    "name": "root"
+                },
+                "name": "root"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-iam-systemctl.log-expected.json
@@ -340,7 +340,7 @@
                 "kind": "event",
                 "original": "2026-08-14T11:03:49.000000+00:00 host01 sudo[3843970]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog",
                 "type": [
-                    "start"
+                    "end"
                 ]
             },
             "host": {
@@ -533,7 +533,7 @@
                 "kind": "event",
                 "original": "2026-08-14T11:04:10.000000+00:00 host01 sudo[3843972]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl stop rsyslog.service",
                 "type": [
-                    "start"
+                    "end"
                 ]
             },
             "host": {
@@ -562,6 +562,116 @@
                 "auth": {
                     "sudo": {
                         "command": "/bin/systemctl stop rsyslog.service",
+                        "pwd": "/home",
+                        "tty": "pts/2",
+                        "user": "root"
+                    }
+                }
+            },
+            "user": {
+                "effective": {
+                    "name": "root"
+                },
+                "name": "root"
+            }
+        },
+        {
+            "@timestamp": "2026-08-14T11:04:20.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-start",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "2026-08-14T11:04:20.000000+00:00 host01 sudo[3843973]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl start --no-block rsyslog",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl start --no-block rsyslog",
+            "process": {
+                "name": "sudo",
+                "pid": 3843973
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "root"
+                ]
+            },
+            "service": {
+                "name": "rsyslog"
+            },
+            "system": {
+                "auth": {
+                    "sudo": {
+                        "command": "/bin/systemctl start --no-block rsyslog",
+                        "pwd": "/home",
+                        "tty": "pts/2",
+                        "user": "root"
+                    }
+                }
+            },
+            "user": {
+                "effective": {
+                    "name": "root"
+                },
+                "name": "root"
+            }
+        },
+        {
+            "@timestamp": "2026-08-14T11:04:30.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "service-stop",
+                "category": [
+                    "process"
+                ],
+                "kind": "event",
+                "original": "2026-08-14T11:04:30.000000+00:00 host01 sudo[3843974]: root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl --user stop --now rsyslog",
+                "type": [
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "host01"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "root : TTY=pts/2 ; PWD=/home ; USER=root ; COMMAND=/bin/systemctl --user stop --now rsyslog",
+            "process": {
+                "name": "sudo",
+                "pid": 3843974
+            },
+            "related": {
+                "hosts": [
+                    "host01"
+                ],
+                "user": [
+                    "root"
+                ]
+            },
+            "service": {
+                "name": "rsyslog"
+            },
+            "system": {
+                "auth": {
+                    "sudo": {
+                        "command": "/bin/systemctl --user stop --now rsyslog",
                         "pwd": "/home",
                         "tty": "pts/2",
                         "user": "root"

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-userdel.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-userdel.log-expected.json
@@ -104,6 +104,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "user-deleted",
                 "category": [
                     "iam"
                 ],
@@ -150,6 +151,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-deleted",
                 "category": [
                     "iam"
                 ],
@@ -190,6 +192,7 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "group-deleted",
                 "category": [
                     "iam"
                 ],

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
@@ -21,6 +21,8 @@ processors:
         - '^%{SPACE}%{DATA:user.name} :(?: ((?!TTY=)%{DATA:system.auth.sudo.error}) ;)?(?: TTY=%{DATA:system.auth.sudo.tty} ;)? PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}'
         - '^new group: name=%{DATA:group.name}, GID=%{NUMBER:group.id}'
         - '^new user: name=%{DATA:user.target.name}, UID=%{NUMBER:user.target.id}, GID=%{NUMBER:group.id}, home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$'
+        - '^group added to /etc/(?:group|gshadow): name=%{DATA:group.name}(?:, GID=%{NUMBER:group.id})?$'
+        - "^group '%{DATA:group.name}' removed(?: from /etc/(?:group|gshadow))?$"
   - set:
       description: >-
         Deprecated duplication of user.target.name for backward compatibility;
@@ -104,7 +106,7 @@ processors:
       patterns:
         - "^delete '%{USERNAME:_temp.userdel_user}' from (?:shadow )?group '%{DATA:_temp.userdel_group}'$"
         - "^delete user '%{USERNAME:_temp.userdel_user}'$"
-        - "^removed (?:shadow )?group '%{DATA:_temp.userdel_group}'"
+        - "^removed (?:shadow )?group '%{DATA:_temp.userdel_group}'(?: owned by '%{DATA:_temp.userdel_owner}')?"
   - grok:
       description: Grok usernames from PAM messages.
       tag: grok-pam-users
@@ -235,6 +237,12 @@ processors:
       copy_from: _temp.userdel_group
       ignore_empty_value: true
       if: ctx._temp?.userdel_group != null
+  - set:
+      tag: set_user_target_name_userdel_owner
+      field: user.target.name
+      copy_from: _temp.userdel_owner
+      ignore_empty_value: true
+      if: ctx._temp?.userdel_owner != null && (ctx.user?.target?.name == null || ctx.user.target.name == '')
   - set:
       tag: set_action_group_member_removed
       field: event.action
@@ -496,6 +504,65 @@ processors:
       type: string
       ignore_failure: true
       if: ctx.system?.auth?.sudo?.user != null
+  - script:
+      description: >-
+        Extract service.name and event.action from sudo systemctl start/stop/restart
+        commands so service lifecycle events match ECS (and system.syslog).
+      tag: script-categorize-sudo-systemctl
+      if: ctx.system?.auth?.sudo?.command != null
+      lang: painless
+      source: >-
+        def cmd = ctx.system.auth.sudo.command;
+        def matcher = /(?:^|\/)systemctl(?=\s|$)/.matcher(cmd);
+        if (!matcher.find()) {
+          return;
+        }
+        def rest = cmd.substring(matcher.end()).trim();
+        if (rest == '') {
+          return;
+        }
+        def parts = rest.splitOnToken(" ");
+        def verb = null;
+        def unit = null;
+        for (int i = 0; i < parts.length; i++) {
+          def part = parts[i];
+          if (part == '' || part.startsWith('-')) {
+            continue;
+          }
+          verb = part;
+          if (i + 1 < parts.length) {
+            unit = parts[i + 1];
+          }
+          break;
+        }
+        if (verb == null || unit == null || unit == '') {
+          return;
+        }
+        def action = null;
+        if (verb == 'start') {
+          action = 'service-start';
+        } else if (verb == 'stop') {
+          action = 'service-stop';
+        } else if (verb == 'restart') {
+          action = 'service-restart';
+        } else {
+          return;
+        }
+        if (unit.endsWith('.service')) {
+          unit = unit.substring(0, unit.length() - 8);
+        }
+        int slash = unit.lastIndexOf('/');
+        if (slash >= 0) {
+          unit = unit.substring(slash + 1);
+        }
+        if (ctx.service == null) {
+          ctx.service = [:];
+        }
+        ctx.service.name = unit;
+        if (ctx.event == null) {
+          ctx.event = [:];
+        }
+        ctx.event.action = action;
   - convert:
       tag: convert_dropped-ip
       field: system.auth.ssh.dropped_ip
@@ -621,6 +688,43 @@ processors:
       field: event.type
       value: change
       if: ctx.process?.name != null && ['usermod', 'groupmod'].contains(ctx.process.name)
+  - script:
+      description: >-
+        Set event.action for user/group management when a more specific action
+        (for example group-member-added) has not already been set.
+      tag: script-categorize-iam-action
+      if: ctx.event?.action == null && ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)
+      lang: painless
+      source: >-
+        def msg = ctx.message;
+        def proc = ctx.process.name;
+        if (msg != null) {
+          if (msg.startsWith('new user:') || msg.startsWith('failed adding user ')) {
+            ctx.event.action = 'user-created';
+            return;
+          }
+          if (msg.startsWith('new group:') || msg.startsWith('group added to ')) {
+            ctx.event.action = 'group-created';
+            return;
+          }
+          if (msg.startsWith("delete user ")) {
+            ctx.event.action = 'user-deleted';
+            return;
+          }
+          if (msg.startsWith("group '") || msg.startsWith('removed group ') || msg.startsWith('removed shadow group ')) {
+            ctx.event.action = 'group-deleted';
+            return;
+          }
+        }
+        if (proc == 'useradd') {
+          ctx.event.action = 'user-created';
+        } else if (proc == 'userdel') {
+          ctx.event.action = 'user-deleted';
+        } else if (proc == 'groupadd') {
+          ctx.event.action = 'group-created';
+        } else if (proc == 'groupdel') {
+          ctx.event.action = 'group-deleted';
+        }
   - append:
       tag: append_related-user-name
       field: related.user

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
@@ -506,8 +506,9 @@ processors:
       if: ctx.system?.auth?.sudo?.user != null
   - script:
       description: >-
-        Extract service.name and event.action from sudo systemctl start/stop/restart
-        commands so service lifecycle events match ECS (and system.syslog).
+        Extract service.name, event.action, and event.type from sudo systemctl
+        start/stop/restart commands so service lifecycle events match ECS (and
+        system.syslog).
       tag: script-categorize-sudo-systemctl
       if: ctx.system?.auth?.sudo?.command != null
       lang: painless
@@ -530,8 +531,13 @@ processors:
             continue;
           }
           verb = part;
-          if (i + 1 < parts.length) {
-            unit = parts[i + 1];
+          for (int j = i + 1; j < parts.length; j++) {
+            def candidate = parts[j];
+            if (candidate == '' || candidate.startsWith('-')) {
+              continue;
+            }
+            unit = candidate;
+            break;
           }
           break;
         }
@@ -539,12 +545,16 @@ processors:
           return;
         }
         def action = null;
+        def eventType = null;
         if (verb == 'start') {
           action = 'service-start';
+          eventType = 'start';
         } else if (verb == 'stop') {
           action = 'service-stop';
+          eventType = 'end';
         } else if (verb == 'restart') {
           action = 'service-restart';
+          eventType = 'change';
         } else {
           return;
         }
@@ -563,6 +573,7 @@ processors:
           ctx.event = [:];
         }
         ctx.event.action = action;
+        ctx.event.type = [eventType];
   - convert:
       tag: convert_dropped-ip
       field: system.auth.ssh.dropped_ip

--- a/packages/system/data_stream/auth/fields/fields.yml
+++ b/packages/system/data_stream/auth/fields/fields.yml
@@ -62,6 +62,8 @@
         # To be moved to ecs.yml after ECS version upgrade
         - name: version
           type: keyword
+- name: service.name
+  external: ecs
 - description: "Operating system version as a raw string."
   ignore_above: 1024
   name: version

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -989,6 +989,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type | keyword |
 | log.offset | Log offset | long |
+| service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |
 | system.auth.ssh.dropped_ip | The client IP from SSH connections that are open and immediately dropped. | ip |
 | system.auth.ssh.event | The SSH event as found in the logs (Accepted, Invalid, Failed, etc.) | keyword |
 | system.auth.ssh.method | The SSH authentication method. Can be one of "password" or "publickey". | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.23.4"
+version: "2.23.5"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

The `system.auth` pipeline already treated `useradd`/`userdel`/`groupadd`/`groupdel` as IAM events but left `event.action` empty. Sudo `systemctl start|stop|restart` also omitted `service.name`.

This fills `event.action` (`user-created`, `user-deleted`, `group-created`, `group-deleted`), extracts `group.name` from `/etc/group` and `/etc/gshadow` lines, and sets `service.name` plus `service-start`/`service-stop`/`service-restart` for sudo systemctl.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) (no dashboard was added).

## How to test this PR locally

```bash
cd packages/system
elastic-package test pipeline --data-streams auth
```

## Related issues

- Closes #20851
- Relates #20063