### PR TITLE
[serverless] add ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION env var

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -30,6 +30,8 @@ env:
   ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-false}"
   # Disable checking for newer versions
   ELASTIC_PACKAGE_CHECK_UPDATE_DISABLED: "true"
+  # Required to install packages via API even if they are already present in EPR (only available in QA)
+  ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION: "true"
 
 steps:
   - input: "Input values for the variables"


### PR DESCRIPTION
## Proposed commit message

Add the `ELASTIC_PACKAGE_SERVERLESS_KIBANA_SKIP_UPLOAD_PACKAGE_VALIDATION` environment variable to `.buildkite/pipeline.serverless.yml`.

**WHAT:** Adds the env var (set to `"true"`) to the global `env` block of the Buildkite Serverless pipeline, alongside other `ELASTIC_PACKAGE_*` settings.

**WHY:** The Kibana setting `xpack.fleet.internal.skipUploadPackageValidation` is required to install packages via the Fleet API even when they are already present in EPR. Without this, the serverless pipeline fails with a 400 error when trying to install packages that exist in the package registry. This setting is only available in QA environments, hence the gate via environment variable.

Relates: elastic/elastic-package#3911

## Author's Checklist

- [x] Verified the variable name matches the one introduced in `elastic/elastic-package#3911`
- [x] Comment follows the same style as the other `ELASTIC_PACKAGE_*` env vars in the file

## How to test this PR locally

Trigger the Buildkite Serverless pipeline and verify that package installation no longer fails with a 400 "already exists in the package registry" error.

Tested in https://buildkite.com/elastic/integrations-serverless/builds/2062 via https://github.com/elastic/integrations/pull/21106

## Related issues

- Relates elastic/elastic-package#3911

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).