### PR TITLE
[citrix_adc] Fix SSLVPN Message parsing and the Logout handler username

### DIFF
--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,15 @@
 # newer versions go on top
+- version: "1.19.2"
+  changes:
+    - description: Fix SSLVPN Message events skipping the SSLVPN and AAATM feature pipeline, which made the Message grok processor unreachable.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21082
+    - description: Fix the Logout handler grok pattern so that citrix_adc.log.username is captured. The alternation was written inside a pattern name, where grok reads it as literal text.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21082
+    - description: Fix a typo that wrote the aaatm_handler assertion client IP to citrix_adx.log.client_ip instead of citrix_adc.log.client_ip.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21082
 - version: "1.19.1"
   changes:
     - description: Fix APPFW_SCHEMA_ENDPOINT_NOTFOUND grok pattern so that url.original captures the actual endpoint URL instead of the literal "Endpoint:" token, and add http.request.method and citrix_adc.log.api_spec fields.

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native.json-expected.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-native.json-expected.json
@@ -1089,7 +1089,8 @@
             },
             "citrix_adc": {
                 "log": {
-                    "message": "Logout handler : starting 30sec timer after sending saml logout req to IdP, for user <user_name@domain.com>"
+                    "message": "Logout handler : starting 30sec timer after sending saml logout req to IdP, for user <user_name@domain.com>",
+                    "username": "user_name@domain.com"
                 }
             },
             "ecs": {
@@ -1114,10 +1115,21 @@
                 "type": "firewall",
                 "vendor": "Citrix"
             },
+            "related": {
+                "user": [
+                    "user_name",
+                    "user_name@domain.com"
+                ]
+            },
             "tags": [
                 "preserve_original_event",
                 "preserve_duplicate_custom_fields"
-            ]
+            ],
+            "user": {
+                "domain": "domain.com",
+                "email": "user_name@domain.com",
+                "name": "user_name"
+            }
         },
         {
             "@timestamp": "2024-08-21T09:38:41.000Z",

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/native.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/native.yml
@@ -109,7 +109,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "sslvpn_and_aaatm_feature" }}'
       tag: pipeline_sslvpn_and_aaatm_feature
-      if: ctx.citrix?.device_event_class_id != null && ((ctx.citrix.device_event_class_id == "SSLVPN" && !ctx.citrix?.name?.equalsIgnoreCase("MESSAGE")) || ctx.citrix.device_event_class_id == "AAATM")
+      if: ctx.citrix?.device_event_class_id != null && (ctx.citrix.device_event_class_id == "SSLVPN" || ctx.citrix.device_event_class_id == "AAATM")
   - pipeline:
       name: '{{ IngestPipeline "ci_feature" }}'
       tag: pipeline_ci_feature

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/sslvpn_and_aaatm_feature.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/sslvpn_and_aaatm_feature.yml
@@ -164,8 +164,8 @@ processors:
       if: 'ctx.citrix.name == "Message"'
       field: citrix.extended.message
       patterns:
-        - '^Logout handler : %{DATA}, for user <%{USERNAME|EMAILADDRESS:citrix_adc.log.username}>$'
-        - '^aaatm_handler successfully parsed assertion client ip is %{IP:citrix_adx.log.client_ip}, username is %{DATA:citrix_adc.log.user}$'
+        - '^Logout handler : %{DATA}, for user <(?:%{EMAILADDRESS:citrix_adc.log.username}|%{USERNAME:citrix_adc.log.username})>$'
+        - '^aaatm_handler successfully parsed assertion client ip is %{IP:citrix_adc.log.client_ip}, username is %{DATA:citrix_adc.log.user}$'
         - '%{DATA}'
 
   - convert:

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.19.1"
+version: "1.19.2"
 description: This Elastic integration collects logs and metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[citrix_adc] Fix SSLVPN Message parsing and the Logout handler username

SSLVPN Message events skip the SSLVPN and AAATM feature pipeline, which
makes the Message grok processor added in #11668 unreachable. The
exclusion came from #11121, when the pipeline held a single unguarded
grok with ignore_failure: false that threw on Message events; #11668
split it into per-name processors, so the exclusion no longer protects
anything and only hides the Message branch.

The Message pattern could not have captured a username either.
%{USERNAME|EMAILADDRESS:citrix_adc.log.username} is not a grok token,
because a pattern name cannot contain "|", so grok read it as literal
text and the capture never existed.

Also fixes citrix_adx.log.client_ip, a typo for citrix_adc.
```

Note: drafted with :robot: Cursor/Opus 5, under my supervision.

## What this fixes

Three bugs stacked on the same log line, none of which fails loudly. The package's own test data already contains the affected event, and the committed expectation records the missing field — which is why the tests have been green throughout.

### 1. SSLVPN Message events never reach the Message parser

`native.yml` dispatches to `sslvpn_and_aaatm_feature` for everything **except** `SSLVPN` events named `MESSAGE`:

```yaml
if: ctx.citrix?.device_event_class_id != null && ((ctx.citrix.device_event_class_id == "SSLVPN" && !ctx.citrix?.name?.equalsIgnoreCase("MESSAGE")) || ctx.citrix.device_event_class_id == "AAATM")
```

while the processor meant to parse those events lives inside that pipeline:

```yaml
- grok:
    tag: grok_sslvpn_message
    if: 'ctx.citrix.name == "Message"'
```

So the branch is reachable only for `AAATM`, never for the `SSLVPN` events it was written for.

The exclusion was right when it was added. In #11121 (Sep 2024) the feature pipeline held a *single* grok processor with no `if:` and `ignore_failure: false`, so a Message event entering the pipeline threw. #11668 (Nov 2024) split that into one guarded processor per `citrix.name` — removing the reason — and in the same PR added the `Message` branch inside the path the dispatch still skipped. Every processor in the pipeline today is guarded either by `citrix.name` or by field presence, so Message events entering it can only reach the Message branch.

This also matters for what comes after the grok: `client.ip`, `destination.bytes` and the other conversions live in that pipeline too, so parsing Message events anywhere else would not give them the same treatment.

### 2. The Logout handler pattern is not a grok pattern

```yaml
- '^Logout handler : %{DATA}, for user <%{USERNAME|EMAILADDRESS:citrix_adc.log.username}>$'
```

A grok pattern name cannot contain `|` — [`Grok.java`](https://github.com/elastic/elasticsearch/blob/main/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java#L35) allows `[A-z0-9]+` — so `%{USERNAME` is not a token, it is literal text, and the `|` splits the whole pattern into two alternatives:

```
^Logout handler : (?:.*?), for user <%{USERNAME     |     EMAILADDRESS:citrix_adc.log.username}>$
```

Nothing about this is visible at runtime: no `Unable to find pattern`, no `_grokparsefailure`, and the `%{DATA}` catch-all in the same processor matches whatever is left. Verified with `_simulate` — `Logout handler : session closed, for user <alice>` does not match, and the only lines that do are ones literally containing the grok source text.

Rewritten as a real alternation, which handles both spellings the original was reaching for:

```yaml
- '^Logout handler : %{DATA}, for user <(?:%{EMAILADDRESS:citrix_adc.log.username}|%{USERNAME:citrix_adc.log.username})>$'
```

### 3. `citrix_adx.log.client_ip`

One line below, a typo for `citrix_adc`. It is the only `citrix_adx` in the repo, the field is not declared in `fields.yml`, and the `convert` processor immediately after this grok converts `citrix_adc.log.client_ip` to an `ip` — so the captured address was landing outside the schema and skipping the conversion.

## Effect on the test data

`test-citrix-native.json` already contains the event:

```
… default SSLVPN Message 600000 0 : Logout handler : starting 30sec timer after sending saml logout req to IdP, for user <user_name@domain.com>
```

The whole diff to the expectations is that one document, and it now carries the user it always should have:

```diff
             "citrix_adc": {
                 "log": {
-                    "message": "Logout handler : … for user <user_name@domain.com>"
+                    "message": "Logout handler : … for user <user_name@domain.com>",
+                    "username": "user_name@domain.com"
                 }
             },
+            "related": {
+                "user": ["user_name", "user_name@domain.com"]
+            },
+            "user": {
+                "domain": "domain.com",
+                "email": "user_name@domain.com",
+                "name": "user_name"
+            }
```

`user.name`, `user.domain`, `user.email` and `related.user` come from the ECS processors the package already runs on `citrix_adc.log.username` — further evidence that this was meant to work. Every other pipeline test is unchanged.

## How it was found

Instrumenting every grok pattern in this repo and checking each `%{` against Grok's token grammar. Five more packages have the same class of typo — see #21081, which has the census, the reproduction for each, and the ownership breakdown.

