### PR TITLE
[CI] fix PACKAGE_LIST derivation for nested packages

### DIFF
--- a/.buildkite/scripts/test_integrations_with_serverless.sh
+++ b/.buildkite/scripts/test_integrations_with_serverless.sh
@@ -87,9 +87,14 @@ if [[ "${FORCE_CHECK_ALL}" == "true" ]] || echo "${changed_files}" | pr_has_pack
 else
     PACKAGE_LIST=$(
         {
-            echo "${changed_files}" | grep -oE '^packages/[^/]+' | sort -u || true
-            echo "${changed_files}" | grep -oE '^\.buildkite/scripts/packages/[^/]+\.sh' \
-                | sed 's|^\.buildkite/scripts/||; s|\.sh$||' || true
+            all_pkgs=$(list_all_directories)
+            while IFS= read -r pkg_path; do
+                if echo "${changed_files}" | grep -q "^${pkg_path}/"; then
+                    echo "${pkg_path}"
+                elif echo "${changed_files}" | grep -q "^\.buildkite/scripts/${pkg_path}\.sh$"; then
+                    echo "${pkg_path}"
+                fi
+            done <<< "${all_pkgs}"
         } | sort -u | grep -v '^$' || true
     )
     echo "Packages affected by diff: $(echo "${PACKAGE_LIST}" | tr '\n' ' ')"

--- a/.buildkite/scripts/test_integrations_with_serverless.sh
+++ b/.buildkite/scripts/test_integrations_with_serverless.sh
@@ -87,6 +87,11 @@ if [[ "${FORCE_CHECK_ALL}" == "true" ]] || echo "${changed_files}" | pr_has_pack
 else
     PACKAGE_LIST=$(
         {
+            # Use list_all_directories (mage listPackages) instead of grepping ^packages/[^/]+
+            # directly from the diff output: the regex would only capture the first path segment
+            # and break for nested packages (e.g. packages/technology/foo → packages/technology,
+            # which has no manifest.yml). mage listPackages discovers valid package roots at any
+            # depth via WalkDir, so we cross-reference its output against the changed files.
             all_pkgs=$(list_all_directories)
             while IFS= read -r pkg_path; do
                 if echo "${changed_files}" | grep -q "^${pkg_path}/"; then

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -56,6 +56,11 @@ if [[ "${FORCE_CHECK_ALL}" == "true" ]] || echo "${changed_files}" | pr_has_pack
 else
     PACKAGE_LIST=$(
         {
+            # Use list_all_directories (mage listPackages) instead of grepping ^packages/[^/]+
+            # directly from the diff output: the regex would only capture the first path segment
+            # and break for nested packages (e.g. packages/technology/foo → packages/technology,
+            # which has no manifest.yml). mage listPackages discovers valid package roots at any
+            # depth via WalkDir, so we cross-reference its output against the changed files.
             all_pkgs=$(list_all_directories)
             while IFS= read -r pkg_path; do
                 if echo "${changed_files}" | grep -q "^${pkg_path}/"; then

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -56,9 +56,14 @@ if [[ "${FORCE_CHECK_ALL}" == "true" ]] || echo "${changed_files}" | pr_has_pack
 else
     PACKAGE_LIST=$(
         {
-            echo "${changed_files}" | grep -oE '^packages/[^/]+' | sort -u || true
-            echo "${changed_files}" | grep -oE '^\.buildkite/scripts/packages/[^/]+\.sh' \
-                | sed 's|^\.buildkite/scripts/||; s|\.sh$||' || true
+            all_pkgs=$(list_all_directories)
+            while IFS= read -r pkg_path; do
+                if echo "${changed_files}" | grep -q "^${pkg_path}/"; then
+                    echo "${pkg_path}"
+                elif echo "${changed_files}" | grep -q "^\.buildkite/scripts/${pkg_path}\.sh$"; then
+                    echo "${pkg_path}"
+                fi
+            done <<< "${all_pkgs}"
         } | sort -u | grep -v '^$' || true
     )
     echo "Packages affected by diff: $(echo "${PACKAGE_LIST}" | tr '\n' ' ')"

--- a/dev/citools/kibana_test.go
+++ b/dev/citools/kibana_test.go
@@ -24,7 +24,7 @@ func TestKibanaConstraintPackage(t *testing.T) {
 		expected *semver.Constraints
 	}{
 		{
-			title: "kibana constrasint defined",
+			title: "kibana constraint defined",
 			contents: `name: "version"
 conditions:
   kibana:

--- a/dev/citools/logsdb_test.go
+++ b/dev/citools/logsdb_test.go
@@ -26,7 +26,7 @@ func TestIsVersionLessThanLogsDBGA(t *testing.T) {
 			expected: true,
 		},
 		{
-			title:    "greater or equal than LogsSB GA",
+			title:    "greater or equal than LogsDB GA",
 			version:  semver.MustParse("8.17.0"),
 			expected: false,
 		},
@@ -38,7 +38,6 @@ func TestIsVersionLessThanLogsDBGA(t *testing.T) {
 			assert.Equal(t, c.expected, value)
 		})
 	}
-
 }
 
 func TestIsLogsDBSupportedInPackage(t *testing.T) {
@@ -100,5 +99,4 @@ conditions:
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
# [CI] fix PACKAGE_LIST derivation for nested packages

<!-- Type of change: Bug -->

## Proposed commit message

```
[CI] fix PACKAGE_LIST derivation for nested packages

The diff-based `PACKAGE_LIST` introduced in #20926 used
`grep -oE '^packages/[^/]+'` to extract affected package paths from the
changed-files list. This regex only captures the first path segment, so a
nested package such as `packages/technology/elastic_package_registry/foo.yml`
would resolve to `packages/technology` — a directory with no `manifest.yml` —
causing `should_test_package` and `package_name_manifest` to fail.

The same issue affected the `.buildkite/scripts/packages/<pkg>.sh` detection:
the pattern `[^/]+\.sh` cannot match a script at a nested path such as
`.buildkite/scripts/packages/technology/elastic_package_registry.sh`.

Fix both by replacing the regex with a loop over `list_all_directories`
(`mage listPackages`), which already discovers valid package roots at any
depth via `WalkDir`. For each known package path the loop checks whether any
changed file falls under it, or whether its corresponding
`.buildkite/scripts/<pkg_path>.sh` was modified.

Applied to `trigger_integrations_in_parallel.sh` and
`test_integrations_with_serverless.sh`.
```

## Author's Checklist

- [x] Verified that `list_all_directories` is already available at the point where `PACKAGE_LIST` is computed in both scripts (mage is installed earlier via `with_mage`).

## How to test this PR locally

Run the self-contained test script included in the branch (not committed to the repo):

```bash
bash .buildkite/scripts/test_package_list.sh
```

It mocks `list_all_directories` with flat and nested packages and validates all
combinations: flat package files, nested package files, intermediate
non-package directories, buildkite scripts (flat and nested), multiple changed
packages, unrelated files, and deduplication.

## Related issues

- Observed via review comment on #20426
- Introduced by #20926

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).