### PR TITLE
[temporal] Rename README display name to Temporal OpenTelemetry Integration

### DIFF
--- a/packages/temporal/_dev/build/docs/README.md
+++ b/packages/temporal/_dev/build/docs/README.md
@@ -1,6 +1,6 @@
-# Temporal (OpenTelemetry)
+# Temporal OpenTelemetry Integration
 
-Collect operational metrics from [Temporal Cloud](https://temporal.io/cloud/) using the Temporal (OpenTelemetry) integration.
+Collect operational metrics from [Temporal Cloud](https://temporal.io/cloud/) using the Temporal OpenTelemetry Integration.
 
 ## Overview
 
@@ -28,8 +28,8 @@ Once data starts flowing, the **[Temporal OpenTelemetry Assets](https://www.elas
    - Generate an API key for that Service Account and store it securely
 
 2. **Add the integration in Kibana**:
-   - Go to **Management** → **Integrations** → search for "Temporal (OpenTelemetry)"
-   - Click **Add Temporal (OpenTelemetry)**
+   - Go to **Management** → **Integrations** → search for "Temporal OpenTelemetry Integration"
+   - Click **Add Temporal OpenTelemetry Integration**
    - Fill in:
      - **Temporal Cloud Metrics Endpoint**: `metrics.temporal.io:443` (default)
      - **Metrics Path**: `/v1/metrics` (optionally append `?namespaces=<namespace>` to filter)

--- a/packages/temporal/_dev/build/docs/README.md
+++ b/packages/temporal/_dev/build/docs/README.md
@@ -28,8 +28,8 @@ Once data starts flowing, the **[Temporal OpenTelemetry Assets](https://www.elas
    - Generate an API key for that Service Account and store it securely
 
 2. **Add the integration in Kibana**:
-   - Go to **Management** → **Integrations** → search for "Temporal OpenTelemetry Integration"
-   - Click **Add Temporal OpenTelemetry Integration**
+   - Go to **Management** → **Integrations** → search for "Temporal(OpenTelemetry) Integration"
+   - Click **Add Temporal(OpenTelemetry) Integration**
    - Fill in:
      - **Temporal Cloud Metrics Endpoint**: `metrics.temporal.io:443` (default)
      - **Metrics Path**: `/v1/metrics` (optionally append `?namespaces=<namespace>` to filter)

--- a/packages/temporal/changelog.yml
+++ b/packages/temporal/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Rename the integration display name in the README to Temporal OpenTelemetry Integration.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Add the `temporal_otel` content package as a dependency and document it in the README.

--- a/packages/temporal/changelog.yml
+++ b/packages/temporal/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Rename the integration display name in the README to Temporal OpenTelemetry Integration.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21080
 - version: "0.3.0"
   changes:
     - description: Add the `temporal_otel` content package as a dependency and document it in the README.

--- a/packages/temporal/docs/README.md
+++ b/packages/temporal/docs/README.md
@@ -1,6 +1,6 @@
-# Temporal (OpenTelemetry)
+# Temporal OpenTelemetry Integration
 
-Collect operational metrics from [Temporal Cloud](https://temporal.io/cloud/) using the Temporal (OpenTelemetry) integration.
+Collect operational metrics from [Temporal Cloud](https://temporal.io/cloud/) using the Temporal OpenTelemetry Integration.
 
 ## Overview
 
@@ -28,8 +28,8 @@ Once data starts flowing, the **[Temporal OpenTelemetry Assets](https://www.elas
    - Generate an API key for that Service Account and store it securely
 
 2. **Add the integration in Kibana**:
-   - Go to **Management** → **Integrations** → search for "Temporal (OpenTelemetry)"
-   - Click **Add Temporal (OpenTelemetry)**
+   - Go to **Management** → **Integrations** → search for "Temporal OpenTelemetry Integration"
+   - Click **Add Temporal OpenTelemetry Integration**
    - Fill in:
      - **Temporal Cloud Metrics Endpoint**: `metrics.temporal.io:443` (default)
      - **Metrics Path**: `/v1/metrics` (optionally append `?namespaces=<namespace>` to filter)

--- a/packages/temporal/docs/README.md
+++ b/packages/temporal/docs/README.md
@@ -28,8 +28,8 @@ Once data starts flowing, the **[Temporal OpenTelemetry Assets](https://www.elas
    - Generate an API key for that Service Account and store it securely
 
 2. **Add the integration in Kibana**:
-   - Go to **Management** → **Integrations** → search for "Temporal (OpenTelemetry)"
-   - Click **Add Temporal (OpenTelemetry)**
+   - Go to **Management** → **Integrations** → search for "Temporal(OpenTelemetry) Integration"
+   - Click **Add Temporal(OpenTelemetry) Integration**
    - Fill in:
      - **Temporal Cloud Metrics Endpoint**: `metrics.temporal.io:443` (default)
      - **Metrics Path**: `/v1/metrics` (optionally append `?namespaces=<namespace>` to filter)

--- a/packages/temporal/docs/README.md
+++ b/packages/temporal/docs/README.md
@@ -28,8 +28,8 @@ Once data starts flowing, the **[Temporal OpenTelemetry Assets](https://www.elas
    - Generate an API key for that Service Account and store it securely
 
 2. **Add the integration in Kibana**:
-   - Go to **Management** → **Integrations** → search for "Temporal OpenTelemetry Integration"
-   - Click **Add Temporal OpenTelemetry Integration**
+   - Go to **Management** → **Integrations** → search for "Temporal (OpenTelemetry)"
+   - Click **Add Temporal (OpenTelemetry)**
    - Fill in:
      - **Temporal Cloud Metrics Endpoint**: `metrics.temporal.io:443` (default)
      - **Metrics Path**: `/v1/metrics` (optionally append `?namespaces=<namespace>` to filter)

--- a/packages/temporal/manifest.yml
+++ b/packages/temporal/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.6.5"
 name: temporal
 title: "Temporal (OpenTelemetry)"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: >-


### PR DESCRIPTION
## Summary
- Rename the Temporal package README display name from `Temporal (OpenTelemetry)` to `Temporal OpenTelemetry Integration`.
- Bump the package to `0.3.1` and record the change in the changelog.

## Test plan
- [x] `elastic-package check` passes for `packages/temporal`
- [ ] Confirm rendered docs title in the built package README


Made with [Cursor](https://cursor.com)