### PR TITLE
[php_fpm] Upgrade system-test image to PHP 8.1.31 on Debian 12

### DIFF
--- a/packages/php_fpm/_dev/deploy/docker/files/Dockerfile
+++ b/packages/php_fpm/_dev/deploy/docker/files/Dockerfile
@@ -1,16 +1,14 @@
-FROM bitnamilegacy/php-fpm:8.1.12-debian-11-r4
+FROM bitnamilegacy/php-fpm:8.1.31-debian-12-r2
 
 # Following command enables "/status" endpoint
 
 RUN echo >> /opt/bitnami/php/etc/php-fpm.d/www.conf &&\
     echo "pm.status_path = /status" >> /opt/bitnami/php/etc/php-fpm.d/www.conf
 
-# Debian 11 LTS ended 31 Aug 2026. bullseye-security InRelease is expired and
-# its pool 404s, so use archive.debian.org and skip the security repo.
-RUN printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list && \
-    printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid-until && \
-    apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nginx && \
+# Following command installs nginx
+
+RUN apt-get update -y &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nginx &&\
     rm -rf /var/lib/apt/lists/*
 
 COPY ./default /etc/nginx/sites-enabled/default

--- a/packages/php_fpm/_dev/deploy/docker/files/Dockerfile
+++ b/packages/php_fpm/_dev/deploy/docker/files/Dockerfile
@@ -5,11 +5,13 @@ FROM bitnamilegacy/php-fpm:8.1.12-debian-11-r4
 RUN echo >> /opt/bitnami/php/etc/php-fpm.d/www.conf &&\
     echo "pm.status_path = /status" >> /opt/bitnami/php/etc/php-fpm.d/www.conf
 
-# Following command installs nginx
-
-RUN apt-get update -y &&\
-    apt-get upgrade -y &&\
-    apt-get install nginx -y
+# Debian 11 LTS ended 31 Aug 2026. bullseye-security InRelease is expired and
+# its pool 404s, so use archive.debian.org and skip the security repo.
+RUN printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list && \
+    printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid-until && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nginx && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY ./default /etc/nginx/sites-enabled/default
 COPY ./entrypoint.sh /home/entrypoint.sh


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Upgrade the PHP-FPM system-test image from Debian 11 to Debian 12 so `apt-get` can still install nginx after Bullseye LTS ended.

The test Dockerfile used `bitnamilegacy/php-fpm:8.1.12-debian-11-r4`. After 31 August 2026, `apt-get update` fails because `bullseye-security` InRelease is expired and its package pool 404s. Move to `bitnamilegacy/php-fpm:8.1.31-debian-12-r2`: same PHP 8.1 series and Bitnami paths, on Debian 12 (supported until 2028). No changelog or package version bump: this only affects `_dev` system-test image builds.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

Changelog is intentionally omitted: this is a `_dev` test-image fix and does not change the published package.

## Author's Checklist

- [x] System-test Dockerfile builds on Debian 12 after the Bullseye apt expiry.
- [x] Bitnami paths (`/opt/bitnami/php/...`) and `/status` config still work.
- [x] No `changelog.yml` / `manifest.yml` bump (test-only).

## How to test this PR locally

From the repo root:

```
docker build --platform linux/amd64 -t php_fpm-test packages/php_fpm/_dev/deploy/docker/files
```

Confirm the image builds, `php-fpm -v` reports 8.1.31, and nginx is installed. Optionally run PHP-FPM system tests:

```
cd packages/php_fpm
elastic-package test system -v
```

## Related issues

- Relates https://github.com/elastic/beats/pull/53081

## Screenshots

N/A