### PR TITLE
anthropic: fix cursor capturing first-page ID on multi-page forward runs

### DIFF
--- a/packages/anthropic/_dev/deploy/docker/files/config-audit.yml
+++ b/packages/anthropic/_dev/deploy/docker/files/config-audit.yml
@@ -1,5 +1,6 @@
 rules:
-  # Round 2 — forward tail resume after persisted bookmark.
+  # Round 2, page 1 — first page of multi-page forward tail.
+  # Cursor after round 1 is activity_01MOCKnewest01. New events arrive newest-first.
   - path: /v1/compliance/activities
     methods: ["GET"]
     query_params:
@@ -22,7 +23,7 @@ rules:
           {
             "data": [
               {
-                "id": "activity_01MOCKround2new",
+                "id": "activity_01MOCKr2p1a",
                 "created_at": "2026-05-22T11:05:00Z",
                 "organization_id": "org_01EXAMPLEabcdef123456789",
                 "organization_uuid": "91011112-1314-4151-6171-8191a1b1c1d1",
@@ -37,19 +38,78 @@ rules:
                 "invite_id": "invite_01EXAMPLEinvite01",
                 "invited_email": "new.user@example.com",
                 "invited_role": "member"
+              },
+              {
+                "id": "activity_01MOCKr2p1b",
+                "created_at": "2026-05-22T11:02:00Z",
+                "organization_id": "org_01EXAMPLEabcdef123456789",
+                "organization_uuid": "91011112-1314-4151-6171-8191a1b1c1d1",
+                "type": "sso_login_succeeded",
+                "actor": {
+                  "type": "user_actor",
+                  "email_address": "bob.smith@example.com",
+                  "user_id": "user_01EXAMPLEbob01",
+                  "ip_address": "192.0.2.34",
+                  "user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+                }
               }
             ],
-            "first_id": "activity_01MOCKround2new",
-            "last_id": "activity_01MOCKround2new",
-            "has_more": false
+            "first_id": "activity_01MOCKr2p1a",
+            "last_id": "activity_01MOCKr2p1b",
+            "has_more": true
           }
           ` }}
-  # Steady state — no new events after round 2 bookmark advances.
+  # Round 2, page 2 — terminal page; newest event is activity_01MOCKr2p2a.
+  # The cursor must advance to this ID, not to the first page's first_id.
   - path: /v1/compliance/activities
     methods: ["GET"]
     query_params:
       limit: "2"
-      before_id: activity_01MOCKround2new
+      before_id: activity_01MOCKr2p1a
+    request_headers:
+      x-api-key:
+        - "test-api-key-12345"
+      anthropic-version:
+        - "2023-06-01"
+      Accept:
+        - "application/json"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {{ minify_json `
+          {
+            "data": [
+              {
+                "id": "activity_01MOCKr2p2a",
+                "created_at": "2026-05-22T11:08:00Z",
+                "organization_id": "org_01EXAMPLEabcdef123456789",
+                "organization_uuid": "91011112-1314-4151-6171-8191a1b1c1d1",
+                "type": "admin_api_key_created",
+                "actor": {
+                  "type": "user_actor",
+                  "email_address": "admin@example.org",
+                  "user_id": "user_01EXAMPLEadmin01",
+                  "ip_address": "198.51.100.42",
+                  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                },
+                "admin_api_key_id": "admin_key_01EXAMPLEkey01",
+                "scopes": ["read:compliance_activities"]
+              }
+            ],
+            "first_id": "activity_01MOCKr2p2a",
+            "last_id": "activity_01MOCKr2p2a",
+            "has_more": false
+          }
+          ` }}
+  # Steady state — no new events after round 2 bookmark correctly advances to r2p2a.
+  - path: /v1/compliance/activities
+    methods: ["GET"]
+    query_params:
+      limit: "2"
+      before_id: activity_01MOCKr2p2a
     request_headers:
       x-api-key:
         - "test-api-key-12345"

--- a/packages/anthropic/_dev/deploy/docker/files/config-audit.yml
+++ b/packages/anthropic/_dev/deploy/docker/files/config-audit.yml
@@ -123,7 +123,7 @@ rules:
           Content-Type:
             - "application/json"
         body: |-
-          {"data":[],"has_more":false}
+          {"data":[],"first_id":null,"last_id":null,"has_more":false}
   # Round 1, page 3 — terminal backfill page.
   - path: /v1/compliance/activities
     methods: ["GET"]

--- a/packages/anthropic/changelog.yml
+++ b/packages/anthropic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Fix incorrect pagination cursor on subsequent pages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21062
 - version: "1.1.1"
   changes:
     - description: Remove empty ILM policies section from the README.

--- a/packages/anthropic/data_stream/audit/_dev/test/system/test-default-config.yml
+++ b/packages/anthropic/data_stream/audit/_dev/test/system/test-default-config.yml
@@ -11,4 +11,4 @@ data_stream:
     batch_size: 2
     preserve_original_event: false
 assert:
-  hit_count: 6
+  hit_count: 8

--- a/packages/anthropic/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/anthropic/data_stream/audit/agent/stream/cel.yml.hbs
@@ -92,7 +92,9 @@ program: |-
                 }
               :
                 {
-                  ?"first_id": state.?cursor.run_first_id.hasValue() ?
+                  ?"first_id": state.?cursor.first_id.hasValue() ?
+                    (has(body.first_id) ? optional.of(body.first_id) : state.?cursor.first_id)
+                  : state.?cursor.run_first_id.hasValue() ?
                     state.?cursor.run_first_id
                   : (!state.?cursor.page_id.hasValue() && has(body.first_id)) ?
                     optional.of(body.first_id)

--- a/packages/anthropic/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/anthropic/data_stream/audit/agent/stream/cel.yml.hbs
@@ -93,10 +93,10 @@ program: |-
               :
                 {
                   ?"first_id": state.?cursor.first_id.hasValue() ?
-                    (has(body.first_id) ? optional.of(body.first_id) : state.?cursor.first_id)
+                    ((has(body.first_id) && body.first_id != null) ? optional.of(body.first_id) : state.?cursor.first_id)
                   : state.?cursor.run_first_id.hasValue() ?
                     state.?cursor.run_first_id
-                  : (!state.?cursor.page_id.hasValue() && has(body.first_id)) ?
+                  : (!state.?cursor.page_id.hasValue() && has(body.first_id) && body.first_id != null) ?
                     optional.of(body.first_id)
                   :
                     state.?cursor.first_id,

--- a/packages/anthropic/manifest.yml
+++ b/packages/anthropic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.2"
 name: anthropic
 title: Anthropic
-version: "1.1.1"
+version: "1.1.2"
 source:
   license: "Elastic-2.0"
 description: Collect activity logs from Claude's Compliance API.


### PR DESCRIPTION
On subsequent runs the CEL input uses before_id paging, walking forward from the last bookmark toward newer events. The newest events appear on the last page of the run, but run_first_id was captured from the first page only. When has_more became false the persisted first_id was set from run_first_id, so the cursor advanced by only one page's worth of activity per run regardless of how many pages were fetched.

Fix the has_more=false branch: when cursor.first_id already has a value (a subsequent run), take body.first_id from the terminal page directly rather than the stale run_first_id.

Extend the system test mock to cover multi-page subsequent runs: Round 2 now spans two pages so that steady state is reached only if the cursor advances to the terminal page's event.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

The system mock now properly tests the pagination as it is intended, so the sorting order is different on page 1 and 2


```bash
elastic-package test system 
--- Test results for package: anthropic - START ---
╭───────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE   │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├───────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ anthropic │ audit       │ system    │ default   │ PASS   │ 51.082320815s │
╰───────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: anthropic - END   ---
Done
```