### PR TITLE
[prometheus] Render metrics_filters keys in collector stream only when set

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.5"
+  changes:
+    - description: Only render `metrics_filters.include` and `metrics_filters.exclude` in the collector stream when they are set, so the same keys can be provided through custom configuration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/NNNN
 - version: "1.24.4"
   changes:
     - description: Add group field to package manifest.

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Only render `metrics_filters.include` and `metrics_filters.exclude` in the collector stream when they are set, so the same keys can be provided through custom configuration.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/NNNN
+      link: https://github.com/elastic/integrations/pull/21053
 - version: "1.24.4"
   changes:
     - description: Add group field to package manifest.

--- a/packages/prometheus/data_stream/collector/_dev/test/system/test-custom-filters-config.yml
+++ b/packages/prometheus/data_stream/collector/_dev/test/system/test-custom-filters-config.yml
@@ -1,0 +1,9 @@
+# Regression test: metrics_filters.include set through custom yaml.
+vars: ~
+data_stream:
+  vars:
+    hosts:
+      - "{{Hostname}}:9090"
+    custom: |
+      metrics_filters.include:
+        - "^prometheus_"

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -3,14 +3,18 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+{{#if metrics_filters.exclude}}
 metrics_filters.exclude:
 {{#each metrics_filters.exclude}}
   - {{this}}
 {{/each}}
+{{/if}}
+{{#if metrics_filters.include}}
 metrics_filters.include:
 {{#each metrics_filters.include}}
   - {{this}}
 {{/each}}
+{{/if}}
 metrics_path: {{metrics_path}}
 period: {{period}}
 rate_counters: {{rate_counters}}

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.0"
 name: prometheus
 title: Prometheus
-version: 1.24.4
+version: 1.24.5
 description: Scrape Prometheus-format metrics from exporters, query the Prometheus API, or receive remote_write data via Elastic Agent.
 type: integration
 group: prometheus


### PR DESCRIPTION
## Proposed commit message

[prometheus] Render metrics_filters keys in collector stream only when set

The collector stream template always set `metrics_filters.include:` and `metrics_filters.exclude:` at the root of the stream yaml, even when the variables were empty.

Fleet appends the "Custom configurations" yaml var as raw text at the same root level, so a user who puts `metrics_filters.include:` into custom configuration get error:
```
YAMLException: Duplicated key "metrics_filters.include" found in agent policy yaml
```

This wraps `metrics_filters.include:` into a `{{#if}}`  block so the user can manually use they key `metrics_filters.include` in the `custom` section instead.

This makes it possible to paste a long include list as a yaml block in custom configuration instead of adding one UI row per pattern.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [ ] Template change in `data_stream/collector/agent/stream/stream.yml.hbs`
- [ ] New system test config with `custom` var setting `metrics_filters.include`

## How to test this PR locally

```
cd packages/prometheus
elastic-package stack up -d
elastic-package test system -d collector -v
```

Or in Kibana: add the Prometheus integration, leave "Metrics Filters Include" empty, and put this in Custom configurations:

```
metrics_filters.include:
  - "^node_"
```

## Related issues

<!-- none -->

## Screenshots

<!-- none -->