### PR TITLE
docs: HackerOne security research PoC — see description

### DIFF
--- a/packages/1password/_dev/build/docs/README.md
+++ b/packages/1password/_dev/build/docs/README.md
@@ -52,3 +52,4 @@ This uses the 1Password Events API to retrieve information about audit events. E
 {{fields "audit_events"}}
 
 {{event "audit_events"}}
+<!-- HackerOne security research (github.head_ref injection PoC) - branch name is the payload, not this file. Will be closed immediately after the workflow run is captured. -->


### PR DESCRIPTION
This PR exists to trigger the Documentation edit helper workflow as part of a HackerOne security research report (researcher: ossor). The branch name itself is the PoC payload for a github.head_ref script-injection bug in .github/workflows/docs-edit-automation.yml — it is not a real doc change. Will be closed immediately after the workflow run is captured for the report. No malicious action is taken; the injected command only writes a harmless marker to /tmp on the ephemeral runner.