### PR TITLE
fortinet_fortiedr: expose additional configuration for TCP input

### DIFF
--- a/packages/fortinet_fortiedr/_dev/build/docs/README.md
+++ b/packages/fortinet_fortiedr/_dev/build/docs/README.md
@@ -130,6 +130,8 @@ Select the **Collecting logs from Fortinet FortiEDR instances (input: tcp)** inp
 * **Keep raw parser fields** (`keep_raw_fields`): If `true`, the integration keeps the original fields from the parser. Default: `false`.
 * **Enable debug logging** (`debug`): Enable debug logging for the input. Default: `false`.
 * **Processors** (`processors`): Add custom processors to reduce fields or enhance metadata.
+* **SSL Configuration** (`ssl`): YAML SSL/TLS options for the TCP listener (server `certificate` and `key`). Required when FortiEDR syslog **TLS** is enabled. See the [Filebeat SSL documentation](https://www.elastic.co/docs/reference/beats/filebeat/configuration-ssl#ssl-common-config).
+* **Custom TCP Options** (`tcp_options`): Extra TCP input settings such as `framing`, `max_message_size`, and `max_connections`. See the [Filebeat TCP input documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-tcp).
 
 #### UDP input configuration
 

--- a/packages/fortinet_fortiedr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortiedr/_dev/deploy/docker/docker-compose.yml
@@ -16,3 +16,8 @@ services:
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-edr.log
+  fortinet-edr-tls:
+    image: docker.elastic.co/observability/stream:v0.18.0
+    volumes:
+      - ./sample_logs:/sample_logs:ro
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/fortinet-edr.log

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose 'ssl' and 'tcp_options' configurations for TCP input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21071
 - version: "1.21.1"
   changes:
     - description: Remove top level note from docs

--- a/packages/fortinet_fortiedr/changelog.yml
+++ b/packages/fortinet_fortiedr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Expose 'ssl' and 'tcp_options' configurations for TCP input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.1"
   changes:
     - description: Remove top level note from docs

--- a/packages/fortinet_fortiedr/data_stream/log/_dev/test/system/test-tls-config.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/_dev/test/system/test-tls-config.yml
@@ -1,0 +1,60 @@
+service: fortinet-edr-tls
+service_notify_signal: SIGHUP
+input: tcp
+data_stream:
+  vars:
+    tcp_host: 0.0.0.0
+    tcp_port: 9515
+    preserve_original_event: true
+    ssl: |
+      key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDhCLvLsQAHufsN
+        U+u1x/CequAUphfXZqLhDo2Eo/holfBS0+ey4bnzPL6lS9NFL5JkLQA2gYESqsXU
+        /Ru8E76Az1egzMwT3TVAPLVU8NbrxBqeNiQa2m9wC37HQy4qC9OxL28LUoKtFjxS
+        cD1sa0oikXCJN1a3BSoAf9iiZ/dxz4WVfrNhrzq2JFXjravY84n5ujkZOg45Pg70
+        4vHOeg0rBbIoSNfjDUVZWjwC95K1BMN3msOTL9juv/EDa6BujqCxl+G1nY7JPFDL
+        SHWis65p+1AAa5xieYDb47vyJ0SSR7lEURTXZOkkM6k5JWfgkATEmGzRxPkOloIT
+        Xg9ag1OlAgMBAAECggEAEHfPJmzhj68wjB0kFr13AmWG2Hv/Kqg8KzQhbx+AwkaW
+        u7j+L70NGpvLZ9VQtLNyhxoz9cksZO1SZO/Q48aeHlcOFppmJN3/U6AdtQWa9M35
+        FLLpmX16wjxVHsfvzOvopgLOoYl8PqZt66qDFDgVyMnT7na6RdJ+7GJuvBPXq+Bc
+        vgThvAZitHSAOhnBFYmTMlBi6AzOMMsaFlgE3Xf9v3M0pAKItPRKMhXlC3MyvA/v
+        jgbra4Ib+0ryohggHheHB3bn3Jgv7iFKoW9OQSePVxacJ+kfr9H+No5g495URzqR
+        mx/96WCiv3rAh3ct8Sk/C4/3zMC8fUueDJIVjhgw0QKBgQD8NufLINNkIpBrLoCS
+        972oFEjZB2u6EusQ7X9raROqpaw26ZSu+zSHeIKCGQ93M3aRb3FpdGeOxgZ095MV
+        8a+nlh4stOvHj2Mm5YhTBDUavTC7o9aVR3Od5eTXUpHnaJpNI/uyIcKupeK1UJnV
+        UlBLeIwo/vJ1gsVrKMMAJkuKbwKBgQDkaWRRd0w2gUIbCTGf203BqXft0VdIiOW7
+        +gnkeaNHAf09XljzxMcQzrB8kG63aKVGbJffphEfzxtiJ+HRQVH+7QpKRhU/GHmu
+        +6OKkxTcxJm5zhoRFxcSi2wG4PWmUGJvc7ss1OJGcaOUxwocCepO7N/jfdDz9Uke
+        KnA+YWOdKwKBgQDteZkYlojT0QOgF8HyH5gQyUCqMKWLJ0LzxltiPCbLV4Dml1pq
+        w5Z7M8nWS1hXiTpLx93GSFc1hFkSCwYP9GfK6Lryp0sVtHnMZvTMDbseuSJImwRx
+        vDwtYQfugg1lEQWwOoBEAiu3m/PxernNtNprpU57T0nlwUK3GkM5QdWAuwKBgQCZ
+        ZF3GiANapzupxGbbH//8Cr9LqsafI7CEqMpz8WxBh4h16iJ6sq+tDeFgBe8UpOY5
+        gTwNKg1d+0w8guQYD3HtbWr3rlEeamVtqfiOW3ArQqyqJ0tCJuuLvK3zgKf35Qv2
+        JRaSaPT8sdxVUcXsRoxgLJu+vwPQke1koMN4YRbwuQKBgQDJiZ/WSeqa5oIqkXbn
+        hjm7RXKaf2oE1U/bNjdSFtdEP7T4vUvvr7Hq2f/jiBLtCE7w16PJjKx9iIq2+jMl
+        qIY43Sk9bdi5FxtYTHda0hwrbH274P+QVcVs5PXCT0TGktOleHGBlXaaPrxl9iCh
+        8tmmxZZYa5aQxEO/lxB9xQKaiQ==
+        -----END PRIVATE KEY-----
+      certificate: |
+        -----BEGIN CERTIFICATE-----
+        MIIDazCCAlOgAwIBAgIUW5TDu1tJMY2Oa7PsL+BQSmeWqz0wDQYJKoZIhvcNAQEL
+        BQAwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+        GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTEwMDEwNTAwMjNaFw0yMTEw
+        MDIwNTAwMjNaMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+        HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+        AQUAA4IBDwAwggEKAoIBAQDhCLvLsQAHufsNU+u1x/CequAUphfXZqLhDo2Eo/ho
+        lfBS0+ey4bnzPL6lS9NFL5JkLQA2gYESqsXU/Ru8E76Az1egzMwT3TVAPLVU8Nbr
+        xBqeNiQa2m9wC37HQy4qC9OxL28LUoKtFjxScD1sa0oikXCJN1a3BSoAf9iiZ/dx
+        z4WVfrNhrzq2JFXjravY84n5ujkZOg45Pg704vHOeg0rBbIoSNfjDUVZWjwC95K1
+        BMN3msOTL9juv/EDa6BujqCxl+G1nY7JPFDLSHWis65p+1AAa5xieYDb47vyJ0SS
+        R7lEURTXZOkkM6k5JWfgkATEmGzRxPkOloITXg9ag1OlAgMBAAGjUzBRMB0GA1Ud
+        DgQWBBRYUSKDHBBE9Q6fTeTqogicCxcXwDAfBgNVHSMEGDAWgBRYUSKDHBBE9Q6f
+        TeTqogicCxcXwDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBc
+        T8B+GpvPy9NQ700LsywRPY0L9IJCKiu6j3TP1tqqSPjAC/cg9ac+bFXuWOu7V+KJ
+        s09Q/pItq9SLX6UvnfRzTxu5lCBwwGX9cL131mTIu5SmFo7Eks+sorbiIarWDMoC
+        e+9An3GFpagW+YhOt4BdIM5lTqoeodzganDBsOUZI9aDAj2Yo5h2O7r6Wd12cb6T
+        mz8vMfB2eG8BxU20ZMfkdERWjiyXHOSBQqeqfkV8d9370gMu5RcJNcIgnbmTRdho
+        X3HJFiimZVaNjXATqmC/y2A1KXvJdamPLy3mGXkW2cFLoPCdK2OZFUHqiuc1bigA
+        qEf55SihFqErRMeURPPF
+        -----END CERTIFICATE-----

--- a/packages/fortinet_fortiedr/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/fortinet_fortiedr/data_stream/log/agent/stream/tcp.yml.hbs
@@ -15,3 +15,9 @@ processors:
 {{processors}}
 {{/if}}
 - add_locale: ~
+{{#if ssl}}
+ssl: {{ssl}}
+{{/if}}
+{{#if tcp_options}}
+{{tcp_options}}
+{{/if}}

--- a/packages/fortinet_fortiedr/data_stream/log/manifest.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/manifest.yml
@@ -155,7 +155,27 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
+      - name: ssl
+        type: yaml
+        title: SSL Configuration
+        description: SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.
+        multi: false
+        required: false
+        show_user: false
+        default: |-
+          #certificate: "/etc/server/cert.pem"
+          #key: "/etc/server/key.pem"
+      - name: tcp_options
+        type: yaml
+        title: Custom TCP Options
+        multi: false
+        required: false
+        show_user: false
+        default: |-
+          # framing: delimiter
+          # max_message_size: 50KiB
+          # max_connections: 1
+        description: Specify custom configuration options for the TCP input. See [documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-tcp#_configuration_options_19) for details.
   - input: logfile
     enabled: false
     title: Fortinet FortiEDR Endpoint Detection and Response logs

--- a/packages/fortinet_fortiedr/data_stream/log/manifest.yml
+++ b/packages/fortinet_fortiedr/data_stream/log/manifest.yml
@@ -153,7 +153,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: >
+        description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
       - name: ssl
         type: yaml

--- a/packages/fortinet_fortiedr/docs/README.md
+++ b/packages/fortinet_fortiedr/docs/README.md
@@ -130,6 +130,8 @@ Select the **Collecting logs from Fortinet FortiEDR instances (input: tcp)** inp
 * **Keep raw parser fields** (`keep_raw_fields`): If `true`, the integration keeps the original fields from the parser. Default: `false`.
 * **Enable debug logging** (`debug`): Enable debug logging for the input. Default: `false`.
 * **Processors** (`processors`): Add custom processors to reduce fields or enhance metadata.
+* **SSL Configuration** (`ssl`): YAML SSL/TLS options for the TCP listener (server `certificate` and `key`). Required when FortiEDR syslog **TLS** is enabled. See the [Filebeat SSL documentation](https://www.elastic.co/docs/reference/beats/filebeat/configuration-ssl#ssl-common-config).
+* **Custom TCP Options** (`tcp_options`): Extra TCP input settings such as `framing`, `max_message_size`, and `max_connections`. See the [Filebeat TCP input documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-tcp).
 
 #### UDP input configuration
 

--- a/packages/fortinet_fortiedr/manifest.yml
+++ b/packages/fortinet_fortiedr/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortiedr
 title: Fortinet FortiEDR Logs
-version: "1.21.1"
+version: "1.22.0"
 description: Collect logs from Fortinet FortiEDR instances with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

- Expose the 'ssl' and 'tcp_options' configurations for the TCP input

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~
