### PR TITLE
traefik_otel: aggregate counter metrics with the ES|QL TS command and scope cumulativetodelta to histograms

### DIFF
--- a/packages/traefik_otel/_dev/shared/kibana/traefik_otel-overview.yaml
+++ b/packages/traefik_otel/_dev/shared/kibana/traefik_otel-overview.yaml
@@ -65,14 +65,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-            - EVAL duration_sec = DATE_DIFF("seconds", min_ts, max_ts)
-            - EVAL request_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)
-            - KEEP request_rate
+            - STATS request_rate = SUM(RATE(traefik_entrypoint_requests_total))
           primary:
             field: request_rate
             label: Req/sec
@@ -87,14 +83,12 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_requests_total),
-              errors_5xx = SUM(traefik_entrypoint_requests_total)
-                WHERE attributes.code LIKE "5*"
+            - STATS total = SUM(RATE(traefik_entrypoint_requests_total)), errors_5xx = SUM(RATE(traefik_entrypoint_requests_total)) WHERE attributes.code LIKE "5*"
             - EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)
-            - STATS error_rate = MAX(error_rate)
+            - KEEP error_rate
           primary:
             field: error_rate
             label: 5xx Rate
@@ -125,14 +119,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_responses_bytes_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-            - EVAL duration_sec = DATE_DIFF("seconds", min_ts, max_ts)
-            - EVAL bytes_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)
-            - KEEP bytes_rate
+            - STATS bytes_rate = SUM(RATE(traefik_entrypoint_responses_bytes_total))
           primary:
             field: bytes_rate
             label: Bytes/sec
@@ -147,15 +137,11 @@ dashboards:
           type: area
           mode: stacked
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
-                attributes.entrypoint
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL request_rate = total / bucket_secs
+            - STATS request_rate = SUM(RATE(traefik_entrypoint_requests_total))
+              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.entrypoint
             - KEEP time_bucket, attributes.entrypoint, request_rate
             - SORT time_bucket ASC
           dimension:
@@ -180,15 +166,11 @@ dashboards:
           type: bar
           mode: stacked
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
-                attributes.code
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL requests = total / bucket_secs
+            - STATS requests = SUM(RATE(traefik_entrypoint_requests_total))
+              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code
             - KEEP time_bucket, attributes.code, requests
             - SORT time_bucket ASC
           dimension:
@@ -249,11 +231,10 @@ dashboards:
         esql:
           type: pie
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_total IS NOT NULL
-            - STATS total_requests = SUM(traefik_entrypoint_requests_total)
-              BY attributes.code
+            - STATS total_requests = SUM(INCREASE(traefik_entrypoint_requests_total)) BY attributes.code
             - SORT total_requests DESC
             - LIMIT 10
           metrics:
@@ -270,14 +251,11 @@ dashboards:
         esql:
           type: line
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_responses_bytes_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
+            - STATS bytes_rate = SUM(RATE(traefik_entrypoint_responses_bytes_total))
               BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL bytes_rate = total / bucket_secs
             - KEEP time_bucket, bytes_rate
             - SORT time_bucket ASC
           dimension:
@@ -298,11 +276,10 @@ dashboards:
         esql:
           type: datatable
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_total IS NOT NULL
-            - STATS total_requests = SUM(traefik_entrypoint_requests_total)
-              BY attributes.entrypoint
+            - STATS total_requests = SUM(INCREASE(traefik_entrypoint_requests_total)) BY attributes.entrypoint
             - SORT total_requests DESC
             - LIMIT 20
           breakdowns:

--- a/packages/traefik_otel/_dev/shared/kibana/traefik_otel-process.yaml
+++ b/packages/traefik_otel/_dev/shared/kibana/traefik_otel-process.yaml
@@ -61,14 +61,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE process_cpu_seconds_total IS NOT NULL
-            - STATS total = SUM(process_cpu_seconds_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-            - EVAL duration_sec = DATE_DIFF("seconds", min_ts, max_ts)
-            - EVAL cpu_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)
-            - KEEP cpu_rate
+            - STATS cpu_rate = SUM(RATE(process_cpu_seconds_total))
           primary:
             field: cpu_rate
             label: CPU sec/sec
@@ -159,14 +155,11 @@ dashboards:
         esql:
           type: line
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE process_cpu_seconds_total IS NOT NULL
-            - STATS total = SUM(process_cpu_seconds_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
+            - STATS cpu_rate = SUM(RATE(process_cpu_seconds_total))
               BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL cpu_rate = total / bucket_secs
             - KEEP time_bucket, cpu_rate
             - SORT time_bucket ASC
           dimension:

--- a/packages/traefik_otel/_dev/shared/kibana/traefik_otel-services.yaml
+++ b/packages/traefik_otel/_dev/shared/kibana/traefik_otel-services.yaml
@@ -64,14 +64,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_service_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-            - EVAL duration_sec = DATE_DIFF("seconds", min_ts, max_ts)
-            - EVAL request_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)
-            - KEEP request_rate
+            - STATS request_rate = SUM(RATE(traefik_service_requests_total))
           primary:
             field: request_rate
             label: Req/sec
@@ -86,14 +82,12 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_service_requests_total),
-              errors_5xx = SUM(traefik_service_requests_total)
-                WHERE attributes.code LIKE "5*"
+            - STATS total = SUM(RATE(traefik_service_requests_total)), errors_5xx = SUM(RATE(traefik_service_requests_total)) WHERE attributes.code LIKE "5*"
             - EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)
-            - STATS error_rate = MAX(error_rate)
+            - KEEP error_rate
           primary:
             field: error_rate
             label: 5xx Rate
@@ -124,14 +118,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_responses_bytes_total IS NOT NULL
-            - STATS total = SUM(traefik_service_responses_bytes_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-            - EVAL duration_sec = DATE_DIFF("seconds", min_ts, max_ts)
-            - EVAL bytes_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)
-            - KEEP bytes_rate
+            - STATS bytes_rate = SUM(RATE(traefik_service_responses_bytes_total))
           primary:
             field: bytes_rate
             label: Bytes/sec
@@ -145,15 +135,11 @@ dashboards:
           type: area
           mode: stacked
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_service_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
-                attributes.service
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL request_rate = total / bucket_secs
+            - STATS request_rate = SUM(RATE(traefik_service_requests_total))
+              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service
             - KEEP time_bucket, attributes.service, request_rate
             - SORT time_bucket ASC
           dimension:
@@ -178,16 +164,12 @@ dashboards:
           type: bar
           mode: stacked
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
             - WHERE attributes.code LIKE "5*"
-            - STATS total = SUM(traefik_service_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
-                attributes.service
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL errors = total / bucket_secs
+            - STATS errors = SUM(RATE(traefik_service_requests_total))
+              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service
             - KEEP time_bucket, attributes.service, errors
             - SORT time_bucket ASC
           dimension:
@@ -212,15 +194,11 @@ dashboards:
           type: bar
           mode: stacked
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
-            - STATS total = SUM(traefik_service_requests_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
-                attributes.code
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL requests = total / bucket_secs
+            - STATS requests = SUM(RATE(traefik_service_requests_total))
+              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code
             - KEEP time_bucket, attributes.code, requests
             - SORT time_bucket ASC
           dimension:
@@ -251,12 +229,10 @@ dashboards:
         esql:
           type: datatable
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
-            - STATS total_requests = SUM(traefik_service_requests_total),
-              errors_5xx = SUM(traefik_service_requests_total)
-                WHERE attributes.code LIKE "5*"
+            - STATS total_requests = SUM(INCREASE(traefik_service_requests_total)), errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE "5*"
               BY attributes.service
             - EVAL error_rate = CASE(total_requests > 0, errors_5xx / total_requests, 0.0)
             - SORT total_requests DESC
@@ -282,12 +258,10 @@ dashboards:
         esql:
           type: datatable
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_service_requests_total IS NOT NULL
-            - STATS total_requests = SUM(traefik_service_requests_total),
-              errors_5xx = SUM(traefik_service_requests_total)
-                WHERE attributes.code LIKE "5*"
+            - STATS total_requests = SUM(INCREASE(traefik_service_requests_total)), errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE "5*"
               BY attributes.service
             - WHERE total_requests > 0
             - EVAL error_rate = errors_5xx / total_requests

--- a/packages/traefik_otel/_dev/shared/kibana/traefik_otel-tls-config.yaml
+++ b/packages/traefik_otel/_dev/shared/kibana/traefik_otel-tls-config.yaml
@@ -80,14 +80,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_tls_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_requests_tls_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-            - EVAL duration_sec = DATE_DIFF("seconds", min_ts, max_ts)
-            - EVAL tls_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)
-            - KEEP tls_rate
+            - STATS tls_rate = SUM(RATE(traefik_entrypoint_requests_tls_total))
           primary:
             field: tls_rate
             label: TLS Req/sec
@@ -102,10 +98,10 @@ dashboards:
         esql:
           type: metric
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_config_reloads_total IS NOT NULL
-            - STATS reloads = MAX(traefik_config_reloads_total)
+            - STATS reloads = MAX(LAST_OVER_TIME(traefik_config_reloads_total))
           primary:
             field: reloads
             label: Total Reloads
@@ -138,15 +134,11 @@ dashboards:
           type: area
           mode: stacked
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_tls_total IS NOT NULL
-            - STATS total = SUM(traefik_entrypoint_requests_tls_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
-              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
-                attributes.tls_version
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL tls_rate = total / bucket_secs
+            - STATS tls_rate = SUM(RATE(traefik_entrypoint_requests_tls_total))
+              BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.tls_version
             - KEEP time_bucket, attributes.tls_version, tls_rate
             - SORT time_bucket ASC
           dimension:
@@ -170,10 +162,10 @@ dashboards:
         esql:
           type: pie
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_tls_total IS NOT NULL
-            - STATS tls_requests = SUM(traefik_entrypoint_requests_tls_total)
+            - STATS tls_requests = SUM(INCREASE(traefik_entrypoint_requests_tls_total))
               BY attributes.tls_version
             - SORT tls_requests DESC
             - LIMIT 10
@@ -217,14 +209,11 @@ dashboards:
         esql:
           type: line
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_config_reloads_total IS NOT NULL
-            - STATS total = SUM(traefik_config_reloads_total),
-              min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)
+            - STATS reload_rate = SUM(RATE(traefik_config_reloads_total))
               BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
-            - EVAL bucket_secs = GREATEST(DATE_DIFF("seconds", min_ts, max_ts), 1)
-            - EVAL reload_rate = total / bucket_secs
             - KEEP time_bucket, reload_rate
             - SORT time_bucket ASC
           dimension:
@@ -243,10 +232,10 @@ dashboards:
         esql:
           type: pie
           query:
-            - FROM metrics-traefik.otel-*
+            - TS metrics-traefik.otel-*
             - WHERE data_stream.dataset == "traefik.otel"
             - WHERE traefik_entrypoint_requests_tls_total IS NOT NULL
-            - STATS tls_requests = SUM(traefik_entrypoint_requests_tls_total)
+            - STATS tls_requests = SUM(INCREASE(traefik_entrypoint_requests_tls_total))
               BY attributes.tls_cipher
             - SORT tls_requests DESC
             - LIMIT 10

--- a/packages/traefik_otel/changelog.yml
+++ b/packages/traefik_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.2"
+  changes:
+    - description: Aggregate counter metrics with the ES|QL `TS` command so dashboard panels and alerting rules no longer fail with `verification_exception`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21015
 - version: "0.3.1"
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.

--- a/packages/traefik_otel/changelog.yml
+++ b/packages/traefik_otel/changelog.yml
@@ -4,6 +4,9 @@
     - description: Aggregate counter metrics with the ES|QL `TS` command so dashboard panels and alerting rules no longer fail with `verification_exception`.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/21015
+    - description: Scope the documented `cumulativetodelta` processor to the request-duration histograms so counter metrics are mapped as counters, and document how to recover data streams that were ingested as gauges.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21015
 - version: "0.3.1"
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.

--- a/packages/traefik_otel/changelog.yml
+++ b/packages/traefik_otel/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Aggregate counter metrics with the ES|QL `TS` command so dashboard panels and alerting rules no longer fail with `verification_exception`.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/21015
+      link: https://github.com/elastic/integrations/pull/21044
     - description: Scope the documented `cumulativetodelta` processor to the request-duration histograms so counter metrics are mapped as counters, and document how to recover data streams that were ingested as gauges.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/21015
+      link: https://github.com/elastic/integrations/pull/21044
 - version: "0.3.1"
   changes:
     - description: Regenerate Kibana dashboards so ES|QL Lens panels include populated adHocDataViews, internalReferences, and per-layer index, fixing the broken "Explore in Discover" action on Kibana 9.3+.

--- a/packages/traefik_otel/docs/README.md
+++ b/packages/traefik_otel/docs/README.md
@@ -71,10 +71,16 @@ processors:
   # Required for Traefik request-duration histograms: the Prometheus receiver emits cumulative-temporality histograms,
   # but the Elasticsearch exporter in `otel` mapping mode expects delta-temporality histograms.
   # Without this, you’ll see logs like "dropping cumulative temporality histogram traefik_*_request_duration_seconds".
+  #
+  # Scope this to the duration histograms only. Counter metrics (`traefik_*_total`, `process_cpu_seconds_total`)
+  # must reach Elasticsearch with cumulative temporality so that they are mapped as counters, which is what the
+  # `RATE()` and `INCREASE()` functions in this package’s dashboards and alert rules require. Widening this
+  # filter to `traefik_.*` or `process_.*` converts those counters to delta sums, which are mapped as gauges
+  # and cause the panels to fail with "must be [counter_long, counter_integer or counter_double], found ... gauge".
   cumulativetodelta:
     include:
       match_type: regexp
-      metrics: ['traefik_.*', 'go_.*', 'process_.*']
+      metrics: ['traefik_.*_request_duration_seconds']
   # Ensures metrics land in the dataset this package’s dashboards/alerts expect.
   # Sets `data_stream.dataset=traefik` (upsert); the Elasticsearch exporter appends `.otel`, so it becomes `traefik.otel`.
   resource/dataset:
@@ -97,6 +103,30 @@ service:
       processors: [resourcedetection/system, cumulativetodelta, resource/dataset]
       exporters: [elasticsearch/otel]
 ```
+
+### Troubleshooting
+
+If dashboard panels or alert rules fail with an error such as `first argument of [RATE(traefik_entrypoint_requests_total)] must be [counter_long, counter_integer or counter_double]`, the counter metrics were ingested as gauges. This happens when `cumulativetodelta` is applied to them, so verify that its `include` filter matches only `traefik_.*_request_duration_seconds`.
+
+A field's time-series type is fixed when the backing index is created, so correcting the collector configuration alone does not repair existing data. Roll the data stream over so that a new backing index picks up the counter type:
+
+```console
+POST /metrics-traefik.otel-default/_rollover
+```
+
+Because these are time-series data streams, documents are routed by `@timestamp` rather than to the newest index. The previous backing index keeps accepting writes until its `index.time_series.end_time` has passed, so allow that window to elapse before the panels recover. Check it with:
+
+```console
+GET /.ds-metrics-traefik.otel-default-*/_settings/index.time_series.end_time?flat_settings=true
+```
+
+To confirm which type a metric has in each backing index:
+
+```console
+GET /metrics-traefik.otel-default/_mapping/field/*requests_total*
+```
+
+The `time_series_metric` value should be `counter` for `traefik_*_total` and `process_cpu_seconds_total`. Panels remain affected for as long as gauge-mapped indices are still within the dashboard's time range.
 
 ## Reference
 

--- a/packages/traefik_otel/kibana/alerting_rule_template/traefik_otel-high-5xx-rate-by-entrypoint.json
+++ b/packages/traefik_otel/kibana/alerting_rule_template/traefik_otel-high-5xx-rate-by-entrypoint.json
@@ -36,7 +36,7 @@
     "params": {
       "searchType": "esqlQuery",
       "esqlQuery": {
-        "esql": "FROM metrics-traefik.otel-*\n// Limit to entrypoint-level request counters (counter requires TS + INCREASE)\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n// Aggregate total and 5xx requests per entrypoint over the time window\n| STATS\n    total = SUM(traefik_entrypoint_requests_total),\n    errors_5xx = SUM(traefik_entrypoint_requests_total) WHERE attributes.code LIKE \"5*\"\n  BY attributes.entrypoint\n// Minimum sample size; adjust based on expected traffic per entrypoint\n| WHERE total > 100\n| EVAL error_rate_pct = ROUND(errors_5xx / total * 100.0, 2)\n// Alert threshold: tune for sensitivity\n| WHERE error_rate_pct > 5.0\n| SORT error_rate_pct DESC\n| LIMIT 10"
+        "esql": "TS metrics-traefik.otel-*\n// Limit to entrypoint-level request counters (counter fields require TS + INCREASE)\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n// Aggregate total and 5xx requests per entrypoint over the time window\n| STATS\n    total = SUM(INCREASE(traefik_entrypoint_requests_total)),\n    errors_5xx = SUM(INCREASE(traefik_entrypoint_requests_total)) WHERE attributes.code LIKE \"5*\"\n  BY attributes.entrypoint\n// Minimum sample size; adjust based on expected traffic per entrypoint\n| WHERE total > 100\n| EVAL error_rate_pct = ROUND(errors_5xx / total * 100.0, 2)\n// Alert threshold: tune for sensitivity\n| WHERE error_rate_pct > 5.0\n| SORT error_rate_pct DESC\n| LIMIT 10"
       },
       "size": 0,
       "threshold": [

--- a/packages/traefik_otel/kibana/alerting_rule_template/traefik_otel-high-5xx-rate-by-router.json
+++ b/packages/traefik_otel/kibana/alerting_rule_template/traefik_otel-high-5xx-rate-by-router.json
@@ -36,7 +36,7 @@
     "params": {
       "searchType": "esqlQuery",
       "esqlQuery": {
-        "esql": "FROM metrics-traefik.otel-*\n// Limit to router-level request counters (counter requires TS + INCREASE)\n| WHERE traefik_router_requests_total IS NOT NULL\n// Aggregate total and 5xx requests per router over the time window\n| STATS\n    total = SUM(traefik_router_requests_total),\n    errors_5xx = SUM(traefik_router_requests_total) WHERE attributes.code LIKE \"5*\"\n  BY attributes.router\n// Minimum sample size; adjust based on expected traffic per router\n| WHERE total > 50\n| EVAL error_rate_pct = ROUND(errors_5xx / total * 100.0, 2)\n// Alert threshold: tune for sensitivity\n| WHERE error_rate_pct > 5.0\n| SORT error_rate_pct DESC\n| LIMIT 10"
+        "esql": "TS metrics-traefik.otel-*\n// Limit to router-level request counters (counter fields require TS + INCREASE)\n| WHERE traefik_router_requests_total IS NOT NULL\n// Aggregate total and 5xx requests per router over the time window\n| STATS\n    total = SUM(INCREASE(traefik_router_requests_total)),\n    errors_5xx = SUM(INCREASE(traefik_router_requests_total)) WHERE attributes.code LIKE \"5*\"\n  BY attributes.router\n// Minimum sample size; adjust based on expected traffic per router\n| WHERE total > 50\n| EVAL error_rate_pct = ROUND(errors_5xx / total * 100.0, 2)\n// Alert threshold: tune for sensitivity\n| WHERE error_rate_pct > 5.0\n| SORT error_rate_pct DESC\n| LIMIT 10"
       },
       "size": 0,
       "threshold": [

--- a/packages/traefik_otel/kibana/alerting_rule_template/traefik_otel-high-5xx-rate-by-service.json
+++ b/packages/traefik_otel/kibana/alerting_rule_template/traefik_otel-high-5xx-rate-by-service.json
@@ -36,7 +36,7 @@
     "params": {
       "searchType": "esqlQuery",
       "esqlQuery": {
-        "esql": "FROM metrics-traefik.otel-*\n// Limit to service-level request counters (counter requires TS + INCREASE)\n| WHERE traefik_service_requests_total IS NOT NULL\n// Aggregate total and 5xx requests per service over the time window\n| STATS\n    total = SUM(traefik_service_requests_total),\n    errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\"\n  BY attributes.service\n// Minimum sample size to avoid noisy low-traffic services; adjust based on expected volume\n| WHERE total > 100\n// Calculate error rate as percentage\n| EVAL error_rate_pct = ROUND(errors_5xx / total * 100.0, 2)\n// Alert threshold: tune for sensitivity (e.g. 5.0 = 5%)\n| WHERE error_rate_pct > 5.0\n| SORT error_rate_pct DESC\n| LIMIT 10"
+        "esql": "TS metrics-traefik.otel-*\n// Limit to service-level request counters (counter fields require TS + INCREASE)\n| WHERE traefik_service_requests_total IS NOT NULL\n// Aggregate total and 5xx requests per service over the time window\n| STATS\n    total = SUM(INCREASE(traefik_service_requests_total)),\n    errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\"\n  BY attributes.service\n// Minimum sample size to avoid noisy low-traffic services; adjust based on expected volume\n| WHERE total > 100\n// Calculate error rate as percentage\n| EVAL error_rate_pct = ROUND(errors_5xx / total * 100.0, 2)\n// Alert threshold: tune for sensitivity (e.g. 5.0 = 5%)\n| WHERE error_rate_pct > 5.0\n| SORT error_rate_pct DESC\n| LIMIT 10"
       },
       "size": 0,
       "threshold": [

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-overview.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-overview.json
@@ -123,7 +123,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL request_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP request_rate"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_entrypoint_requests_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -131,7 +131,7 @@
                                     "layers": {
                                         "d2a62428-55bf-f397-73d8-ef8de23036f1": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL request_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP request_rate"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_entrypoint_requests_total))"
                                             },
                                             "columns": [
                                                 {
@@ -248,7 +248,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), errors_5xx = SUM(traefik_entrypoint_requests_total) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| STATS error_rate = MAX(error_rate)"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(RATE(traefik_entrypoint_requests_total)), errors_5xx = SUM(RATE(traefik_entrypoint_requests_total)) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| KEEP error_rate"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -256,7 +256,7 @@
                                     "layers": {
                                         "213e51a5-bb57-44e4-426a-2bc6c1156e30": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), errors_5xx = SUM(traefik_entrypoint_requests_total) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| STATS error_rate = MAX(error_rate)"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(RATE(traefik_entrypoint_requests_total)), errors_5xx = SUM(RATE(traefik_entrypoint_requests_total)) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| KEEP error_rate"
                                             },
                                             "columns": [
                                                 {
@@ -494,7 +494,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_responses_bytes_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL bytes_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP bytes_rate"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS bytes_rate = SUM(RATE(traefik_entrypoint_responses_bytes_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -502,7 +502,7 @@
                                     "layers": {
                                         "2534cb18-a368-812b-8ac0-4cb2e45438bf": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_responses_bytes_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL bytes_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP bytes_rate"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS bytes_rate = SUM(RATE(traefik_entrypoint_responses_bytes_total))"
                                             },
                                             "columns": [
                                                 {
@@ -649,7 +649,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.entrypoint\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL request_rate = total / bucket_secs\n| KEEP time_bucket, attributes.entrypoint, request_rate\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_entrypoint_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.entrypoint\n| KEEP time_bucket, attributes.entrypoint, request_rate\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -657,7 +657,7 @@
                                     "layers": {
                                         "bc49e397-7457-6be1-83ca-ef806fe774b2": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.entrypoint\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL request_rate = total / bucket_secs\n| KEEP time_bucket, attributes.entrypoint, request_rate\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_entrypoint_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.entrypoint\n| KEEP time_bucket, attributes.entrypoint, request_rate\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -882,7 +882,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL requests = total / bucket_secs\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS requests = SUM(RATE(traefik_entrypoint_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -890,7 +890,7 @@
                                     "layers": {
                                         "fc4791a2-fdd7-95dc-c139-4017b43935a5": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL requests = total / bucket_secs\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS requests = SUM(RATE(traefik_entrypoint_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -1255,7 +1255,7 @@
                                 "shape": "donut"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_entrypoint_requests_total) BY attributes.code\n| SORT total_requests DESC\n| LIMIT 10"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_entrypoint_requests_total)) BY attributes.code\n| SORT total_requests DESC\n| LIMIT 10"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1263,7 +1263,7 @@
                                     "layers": {
                                         "2fcc441e-f741-8c78-e998-0e6222cb3954": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_entrypoint_requests_total) BY attributes.code\n| SORT total_requests DESC\n| LIMIT 10"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_entrypoint_requests_total)) BY attributes.code\n| SORT total_requests DESC\n| LIMIT 10"
                                             },
                                             "columns": [
                                                 {
@@ -1405,7 +1405,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_responses_bytes_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL bytes_rate = total / bucket_secs\n| KEEP time_bucket, bytes_rate\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS bytes_rate = SUM(RATE(traefik_entrypoint_responses_bytes_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| KEEP time_bucket, bytes_rate\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1413,7 +1413,7 @@
                                     "layers": {
                                         "6bfaabfd-9472-2da5-b24d-481c2447686c": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_responses_bytes_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL bytes_rate = total / bucket_secs\n| KEEP time_bucket, bytes_rate\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_responses_bytes_total IS NOT NULL\n| STATS bytes_rate = SUM(RATE(traefik_entrypoint_responses_bytes_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| KEEP time_bucket, bytes_rate\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -1556,7 +1556,7 @@
                                 "layerType": "data"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_entrypoint_requests_total) BY attributes.entrypoint\n| SORT total_requests DESC\n| LIMIT 20"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_entrypoint_requests_total)) BY attributes.entrypoint\n| SORT total_requests DESC\n| LIMIT 20"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1564,7 +1564,7 @@
                                     "layers": {
                                         "3e200d8b-03be-0ace-8618-ce0ca3000a92": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_entrypoint_requests_total) BY attributes.entrypoint\n| SORT total_requests DESC\n| LIMIT 20"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_entrypoint_requests_total)) BY attributes.entrypoint\n| SORT total_requests DESC\n| LIMIT 20"
                                             },
                                             "columns": [
                                                 {

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-process.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-process.json
@@ -123,7 +123,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS total = SUM(process_cpu_seconds_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL cpu_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP cpu_rate"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS cpu_rate = SUM(RATE(process_cpu_seconds_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -131,7 +131,7 @@
                                     "layers": {
                                         "358e8389-7a01-dd37-26a4-babb648d2d1c": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS total = SUM(process_cpu_seconds_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL cpu_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP cpu_rate"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS cpu_rate = SUM(RATE(process_cpu_seconds_total))"
                                             },
                                             "columns": [
                                                 {
@@ -815,7 +815,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS total = SUM(process_cpu_seconds_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL cpu_rate = total / bucket_secs\n| KEEP time_bucket, cpu_rate\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS cpu_rate = SUM(RATE(process_cpu_seconds_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| KEEP time_bucket, cpu_rate\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -823,7 +823,7 @@
                                     "layers": {
                                         "a9a510cf-e039-a3aa-b81e-9caa3ec63df9": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS total = SUM(process_cpu_seconds_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL cpu_rate = total / bucket_secs\n| KEEP time_bucket, cpu_rate\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE process_cpu_seconds_total IS NOT NULL\n| STATS cpu_rate = SUM(RATE(process_cpu_seconds_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| KEEP time_bucket, cpu_rate\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-services.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-services.json
@@ -123,7 +123,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL request_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP request_rate"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_service_requests_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -131,7 +131,7 @@
                                     "layers": {
                                         "24923788-bf95-415f-a024-b10aeec210c3": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL request_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP request_rate"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_service_requests_total))"
                                             },
                                             "columns": [
                                                 {
@@ -248,7 +248,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| STATS error_rate = MAX(error_rate)"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(RATE(traefik_service_requests_total)), errors_5xx = SUM(RATE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| KEEP error_rate"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -256,7 +256,7 @@
                                     "layers": {
                                         "bee789bd-d827-5064-2fc1-d13cd64237d4": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| STATS error_rate = MAX(error_rate)"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(RATE(traefik_service_requests_total)), errors_5xx = SUM(RATE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\"\n| EVAL error_rate = CASE(total > 0, errors_5xx / total, 0.0)\n| KEEP error_rate"
                                             },
                                             "columns": [
                                                 {
@@ -494,7 +494,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_responses_bytes_total IS NOT NULL\n| STATS total = SUM(traefik_service_responses_bytes_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL bytes_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP bytes_rate"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_responses_bytes_total IS NOT NULL\n| STATS bytes_rate = SUM(RATE(traefik_service_responses_bytes_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -502,7 +502,7 @@
                                     "layers": {
                                         "d8699402-679b-8c07-f4c7-ad960cb00522": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_responses_bytes_total IS NOT NULL\n| STATS total = SUM(traefik_service_responses_bytes_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL bytes_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP bytes_rate"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_responses_bytes_total IS NOT NULL\n| STATS bytes_rate = SUM(RATE(traefik_service_responses_bytes_total))"
                                             },
                                             "columns": [
                                                 {
@@ -649,7 +649,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL request_rate = total / bucket_secs\n| KEEP time_bucket, attributes.service, request_rate\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_service_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| KEEP time_bucket, attributes.service, request_rate\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -657,7 +657,7 @@
                                     "layers": {
                                         "a8d28977-5fc1-8b65-8dff-c809a5b6b327": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL request_rate = total / bucket_secs\n| KEEP time_bucket, attributes.service, request_rate\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS request_rate = SUM(RATE(traefik_service_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| KEEP time_bucket, attributes.service, request_rate\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -836,7 +836,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| WHERE attributes.code LIKE \"5*\"\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL errors = total / bucket_secs\n| KEEP time_bucket, attributes.service, errors\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| WHERE attributes.code LIKE \"5*\"\n| STATS errors = SUM(RATE(traefik_service_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| KEEP time_bucket, attributes.service, errors\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -844,7 +844,7 @@
                                     "layers": {
                                         "95b39c83-08b6-e6ce-2504-7801e818b803": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| WHERE attributes.code LIKE \"5*\"\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL errors = total / bucket_secs\n| KEEP time_bucket, attributes.service, errors\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| WHERE attributes.code LIKE \"5*\"\n| STATS errors = SUM(RATE(traefik_service_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.service\n| KEEP time_bucket, attributes.service, errors\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -1053,7 +1053,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL requests = total / bucket_secs\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS requests = SUM(RATE(traefik_service_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1061,7 +1061,7 @@
                                     "layers": {
                                         "9204b3d6-aa38-79b2-b713-6e782b5302f5": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total = SUM(traefik_service_requests_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL requests = total / bucket_secs\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS requests = SUM(RATE(traefik_service_requests_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.code\n| KEEP time_bucket, attributes.code, requests\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -1221,7 +1221,7 @@
                                 "layerType": "data"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_service_requests_total), errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| EVAL error_rate = CASE(total_requests > 0, errors_5xx / total_requests, 0.0)\n| SORT total_requests DESC\n| LIMIT 20"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_service_requests_total)), errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| EVAL error_rate = CASE(total_requests > 0, errors_5xx / total_requests, 0.0)\n| SORT total_requests DESC\n| LIMIT 20"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1229,7 +1229,7 @@
                                     "layers": {
                                         "9ebe9a80-3080-c144-8823-ed1688de4f6f": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_service_requests_total), errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| EVAL error_rate = CASE(total_requests > 0, errors_5xx / total_requests, 0.0)\n| SORT total_requests DESC\n| LIMIT 20"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_service_requests_total)), errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| EVAL error_rate = CASE(total_requests > 0, errors_5xx / total_requests, 0.0)\n| SORT total_requests DESC\n| LIMIT 20"
                                             },
                                             "columns": [
                                                 {
@@ -1409,7 +1409,7 @@
                                 "layerType": "data"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_service_requests_total), errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| WHERE total_requests > 0\n| EVAL error_rate = errors_5xx / total_requests\n| WHERE error_rate > 0\n| SORT error_rate DESC\n| LIMIT 20"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_service_requests_total)), errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| WHERE total_requests > 0\n| EVAL error_rate = errors_5xx / total_requests\n| WHERE error_rate > 0\n| SORT error_rate DESC\n| LIMIT 20"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1417,7 +1417,7 @@
                                     "layers": {
                                         "52dc3ccb-8cd0-9c15-a55f-3715f8968516": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(traefik_service_requests_total), errors_5xx = SUM(traefik_service_requests_total) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| WHERE total_requests > 0\n| EVAL error_rate = errors_5xx / total_requests\n| WHERE error_rate > 0\n| SORT error_rate DESC\n| LIMIT 20"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_service_requests_total IS NOT NULL\n| STATS total_requests = SUM(INCREASE(traefik_service_requests_total)), errors_5xx = SUM(INCREASE(traefik_service_requests_total)) WHERE attributes.code LIKE \"5*\" BY attributes.service\n| WHERE total_requests > 0\n| EVAL error_rate = errors_5xx / total_requests\n| WHERE error_rate > 0\n| SORT error_rate DESC\n| LIMIT 20"
                                             },
                                             "columns": [
                                                 {

--- a/packages/traefik_otel/kibana/dashboard/traefik_otel-tls-config.json
+++ b/packages/traefik_otel/kibana/dashboard/traefik_otel-tls-config.json
@@ -246,7 +246,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_tls_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL tls_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP tls_rate"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_rate = SUM(RATE(traefik_entrypoint_requests_tls_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -254,7 +254,7 @@
                                     "layers": {
                                         "83931d67-3b12-4680-0e38-897455a8a794": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_tls_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp)\n| EVAL duration_sec = DATE_DIFF(\"seconds\", min_ts, max_ts)\n| EVAL tls_rate = CASE(duration_sec > 0, total / duration_sec, 0.0)\n| KEEP tls_rate"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_rate = SUM(RATE(traefik_entrypoint_requests_tls_total))"
                                             },
                                             "columns": [
                                                 {
@@ -371,7 +371,7 @@
                                 "applyColorTo": "background"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS reloads = MAX(traefik_config_reloads_total)"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS reloads = MAX(LAST_OVER_TIME(traefik_config_reloads_total))"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -379,7 +379,7 @@
                                     "layers": {
                                         "f6c244a6-782e-f1af-fe1d-f3ed703ef826": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS reloads = MAX(traefik_config_reloads_total)"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS reloads = MAX(LAST_OVER_TIME(traefik_config_reloads_total))"
                                             },
                                             "columns": [
                                                 {
@@ -649,7 +649,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_tls_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.tls_version\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL tls_rate = total / bucket_secs\n| KEEP time_bucket, attributes.tls_version, tls_rate\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_rate = SUM(RATE(traefik_entrypoint_requests_tls_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.tls_version\n| KEEP time_bucket, attributes.tls_version, tls_rate\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -657,7 +657,7 @@
                                     "layers": {
                                         "ed8695b1-edbe-072d-2c19-ac236ed70386": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS total = SUM(traefik_entrypoint_requests_tls_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.tls_version\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL tls_rate = total / bucket_secs\n| KEEP time_bucket, attributes.tls_version, tls_rate\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_rate = SUM(RATE(traefik_entrypoint_requests_tls_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.tls_version\n| KEEP time_bucket, attributes.tls_version, tls_rate\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -835,7 +835,7 @@
                                 "shape": "donut"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(traefik_entrypoint_requests_tls_total) BY attributes.tls_version\n| SORT tls_requests DESC\n| LIMIT 10"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(INCREASE(traefik_entrypoint_requests_tls_total)) BY attributes.tls_version\n| SORT tls_requests DESC\n| LIMIT 10"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -843,7 +843,7 @@
                                     "layers": {
                                         "da970c0b-a67d-96d3-5bc5-5316b772090d": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(traefik_entrypoint_requests_tls_total) BY attributes.tls_version\n| SORT tls_requests DESC\n| LIMIT 10"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(INCREASE(traefik_entrypoint_requests_tls_total)) BY attributes.tls_version\n| SORT tls_requests DESC\n| LIMIT 10"
                                             },
                                             "columns": [
                                                 {
@@ -1144,7 +1144,7 @@
                                 "valueLabels": "hide"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS total = SUM(traefik_config_reloads_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL reload_rate = total / bucket_secs\n| KEEP time_bucket, reload_rate\n| SORT time_bucket ASC"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS reload_rate = SUM(RATE(traefik_config_reloads_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| KEEP time_bucket, reload_rate\n| SORT time_bucket ASC"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1152,7 +1152,7 @@
                                     "layers": {
                                         "8303432c-9414-c7f0-f513-9fd97a332047": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS total = SUM(traefik_config_reloads_total), min_ts = MIN(@timestamp), max_ts = MAX(@timestamp) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL bucket_secs = GREATEST(DATE_DIFF(\"seconds\", min_ts, max_ts), 1)\n| EVAL reload_rate = total / bucket_secs\n| KEEP time_bucket, reload_rate\n| SORT time_bucket ASC"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_config_reloads_total IS NOT NULL\n| STATS reload_rate = SUM(RATE(traefik_config_reloads_total)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| KEEP time_bucket, reload_rate\n| SORT time_bucket ASC"
                                             },
                                             "columns": [
                                                 {
@@ -1318,7 +1318,7 @@
                                 "shape": "donut"
                             },
                             "query": {
-                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(traefik_entrypoint_requests_tls_total) BY attributes.tls_cipher\n| SORT tls_requests DESC\n| LIMIT 10"
+                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(INCREASE(traefik_entrypoint_requests_tls_total)) BY attributes.tls_cipher\n| SORT tls_requests DESC\n| LIMIT 10"
                             },
                             "filters": [],
                             "datasourceStates": {
@@ -1326,7 +1326,7 @@
                                     "layers": {
                                         "7c67f00e-37fa-3890-f8b2-95d6010eb9b4": {
                                             "query": {
-                                                "esql": "FROM metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(traefik_entrypoint_requests_tls_total) BY attributes.tls_cipher\n| SORT tls_requests DESC\n| LIMIT 10"
+                                                "esql": "TS metrics-traefik.otel-*\n| WHERE data_stream.dataset == \"traefik.otel\"\n| WHERE traefik_entrypoint_requests_tls_total IS NOT NULL\n| STATS tls_requests = SUM(INCREASE(traefik_entrypoint_requests_tls_total)) BY attributes.tls_cipher\n| SORT tls_requests DESC\n| LIMIT 10"
                                             },
                                             "columns": [
                                                 {

--- a/packages/traefik_otel/manifest.yml
+++ b/packages/traefik_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: traefik_otel
 title: "Traefik OpenTelemetry Assets"
-version: 0.3.1
+version: 0.3.2
 source:
   license: "Elastic-2.0"
 description: "Traefik Assets for OpenTelemetry Collector"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

**WHY**

`traefik_otel` 0.3.1 and its documented collector configuration disagree about the aggregation
temporality of Traefik's Prometheus counters, and ES|QL will not let both be right at once:

| Field mapping | Works | Rejected |
|---|---|---|
| `time_series_metric: counter` | `TS` + `RATE()` / `INCREASE()` | plain `SUM()` / `MAX()` |
| `time_series_metric: gauge` | plain `SUM()` / `MAX()` | `RATE()` / `INCREASE()` |

The mapping is decided by the collector. The Elasticsearch exporter maps a monotonic sum as a
counter only while its temporality is still cumulative:

```go
// exporter/elasticsearchexporter/internal/datapoints/number.go
isCounter := sum.IsMonotonic() && sum.AggregationTemporality() == pmetric.AggregationTemporalityCumulative
```

The README applied `cumulativetodelta` with `metrics: ['traefik_.*', 'go_.*', 'process_.*']`, which
is wide enough to catch every counter and convert it to a delta sum, so it lands as a **gauge**. The
dashboards' `FROM` + `SUM()` queries only work in that state. Any user who omits or narrows the
processor gets `counter_double` fields and 27 assets that fail on load with:

```
line 1:48: argument of [SUM(traefik_entrypoint_requests_total)] must be
[aggregate_metric_double, exponential_histogram, tdigest or numeric except unsigned_long
or counter types], found value [traefik_entrypoint_requests_total] type [counter_double]
```

That the counter contract was the original intent is visible in the shipped alert rules, which carry
this comment directly above a query doing the opposite:

```
// Limit to entrypoint-level request counters (counter requires TS + INCREASE)
| WHERE traefik_entrypoint_requests_total IS NOT NULL
| STATS total = SUM(traefik_entrypoint_requests_total), ...
```

**WHAT**

This standardises on the counter contract, which is the idiomatic representation for Prometheus
counters and handles counter resets correctly.

1. Rewrite 27 ES|QL assets (24 dashboard panels, 3 alerting rule templates) to the `TS` source
   command with counter-aware functions: `RATE()` where the panel reported a per-second rate (it
   previously divided a `SUM()` by a `DATE_DIFF` window), `INCREASE()` where it reported a total
   over the selected range, and `MAX(LAST_OVER_TIME())` for the cumulative "Total Reloads" metric.
   Output column names, bucketing and result shapes are unchanged so the Lens configurations keep
   working. Both the `_dev/shared/kibana/*.yaml` authoring sources and the generated
   `kibana/dashboard/*.json` are updated so regeneration cannot reintroduce the old queries.
2. Narrow the README's `cumulativetodelta` filter to `['traefik_.*_request_duration_seconds']`. The
   processor is genuinely required, but only for the request-duration histograms, which the
   Prometheus receiver emits as cumulative and the exporter drops in `otel` mapping mode. Applying
   it to the counters was collateral damage.
3. Add a troubleshooting section, since a field's time-series type is fixed when the backing index is
   created. Recovery needs a rollover, and because documents are routed by `@timestamp` the previous
   backing index keeps accepting writes until its `index.time_series.end_time` has passed.

Gauge-backed panels and rules are untouched. The SLO templates aggregate through the DSL rather than
ES|QL and were never affected.

`TS`, `RATE`, `INCREASE` and `LAST_OVER_TIME` are GA since 9.4, matching the package's existing
`kibana.version: ^9.4.0` constraint, so no constraint change is required.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm that standardising on the counter contract is the direction we want, rather than keeping the delta contract and fixing only the documentation.
- [ ] Decide whether this warrants a breaking-change note and a minor bump instead of the current patch bump to 0.3.2. Existing users following the old README have gauge-mapped counters and will need both the narrowed collector filter and a data stream rollover.
- [ ] Confirm `['traefik_.*_request_duration_seconds']` covers every histogram metric that the latency SLO template depends on (`traefik_service_request_duration_seconds`).
- [ ] Confirm the rewritten panels render as expected in Kibana, in particular that `RATE()` vs the previous `SUM()/DATE_DIFF()` produces the intended values on the "Over Time" panels.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
**Executed on this branch (Elasticsearch 9.5.0-SNAPSHOT via `elastic-package stack up`, OTel-native `metrics-traefik.otel-*` fixture with counter-mapped fields):**

Every dashboard panel and alerting rule query was run against the stack, on the base commit and on this branch:

```
base main : TOTAL: ok=19 fail=27
this branch: TOTAL: ok=46 fail=0
```

Rewritten panels return values consistent with the analytically known rates in the fixture:

```
Overview / Bandwidth (bytes/sec)                394792.960  394992.529  0.05%  PASS
Services / Total Service Requests (req/sec)        135.460     135.299  0.12%  PASS
TLS / TLS Request Rate (req/sec)                    72.000      71.709  0.40%  PASS
Process / CPU Rate (cores)                           0.350       0.347  0.72%  PASS
Overview / Requests by Status Code, 200 (count) 594405.000  593568.371  0.14%  PASS
failures: 0
```

The YAML authoring sources reconstruct the JSON queries byte for byte, so regeneration is safe:

```
checked=37 mismatched=0
```

Package validation:

```
elastic-package lint   -> Done
elastic-package check  -> Package built: build/packages/traefik_otel-0.3.2.zip
```

The mapping claim behind the README change was verified with a real
`otel/opentelemetry-collector-contrib:0.160.0` scraping a Prometheus endpoint into the same cluster,
varying only the `cumulativetodelta` filter:

| Filter | Resulting `time_series_metric` | `SUM(field)` | `SUM(RATE(field))` |
|---|---|---|---|
| Broad, matches counters (old README) | `gauge` | works | fails |
| Scoped to `.*_request_duration_seconds` (new README) | `counter` | fails | works |

**For the reviewer (not yet run in this session):**

1. Install the built package and configure a collector using the README snippet in this PR, pointed at a Traefik instance with `metrics.prometheus` enabled.
2. Confirm `GET /metrics-traefik.otel-default/_mapping/field/*requests_total*` reports `time_series_metric: counter`.
3. Open the Overview, Services, TLS & Config and Process dashboards and confirm no panel shows `verification_exception` and that rate panels show plausible values.
4. Repeat on a 9.4.x stack, the minimum the package supports and the version reported in the SDH.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates elastic/obs-integration-team#1205
- Relates elastic/sdh-beats#7557

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
Pending — the four affected dashboards should be captured against a counter-mapped data stream before this leaves draft.
