### PR TITLE
[iptables] Remove unused ECS_SYSLOG_PRI pattern definition

### DIFF
--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.2"
+  changes:
+    - description: Remove an unused ECS_SYSLOG_PRI pattern definition that was missing its closing brace. No change to parsing.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21084
 - version: "1.23.1"
   changes:
     - description: Remove top level note from docs

--- a/packages/iptables/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/iptables/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -70,7 +70,6 @@ processors:
       - '%{GREEDYDATA}\[%{UBIQUITI_LABEL}\](%{SPACE})?%{IPTABLES}'
       - '%{GREEDYDATA}%{IPTABLES}'
       pattern_definitions:
-        ECS_SYSLOG_PRI: '<%{NONNEGINT:log.syslog.priority>'
         IPTABLES_HOSTNAME: '%{HOSTNAME:observer.name}%{SPACE}(%{NOTSPACE}%{SPACE})?kernel:'
         IPTABLES_ACTION: '(:?%{WORD:event.action}:|%{IPTABLES_HOSTNAME}%{SPACE}iptables%{SPACE}%{WORD:event.action}|%{IPTABLES_HOSTNAME})'
         UNSIGNED_INT: '[0-9]+'

--- a/packages/iptables/manifest.yml
+++ b/packages/iptables/manifest.yml
@@ -1,6 +1,6 @@
 name: iptables
 title: Iptables
-version: "1.23.1"
+version: "1.23.2"
 description: Collect logs from Iptables with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

```
[iptables] Remove unused ECS_SYSLOG_PRI pattern definition

The definition in the second grok processor is missing its closing
brace — `'<%{NONNEGINT:log.syslog.priority>'` — so `%{NONNEGINT:…}` is
literal text rather than a token. Nothing in that processor references
it, so this is dead weight rather than a bug; removed so it is not
copied onward. The processor above it has the same definition spelled
correctly.
```

Note: drafted with :robot: Cursor/Opus 5, under my supervision.

## Detail

```yaml
pattern_definitions:
  ECS_SYSLOG_PRI: '<%{NONNEGINT:log.syslog.priority>'   # `>` where `}` belongs
```

A `>` closes nothing, so the text does not match [Grok's token grammar](https://github.com/elastic/elasticsearch/blob/main/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java#L35) and would be matched literally if anything used it. Nothing does: none of that processor's five patterns reference `%{ECS_SYSLOG_PRI}`, directly or through another definition. The syslog priority for these events is already extracted by the earlier processor, which spells the same definition correctly:

```yaml
ECS_SYSLOG_PRI: '<%{NONNEGINT:log.syslog.priority:long}>'
```

So this is a no-op at runtime and the pipeline tests are unchanged — the version bump is only because the package's YAML changed. Removing it rather than repairing it avoids a second, divergent copy of a definition that is already defined correctly 20 lines above.

## How it was found

Instrumenting every grok pattern in this repo and checking each `%{` against Grok's token grammar. This one is the harmless member of a family of six; the other five silently drop a field. See #21081.

