### PR TITLE
tenable_io: stop polling terminal exports and advance cursor only after download

### DIFF
--- a/packages/tenable_io/_dev/build/docs/README.md
+++ b/packages/tenable_io/_dev/build/docs/README.md
@@ -32,7 +32,8 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
   - In this integration, export and plugin endpoints of vulnerability management are used to fetch data.
   - The default value is the recommended value for a batch size by Tenable. Using a smaller batch size can improve performance. A very large value might not work as intended depending on the API and instance limitations.
   - If any long-running export jobs are stuck in the "PROCESSING" state and reach the user-provided timeout, the export job will be terminated, allowing for the initiation of a new export job after the specified interval.
-  - While an export job is queued or processing, its status is checked once every "Export Status Poll Interval" (default 30s). Export jobs that Tenable reports as "CANCELLED" or "ERROR" are abandoned and reported as an error; the data window is retried with a new export job at the next interval, so no data is skipped.
+  - While an export job is queued or processing, its status is checked once every "Export Status Poll Interval" (default 30s). Export jobs that Tenable reports as "CANCELLED", "ERROR", or "FINISHED" with failed chunks are abandoned and reported as an error. The same data window is retried with a new export job at the next interval.
+  - "Maximum Pages Per Interval" bounds the total number of status checks and chunk downloads per interval. A 12h export status timeout at the default 30s poll interval alone accounts for 1440 of them.
 
 ## Agentless-enabled integration
 

--- a/packages/tenable_io/_dev/build/docs/README.md
+++ b/packages/tenable_io/_dev/build/docs/README.md
@@ -32,6 +32,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
   - In this integration, export and plugin endpoints of vulnerability management are used to fetch data.
   - The default value is the recommended value for a batch size by Tenable. Using a smaller batch size can improve performance. A very large value might not work as intended depending on the API and instance limitations.
   - If any long-running export jobs are stuck in the "PROCESSING" state and reach the user-provided timeout, the export job will be terminated, allowing for the initiation of a new export job after the specified interval.
+  - While an export job is queued or processing, its status is checked once every "Export Status Poll Interval" (default 30s). Export jobs that Tenable reports as "CANCELLED" or "ERROR" are abandoned and reported as an error; the data window is retried with a new export job at the next interval, so no data is skipped.
 
 ## Agentless-enabled integration
 

--- a/packages/tenable_io/_dev/deploy/docker/files/config.yml
+++ b/packages/tenable_io/_dev/deploy/docker/files/config.yml
@@ -10,6 +10,9 @@ rules:
     responses:
       - status_code: 200
         body: |
+          {"status":"PROCESSING","chunks_available":[]}
+      - status_code: 200
+        body: |
           {"status":"FINISHED","chunks_available":[1]}
   - path: /assets/export/xxx/chunks/1
     methods: ["GET"]
@@ -37,7 +40,18 @@ rules:
           {"export_uuid":"xxx"}
   - path: /vulns/export/xxx/status
     methods: ["GET"]
+    # Responses are served in rolling sequence, so every export cycle walks
+    # QUEUED -> PROCESSING -> FINISHED and exercises the wait between polls.
+    # Terminal statuses (CANCELLED, ERROR, failed chunks) are not mocked here:
+    # they degrade the input by design, which the system test runner treats as
+    # a failure.
     responses:
+      - status_code: 200
+        body: |
+          {"status":"QUEUED","chunks_available":[]}
+      - status_code: 200
+        body: |
+          {"status":"PROCESSING","chunks_available":[]}
       - status_code: 200
         body: |
           {"status":"FINISHED","chunks_available":[1,2]}

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: In the asset and vulnerability data streams, stop polling exports that are `CANCELLED` or `ERROR`, wait between export status checks, and only advance the cursor after all chunks of an export have been downloaded.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21067
 - version: "4.13.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.13.1"
+  changes:
+    - description: In the asset and vulnerability data streams, stop polling exports that are `CANCELLED` or `ERROR`, wait between export status checks, and only advance the cursor after all chunks of an export have been downloaded.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "4.13.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/tenable_io/data_stream/asset/_dev/test/system/test-default-config.yml
+++ b/packages/tenable_io/data_stream/asset/_dev/test/system/test-default-config.yml
@@ -8,6 +8,8 @@ vars:
 data_stream:
   vars:
     batch_size: 100
+    # Poll quickly so the test does not wait 30s for the PROCESSING -> FINISHED step.
+    export_status_poll_interval: 1s
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
 assert:

--- a/packages/tenable_io/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/asset/agent/stream/cel.yml.hbs
@@ -39,12 +39,14 @@ program: |-
   // next interval instead of silently skipping its window.
   //
   // Phases, selected in this order: "create" when there is no active export,
-  // which requests a new export since the cursor; "cancel" when the active
-  // export is past export_status_timeout, which cancels and drops it so the
-  // next interval starts afresh; "download" when the active export has chunks
-  // left to fetch; otherwise "status", which polls the export job. QUEUED and
-  // PROCESSING wait export_status_poll_interval before the next poll, while
-  // CANCELLED and ERROR are terminal and reported as errors.
+  // which requests a new export since the cursor; "download" when the active
+  // export has chunks left to fetch, so an interrupted download resumes while
+  // Tenable still has the chunks; "cancel" when the active export is still
+  // being built past export_status_timeout, which cancels and drops it so the
+  // next interval starts afresh; otherwise "status", which polls the export
+  // job. QUEUED and PROCESSING wait export_status_poll_interval before the
+  // next poll, while CANCELLED and ERROR are
+  // terminal and reported as errors.
   {
     "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
     "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"],
@@ -52,10 +54,10 @@ program: |-
     (
       !has(state.?export.uuid) ?
         "create"
-      : (int(now) > int(state.export.expires)) ?
-        "cancel"
       : (size(state.?chunks.orValue([])) > 0) ?
         "download"
+      : (int(now) > int(state.export.expires)) ?
+        "cancel"
       :
         "status"
     ).as(phase,
@@ -148,9 +150,14 @@ program: |-
                 )
               )
             :
-              // Keep the export and chunk position so the next interval
-              // resumes the download (or cancels once it has expired).
+              // The chunk is gone (Tenable expires chunks after 24h) or keeps
+              // failing after the client's own retries: drop the export. The
+              // cursor is untouched, so the next interval creates a fresh export
+              // from the same point.
               {
+                "export": {},
+                "chunks": [],
+                "next": 0,
                 "events": {
                   "error": {
                     "code": string(resp.StatusCode),

--- a/packages/tenable_io/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/asset/agent/stream/cel.yml.hbs
@@ -17,10 +17,10 @@ resource.url: {{url}}
 state:
   access_key: {{access_key}}
   secret_key: {{secret_key}}
-  chunk_status: "QUEUED"
   batch_size: {{batch_size}}
   initial_interval: {{initial_interval}}
   export_status_timeout: {{export_status_timeout}}
+  export_status_poll_interval: {{export_status_poll_interval}}
 redact:
   fields:
     - access_key
@@ -28,271 +28,210 @@ redact:
 {{#if max_executions}}
 max_executions: {{max_executions}}
 {{/if}}
-program: |
-  state.with(state.?chunk_status.orValue("") != "PROCESSING" && !state.?want_more.orValue(false) ?
-    post_request(
-      state.url.trim_right("/") + "/assets/export", "application/json",
-      '{"chunk_size":' + state.batch_size.encode_json() + ',"filters":{"updated_at": ' + state.?cursor.last_event_ts.orValue(int(now - duration(state.initial_interval))).encode_json() + '}}'
-    ).with({
-      "Header":{
-        "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-        "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-      },
-    }).do_request().as(resp,
-      resp.StatusCode == 200 ?
-        {
-          "export_response": bytes(resp.Body).decode_json(),
-          "export_status_timeout": state.export_status_timeout,
-          "expires": now + duration(state.export_status_timeout),
-          "cursor": {
-            "last_event_ts": int(now)
-          }
-        }
+program: |-
+  // The asset export is a small state machine that makes one HTTP
+  // request per evaluation. state.export holds the active export job
+  // ({uuid, created, expires}); state.chunks and state.next track the chunk
+  // downloads. Everything except the cursor is in-memory only and is lost on
+  // restart, so the cursor (last_event_ts) is advanced only once every
+  // chunk of an export has been downloaded. A cancelled, failed, expired or
+  // orphaned export is therefore retried from the same point in time at the
+  // next interval instead of silently skipping its window.
+  //
+  // Phases, selected in this order: "create" when there is no active export,
+  // which requests a new export since the cursor; "cancel" when the active
+  // export is past export_status_timeout, which cancels and drops it so the
+  // next interval starts afresh; "download" when the active export has chunks
+  // left to fetch; otherwise "status", which polls the export job. QUEUED and
+  // PROCESSING wait export_status_poll_interval before the next poll, while
+  // CANCELLED and ERROR are terminal and reported as errors.
+  {
+    "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
+    "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"],
+  }.as(headers,
+    (
+      !has(state.?export.uuid) ?
+        "create"
+      : (int(now) > int(state.export.expires)) ?
+        "cancel"
+      : (size(state.?chunks.orValue([])) > 0) ?
+        "download"
       :
-        {
-          "response_error": {
-            "error": {
-              "code": string(resp.StatusCode),
-              "id": string(resp.Status),
-              "message": string(resp.Body)
-            },
-          },
-          "want_more": false,
-          "export_response": {},
-          "export_status_timeout": state.export_status_timeout,
-          "expires": now + duration(state.export_status_timeout),
-        }
+        "status"
+    ).as(phase,
+      state.with(
+        (phase == "create") ?
+          // Create: request an export for everything updated since the cursor.
+          post_request(
+            state.url.trim_right("/") + "/assets/export",
+            "application/json",
+            {
+              "chunk_size": state.batch_size,
+              "filters": {
+                "updated_at": int(state.?cursor.last_event_ts.orValue(int(now - duration(state.initial_interval)))),
+              },
+            }.encode_json()
+          ).with({"Header": headers}).do_request().as(resp,
+            (resp.StatusCode == 200) ?
+              {
+                "export": {
+                  "uuid": resp.Body.decode_json().export_uuid,
+                  "created": int(now),
+                  "expires": int(now + duration(state.export_status_timeout)),
+                },
+                "chunks": [],
+                "next": 0,
+                "events": [{"retry": true}],
+                "want_more": true,
+              }
+            :
+              {
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "POST /assets/export: " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status)),
+                  },
+                },
+                "want_more": false,
+              }
+          )
+        : (phase == "cancel") ?
+          // Cancel: the export did not finish in time. Drop it whatever the
+          // API says; the cursor is untouched so the next interval retries.
+          post_request(
+            state.url.trim_right("/") + "/assets/export/" + state.export.uuid + "/cancel",
+            "application/json",
+            ""
+          ).with({"Header": headers}).do_request().as(resp,
+            {
+              "export": {},
+              "chunks": [],
+              "next": 0,
+              "events": {
+                "error": {
+                  "code": "EXPIRED",
+                  "id": state.export.uuid,
+                  "message": "POST /assets/export/" + state.export.uuid + "/cancel: export did not finish within " + state.export_status_timeout + (
+                    (resp.StatusCode == 200) ?
+                      ""
+                    :
+                      "; cancel failed: " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status))
+                  ),
+                },
+              },
+              "want_more": false,
+            }
+          )
+        : (phase == "download") ?
+          // Download: fetch the next chunk. Once the last chunk is in, the
+          // export is complete and the cursor moves to the export's creation
+          // time.
+          request(
+            "GET",
+            state.url.trim_right("/") + "/assets/export/" + state.export.uuid + "/chunks/" + string(int(state.chunks[int(state.next)]))
+          ).with({"Header": headers}).do_request().as(resp,
+            (resp.StatusCode == 200) ?
+              resp.Body.decode_json().as(body,
+                (int(state.next) + 1 < size(state.chunks)).as(more,
+                  {
+                    "events": (body != null && size(body) > 0) ?
+                      dyn(body.map(e, {"message": e.encode_json()}))
+                    :
+                      dyn([{"retry": true}]),
+                    "export": more ? state.export : {},
+                    "chunks": more ? state.chunks : [],
+                    "next": more ? (int(state.next) + 1) : 0,
+                    ?"cursor": more ? optional.none() : optional.of({"last_event_ts": int(state.export.created)}),
+                    "want_more": more,
+                  }
+                )
+              )
+            :
+              // Keep the export and chunk position so the next interval
+              // resumes the download (or cancels once it has expired).
+              {
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "GET /assets/export/" + state.export.uuid + "/chunks/" + string(int(state.chunks[int(state.next)])) + ": " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status)),
+                  },
+                },
+                "want_more": false,
+              }
+          )
+        :
+          // Status: poll the export job.
+          request(
+            "GET",
+            state.url.trim_right("/") + "/assets/export/" + state.export.uuid + "/status"
+          ).with({"Header": headers}).do_request().as(resp,
+            (resp.StatusCode == 200) ?
+              resp.Body.decode_json().as(body,
+                (body.?status.orValue("") == "FINISHED" && size(body.?chunks_available.orValue([])) > 0) ?
+                  {
+                    "chunks": body.chunks_available,
+                    "next": 0,
+                    "events": [{"retry": true}],
+                    "want_more": true,
+                  }
+                : (body.?status.orValue("") == "FINISHED") ?
+                  // Finished with nothing to download: the export is complete.
+                  {
+                    "export": {},
+                    "chunks": [],
+                    "next": 0,
+                    "cursor": {"last_event_ts": int(state.export.created)},
+                    "events": [{"retry": true}],
+                    "want_more": false,
+                  }
+                : (body.?status.orValue("") in ["CANCELLED", "ERROR"]) ?
+                  // Terminal failure: report it and drop the export. The cursor
+                  // is untouched so the next interval retries the same window.
+                  {
+                    "export": {},
+                    "chunks": [],
+                    "next": 0,
+                    "events": {
+                      "error": {
+                        "code": body.status,
+                        "id": state.export.uuid,
+                        "message": "GET /assets/export/" + state.export.uuid + "/status: export " + body.status + ((body.?reason.orValue(null) != null) ? (": " + string(body.reason)) : ""),
+                      },
+                    },
+                    "want_more": false,
+                  }
+                :
+                  // QUEUED or PROCESSING: ask the input to wait before the next
+                  // evaluation instead of polling back-to-back.
+                  {
+                    "events": [{"retry": true}],
+                    "want_more": true,
+                    "rate_limit": {
+                      "rate": 0,
+                      "burst": 1,
+                      "next": "inf",
+                      "reset": string(now + duration(state.export_status_poll_interval)),
+                    },
+                  }
+              )
+            :
+              // Keep the export so the next interval polls it again (or
+              // cancels it once it has expired).
+              {
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "GET /assets/export/" + state.export.uuid + "/status: " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status)),
+                  },
+                },
+                "want_more": false,
+              }
+          )
+      )
     )
-  :
-    {
-      "url": state.url,
-      "export_status_timeout": state.export_status_timeout,
-      "expires": state.expires,
-      "want_more": state.want_more,
-      "chunks": state.?chunks.orValue([]),
-      "chunk_status": state.chunk_status,
-      "export_response": state.?export_response.orValue({}),
-      "next": state.?next.orValue(0),
-      "access_key": state.access_key,
-      "secret_key": state.secret_key,
-      "initial_interval": state.initial_interval,
-      "batch_size": state.batch_size,
-      "response_error": state.?response_error.orValue({}),
-      "cursor": {
-        "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-      }
-    }
-  ).as(state,
-    has(state.?export_response.export_uuid) && state.?chunk_status.orValue("") != "FINISHED" ?
-      request("GET",
-        state.url.trim_right("/") +"/assets/export/" + state.export_response.export_uuid + "/status"
-      ).with({
-        "Header":{
-          "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-          "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-        }
-      }).do_request().as(response,
-        response.StatusCode == 200 ?
-          bytes(response.Body).decode_json().as(inner_body, {
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": (inner_body.?status.orValue("") != "FINISHED" || size(inner_body.chunks_available) > 0) && (string(now) <= string(state.expires)),
-            "chunk_status": inner_body.?status.orValue("") == "FINISHED" && size(inner_body.chunks_available) == 0 ? "QUEUED" : inner_body.status,
-            "export_response": state.export_response,
-            "chunks": inner_body.chunks_available,
-            "url": state.url,
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "cursor": {
-              "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-            }
-          })
-        :
-          {
-            "response_error": {
-              "error": {
-                "code": string(response.StatusCode),
-                "id": string(response.Status),
-                "message": string(response.Body)
-              },
-            },
-            "url": state.url,
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunks": [],
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-          }
-      )
-    :
-      {
-        "url": state.url,
-        "export_status_timeout": state.export_status_timeout,
-        "expires": state.expires,
-        "want_more": state.want_more,
-        "chunks": state.?chunks.orValue([]),
-        "chunk_status": state.chunk_status,
-        "export_response": state.?export_response.orValue({}),
-        "next": state.?next.orValue(0),
-        "access_key": state.access_key,
-        "secret_key": state.secret_key,
-        "initial_interval": state.initial_interval,
-        "batch_size": state.batch_size,
-        "response_error": state.?response_error.orValue({}),
-        "cursor": {
-          "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-        }
-      }
-  ).as(state,
-    has(state.?export_response.export_uuid) && state.?chunk_status.orValue("") != "FINISHED" && (string(now) > string(state.expires))?
-      post_request(
-        state.url.trim_right("/") +"/assets/export/" + state.export_response.export_uuid + "/cancel", "application/json", ""
-      ).with({
-        "Header":{
-          "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-          "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-        }
-      }).do_request().as(response,
-        response.StatusCode == 200 ?
-          bytes(response.Body).decode_json().as(inner_body, {
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "chunks": [],
-            "url": state.url,
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "cursor": {
-              "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-            }
-          })
-        :
-          {
-            "response_error": {
-              "error": {
-                "code": string(response.StatusCode),
-                "id": string(response.Status),
-                "message": string(response.Body)
-              },
-            },
-            "url": state.url,
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunks": [],
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-          }
-      )
-    :
-      {
-        "url": state.url,
-        "export_status_timeout": state.export_status_timeout,
-        "expires": state.expires,
-        "want_more": state.want_more,
-        "chunks": state.?chunks.orValue([]),
-        "chunk_status": state.chunk_status,
-        "export_response": state.?export_response.orValue({}),
-        "next": state.?next.orValue(0),
-        "access_key": state.access_key,
-        "secret_key": state.secret_key,
-        "initial_interval": state.initial_interval,
-        "batch_size": state.batch_size,
-        "response_error": state.?response_error.orValue({}),
-        "cursor": {
-          "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-        }
-      }
-  ).as(state,
-    has(state.?export_response.export_uuid) && state.?chunk_status.orValue("") == "FINISHED" && size(state.chunks) > 0 ?
-      request("GET",
-        state.url.trim_right("/") +"/assets/export/" + state.export_response.export_uuid + "/chunks/" + string(state.chunks[state.next])
-      ).with({
-        "Header":{
-          "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-          "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-        }
-      }).do_request().as(response1,
-        response1.StatusCode == 200 ?
-          bytes(response1.Body).decode_json().as(second_chain_body, {
-            "events": second_chain_body != null ? second_chain_body.map(e, { "message": e.encode_json() }) : [{}],
-            "expires": state.expires,
-            "export_status_timeout": state.export_status_timeout,
-            "want_more": (int(state.next)+1) < size(state.chunks),
-            "export_response": (int(state.next)+1) < size(state.chunks) ? state.export_response : {},
-            "next": (int(state.next)+1) < size(state.chunks) ? (int(state.next)+1) : 0,
-            "chunk_status": ((int(state.next)+1) < size(state.chunks)) || (second_chain_body == null) ? state.chunk_status : "QUEUED",
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "chunks": (int(state.next)+1) < size(state.chunks) ? state.chunks : [],
-            "url": state.url,
-            "cursor": {
-              "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-            }
-          })
-        :
-          {
-            "events": {
-              "error": {
-                "code": string(response1.StatusCode),
-                "id": string(response1.Status),
-                "message": string(response1.Body)
-              },
-            },
-            "url": state.url,
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunks": [],
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-          }
-      )
-    :
-      {
-        "events": state.?response_error.error.orValue(null) != null ? state.response_error : [{}],
-        "export_status_timeout": state.export_status_timeout,
-        "expires": state.expires,
-        "url": state.url,
-        "chunks": state.?chunks.orValue([]),
-        "chunk_status": state.chunk_status,
-        "want_more": state.want_more,
-        "export_response": state.?export_response.orValue({}),
-        "next": state.?next.orValue(0),
-        "access_key": state.access_key,
-        "secret_key": state.secret_key,
-        "initial_interval": state.initial_interval,
-        "batch_size": state.batch_size,
-        "cursor": {
-          "last_event_ts": state.?cursor.last_event_ts.orValue(int(now))
-        }
-      }
   )
 tags:
 {{#if preserve_original_event}}
@@ -307,7 +246,8 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors}}
 processors:
+- drop_event.when.equals.retry: true
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/tenable_io/data_stream/asset/manifest.yml
+++ b/packages/tenable_io/data_stream/asset/manifest.yml
@@ -30,6 +30,14 @@ streams:
         required: true
         show_user: true
         default: 12h
+      - name: export_status_poll_interval
+        type: text
+        title: Export Status Poll Interval
+        description: "Duration to wait between checks of the export job status while the export is queued or processing. NOTE: Supported units for this parameter are h/m/s."
+        multi: false
+        required: true
+        show_user: false
+        default: 30s
       - name: batch_size
         type: integer
         title: Chunk Size

--- a/packages/tenable_io/data_stream/vulnerability/_dev/test/system/test-default-config.yml
+++ b/packages/tenable_io/data_stream/vulnerability/_dev/test/system/test-default-config.yml
@@ -15,6 +15,9 @@ data_stream:
     # severity_level filter is applied only on the first export and dropped
     # from CEL state on subsequent cycles.
     interval: 1m
+    # The mock walks each export through QUEUED -> PROCESSING -> FINISHED. Poll
+    # quickly so the test does not wait 30s per status check.
+    export_status_poll_interval: 1s
     num_assets: 500
     preserve_original_event: true
     preserve_duplicate_custom_fields: true

--- a/packages/tenable_io/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -17,10 +17,10 @@ resource.url: {{url}}
 state:
   access_key: {{access_key}}
   secret_key: {{secret_key}}
-  chunk_status: "QUEUED"
   batch_size: {{num_assets}}
   initial_interval: {{initial_interval}}
   export_status_timeout: {{export_status_timeout}}
+  export_status_poll_interval: {{export_status_poll_interval}}
 {{#if severity_level}}
   severity_level:
 {{#each severity_level as |l|}}
@@ -34,288 +34,212 @@ redact:
 {{#if max_executions}}
 max_executions: {{max_executions}}
 {{/if}}
-program: |
-  state.with(state.?chunk_status.orValue("") != "PROCESSING" && !state.?want_more.orValue(false) ?
-    post_request(
-      state.url.trim_right("/") + "/vulns/export", "application/json",
-      {
-        "num_assets": state.batch_size,
-        "filters": {
-          "since": state.?cursor.last_event_time.orValue(int(now - duration(state.initial_interval))),
-          "state": ["open", "reopened", "fixed"],
-          "severity": state.?severity_level.orValue([])
-        }
-      }.encode_json()
-    ).with({
-      "Header":{
-        "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-        "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-      },
-    }).do_request().as(resp,
-      resp.StatusCode == 200 ?
-        {
-          "export_response": bytes(resp.Body).decode_json(),
-          "export_status_timeout": state.export_status_timeout,
-          "expires": now + duration(state.export_status_timeout),
-          "cursor": {
-            "last_event_time": int(now)
-          }
-        }
+program: |-
+  // The vulnerability export is a small state machine that makes one HTTP
+  // request per evaluation. state.export holds the active export job
+  // ({uuid, created, expires}); state.chunks and state.next track the chunk
+  // downloads. Everything except the cursor is in-memory only and is lost on
+  // restart, so the cursor (last_event_time) is advanced only once every
+  // chunk of an export has been downloaded. A cancelled, failed, expired or
+  // orphaned export is therefore retried from the same point in time at the
+  // next interval instead of silently skipping its window.
+  //
+  // Phases, selected in this order: "create" when there is no active export,
+  // which requests a new export since the cursor; "cancel" when the active
+  // export is past export_status_timeout, which cancels and drops it so the
+  // next interval starts afresh; "download" when the active export has chunks
+  // left to fetch; otherwise "status", which polls the export job. QUEUED and
+  // PROCESSING wait export_status_poll_interval before the next poll, while
+  // CANCELLED and ERROR are terminal and reported as errors.
+  {
+    "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
+    "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"],
+  }.as(headers,
+    (
+      !has(state.?export.uuid) ?
+        "create"
+      : (int(now) > int(state.export.expires)) ?
+        "cancel"
+      : (size(state.?chunks.orValue([])) > 0) ?
+        "download"
       :
-        {
-          "response_error": {
-            "error": {
-              "code": string(resp.StatusCode),
-              "id": string(resp.Status),
-              "message": string(resp.Body)
-            },
-          },
-          "want_more": false,
-          "export_response": {},
-          "export_status_timeout": state.export_status_timeout,
-          "expires": now + duration(state.export_status_timeout),
-        }
+        "status"
+    ).as(phase,
+      state.with(
+        (phase == "create") ?
+          // Create: request an export for everything updated since the cursor.
+          post_request(
+            state.url.trim_right("/") + "/vulns/export",
+            "application/json",
+            {
+              "num_assets": state.batch_size,
+              "filters": {
+                "since": int(state.?cursor.last_event_time.orValue(int(now - duration(state.initial_interval)))),
+                "state": ["open", "reopened", "fixed"],
+                "severity": state.?severity_level.orValue([]),
+              },
+            }.encode_json()
+          ).with({"Header": headers}).do_request().as(resp,
+            (resp.StatusCode == 200) ?
+              {
+                "export": {
+                  "uuid": resp.Body.decode_json().export_uuid,
+                  "created": int(now),
+                  "expires": int(now + duration(state.export_status_timeout)),
+                },
+                "chunks": [],
+                "next": 0,
+                "events": [{"retry": true}],
+                "want_more": true,
+              }
+            :
+              {
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "POST /vulns/export: " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status)),
+                  },
+                },
+                "want_more": false,
+              }
+          )
+        : (phase == "cancel") ?
+          // Cancel: the export did not finish in time. Drop it whatever the
+          // API says; the cursor is untouched so the next interval retries.
+          post_request(
+            state.url.trim_right("/") + "/vulns/export/" + state.export.uuid + "/cancel",
+            "application/json",
+            ""
+          ).with({"Header": headers}).do_request().as(resp,
+            {
+              "export": {},
+              "chunks": [],
+              "next": 0,
+              "events": {
+                "error": {
+                  "code": "EXPIRED",
+                  "id": state.export.uuid,
+                  "message": "POST /vulns/export/" + state.export.uuid + "/cancel: export did not finish within " + state.export_status_timeout + (
+                    (resp.StatusCode == 200) ?
+                      ""
+                    :
+                      "; cancel failed: " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status))
+                  ),
+                },
+              },
+              "want_more": false,
+            }
+          )
+        : (phase == "download") ?
+          // Download: fetch the next chunk. Once the last chunk is in, the
+          // export is complete and the cursor moves to the export's creation
+          // time.
+          request(
+            "GET",
+            state.url.trim_right("/") + "/vulns/export/" + state.export.uuid + "/chunks/" + string(int(state.chunks[int(state.next)]))
+          ).with({"Header": headers}).do_request().as(resp,
+            (resp.StatusCode == 200) ?
+              resp.Body.decode_json().as(body,
+                (int(state.next) + 1 < size(state.chunks)).as(more,
+                  {
+                    "events": (body != null && size(body) > 0) ?
+                      dyn(body.map(e, {"message": e.encode_json()}))
+                    :
+                      dyn([{"retry": true}]),
+                    "export": more ? state.export : {},
+                    "chunks": more ? state.chunks : [],
+                    "next": more ? (int(state.next) + 1) : 0,
+                    ?"cursor": more ? optional.none() : optional.of({"last_event_time": int(state.export.created)}),
+                    "want_more": more,
+                  }
+                )
+              )
+            :
+              // Keep the export and chunk position so the next interval
+              // resumes the download (or cancels once it has expired).
+              {
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "GET /vulns/export/" + state.export.uuid + "/chunks/" + string(int(state.chunks[int(state.next)])) + ": " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status)),
+                  },
+                },
+                "want_more": false,
+              }
+          )
+        :
+          // Status: poll the export job.
+          request(
+            "GET",
+            state.url.trim_right("/") + "/vulns/export/" + state.export.uuid + "/status"
+          ).with({"Header": headers}).do_request().as(resp,
+            (resp.StatusCode == 200) ?
+              resp.Body.decode_json().as(body,
+                (body.?status.orValue("") == "FINISHED" && size(body.?chunks_available.orValue([])) > 0) ?
+                  {
+                    "chunks": body.chunks_available,
+                    "next": 0,
+                    "events": [{"retry": true}],
+                    "want_more": true,
+                  }
+                : (body.?status.orValue("") == "FINISHED") ?
+                  // Finished with nothing to download: the export is complete.
+                  {
+                    "export": {},
+                    "chunks": [],
+                    "next": 0,
+                    "cursor": {"last_event_time": int(state.export.created)},
+                    "events": [{"retry": true}],
+                    "want_more": false,
+                  }
+                : (body.?status.orValue("") in ["CANCELLED", "ERROR"]) ?
+                  // Terminal failure: report it and drop the export. The cursor
+                  // is untouched so the next interval retries the same window.
+                  {
+                    "export": {},
+                    "chunks": [],
+                    "next": 0,
+                    "events": {
+                      "error": {
+                        "code": body.status,
+                        "id": state.export.uuid,
+                        "message": "GET /vulns/export/" + state.export.uuid + "/status: export " + body.status + ((body.?reason.orValue(null) != null) ? (": " + string(body.reason)) : ""),
+                      },
+                    },
+                    "want_more": false,
+                  }
+                :
+                  // QUEUED or PROCESSING: ask the input to wait before the next
+                  // evaluation instead of polling back-to-back.
+                  {
+                    "events": [{"retry": true}],
+                    "want_more": true,
+                    "rate_limit": {
+                      "rate": 0,
+                      "burst": 1,
+                      "next": "inf",
+                      "reset": string(now + duration(state.export_status_poll_interval)),
+                    },
+                  }
+              )
+            :
+              // Keep the export so the next interval polls it again (or
+              // cancels it once it has expired).
+              {
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "GET /vulns/export/" + state.export.uuid + "/status: " + ((size(resp.Body) != 0) ? string(resp.Body) : string(resp.Status)),
+                  },
+                },
+                "want_more": false,
+              }
+          )
+      )
     )
-  :
-    {
-      "url": state.url,
-      "export_status_timeout": state.export_status_timeout,
-      "expires": state.expires,
-      "want_more": state.want_more,
-      "chunks": state.?chunks.orValue([]),
-      "chunk_status": state.chunk_status,
-      "export_response": state.?export_response.orValue({}),
-      "next": state.?next.orValue(0),
-      "access_key": state.access_key,
-      "secret_key": state.secret_key,
-      "initial_interval": state.initial_interval,
-      "batch_size": state.batch_size,
-      "severity_level": state.?severity_level.orValue([]),
-      "response_error": state.?response_error.orValue({}),
-      "cursor": {
-        "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-      }
-    }
-  ).as(state,
-    has(state.?export_response.export_uuid) && state.?chunk_status.orValue("") != "FINISHED" ?
-      request("GET",
-        state.url.trim_right("/") +"/vulns/export/" + state.export_response.export_uuid + "/status"
-      ).with({
-        "Header":{
-          "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-          "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-        }
-      }).do_request().as(response,
-        response.StatusCode == 200 ?
-          bytes(response.Body).decode_json().as(inner_body, {
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": (inner_body.?status.orValue("") != "FINISHED" || size(inner_body.chunks_available) > 0) && (string(now) <= string(state.expires)),
-            "chunk_status": inner_body.?status.orValue("") == "FINISHED" && size(inner_body.chunks_available) == 0 ? "QUEUED" : inner_body.status,
-            "export_response": state.export_response,
-            "chunks": inner_body.chunks_available,
-            "url": state.url,
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "severity_level": state.?severity_level.orValue([]),
-            "cursor": {
-              "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-            }
-          })
-        :
-          {
-            "response_error": {
-              "error": {
-                "code": string(response.StatusCode),
-                "id": string(response.Status),
-                "message": string(response.Body)
-              },
-            },
-            "url": state.url,
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunks": [],
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "severity_level": state.?severity_level.orValue([]),
-          }
-      )
-    :
-      {
-        "url": state.url,
-        "export_status_timeout": state.export_status_timeout,
-        "expires": state.expires,
-        "want_more": state.want_more,
-        "chunks": state.?chunks.orValue([]),
-        "chunk_status": state.chunk_status,
-        "export_response": state.?export_response.orValue({}),
-        "next": state.?next.orValue(0),
-        "access_key": state.access_key,
-        "secret_key": state.secret_key,
-        "initial_interval": state.initial_interval,
-        "batch_size": state.batch_size,
-        "severity_level": state.?severity_level.orValue([]),
-        "response_error": state.?response_error.orValue({}),
-        "cursor": {
-          "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-        }
-      }
-  ).as(state,
-    has(state.?export_response.export_uuid) && state.?chunk_status.orValue("") != "FINISHED" && (string(now) > string(state.expires))?
-      post_request(
-        state.url.trim_right("/") +"/vulns/export/" + state.export_response.export_uuid + "/cancel", "application/json", ""
-      ).with({
-        "Header":{
-          "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-          "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-        }
-      }).do_request().as(response,
-        response.StatusCode == 200 ?
-          bytes(response.Body).decode_json().as(inner_body, {
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "chunks": [],
-            "url": state.url,
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "severity_level": state.?severity_level.orValue([]),
-            "cursor": {
-              "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-            }
-          })
-        :
-          {
-            "response_error": {
-              "error": {
-                "code": string(response.StatusCode),
-                "id": string(response.Status),
-                "message": string(response.Body)
-              },
-            },
-            "url": state.url,
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunks": [],
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "severity_level": state.?severity_level.orValue([]),
-          }
-      )
-    :
-      {
-        "url": state.url,
-        "export_status_timeout": state.export_status_timeout,
-        "expires": state.expires,
-        "want_more": state.want_more,
-        "chunks": state.?chunks.orValue([]),
-        "chunk_status": state.chunk_status,
-        "export_response": state.?export_response.orValue({}),
-        "next": state.?next.orValue(0),
-        "access_key": state.access_key,
-        "secret_key": state.secret_key,
-        "initial_interval": state.initial_interval,
-        "batch_size": state.batch_size,
-        "severity_level": state.?severity_level.orValue([]),
-        "response_error": state.?response_error.orValue({}),
-        "cursor": {
-          "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-        }
-      }
-  ).as(state,
-    has(state.?export_response.export_uuid) && state.?chunk_status.orValue("") == "FINISHED" && size(state.chunks) > 0 ?
-      request("GET",
-        state.url.trim_right("/") +"/vulns/export/" + state.export_response.export_uuid + "/chunks/" + string(state.chunks[state.next])
-      ).with({
-        "Header":{
-          "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
-          "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"]
-        }
-      }).do_request().as(response1,
-        response1.StatusCode == 200 ?
-          bytes(response1.Body).decode_json().as(second_chain_body, {
-            "events": second_chain_body != null ? dyn(second_chain_body.map(e, { "message": e.encode_json() })) : dyn([{"retry":true}]),
-            "expires": state.expires,
-            "export_status_timeout": state.export_status_timeout,
-            "want_more": (int(state.next)+1) < size(state.chunks),
-            "export_response": (int(state.next)+1) < size(state.chunks) ? state.export_response : {},
-            "next": (int(state.next)+1) < size(state.chunks) ? (int(state.next)+1) : 0,
-            "chunk_status": ((int(state.next)+1) < size(state.chunks)) || (second_chain_body == null) ? state.chunk_status : "QUEUED",
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "severity_level": state.?severity_level.orValue([]),
-            "chunks": (int(state.next)+1) < size(state.chunks) ? state.chunks : [],
-            "url": state.url,
-            "cursor": {
-              "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-            } 
-          })
-        :
-          {
-            "events": {
-              "error": {
-                "code": string(response1.StatusCode),
-                "id": string(response1.Status),
-                "message": string(response1.Body)
-              },
-            },
-            "url": state.url,
-            "export_status_timeout": state.export_status_timeout,
-            "expires": state.expires,
-            "want_more": false,
-            "chunks": [],
-            "chunk_status": "QUEUED",
-            "export_response": {},
-            "next": 0,
-            "access_key": state.access_key,
-            "secret_key": state.secret_key,
-            "initial_interval": state.initial_interval,
-            "batch_size": state.batch_size,
-            "severity_level": state.?severity_level.orValue([]),
-          }
-      )
-    :
-      {
-        "events": state.?response_error.error.orValue(null) != null ? dyn(state.response_error) : dyn([{"retry":true}]),
-        "export_status_timeout": state.export_status_timeout,
-        "expires": state.expires,
-        "url": state.url,
-        "chunks": state.?chunks.orValue([]),
-        "chunk_status": state.chunk_status,
-        "want_more": state.want_more,
-        "export_response": state.?export_response.orValue({}),
-        "next": state.?next.orValue(0),
-        "access_key": state.access_key,
-        "secret_key": state.secret_key,
-        "initial_interval": state.initial_interval,
-        "batch_size": state.batch_size,
-        "severity_level": state.?severity_level.orValue([]),
-        "cursor": {
-          "last_event_time": state.?cursor.last_event_time.orValue(int(now))
-        }
-      }
   )
 tags:
 {{#if preserve_original_event}}

--- a/packages/tenable_io/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -45,12 +45,14 @@ program: |-
   // next interval instead of silently skipping its window.
   //
   // Phases, selected in this order: "create" when there is no active export,
-  // which requests a new export since the cursor; "cancel" when the active
-  // export is past export_status_timeout, which cancels and drops it so the
-  // next interval starts afresh; "download" when the active export has chunks
-  // left to fetch; otherwise "status", which polls the export job. QUEUED and
-  // PROCESSING wait export_status_poll_interval before the next poll, while
-  // CANCELLED and ERROR are terminal and reported as errors.
+  // which requests a new export since the cursor; "download" when the active
+  // export has chunks left to fetch, so an interrupted download resumes while
+  // Tenable still has the chunks; "cancel" when the active export is still
+  // being built past export_status_timeout, which cancels and drops it so the
+  // next interval starts afresh; otherwise "status", which polls the export
+  // job. QUEUED and PROCESSING wait export_status_poll_interval before the
+  // next poll, while CANCELLED, ERROR and FINISHED with failed chunks are
+  // terminal and reported as errors.
   {
     "X-ApiKeys": ["accessKey=" + state.access_key + ";secretKey=" + state.secret_key],
     "User-Agent": ["Integration/1.0 (Elastic; Tenable.io; Build/3.0.0)"],
@@ -58,10 +60,10 @@ program: |-
     (
       !has(state.?export.uuid) ?
         "create"
-      : (int(now) > int(state.export.expires)) ?
-        "cancel"
       : (size(state.?chunks.orValue([])) > 0) ?
         "download"
+      : (int(now) > int(state.export.expires)) ?
+        "cancel"
       :
         "status"
     ).as(phase,
@@ -156,9 +158,14 @@ program: |-
                 )
               )
             :
-              // Keep the export and chunk position so the next interval
-              // resumes the download (or cancels once it has expired).
+              // The chunk is gone (Tenable expires chunks after 24h) or keeps
+              // failing after the client's own retries: drop the export. The
+              // cursor is untouched, so the next interval creates a fresh export
+              // from the same point.
               {
+                "export": {},
+                "chunks": [],
+                "next": 0,
                 "events": {
                   "error": {
                     "code": string(resp.StatusCode),
@@ -177,7 +184,24 @@ program: |-
           ).with({"Header": headers}).do_request().as(resp,
             (resp.StatusCode == 200) ?
               resp.Body.decode_json().as(body,
-                (body.?status.orValue("") == "FINISHED" && size(body.?chunks_available.orValue([])) > 0) ?
+                (body.?status.orValue("") == "FINISHED" && size(body.?chunks_failed.orValue([])) > 0) ?
+                  // Some chunks failed. Tenable says to submit the export again,
+                  // so drop it and leave the cursor alone; the next interval
+                  // retries the same window.
+                  {
+                    "export": {},
+                    "chunks": [],
+                    "next": 0,
+                    "events": {
+                      "error": {
+                        "code": "CHUNKS_FAILED",
+                        "id": state.export.uuid,
+                        "message": "GET /vulns/export/" + state.export.uuid + "/status: " + string(size(body.chunks_failed)) + " chunk(s) failed" + ((body.?reason.orValue(null) != null) ? (": " + string(body.reason)) : ""),
+                      },
+                    },
+                    "want_more": false,
+                  }
+                : (body.?status.orValue("") == "FINISHED" && size(body.?chunks_available.orValue([])) > 0) ?
                   {
                     "chunks": body.chunks_available,
                     "next": 0,

--- a/packages/tenable_io/data_stream/vulnerability/manifest.yml
+++ b/packages/tenable_io/data_stream/vulnerability/manifest.yml
@@ -30,6 +30,14 @@ streams:
         required: true
         show_user: true
         default: 12h
+      - name: export_status_poll_interval
+        type: text
+        title: Export Status Poll Interval
+        description: "Duration to wait between checks of the export job status while the export is queued or processing. NOTE: Supported units for this parameter are h/m/s."
+        multi: false
+        required: true
+        show_user: false
+        default: 30s
       - name: severity_level
         type: text
         title: Severity Level

--- a/packages/tenable_io/docs/README.md
+++ b/packages/tenable_io/docs/README.md
@@ -32,7 +32,8 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
   - In this integration, export and plugin endpoints of vulnerability management are used to fetch data.
   - The default value is the recommended value for a batch size by Tenable. Using a smaller batch size can improve performance. A very large value might not work as intended depending on the API and instance limitations.
   - If any long-running export jobs are stuck in the "PROCESSING" state and reach the user-provided timeout, the export job will be terminated, allowing for the initiation of a new export job after the specified interval.
-  - While an export job is queued or processing, its status is checked once every "Export Status Poll Interval" (default 30s). Export jobs that Tenable reports as "CANCELLED" or "ERROR" are abandoned and reported as an error; the data window is retried with a new export job at the next interval, so no data is skipped.
+  - While an export job is queued or processing, its status is checked once every "Export Status Poll Interval" (default 30s). Export jobs that Tenable reports as "CANCELLED", "ERROR", or "FINISHED" with failed chunks are abandoned and reported as an error. The same data window is retried with a new export job at the next interval.
+  - "Maximum Pages Per Interval" bounds the total number of status checks and chunk downloads per interval. A 12h export status timeout at the default 30s poll interval alone accounts for 1440 of them.
 
 ## Agentless-enabled integration
 

--- a/packages/tenable_io/docs/README.md
+++ b/packages/tenable_io/docs/README.md
@@ -32,6 +32,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
   - In this integration, export and plugin endpoints of vulnerability management are used to fetch data.
   - The default value is the recommended value for a batch size by Tenable. Using a smaller batch size can improve performance. A very large value might not work as intended depending on the API and instance limitations.
   - If any long-running export jobs are stuck in the "PROCESSING" state and reach the user-provided timeout, the export job will be terminated, allowing for the initiation of a new export job after the specified interval.
+  - While an export job is queued or processing, its status is checked once every "Export Status Poll Interval" (default 30s). Export jobs that Tenable reports as "CANCELLED" or "ERROR" are abandoned and reported as an error; the data window is retried with a new export job at the next interval, so no data is skipped.
 
 ## Agentless-enabled integration
 

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "4.13.0"
+version: "4.13.1"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
tenable_io: stop polling terminal exports and advance cursor only after download

The asset and vulnerability data streams drive Tenable's asynchronous
export API: create an export, poll its status, then download each
chunk. The previous CEL programs had three defects in that flow.

First, the cursor (last_event_ts / last_event_time) was advanced to the
current time as soon as the export was created. If the export was later
cancelled, failed, expired or the agent restarted before all chunks were
downloaded, the window was skipped permanently and the data was lost.

Second, want_more was derived from status != "FINISHED", so an export
that Tenable reported as CANCELLED or ERROR was polled back-to-back
until export_status_timeout elapsed, several requests per second with
no chance of ever completing. Between polls of a QUEUED or PROCESSING
export there was likewise no pause.

Third, an export that outlived export_status_timeout was simply
forgotten; it was never cancelled on the Tenable side.

Rewrite both programs as an explicit state machine that issues one HTTP
request per evaluation and selects a phase in order: "create" when no
export is active, "download" when chunks remain, "cancel" when the
active export is still being built past export_status_timeout,
otherwise "status". Checking "download" before "cancel" lets an
interrupted download resume at the next interval while Tenable still
holds the chunks (24h); once they are gone the chunk request returns
404, the export is dropped and the next interval starts afresh. Only
the cursor is persisted; export, chunks and next are in-memory, so a
restart mid-export starts a fresh export from the same cursor. The
cursor is set to the export's creation time only once the last chunk
has been downloaded (or the export finished with no chunks). Using the
creation time rather than the completion time means findings updated
while Tenable was building the export may be re-exported once, but none
are missed; Tenable's "since" filter is a lower bound with no documented
snapshot semantics.

CANCELLED and ERROR are now terminal, as is a vulnerability export that
is FINISHED with a non-empty chunks_failed, for which Tenable's
documentation says to submit the export again. In all three cases the
export is dropped, an error event is emitted with the status and reason,
and the cursor is left untouched so the next interval retries the same
window. A failed chunk download is handled the same way. An expired
export is cancelled via POST /export/{uuid}/cancel before being dropped.
While an export is QUEUED or PROCESSING the program returns a rate_limit
map with rate 0 and reset now+export_status_poll_interval, which is the
only way to make the CEL input sleep between evaluations; next is "inf"
so the HTTP client is not throttled once the wait ends. The placeholder
[{"retry": true}] event keeps the want_more loop alive and is removed by
a drop_event processor.

Add the export_status_poll_interval variable (default 30s) to both data
streams and document the polling and terminal-status behaviour in the
README, including that max_executions now bounds status polls and chunk
downloads together. The system test mocks walk each export through
QUEUED, PROCESSING and FINISHED so the wait path is exercised. Terminal
statuses are deliberately not mocked there: they degrade the input by
design and the system test runner fails on any DEGRADED transition in
the agent logs.

Fixes #20061
```

Closes #20061

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist
