### PR TITLE
[backports] fix stale path references after migration to cmd/backport

### DIFF
--- a/.buildkite/pipeline.backport-dispatch.yml
+++ b/.buildkite/pipeline.backport-dispatch.yml
@@ -17,7 +17,7 @@ steps:
       - ".backports.yml"
       - ".buildkite/scripts/run_dev_scripts_tests.sh"
       - "dev/scripts/**.sh"
-      - "dev/backports/**"
+      - "cmd/backport/**"
     if: |
       build.env('BUILDKITE_PULL_REQUEST') == "false" && build.branch == "main"
 

--- a/cmd/backport/backports/apply/apply.go
+++ b/cmd/backport/backports/apply/apply.go
@@ -62,7 +62,7 @@ type Result struct {
 	OwnerSyncWarning string   `json:"owner_sync_warning,omitempty"` // non-empty when owner sync was skipped
 }
 
-// branchRE matches valid backport branch names (mirrors dev/backports/inventory.go).
+// branchRE matches valid backport branch names (mirrors cmd/backport/backports/inventory.go).
 var branchRE = regexp.MustCompile(`^backport-[a-zA-Z0-9_]+-[0-9][0-9.]*x?$`)
 
 // applier holds the shared git context used by the apply pipeline steps.

--- a/cmd/backport/backports/apply/apply_test.go
+++ b/cmd/backport/backports/apply/apply_test.go
@@ -392,7 +392,7 @@ func TestSetManifestOwner(t *testing.T) {
 }
 
 // The CODEOWNERS-rewriting logic itself is tested directly in
-// dev/backports/owners (owners.ApplyUpdates) — writeOwnerSyncPlan is a thin
+// cmd/backport/backports/owners (owners.ApplyUpdates) — writeOwnerSyncPlan is a thin
 // file-I/O wrapper around it plus setManifestOwner, tested here.
 func TestWriteOwnerSyncPlan(t *testing.T) {
 	workDir := t.TempDir()

--- a/cmd/backport/backports/owners/check.go
+++ b/cmd/backport/backports/owners/check.go
@@ -27,7 +27,7 @@ type Mismatch struct {
 
 // CheckPackages reports owner mismatches for each named package against
 // remoteRef (e.g. "origin/main"). pkgDirs maps package name to its directory
-// relative to workDir (e.g. from dev/backports/changelog.BuildPackageIndex);
+// relative to workDir (e.g. from cmd/backport/backports/changelog.BuildPackageIndex);
 // a name absent from pkgDirs (the package was removed in this PR) is
 // silently skipped, same as a package Compare reports as not found on
 // remoteRef.

--- a/cmd/backport/backports/packages/detect_test.go
+++ b/cmd/backport/backports/packages/detect_test.go
@@ -57,7 +57,7 @@ func TestDetectPackages(t *testing.T) {
 
 		result, err := DetectPackages([]string{
 			".buildkite/scripts/common.sh",
-			"dev/backports/inventory.go",
+			"cmd/backports/inventory.go",
 		}, pkgs)
 		require.NoError(t, err)
 		assert.Empty(t, result)
@@ -129,7 +129,7 @@ func TestDetectPackages(t *testing.T) {
 		result, err := DetectPackages([]string{
 			".github/workflows/test.yml",
 			filepath.Join(pkgs, "aws", "changelog.yml"),
-			"dev/backports/inventory.go",
+			"cmd/backports/inventory.go",
 		}, pkgs)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"aws"}, result)

--- a/cmd/backport/backports/packages/detect_test.go
+++ b/cmd/backport/backports/packages/detect_test.go
@@ -57,7 +57,7 @@ func TestDetectPackages(t *testing.T) {
 
 		result, err := DetectPackages([]string{
 			".buildkite/scripts/common.sh",
-			"cmd/backports/inventory.go",
+			"cmd/backport/backports/inventory.go",
 		}, pkgs)
 		require.NoError(t, err)
 		assert.Empty(t, result)
@@ -129,7 +129,7 @@ func TestDetectPackages(t *testing.T) {
 		result, err := DetectPackages([]string{
 			".github/workflows/test.yml",
 			filepath.Join(pkgs, "aws", "changelog.yml"),
-			"cmd/backports/inventory.go",
+			"cmd/backport/backports/inventory.go",
 		}, pkgs)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"aws"}, result)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## Proposed commit message

```
[backports] fix stale path references after migration to cmd/backport

Update dev/backports/** references left over from the move to the
cmd/backport sub-module:

- Fix if_changed glob in .buildkite/pipeline.backport-dispatch.yml so
  changes to the backport tool correctly trigger inventory validation.
- Update stale path references in comments in apply.go, apply_test.go,
  and owners/check.go.
- Fix test fixture paths in packages/detect_test.go.
```

## Author's Checklist

- [ ] Verify the `if_changed` path in `.buildkite/pipeline.backport-dispatch.yml` triggers on actual backport tool changes post-merge.

## How to test this PR locally

1. Confirm `cmd/backports/**` glob matches files under `cmd/backport/backports/`:
   ```
   git diff main -- .buildkite/pipeline.backport-dispatch.yml
   ```
2. Run the backport package tests to confirm fixture paths resolve correctly:
   ```
   cd cmd/backport && go test ./backports/packages/...
   ```

## Related issues

- Relates #19211 (PR-driven backport creation / cmd/backport migration)
- Observed in https://github.com/elastic/integrations/pull/20416#discussion_r3935659860

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).