### PR TITLE
[FIM] Add dashboard level data_stream.dataset filter

### DIFF
--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Add dashboard-level data_stream.dataset filter.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.18.0"
   changes:
     - description: Use links panel in Dashboard.

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dashboard-level data_stream.dataset filter.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21079
 - version: "1.18.0"
   changes:
     - description: Use links panel in Dashboard.

--- a/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
@@ -1102,11 +1102,6 @@
             "type": "search"
         },
         {
-            "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
-            "name": "b21b9704-5a34-4ee9-9d67-bde8b2b4e477:link_8b2f7e85-3b32-42bb-8812-ee18001f32d1_dashboard",
-            "type": "dashboard"
-        },
-        {
             "id": "logs-*",
             "name": "controlGroup_2e1f7a9a-9603-452d-a303-948334f86026:optionsListDataView",
             "type": "index-pattern"

--- a/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/dashboard/fim-97c782f0-4291-11ee-a0f4-51818a115e85.json
@@ -149,7 +149,30 @@
         "description": "Events collected by the File Integrity Monitoring integration.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "data_stream.dataset",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "fim.event"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "fim.event"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1020,7 +1043,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-08-31T09:08:10.942Z",
+    "created_at": "2026-09-04T08:42:25.086Z",
     "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
     "references": [
         {
@@ -1079,6 +1102,11 @@
             "type": "search"
         },
         {
+            "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
+            "name": "b21b9704-5a34-4ee9-9d67-bde8b2b4e477:link_8b2f7e85-3b32-42bb-8812-ee18001f32d1_dashboard",
+            "type": "dashboard"
+        },
+        {
             "id": "logs-*",
             "name": "controlGroup_2e1f7a9a-9603-452d-a303-948334f86026:optionsListDataView",
             "type": "index-pattern"
@@ -1117,6 +1145,11 @@
             "id": "fim-97c782f0-4291-11ee-a0f4-51818a115e85",
             "name": "b21b9704-5a34-4ee9-9d67-bde8b2b4e477:link_8b2f7e85-3b32-42bb-8812-ee18001f32d1_dashboard",
             "type": "dashboard"
+        },
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
         }
     ],
     "type": "dashboard",

--- a/packages/fim/kibana/search/fim-6c045e50-4295-11ee-a0f4-51818a115e85.json
+++ b/packages/fim/kibana/search/fim-6c045e50-4295-11ee-a0f4-51818a115e85.json
@@ -82,7 +82,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-08-31T09:07:56.611Z",
+    "created_at": "2026-09-04T08:39:53.680Z",
     "id": "fim-6c045e50-4295-11ee-a0f4-51818a115e85",
     "references": [
         {

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: fim
 title: "File Integrity Monitoring"
-version: "1.18.0"
+version: "1.18.1"
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
fim: Add dashboard-level data_stream.dataset filter

Scope the File Integrity Monitoring dashboard to `fim.event` so control
panels do not show values from other datasets.
```

## Checklist

- [X] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes #20988 

## Screenshots

<img width="1722" height="717" alt="image" src="https://github.com/user-attachments/assets/e034fdce-3fb4-4d6e-93aa-81ef524a2347" />
