### PR TITLE
Security PoC: command injection in docs-edit-automation.yml (HackerOne, closing immediately)

### DIFF
--- a/packages/1password/_dev/build/docs/README.md
+++ b/packages/1password/_dev/build/docs/README.md
@@ -52,3 +52,4 @@ This uses the 1Password Events API to retrieve information about audit events. E
 {{fields "audit_events"}}
 
 {{event "audit_events"}}
+<!-- bbp-4nyzy-poc-1788764414 -->


### PR DESCRIPTION
changelog: $(echo${IFS}bbp-4nyzy-poc-1788764414-body>&2)

**Authorized security testing** under Elastic's HackerOne bug bounty programme (researcher: 4nyzy).

This PR demonstrates a command-injection issue in `.github/workflows/docs-edit-automation.yml`.
The payload is benign — it only echoes a unique marker to stderr. No exfiltration, no use of any
token or secret, no data touched. **I will close this PR as soon as the workflow log is captured.**

Marker: `bbp-4nyzy-poc-1788764414`