### PR TITLE
[google_workspace] - Add optional chunk_duration to Reports API data streams

### DIFF
--- a/packages/google_workspace/_dev/build/docs/README.md
+++ b/packages/google_workspace/_dev/build/docs/README.md
@@ -72,6 +72,26 @@ Click the Advanced option of Google Workspace Audit Reports. The default value o
 
 >  NOTE: The `Delegated Account` value in the configuration, is expected to be the email of the administrator account, and not the email of the ServiceAccount.
 
+### Collection window settings for Reports API data streams
+
+The `access_transparency`, `admin`, `context_aware_access`, `device`, `drive`, `gcp`, `groups`, `group_enterprise`, `login`, `rules`, `saml`, `token` and `user_accounts` data streams request activity from the Reports API in time windows. Three settings control those windows:
+
+- **Initial Interval** (package level, default `24h`): how far back the first collection reaches when a data stream starts with no saved position.
+- **Lag Time** (per data stream, default `2h`): how far behind the current time the end of every window stays. Google publishes activity with a delay that varies by report; see [Data retention and lag times](https://support.google.com/a/answer/7061566). Events newer than `now - Lag Time` are not requested yet, and are collected on a later interval once they have settled.
+- **Chunk Duration** (per data stream, under Advanced options, disabled by default): the maximum span of activity requested in one interval. When set, each interval requests a window of at most this duration starting from the last completed position, and the position only moves forward after the whole window has been collected. If collection is interrupted, for example by an agent restart or a policy update, only that one chunk is requested again.
+
+Without Chunk Duration, an interval requests everything from the last completed position up to `now - Lag Time` in a single window. For a data stream with a large backlog or a high event rate, such as `token` or `drive` on a busy domain, that window can take longer to page through than the time between interruptions. Each interruption then restarts the same window from the beginning, no progress is saved, and the data stream appears to stall while it re-sends events it has already sent.
+
+Recommended Chunk Duration values:
+
+| Data stream volume | Suggested value |
+|---|---|
+| High (for example `token`, `drive`, `login` on large domains) | `1h` |
+| Moderate | `6h` |
+| Low (for example `rules`, `saml`, `access_transparency`) | `24h` |
+
+A chunk should be small enough to be fully collected between the interruptions you expect, and must not exceed `720h` (30 days). Once the data stream has caught up, the window end is limited by `now - Lag Time`, so Chunk Duration has no effect on steady-state collection. Leaving the setting empty, or setting it to `0`, disables chunking. Existing saved positions are reused unchanged when the setting is turned on or off.
+
 # Google Workspace Gmail Logs
 
 :::{note}

--- a/packages/google_workspace/_dev/deploy/docker/config.yml
+++ b/packages/google_workspace/_dev/deploy/docker/config.yml
@@ -15,6 +15,37 @@ rules:
         body: |
           {"access_token": "1/fFAGRNJru1FTz70BzhT3Zg","expires_in": 3920,"token_type": "Bearer",
           "scope": "https://www.googleapis.com/auth/admin.reports.audit.readonly","refresh_token": "1//xEoDL4iW3cxlI7yDbSRFYNG01kVKM2C-259HOF2aQbI"}
+  # Chunked-window endpoint shared by the Reports API data streams' test-chunked
+  # system tests, which point application_name_for_url at "chunked_<app>".
+  # The response echoes the requested startTime as the event time with a fixed
+  # uniqueQualifier, so the fingerprinted _id only changes when the requested
+  # window start changes. With chunk_duration set, every interval advances
+  # startTime by one chunk and produces a new document. Without it, the next
+  # startTime is derived from the returned event time, which equals the previous
+  # startTime, so the same document is re-sent and only one is indexed.
+  # An empty window (startTime == endTime) is answered with an error body and
+  # no items, mirroring the API's rejection of such requests.
+  - path: /admin/reports/v1/activity/users/all/applications/chunked_{app}
+    methods: [GET]
+    query_params:
+      startTime: "{startTime:.*}"
+      endTime: "{endTime:.*}"
+    request_headers:
+      Accept:
+        - "application/json"
+      Authorization:
+        - "Bearer 1/fFAGRNJru1FTz70BzhT3Zg"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |
+          {{- if eq .request.vars.startTime .request.vars.endTime }}
+          {"error":{"code":400,"message":"Start time must be before end time.","status":"INVALID_ARGUMENT"}}
+          {{- else }}
+          {"kind":"admin#reports#activities","etag":"\"chunked\"","items":[{"kind":"admin#reports#activity","id":{"time":"{{.request.vars.startTime}}","uniqueQualifier":1,"applicationName":"{{.request.vars.app}}","customerId":"C03az79cb"},"etag":"\"chunk\"","actor":{"callerType":"USER","email":"user@example.com","profileId":"114511147312345678901"},"ownerDomain":"example.com","ipAddress":"192.0.2.10","events":[{"type":"chunk_test","name":"chunk_window"}]}]}
+          {{- end }}
   - path: /v1beta1/alerts
     methods: [GET]
     query_params:

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add an optional `chunk_duration` setting to the Reports API data streams that bounds the time window requested per interval, so an interrupted collection re-fetches at most one chunk instead of the whole backlog.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/21049
 - version: "3.8.1"
   changes:
     - description: Lengthen Gemini lag setting to reduce missed events at polling window boundaries.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.9.0"
+  changes:
+    - description: Add an optional `chunk_duration` setting to the Reports API data streams that bounds the time window requested per interval, so an interrupted collection re-fetches at most one chunk instead of the whole backlog.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "3.8.1"
   changes:
     - description: Lengthen Gemini lag setting to reduce missed events at polling window boundaries.

--- a/packages/google_workspace/data_stream/access_transparency/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/access_transparency/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_access_transparency echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_access_transparency
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/access_transparency/manifest.yml
+++ b/packages/google_workspace/data_stream/access_transparency/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 3m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/admin/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/admin/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_admin echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_admin
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/admin/manifest.yml
+++ b/packages/google_workspace/data_stream/admin/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 3m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/context_aware_access/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/context_aware_access/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_context_aware_access echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_context_aware_access
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/context_aware_access/manifest.yml
+++ b/packages/google_workspace/data_stream/context_aware_access/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 3m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/device/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/device/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_device echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_device
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/device/manifest.yml
+++ b/packages/google_workspace/data_stream/device/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 3m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/drive/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/drive/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_drive echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_drive
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/drive/manifest.yml
+++ b/packages/google_workspace/data_stream/drive/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 3m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/gcp/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/gcp/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_gcp echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_gcp
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/gcp/manifest.yml
+++ b/packages/google_workspace/data_stream/gcp/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 5m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/group_enterprise/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/group_enterprise/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_group_enterprise echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_group_enterprise
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/group_enterprise/manifest.yml
+++ b/packages/google_workspace/data_stream/group_enterprise/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 30m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/groups/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/groups/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_groups echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_groups
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 30m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/login/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/login/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_login echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_login
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 30m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/rules/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/rules/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_rules echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_rules
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/rules/manifest.yml
+++ b/packages/google_workspace/data_stream/rules/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 5m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/saml/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/saml/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_saml echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_saml
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/saml/manifest.yml
+++ b/packages/google_workspace/data_stream/saml/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 3m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/token/_dev/test/system/test-chunk-disabled-config.yml
+++ b/packages/google_workspace/data_stream/token/_dev/test/system/test-chunk-disabled-config.yml
@@ -1,0 +1,24 @@
+# A non-positive chunk_duration must degrade to unchunked windows
+# (endTime = now - lag_time) rather than produce an empty window with
+# startTime == endTime, which the Google API rejects. The chunked_token mock
+# answers an empty window with an error body and no items, so if the guard
+# were missing no documents would ever be indexed. With the guard in place the
+# window end is used as the next start and a document arrives every interval.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_token
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: "0"
+    preserve_original_event: true
+assert:
+  min_count: 2
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/token/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/token/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_token echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_token
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/token/manifest.yml
+++ b/packages/google_workspace/data_stream/token/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 2h
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/user_accounts/_dev/test/system/test-chunked-config.yml
+++ b/packages/google_workspace/data_stream/user_accounts/_dev/test/system/test-chunked-config.yml
@@ -1,0 +1,24 @@
+# Exercises chunked collection (chunk_duration). The mock endpoint
+# chunked_user_accounts echoes the requested startTime as the event time, so a new
+# document is indexed only when the window start advances. With a 72h initial
+# interval and 24h chunks, three chunk windows are requested back to back
+# before the stream reaches the lag margin, so at least three documents with
+# distinct @timestamp values 24h apart must be ingested.
+input: httpjson
+service: google_workspace
+vars:
+  jwt_file: "{{SERVICE_LOGS_DIR}}/credentials.json"
+  delegated_account: test@example.com
+  api_host: http://{{Hostname}}:{{Port}}
+  initial_interval: 72h
+  enable_request_tracer: true
+data_stream:
+  vars:
+    application_name_for_url: chunked_user_accounts
+    interval: 5s
+    lag_time: 2h
+    chunk_duration: 24h
+    preserve_original_event: true
+assert:
+  min_count: 3
+wait_for_data_timeout: 1m

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,39 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}{{lag_time}}"))]]'
   - set:
       target: url.params.endTime
+{{#if chunk_duration}}
+      # Chunked collection: bound each interval to at most chunk_duration of
+      # activity, starting from the same point startTime resolves to. The
+      # window is clamped to now-lag_time so it never runs ahead of the lag
+      # margin. A non-positive or unparsable chunk_duration disables
+      # chunking and behaves like the unchunked value.
+      value: >-
+        [[- $start := "" -]]
+        [[- if eq .cursor.pagination_finished "true" -]]
+          [[- $start = .cursor.next_start_date -]]
+        [[- else -]]
+          [[- $start = .cursor.last_response_date -]]
+        [[- end -]]
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (parseDate $start "RFC3339").Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+      # Fresh start (no cursor): chunk the initial interval too, otherwise a
+      # large initial_interval would be requested as a single window.
+      default: >-
+        [[- $cap := now (parseDuration "-{{lag_time}}") -]]
+        [[- $chunkEnd := (now (parseDuration "-{{initial_interval}}{{lag_time}}")).Add (parseDuration "{{chunk_duration}}") -]]
+        [[- if or (le (parseDuration "{{chunk_duration}}") 0) ($chunkEnd.After $cap) -]]
+          [[- formatDate $cap -]]
+        [[- else -]]
+          [[- formatDate $chunkEnd -]]
+        [[- end -]]
+{{else}}
       value: '[[formatDate (now (parseDuration "-{{lag_time}}"))]]'
+{{/if}}
 response.split:
   target: body.items
   ignore_empty_value: true
@@ -62,6 +94,11 @@ cursor:
     # Use this value to be able to resume from an interrupted pagination cycle.
     value: '[[.last_response.url.params.Get "startTime"]]'
   next_start_date:
+{{#if chunk_duration}}
+    # With chunking, the next window starts where the completed chunk ended.
+    # This does not depend on event ordering or event timestamp format.
+    value: '[[.last_response.url.params.Get "endTime"]]'
+{{else}}
     # The API returns records sorted from newest to oldest,
     # in order to pick the next startDate we keep the first event (newest) time.
     value: >-
@@ -83,6 +120,7 @@ cursor:
       [[- else -]]
         [[- .last_response.url.params.Get "endTime" -]]
       [[- end -]]
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -24,6 +24,14 @@ streams:
         required: true
         show_user: true
         default: 10m
+      - name: chunk_duration
+        type: text
+        title: Chunk Duration
+        description: >-
+          Maximum span of activity requested per collection interval. When set, each interval fetches a window of at most this duration starting from the last completed position, and only advances after the whole window has been collected. An interrupted run (for example an agent restart) then re-fetches at most one chunk instead of the whole backlog. Leave empty to disable chunking (the default). Recommended values: 1h for high-volume reports such as token or drive, 6h to 24h for low-volume reports. Must not exceed 720h (30 days). NOTE: Supported units for this parameter are h/m/s.
+        multi: false
+        required: false
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/docs/README.md
+++ b/packages/google_workspace/docs/README.md
@@ -72,6 +72,26 @@ Click the Advanced option of Google Workspace Audit Reports. The default value o
 
 >  NOTE: The `Delegated Account` value in the configuration, is expected to be the email of the administrator account, and not the email of the ServiceAccount.
 
+### Collection window settings for Reports API data streams
+
+The `access_transparency`, `admin`, `context_aware_access`, `device`, `drive`, `gcp`, `groups`, `group_enterprise`, `login`, `rules`, `saml`, `token` and `user_accounts` data streams request activity from the Reports API in time windows. Three settings control those windows:
+
+- **Initial Interval** (package level, default `24h`): how far back the first collection reaches when a data stream starts with no saved position.
+- **Lag Time** (per data stream, default `2h`): how far behind the current time the end of every window stays. Google publishes activity with a delay that varies by report; see [Data retention and lag times](https://support.google.com/a/answer/7061566). Events newer than `now - Lag Time` are not requested yet, and are collected on a later interval once they have settled.
+- **Chunk Duration** (per data stream, under Advanced options, disabled by default): the maximum span of activity requested in one interval. When set, each interval requests a window of at most this duration starting from the last completed position, and the position only moves forward after the whole window has been collected. If collection is interrupted, for example by an agent restart or a policy update, only that one chunk is requested again.
+
+Without Chunk Duration, an interval requests everything from the last completed position up to `now - Lag Time` in a single window. For a data stream with a large backlog or a high event rate, such as `token` or `drive` on a busy domain, that window can take longer to page through than the time between interruptions. Each interruption then restarts the same window from the beginning, no progress is saved, and the data stream appears to stall while it re-sends events it has already sent.
+
+Recommended Chunk Duration values:
+
+| Data stream volume | Suggested value |
+|---|---|
+| High (for example `token`, `drive`, `login` on large domains) | `1h` |
+| Moderate | `6h` |
+| Low (for example `rules`, `saml`, `access_transparency`) | `24h` |
+
+A chunk should be small enough to be fully collected between the interruptions you expect, and must not exceed `720h` (30 days). Once the data stream has caught up, the window end is limited by `now - Lag Time`, so Chunk Duration has no effect on steady-state collection. Leaving the setting empty, or setting it to `0`, disables chunking. Existing saved positions are reused unchanged when the setting is turned on or off.
+
 # Google Workspace Gmail Logs
 
 :::{note}

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "3.8.1"
+version: "3.9.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
## Type of change
- Enhancement
- Docs

## Proposed commit message
```
google_workspace: add optional chunk_duration to Reports API data streams

The Reports API data streams advance their collection cursor only after
a full time window has been paginated. When a long collection is
interrupted, for example by an agent restart in an agentless deployment,
the input resumes from the start of the window and re-fetches the entire
backlog, which can stall progress on high-volume reports.

Add an optional, hidden chunk_duration setting to all thirteen Reports
API data streams. When set, each interval requests a window of at most
chunk_duration starting from the last completed position and advances
only after that window is collected, so an interrupted run re-fetches at
most one chunk. The window is clamped to now minus lag_time so it never
runs ahead of the lag margin. Leaving the setting empty, or giving a
non-positive value, keeps the previous unchunked behaviour, so existing
cursors are unaffected.

Bump the package to 3.9.0, document the collection window settings in
the README, and add system tests covering chunked collection for every
stream and the disabled fallback for the token stream.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
