### PR TITLE
cloudflare_logpush: uppercase geo country_iso_code fields

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.1"
+  changes:
+    - description: Uppercase `source.geo.country_iso_code` and `destination.geo.country_iso_code` so country codes match ISO 3166-1 alpha-2 and EMS boundary layers in Kibana Maps.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.0.0"
   changes:
     - description: |

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Uppercase `source.geo.country_iso_code` and `destination.geo.country_iso_code` so country codes match ISO 3166-1 alpha-2 and EMS boundary layers in Kibana Maps.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21052
 - version: "2.0.0"
   changes:
     - description: |

--- a/packages/cloudflare_logpush/data_stream/firewall_event/_dev/test/pipeline/test-pipeline-firewall-event.log-expected.json
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/_dev/test/pipeline/test-pipeline-firewall-event.log-expected.json
@@ -107,7 +107,7 @@
                     "number": 15169
                 },
                 "geo": {
-                    "country_iso_code": "us"
+                    "country_iso_code": "US"
                 },
                 "ip": "175.16.199.0"
             },
@@ -242,7 +242,7 @@
                     "number": 15169
                 },
                 "geo": {
-                    "country_iso_code": "us"
+                    "country_iso_code": "US"
                 },
                 "ip": "175.16.199.0"
             },
@@ -377,7 +377,7 @@
                     "number": 15169
                 },
                 "geo": {
-                    "country_iso_code": "us"
+                    "country_iso_code": "US"
                 },
                 "ip": "175.16.199.0"
             },
@@ -484,7 +484,7 @@
                     "number": 12345
                 },
                 "geo": {
-                    "country_iso_code": "ch"
+                    "country_iso_code": "CH"
                 },
                 "ip": "192.168.1.1"
             },
@@ -618,7 +618,7 @@
                     "number": 15169
                 },
                 "geo": {
-                    "country_iso_code": "us"
+                    "country_iso_code": "US"
                 },
                 "ip": "175.16.199.0"
             },
@@ -751,7 +751,7 @@
                     "number": 15169
                 },
                 "geo": {
-                    "country_iso_code": "us"
+                    "country_iso_code": "US"
                 },
                 "ip": "175.16.199.0"
             },

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -191,11 +191,11 @@ processors:
       field: json.ClientCountry
       target_field: cloudflare_logpush.firewall_event.client.country
       ignore_missing: true
-  - set:
-      tag: set_source_geo_country_iso_code_e3426c91
-      field: source.geo.country_iso_code
-      copy_from: cloudflare_logpush.firewall_event.client.country
-      ignore_empty_value: true
+  - uppercase:
+      tag: uppercase_source_geo_country_iso_code_e3426c91
+      field: cloudflare_logpush.firewall_event.client.country
+      target_field: source.geo.country_iso_code
+      ignore_missing: true
   - convert:
       tag: convert_json_ClientIP_to_cloudflare_logpush_firewall_event_client_ip_534d6853
       field: json.ClientIP

--- a/packages/cloudflare_logpush/data_stream/firewall_event/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/sample_event.json
@@ -128,7 +128,7 @@
             "number": 15169
         },
         "geo": {
-            "country_iso_code": "us"
+            "country_iso_code": "US"
         },
         "ip": "175.16.199.0"
     },

--- a/packages/cloudflare_logpush/data_stream/http_request/_dev/test/pipeline/test-pipeline-http-request.log-expected.json
+++ b/packages/cloudflare_logpush/data_stream/http_request/_dev/test/pipeline/test-pipeline-http-request.log-expected.json
@@ -236,7 +236,7 @@
                     "number": 43766
                 },
                 "geo": {
-                    "country_iso_code": "sa"
+                    "country_iso_code": "SA"
                 },
                 "ip": "175.16.199.0",
                 "port": 0
@@ -510,7 +510,7 @@
                     "number": 43766
                 },
                 "geo": {
-                    "country_iso_code": "sa"
+                    "country_iso_code": "SA"
                 },
                 "ip": "175.16.199.0",
                 "port": 0
@@ -780,7 +780,7 @@
                     "number": 43766
                 },
                 "geo": {
-                    "country_iso_code": "sa"
+                    "country_iso_code": "SA"
                 },
                 "ip": "175.16.199.0",
                 "port": 0
@@ -1069,7 +1069,7 @@
                     "number": 43766
                 },
                 "geo": {
-                    "country_iso_code": "sa"
+                    "country_iso_code": "SA"
                 },
                 "ip": "175.16.199.0",
                 "port": 0
@@ -1372,7 +1372,7 @@
                     "number": 43766
                 },
                 "geo": {
-                    "country_iso_code": "sa"
+                    "country_iso_code": "SA"
                 },
                 "ip": "175.16.199.0",
                 "port": 0
@@ -1722,7 +1722,7 @@
                     "number": 43766
                 },
                 "geo": {
-                    "country_iso_code": "sa"
+                    "country_iso_code": "SA"
                 },
                 "ip": "175.16.199.0",
                 "port": 0
@@ -1931,7 +1931,7 @@
                 },
                 "geo": {
                     "city_name": "Athens",
-                    "country_iso_code": "gr",
+                    "country_iso_code": "GR",
                     "region_iso_code": "I"
                 },
                 "ip": "1.128.0.0",
@@ -2171,7 +2171,7 @@
                     "number": 12345
                 },
                 "geo": {
-                    "country_iso_code": "us"
+                    "country_iso_code": "US"
                 },
                 "ip": "203.0.113.99",
                 "port": 56450

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -259,11 +259,11 @@ processors:
       field: json.ClientCountry
       target_field: cloudflare_logpush.http_request.client.country
       ignore_missing: true
-  - set:
-      tag: set_source_geo_country_iso_code_1764ada0
-      field: source.geo.country_iso_code
-      copy_from: cloudflare_logpush.http_request.client.country
-      ignore_empty_value: true
+  - uppercase:
+      tag: uppercase_source_geo_country_iso_code_1764ada0
+      field: cloudflare_logpush.http_request.client.country
+      target_field: source.geo.country_iso_code
+      ignore_missing: true
   - convert:
       tag: convert_json_ClientIP_to_cloudflare_logpush_http_request_client_ip_3d9346d4
       field: json.ClientIP

--- a/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
@@ -264,7 +264,7 @@
             "number": 43766
         },
         "geo": {
-            "country_iso_code": "sa"
+            "country_iso_code": "SA"
         },
         "ip": "175.16.199.0",
         "port": 0

--- a/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
@@ -129,11 +129,11 @@ processors:
       field: json.ClientIPCountry
       target_field: cloudflare_logpush.nel_report.client.ip.country
       ignore_missing: true
-  - set:
-      tag: set_source_geo_country_iso_code_5c3ec239
-      field: source.geo.country_iso_code
-      copy_from: cloudflare_logpush.nel_report.client.ip.country
-      ignore_empty_value: true
+  - uppercase:
+      tag: uppercase_source_geo_country_iso_code_5c3ec239
+      field: cloudflare_logpush.nel_report.client.ip.country
+      target_field: source.geo.country_iso_code
+      ignore_missing: true
   - rename:
       tag: rename_json_LastKnownGoodColoCode_to_cloudflare_logpush_nel_report_last_known_good_colo_code_5bab09a8
       field: json.LastKnownGoodColoCode

--- a/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
@@ -326,11 +326,11 @@ processors:
       field: json.DestinationCountry
       target_field: cloudflare_logpush.network_analytics.destination.country
       ignore_missing: true
-  - set:
-      tag: set_destination_geo_country_iso_code_7ee5973d
-      field: destination.geo.country_iso_code
-      copy_from: cloudflare_logpush.network_analytics.destination.country
-      ignore_empty_value: true
+  - uppercase:
+      tag: uppercase_destination_geo_country_iso_code_7ee5973d
+      field: cloudflare_logpush.network_analytics.destination.country
+      target_field: destination.geo.country_iso_code
+      ignore_missing: true
   - rename:
       tag: rename_json_DestinationGeoHash_to_cloudflare_logpush_network_analytics_destination_geo_hash_3760770c
       field: json.DestinationGeoHash
@@ -883,11 +883,11 @@ processors:
       field: json.SourceCountry
       target_field: cloudflare_logpush.network_analytics.source.country
       ignore_missing: true
-  - set:
-      tag: set_source_geo_country_iso_code_60c57ee7
-      field: source.geo.country_iso_code
-      copy_from: cloudflare_logpush.network_analytics.source.country
-      ignore_empty_value: true
+  - uppercase:
+      tag: uppercase_source_geo_country_iso_code_60c57ee7
+      field: cloudflare_logpush.network_analytics.source.country
+      target_field: source.geo.country_iso_code
+      ignore_missing: true
   - rename:
       tag: rename_json_SourceGeoHash_to_cloudflare_logpush_network_analytics_source_geo_hash_1f37e21e
       field: json.SourceGeoHash

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/test/pipeline/test-pipeline-spectrum-event.log-expected.json
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/_dev/test/pipeline/test-pipeline-spectrum-event.log-expected.json
@@ -100,7 +100,7 @@
                 },
                 "bytes": 0,
                 "geo": {
-                    "country_iso_code": "bg"
+                    "country_iso_code": "BG"
                 },
                 "ip": "67.43.156.0",
                 "port": 40456
@@ -218,7 +218,7 @@
                 },
                 "bytes": 0,
                 "geo": {
-                    "country_iso_code": "bg"
+                    "country_iso_code": "BG"
                 },
                 "ip": "67.43.156.0",
                 "port": 40456
@@ -336,7 +336,7 @@
                 },
                 "bytes": 0,
                 "geo": {
-                    "country_iso_code": "bg"
+                    "country_iso_code": "BG"
                 },
                 "ip": "67.43.156.0",
                 "port": 40456
@@ -449,7 +449,7 @@
                 },
                 "bytes": 0,
                 "geo": {
-                    "country_iso_code": "bg"
+                    "country_iso_code": "BG"
                 },
                 "ip": "67.43.156.0",
                 "port": 40456
@@ -562,7 +562,7 @@
                 },
                 "bytes": 0,
                 "geo": {
-                    "country_iso_code": "bg"
+                    "country_iso_code": "BG"
                 },
                 "ip": "67.43.156.0",
                 "port": 40456
@@ -675,7 +675,7 @@
                 },
                 "bytes": 0,
                 "geo": {
-                    "country_iso_code": "bg"
+                    "country_iso_code": "BG"
                 },
                 "ip": "67.43.156.0",
                 "port": 40456

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -308,11 +308,11 @@ processors:
       field: json.ClientCountry
       target_field: cloudflare_logpush.spectrum_event.client.country
       ignore_missing: true
-  - set:
-      tag: set_source_geo_country_iso_code_a5c289a6
-      field: source.geo.country_iso_code
-      copy_from: cloudflare_logpush.spectrum_event.client.country
-      ignore_empty_value: true
+  - uppercase:
+      tag: uppercase_source_geo_country_iso_code_a5c289a6
+      field: cloudflare_logpush.spectrum_event.client.country
+      target_field: source.geo.country_iso_code
+      ignore_missing: true
   - convert:
       tag: convert_json_ClientIP_to_cloudflare_logpush_spectrum_event_client_ip_8e63b9ca
       field: json.ClientIP

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/sample_event.json
@@ -121,7 +121,7 @@
         },
         "bytes": 0,
         "geo": {
-            "country_iso_code": "bg"
+            "country_iso_code": "BG"
         },
         "ip": "67.43.156.0",
         "port": 40456

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -1779,7 +1779,7 @@ An example event for `firewall_event` looks as following:
             "number": 15169
         },
         "geo": {
-            "country_iso_code": "us"
+            "country_iso_code": "US"
         },
         "ip": "175.16.199.0"
     },
@@ -3017,7 +3017,7 @@ An example event for `http_request` looks as following:
             "number": 43766
         },
         "geo": {
-            "country_iso_code": "sa"
+            "country_iso_code": "SA"
         },
         "ip": "175.16.199.0",
         "port": 0
@@ -4627,7 +4627,7 @@ An example event for `spectrum_event` looks as following:
         },
         "bytes": 0,
         "geo": {
-            "country_iso_code": "bg"
+            "country_iso_code": "BG"
         },
         "ip": "67.43.156.0",
         "port": 40456

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "2.0.0"
+version: "2.0.1"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
cloudflare_logpush: uppercase geo country_iso_code fields

Cloudflare sends ClientCountry and related fields as lowercase ISO
3166-1 alpha-2 codes. Several data streams copied them as-is into
source.geo.country_iso_code and destination.geo.country_iso_code,
breaking Kibana Maps joins to the EMS World Countries layer which
keys on uppercase codes.

Replace set/copy_from with uppercase processors in the http_request,
firewall_event, spectrum_event, nel_report, and network_analytics data
streams, matching the existing access_request behaviour.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
**Pipeline tests run successfully**
```
--- Test results for package: cloudflare_logpush - START ---
╭────────────────────┬───────────────────────┬───────────┬──────────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE            │ DATA STREAM           │ TEST TYPE │ TEST NAME                                                                │ RESULT │ TIME ELAPSED │
├────────────────────┼───────────────────────┼───────────┼──────────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ cloudflare_logpush │ access_request        │ pipeline  │ (ingest pipeline warnings test-pipeline-access-request.log)              │ PASS   │ 459.110834ms │
│ cloudflare_logpush │ access_request        │ pipeline  │ test-pipeline-access-request.log                                         │ PASS   │ 153.059209ms │
│ cloudflare_logpush │ audit                 │ pipeline  │ (ingest pipeline warnings test-pipeline-audit.log)                       │ PASS   │ 591.295333ms │
│ cloudflare_logpush │ audit                 │ pipeline  │ test-pipeline-audit.log                                                  │ PASS   │ 118.441333ms │
│ cloudflare_logpush │ casb                  │ pipeline  │ (ingest pipeline warnings test-pipeline-casb.log)                        │ PASS   │ 450.732125ms │
│ cloudflare_logpush │ casb                  │ pipeline  │ test-pipeline-casb.log                                                   │ PASS   │  84.203166ms │
│ cloudflare_logpush │ device_posture        │ pipeline  │ (ingest pipeline warnings test-pipeline-device-posture.log)              │ PASS   │ 531.001917ms │
│ cloudflare_logpush │ device_posture        │ pipeline  │ test-pipeline-device-posture.log                                         │ PASS   │ 105.402833ms │
│ cloudflare_logpush │ dlp_forensic_copies   │ pipeline  │ (ingest pipeline warnings test-pipeline-dlp-forensic-copies.log)         │ PASS   │ 566.172916ms │
│ cloudflare_logpush │ dlp_forensic_copies   │ pipeline  │ test-pipeline-dlp-forensic-copies.log                                    │ PASS   │     63.321ms │
│ cloudflare_logpush │ dns                   │ pipeline  │ (ingest pipeline warnings test-pipeline-dns.log)                         │ PASS   │ 553.624209ms │
│ cloudflare_logpush │ dns                   │ pipeline  │ test-pipeline-dns.log                                                    │ PASS   │ 103.885375ms │
│ cloudflare_logpush │ dns_firewall          │ pipeline  │ (ingest pipeline warnings test-pipeline-dns-firewall.log)                │ PASS   │ 447.878125ms │
│ cloudflare_logpush │ dns_firewall          │ pipeline  │ test-pipeline-dns-firewall.log                                           │ PASS   │ 133.589834ms │
│ cloudflare_logpush │ email_security_alerts │ pipeline  │ (ingest pipeline warnings test-pipeline-email-security-alerts-event.log) │ PASS   │ 434.086708ms │
│ cloudflare_logpush │ email_security_alerts │ pipeline  │ test-pipeline-email-security-alerts-event.log                            │ PASS   │ 108.833959ms │
│ cloudflare_logpush │ firewall_event        │ pipeline  │ (ingest pipeline warnings test-pipeline-firewall-event.log)              │ PASS   │ 681.125958ms │
│ cloudflare_logpush │ firewall_event        │ pipeline  │ test-pipeline-firewall-event.log                                         │ PASS   │ 333.225208ms │
│ cloudflare_logpush │ gateway_dns           │ pipeline  │ (ingest pipeline warnings test-pipeline-gateway-dns.log)                 │ PASS   │ 429.011666ms │
│ cloudflare_logpush │ gateway_dns           │ pipeline  │ test-pipeline-gateway-dns.log                                            │ PASS   │ 173.170708ms │
│ cloudflare_logpush │ gateway_http          │ pipeline  │ (ingest pipeline warnings test-pipeline-gateway-http.log)                │ PASS   │ 579.758375ms │
│ cloudflare_logpush │ gateway_http          │ pipeline  │ test-pipeline-gateway-http.log                                           │ PASS   │ 286.672541ms │
│ cloudflare_logpush │ gateway_network       │ pipeline  │ (ingest pipeline warnings test-pipeline-gateway-network.log)             │ PASS   │ 466.509541ms │
│ cloudflare_logpush │ gateway_network       │ pipeline  │ test-pipeline-gateway-network.log                                        │ PASS   │ 165.570834ms │
│ cloudflare_logpush │ http_request          │ pipeline  │ (ingest pipeline warnings test-pipeline-http-request.log)                │ PASS   │ 572.938208ms │
│ cloudflare_logpush │ http_request          │ pipeline  │ test-pipeline-http-request.log                                           │ PASS   │ 597.770333ms │
│ cloudflare_logpush │ magic_ids             │ pipeline  │ (ingest pipeline warnings test-pipeline-magic-ids.log)                   │ PASS   │ 432.577208ms │
│ cloudflare_logpush │ magic_ids             │ pipeline  │ test-pipeline-magic-ids.log                                              │ PASS   │  87.246375ms │
│ cloudflare_logpush │ nel_report            │ pipeline  │ (ingest pipeline warnings test-pipeline-nel-report.log)                  │ PASS   │ 542.941042ms │
│ cloudflare_logpush │ nel_report            │ pipeline  │ test-pipeline-nel-report.log                                             │ PASS   │  75.243209ms │
│ cloudflare_logpush │ network_analytics     │ pipeline  │ (ingest pipeline warnings test-pipeline-network-analytics.log)           │ PASS   │ 429.273083ms │
│ cloudflare_logpush │ network_analytics     │ pipeline  │ test-pipeline-network-analytics.log                                      │ PASS   │ 222.116292ms │
│ cloudflare_logpush │ network_session       │ pipeline  │ (ingest pipeline warnings test-pipeline-network-session.log)             │ PASS   │ 473.036917ms │
│ cloudflare_logpush │ network_session       │ pipeline  │ test-pipeline-network-session.log                                        │ PASS   │ 160.092083ms │
│ cloudflare_logpush │ page_shield_events    │ pipeline  │ (ingest pipeline warnings test-pipeline-page-shield-events.log)          │ PASS   │ 413.159167ms │
│ cloudflare_logpush │ page_shield_events    │ pipeline  │ test-pipeline-page-shield-events.log                                     │ PASS   │  93.264209ms │
│ cloudflare_logpush │ sinkhole_http         │ pipeline  │ (ingest pipeline warnings test-pipeline-sinkhole-http.log)               │ PASS   │ 679.155917ms │
│ cloudflare_logpush │ sinkhole_http         │ pipeline  │ test-pipeline-sinkhole-http.log                                          │ PASS   │ 236.566167ms │
│ cloudflare_logpush │ spectrum_event        │ pipeline  │ (ingest pipeline warnings test-pipeline-spectrum-event.log)              │ PASS   │ 482.856458ms │
│ cloudflare_logpush │ spectrum_event        │ pipeline  │ test-pipeline-spectrum-event.log                                         │ PASS   │  195.08825ms │
│ cloudflare_logpush │ workers_trace         │ pipeline  │ (ingest pipeline warnings test-pipeline-workers-trace.log)               │ PASS   │ 596.948125ms │
│ cloudflare_logpush │ workers_trace         │ pipeline  │ test-pipeline-workers-trace.log                                          │ PASS   │  99.402333ms │
╰────────────────────┴───────────────────────┴───────────┴──────────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: cloudflare_logpush - END   ---
Done
```

