### PR TITLE
[Synthetics] Add Kerberos and NTLM authentication to HTTP monitors

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add Kerberos/SPNEGO and NTLM authentication options to HTTP monitors.
       type: enhancement
-      link: https://github.com/elastic/beats/pull/51223
+      link: https://github.com/elastic/integrations/pull/21116
 - version: "1.11.0"
   changes:
     - description: Only emit monitor fields in the agent stream when they differ from the Heartbeat default (http, tcp, icmp), reducing the size of the generated policy.

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Add Kerberos/SPNEGO and NTLM authentication options to HTTP monitors.
+      type: enhancement
+      link: https://github.com/elastic/beats/pull/51223
 - version: "1.11.0"
   changes:
     - description: Only emit monitor fields in the agent stream when they differ from the Heartbeat default (http, tcp, icmp), reducing the size of the generated policy.

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.12.0"
   changes:
-    - description: Add Kerberos/SPNEGO and NTLM authentication options to HTTP monitors.
+    - description: Add Kerberos/SPNEGO and NTLM authentication to HTTP monitors as base64-encoded YAML/JSON fields that Heartbeat decodes.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/21116
 - version: "1.11.0"

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.expected
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.expected
@@ -16,14 +16,7 @@ inputs:
                         - read
           ipv4: true
           ipv6: true
-          kerberos.auth_type: password
-          kerberos.config_path: /etc/krb5.conf
-          kerberos.enabled: true
-          kerberos.keytab: /etc/krb5.keytab
-          kerberos.password: secret
-          kerberos.realm: CORP.LOCAL
-          kerberos.service_name: HTTP/internal.corp.local
-          kerberos.username: svc-heartbeat
+          kerberos: ZW5hYmxlZDogdHJ1ZQphdXRoX3R5cGU6IHBhc3N3b3JkCnJlYWxtOiBDT1JQLkxPQ0FMCmNvbmZpZ19wYXRoOiAvZXRjL2tyYjUuY29uZgp1c2VybmFtZTogc3ZjLWhlYXJ0YmVhdApwYXNzd29yZDogc2VjcmV0Cg==
           max_attempts: 2
           name: null
           response.include_headers: null

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.expected
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.expected
@@ -1,0 +1,52 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-kerberos-synthetics
+      streams:
+        - data_stream:
+            dataset: http
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          ipv4: true
+          ipv6: true
+          kerberos.auth_type: password
+          kerberos.config_path: /etc/krb5.conf
+          kerberos.enabled: true
+          kerberos.keytab: /etc/krb5.keytab
+          kerberos.password: secret
+          kerberos.realm: CORP.LOCAL
+          kerberos.service_name: HTTP/internal.corp.local
+          kerberos.username: svc-heartbeat
+          max_attempts: 2
+          name: null
+          response.include_headers: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          type: http
+          urls: https://internal.corp.local/health
+      type: synthetics/http
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-http-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.yml
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.yml
@@ -1,0 +1,12 @@
+input: synthetics/http
+data_stream:
+  vars:
+    urls: https://internal.corp.local/health
+    kerberos.enabled: true
+    kerberos.auth_type: password
+    kerberos.realm: CORP.LOCAL
+    kerberos.config_path: /etc/krb5.conf
+    kerberos.username: svc-heartbeat
+    kerberos.password: secret
+    kerberos.keytab: /etc/krb5.keytab
+    kerberos.service_name: HTTP/internal.corp.local

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.yml
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-kerberos.yml
@@ -2,11 +2,4 @@ input: synthetics/http
 data_stream:
   vars:
     urls: https://internal.corp.local/health
-    kerberos.enabled: true
-    kerberos.auth_type: password
-    kerberos.realm: CORP.LOCAL
-    kerberos.config_path: /etc/krb5.conf
-    kerberos.username: svc-heartbeat
-    kerberos.password: secret
-    kerberos.keytab: /etc/krb5.keytab
-    kerberos.service_name: HTTP/internal.corp.local
+    kerberos: ZW5hYmxlZDogdHJ1ZQphdXRoX3R5cGU6IHBhc3N3b3JkCnJlYWxtOiBDT1JQLkxPQ0FMCmNvbmZpZ19wYXRoOiAvZXRjL2tyYjUuY29uZgp1c2VybmFtZTogc3ZjLWhlYXJ0YmVhdApwYXNzd29yZDogc2VjcmV0Cg==

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.expected
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.expected
@@ -18,10 +18,7 @@ inputs:
           ipv6: true
           max_attempts: 2
           name: null
-          ntlm.domain: CORP
-          ntlm.enabled: true
-          ntlm.password: secret
-          ntlm.username: svc-heartbeat
+          ntlm: ZW5hYmxlZDogdHJ1ZQp1c2VybmFtZTogc3ZjLWhlYXJ0YmVhdApwYXNzd29yZDogc2VjcmV0CmRvbWFpbjogQ09SUAo=
           response.include_headers: null
           run_from.geo.name: Fleet managed
           run_from.id: fleet_managed

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.expected
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.expected
@@ -1,0 +1,48 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: synthetics
+      name: test-ntlm-synthetics
+      streams:
+        - data_stream:
+            dataset: http
+            elasticsearch:
+                privileges:
+                    indices:
+                        - auto_configure
+                        - create_doc
+                        - read
+          ipv4: true
+          ipv6: true
+          max_attempts: 2
+          name: null
+          ntlm.domain: CORP
+          ntlm.enabled: true
+          ntlm.password: secret
+          ntlm.username: svc-heartbeat
+          response.include_headers: null
+          run_from.geo.name: Fleet managed
+          run_from.id: fleet_managed
+          schedule: '@every 3m'
+          type: http
+          urls: https://iis.corp.local/
+      type: synthetics/http
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - synthetics-http-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                    - read
+secret_references: []

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.yml
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.yml
@@ -2,7 +2,4 @@ input: synthetics/http
 data_stream:
   vars:
     urls: https://iis.corp.local/
-    ntlm.enabled: true
-    ntlm.username: svc-heartbeat
-    ntlm.password: secret
-    ntlm.domain: CORP
+    ntlm: ZW5hYmxlZDogdHJ1ZQp1c2VybmFtZTogc3ZjLWhlYXJ0YmVhdApwYXNzd29yZDogc2VjcmV0CmRvbWFpbjogQ09SUAo=

--- a/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.yml
+++ b/packages/synthetics/data_stream/http/_dev/test/policy/test-ntlm.yml
@@ -1,0 +1,8 @@
+input: synthetics/http
+data_stream:
+  vars:
+    urls: https://iis.corp.local/
+    ntlm.enabled: true
+    ntlm.username: svc-heartbeat
+    ntlm.password: secret
+    ntlm.domain: CORP

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -44,41 +44,11 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
-{{#if kerberos.enabled}}
-kerberos.enabled: {{kerberos.enabled}}
+{{#if kerberos}}
+kerberos: {{kerberos}}
 {{/if}}
-{{#if kerberos.auth_type}}
-kerberos.auth_type: {{kerberos.auth_type}}
-{{/if}}
-{{#if kerberos.realm}}
-kerberos.realm: {{kerberos.realm}}
-{{/if}}
-{{#if kerberos.config_path}}
-kerberos.config_path: {{kerberos.config_path}}
-{{/if}}
-{{#if kerberos.username}}
-kerberos.username: {{kerberos.username}}
-{{/if}}
-{{#if kerberos.password}}
-kerberos.password: {{kerberos.password}}
-{{/if}}
-{{#if kerberos.keytab}}
-kerberos.keytab: {{kerberos.keytab}}
-{{/if}}
-{{#if kerberos.service_name}}
-kerberos.service_name: {{kerberos.service_name}}
-{{/if}}
-{{#if ntlm.enabled}}
-ntlm.enabled: {{ntlm.enabled}}
-{{/if}}
-{{#if ntlm.username}}
-ntlm.username: {{ntlm.username}}
-{{/if}}
-{{#if ntlm.password}}
-ntlm.password: {{ntlm.password}}
-{{/if}}
-{{#if ntlm.domain}}
-ntlm.domain: {{ntlm.domain}}
+{{#if ntlm}}
+ntlm: {{ntlm}}
 {{/if}}
 response.include_headers: {{response.include_headers}}
 {{#if response.include_body}}

--- a/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/synthetics/data_stream/http/agent/stream/http.yml.hbs
@@ -44,6 +44,42 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if kerberos.enabled}}
+kerberos.enabled: {{kerberos.enabled}}
+{{/if}}
+{{#if kerberos.auth_type}}
+kerberos.auth_type: {{kerberos.auth_type}}
+{{/if}}
+{{#if kerberos.realm}}
+kerberos.realm: {{kerberos.realm}}
+{{/if}}
+{{#if kerberos.config_path}}
+kerberos.config_path: {{kerberos.config_path}}
+{{/if}}
+{{#if kerberos.username}}
+kerberos.username: {{kerberos.username}}
+{{/if}}
+{{#if kerberos.password}}
+kerberos.password: {{kerberos.password}}
+{{/if}}
+{{#if kerberos.keytab}}
+kerberos.keytab: {{kerberos.keytab}}
+{{/if}}
+{{#if kerberos.service_name}}
+kerberos.service_name: {{kerberos.service_name}}
+{{/if}}
+{{#if ntlm.enabled}}
+ntlm.enabled: {{ntlm.enabled}}
+{{/if}}
+{{#if ntlm.username}}
+ntlm.username: {{ntlm.username}}
+{{/if}}
+{{#if ntlm.password}}
+ntlm.password: {{ntlm.password}}
+{{/if}}
+{{#if ntlm.domain}}
+ntlm.domain: {{ntlm.domain}}
+{{/if}}
 response.include_headers: {{response.include_headers}}
 {{#if response.include_body}}
 response.include_body: {{response.include_body}}

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -100,16 +100,100 @@ streams:
         show_user: true
       - name: username
         type: text
-        title: Username
+        title: Basic authentication username
         multi: false
         required: false
         show_user: true
+        description: Mutually exclusive with Kerberos and NTLM authentication.
       - name: password
         type: password
-        title: Password
+        title: Basic authentication password
         multi: false
         required: false
         show_user: true
+        description: Mutually exclusive with Kerberos and NTLM authentication.
+      - name: kerberos.enabled
+        type: bool
+        title: Kerberos enabled
+        multi: false
+        required: false
+        show_user: true
+        description: Enable Kerberos/SPNEGO (Negotiate) authentication. Mutually exclusive with basic authentication (username/password) and NTLM. Only usable from Private Location agents that can reach the KDC. Not available in FIPS builds.
+      - name: kerberos.auth_type
+        type: text
+        title: Kerberos authentication type
+        multi: false
+        required: false
+        show_user: true
+        description: Authentication type, `password` or `keytab`.
+      - name: kerberos.realm
+        type: text
+        title: Kerberos realm
+        multi: false
+        required: false
+        show_user: true
+        description: Kerberos realm, for example `EXAMPLE.COM`.
+      - name: kerberos.config_path
+        type: text
+        title: Kerberos config path
+        multi: false
+        required: false
+        show_user: true
+        description: Path to the krb5.conf describing the realm and KDC.
+      - name: kerberos.username
+        type: text
+        title: Kerberos username
+        multi: false
+        required: false
+        show_user: true
+        description: Principal username when `kerberos.auth_type` is `password`.
+      - name: kerberos.password
+        type: password
+        title: Kerberos password
+        multi: false
+        required: false
+        show_user: true
+        description: Principal password when `kerberos.auth_type` is `password`.
+      - name: kerberos.keytab
+        type: text
+        title: Kerberos keytab
+        multi: false
+        required: false
+        show_user: true
+        description: Keytab path when `kerberos.auth_type` is `keytab`.
+      - name: kerberos.service_name
+        type: text
+        title: Kerberos service name
+        multi: false
+        required: false
+        show_user: true
+        description: Optional SPN override, for example `HTTP/host.example.com`. Derived from the URL by default.
+      - name: ntlm.enabled
+        type: bool
+        title: NTLM enabled
+        multi: false
+        required: false
+        show_user: true
+        description: Enable NTLM (Integrated Windows Authentication). Mutually exclusive with basic authentication (username/password) and Kerberos. Not available in FIPS builds.
+      - name: ntlm.username
+        type: text
+        title: NTLM username
+        multi: false
+        required: false
+        show_user: true
+      - name: ntlm.password
+        type: password
+        title: NTLM password
+        multi: false
+        required: false
+        show_user: true
+      - name: ntlm.domain
+        type: text
+        title: NTLM domain
+        multi: false
+        required: false
+        show_user: true
+        description: Optional when the domain is encoded in the username as `DOMAIN\user` or `user@domain`.
       - name: response.include_headers
         type: bool
         title: Index response headers

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -112,88 +112,20 @@ streams:
         required: false
         show_user: true
         description: Mutually exclusive with Kerberos and NTLM authentication.
-      - name: kerberos.enabled
-        type: bool
-        title: Kerberos enabled
-        multi: false
-        required: false
-        show_user: true
-        description: Enable Kerberos/SPNEGO (Negotiate) authentication. Mutually exclusive with basic authentication (username/password) and NTLM. Only usable from Private Location agents that can reach the KDC. Not available in FIPS builds.
-      - name: kerberos.auth_type
+      - name: kerberos
         type: text
-        title: Kerberos authentication type
+        title: Kerberos authentication
         multi: false
         required: false
         show_user: true
-        description: Authentication type, `password` or `keytab`.
-      - name: kerberos.realm
+        description: Base64-encoded YAML or JSON of the Heartbeat `kerberos` block. Mutually exclusive with basic authentication (username/password) and NTLM. Only usable from Private Location agents that can reach the KDC. Not available in FIPS builds.
+      - name: ntlm
         type: text
-        title: Kerberos realm
+        title: NTLM authentication
         multi: false
         required: false
         show_user: true
-        description: Kerberos realm, for example `EXAMPLE.COM`.
-      - name: kerberos.config_path
-        type: text
-        title: Kerberos config path
-        multi: false
-        required: false
-        show_user: true
-        description: Path to the krb5.conf describing the realm and KDC.
-      - name: kerberos.username
-        type: text
-        title: Kerberos username
-        multi: false
-        required: false
-        show_user: true
-        description: Principal username when `kerberos.auth_type` is `password`.
-      - name: kerberos.password
-        type: password
-        title: Kerberos password
-        multi: false
-        required: false
-        show_user: true
-        description: Principal password when `kerberos.auth_type` is `password`.
-      - name: kerberos.keytab
-        type: text
-        title: Kerberos keytab
-        multi: false
-        required: false
-        show_user: true
-        description: Keytab path when `kerberos.auth_type` is `keytab`.
-      - name: kerberos.service_name
-        type: text
-        title: Kerberos service name
-        multi: false
-        required: false
-        show_user: true
-        description: Optional SPN override, for example `HTTP/host.example.com`. Derived from the URL by default.
-      - name: ntlm.enabled
-        type: bool
-        title: NTLM enabled
-        multi: false
-        required: false
-        show_user: true
-        description: Enable NTLM (Integrated Windows Authentication). Mutually exclusive with basic authentication (username/password) and Kerberos. Not available in FIPS builds.
-      - name: ntlm.username
-        type: text
-        title: NTLM username
-        multi: false
-        required: false
-        show_user: true
-      - name: ntlm.password
-        type: password
-        title: NTLM password
-        multi: false
-        required: false
-        show_user: true
-      - name: ntlm.domain
-        type: text
-        title: NTLM domain
-        multi: false
-        required: false
-        show_user: true
-        description: Optional when the domain is encoded in the username as `DOMAIN\user` or `user@domain`.
+        description: Base64-encoded YAML or JSON of the Heartbeat `ntlm` block. Mutually exclusive with basic authentication (username/password) and Kerberos. Not available in FIPS builds.
       - name: response.include_headers
         type: bool
         title: Index response headers

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.11.0
+version: 1.12.0
 categories:
   - observability
   # Added monitoring category as Synthetics provides synthetic monitoring capabilities


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Expose Heartbeat's Kerberos/SPNEGO and NTLM HTTP auth blocks on the synthetics HTTP data stream so Private Location agents can monitor endpoints behind Integrated Windows Authentication. Relates elastic/beats#51223.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] Changelog `link` updated to this PR after open (package lint requires a numeric URL).
- [ ] Policy tests regenerated against a running `elastic-package` stack if CI disagrees with the hand-written expected files.

## How to test this PR locally

```bash
cd packages/synthetics
elastic-package check
elastic-package stack up -d --services kibana,elasticsearch
elastic-package test policy --data-streams http
```

Confirm a compiled HTTP stream with the Kerberos (or NTLM) vars set emits the matching `kerberos.*` / `ntlm.*` keys, and that a default monitor still omits them.

## Related issues

- Relates https://github.com/elastic/beats/pull/51223
- Relates elastic/sdh-synthetics#299

## Screenshots