### PR TITLE
[pulse_connect_secure] Fix Primary authentication grok pattern

### DIFF
--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.2"
+  changes:
+    - description: Fix the Primary authentication grok pattern so that event.outcome is set. The pattern was missing the colon between the pattern name and the field name, which grok reads as literal text.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21083
 - version: "2.6.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-admin.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-admin.log-expected.json
@@ -410,6 +410,7 @@
                 "created": "2021-10-19T10:20:57.000+02:00",
                 "kind": "event",
                 "original": "Oct 19 10:20:57 pcs-node1 1 2021-10-19T10:20:57+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 10:20:57 - pcs-node1 - [89.160.20.156] admin(ADMIN_REALM)[] - Primary authentication failed for admin/Administrators from 89.160.20.156",
+                "outcome": "failure",
                 "timezone": "+02:00"
             },
             "host": {
@@ -740,6 +741,7 @@
                 "created": "2021-10-19T10:21:07.000+02:00",
                 "kind": "event",
                 "original": "Oct 19 10:21:07 pcs-node1 1 2021-10-19T10:21:07+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 10:21:07 - pcs-node1 - [89.160.20.156] admin(ADMIN_REALM)[] - Primary authentication successful for admin/Administrators fr",
+                "outcome": "success",
                 "timezone": "+02:00"
             },
             "host": {

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-syslog.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-syslog.log-expected.json
@@ -34,6 +34,7 @@
                 "created": "2022-01-19T10:19:35.000+01:00",
                 "kind": "event",
                 "original": "<174>1 2022-01-19T10:19:35+01:00 89.160.20.112 PulseSecure: - - - 2022-01-19 10:19:35 - pcs-name - [89.160.20.156] username(REALM)[ROLE] - Primary authentication successful for username/REALM from 89.160.20.156",
+                "outcome": "success",
                 "timezone": "+01:00"
             },
             "log": {

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-vpn.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-vpn.log-expected.json
@@ -34,6 +34,7 @@
                 "created": "2021-10-19T09:16:53.000+02:00",
                 "kind": "event",
                 "original": "Oct 19 09:16:53 pcs-node1 1 2021-10-19T09:16:53+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 09:16:53 - pcs-node1 - [89.160.20.156] user.name(REALM)[] - Primary authentication successful for user.name/REALM from 89.160.20.156",
+                "outcome": "success",
                 "timezone": "+02:00"
             },
             "host": {
@@ -561,6 +562,7 @@
                 "created": "2021-10-19T10:12:11.000+02:00",
                 "kind": "event",
                 "original": "Oct 19 10:12:11 pcs-node1 1 2021-10-19T10:12:11+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 10:12:11 - pcs-node1 - [89.160.20.156] user.name(REALM)[] - Primary authentication failed for user.name/sign-in-page from 89.160.20.156",
+                "outcome": "failure",
                 "timezone": "+02:00"
             },
             "host": {

--- a/packages/pulse_connect_secure/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/pulse_connect_secure/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -59,7 +59,7 @@ processors:
         - 'VPN Tunneling: Session %{WORD:_tmp.type} for user %{SESSION} with %{NOTSPACE:network.type} address %{IP:client.nat.ip}(, hostname %{HOSTNAME:host.name})?'
         - "Session %{WORD} from user agent '%{GREEDYDATA:user_agent.original}' %{SESSION}."
         - 'Login %{WORD:_tmp.outcome}( %{GREEDYDATA})?. Reason: %{GREEDYDATA:event.reason}'
-        - '^Primary authentication %{WORD_tmp.outcome}'
+        - '^Primary authentication %{WORD:_tmp.outcome}'
         - '%{SESSION}'
       pattern_definitions:
         SESSION: \(session:%{SPACE}%{NOTSPACE:pulse_secure.session.id}\)

--- a/packages/pulse_connect_secure/manifest.yml
+++ b/packages/pulse_connect_secure/manifest.yml
@@ -1,6 +1,6 @@
 name: pulse_connect_secure
 title: Pulse Connect Secure
-version: "2.6.1"
+version: "2.6.2"
 description: Collect logs from Pulse Connect Secure with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

```
[pulse_connect_secure] Fix Primary authentication grok pattern

`%{WORD_tmp.outcome}` is missing the colon between the pattern name and
the field name, so it is not a grok token and grok reads it as literal
text. Primary authentication events therefore never set _tmp.outcome,
and never get an event.outcome.
```

Note: drafted with :robot: Cursor/Opus 5, under my supervision.

## What this fixes

```yaml
- 'Login %{WORD:_tmp.outcome}( %{GREEDYDATA})?. Reason: %{GREEDYDATA:event.reason}'
- '^Primary authentication %{WORD_tmp.outcome}'
```

The line above shows the intent. Without the colon, `%{WORD_tmp.outcome}` does not match [Grok's token grammar](https://github.com/elastic/elasticsearch/blob/main/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java#L35) — a field name is only recognised after a `:` — so the text stays in the regex source and the pattern matches only a line that literally contains `%{WORD_tmp.outcome}`. Verified with `_simulate`:

```
'Primary authentication failed'               as shipped: no match
'Primary authentication %{WORD_tmp.outcome}'  as shipped: matches, captures nothing
'Primary authentication failed'               with the colon: _tmp.outcome = "failed"
```

Nothing reports this at runtime. The processor has `ignore_failure: true`, and a name with a `.` in it cannot be looked up in the pattern bank, so there is no `Unable to find pattern` at install time either — had it been written `%{WORD_tmp}`, the pipeline would have refused to install.

`_tmp.outcome` is what the two `set` processors below the grok use to derive `event.outcome`, so the effect is that **`Primary authentication successful` and `Primary authentication failed` events carry no `event.outcome` at all** — including failures, which is the case anyone alerting on authentication would filter for.

## Effect on the test data

Five documents already in the pipeline tests, across three files, gain the outcome they should always have had. Nothing else changes:

```diff
  "original": "… admin(ADMIN_REALM)[] - Primary authentication failed for admin/Administrators from 89.160.20.156",
+ "outcome": "failure",

  "original": "… username(REALM)[ROLE] - Primary authentication successful for username/REALM from 89.160.20.156",
+ "outcome": "success",
```

Three `success`, two `failure`.

## How it was found

Instrumenting every grok pattern in this repo and checking each `%{` against Grok's token grammar. Five more packages have the same class of typo — see #21081 for the census and the reproduction for each.

