### PR TITLE
[aws] Render use_cloud_connectors in s3_daily_storage and s3_request

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "8.1.3"
+  changes:
+    - description: Render `use_cloud_connectors` in the `s3_daily_storage` and `s3_request` stream templates. These two `aws/metrics` streams in the agentless-enabled S3 policy template were missed in 7.2.0, so with Identity Federation selected the agent skipped the Cloud Connectors credential chain and attempted a bare `sts:AssumeRole`, failing with AccessDenied and marking the agent unhealthy.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "8.1.2"
   changes:
     - description: Add an `Instance or Pod IAM Role` option to the `Setup Access` selector so Elastic Agent can authenticate with the AWS SDK default credential chain (EC2 instance profile, EKS Pod Identity or IRSA) without entering access keys or a Role ARN. Since 7.0.0 every option required at least one credential field, which made this documented path impossible to save.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Render `use_cloud_connectors` in the `s3_daily_storage` and `s3_request` stream templates. These two `aws/metrics` streams in the agentless-enabled S3 policy template were missed in 7.2.0, so with Identity Federation selected the agent skipped the Cloud Connectors credential chain and attempted a bare `sts:AssumeRole`, failing with AccessDenied and marking the agent unhealthy.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/21058
 - version: "8.1.2"
   changes:
     - description: Add an `Instance or Pod IAM Role` option to the `Setup Access` selector so Elastic Agent can authenticate with the AWS SDK default credential chain (EC2 instance profile, EKS Pod Identity or IRSA) without entering access keys or a Role ARN. Since 7.0.0 every option required at least one credential field, which made this documented path impossible to save.

--- a/packages/aws/data_stream/s3_daily_storage/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/s3_daily_storage/agent/stream/stream.yml.hbs
@@ -27,6 +27,9 @@ shared_credential_file: {{shared_credential_file}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if default_region}}
 default_region: {{default_region}}
 {{/if}}

--- a/packages/aws/data_stream/s3_request/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/s3_request/agent/stream/stream.yml.hbs
@@ -27,6 +27,9 @@ shared_credential_file: {{shared_credential_file}}
 {{#if role_arn}}
 role_arn: {{role_arn}}
 {{/if}}
+{{#if supports_identity_federation}}
+use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
 {{#if default_region}}
 default_region: {{default_region}}
 {{/if}}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.4
 name: aws
 title: AWS
-version: 8.1.2
+version: 8.1.3
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

See title.

The `s3` policy template is agentless-enabled, but its two `aws/metrics` streams (`s3_daily_storage`, `s3_request`) never rendered `use_cloud_connectors`. With Identity Federation selected, beats skipped the Cloud Connectors credential chain and did a bare `sts:AssumeRole` against the customer role, which returned `AccessDenied` and marked the agent unhealthy:

```
Unit state changed aws/metrics-...-s3-... (STARTING->FAILED): Permanent: error creating aws metricset:
failed to retrieve aws credentials ... operation error STS: AssumeRole ... api error AccessDenied
```

Adds the same guarded block the other 13 `aws/metrics` streams received in 7.2.0 (#20527). Audited the remaining `aws/metrics` streams without the flag (apigateway, emr, firewall, kafka, kinesis, natgateway, redshift, s3_storage_lens, usage, vpn): all are in default-only policy templates where Identity Federation is hidden, so they are not affected. `s3access` uses the `aws-s3` input and does not need the flag.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) (n/a)

## Author's Checklist

- [ ] Rendered stream config for `s3_daily_storage` / `s3_request` includes `use_cloud_connectors: true` when Identity Federation is selected
- [x] No other `aws/metrics` stream in an agentless-enabled template is missing the flag

## How to test this PR locally

```
cd packages/aws && elastic-package check
```

Then install the built `aws-8.1.3.zip` in a serverless project with agentless enabled, add the S3 integration with Identity Federation, enable "Collect S3 metrics", and confirm the agent stays healthy and the `aws/metrics-…-s3-…` unit reaches `HEALTHY`.

## Related issues

- Relates #20527
- RCA: https://docs.google.com/document/d/1HO_AcRl1Artk77850EWRHMMMQoAcIUAtc4wq5US6GfA/edit?tab=t.0
