### PR TITLE
[backport_branch]: preserve K8S_VERSION/KIND_VERSION in pipeline.serverless.yml

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -151,12 +151,20 @@ updateBackportBranchContents() {
   # it with sed, which rewrites only that line and leaves blank lines intact — yq -i
   # rewrites the whole file and strips empty lines as a side effect.
   local pipeline_yml="${BUILDKITE_FOLDER_PATH}/pipeline.yml"
+  local pipeline_serverless_yml="${BUILDKITE_FOLDER_PATH}/pipeline.serverless.yml"
   local k8s_version_line=""
   local kind_version_line=""
+  local serverless_k8s_version_line=""
+  local serverless_kind_version_line=""
   if [ -f "${pipeline_yml}" ]; then
     k8s_version_line=$(grep -E '^\s*K8S_VERSION:' "${pipeline_yml}" || true)
     kind_version_line=$(grep -E '^\s*KIND_VERSION:' "${pipeline_yml}" || true)
-    echo "Preserving from backport branch: ${k8s_version_line}, ${kind_version_line}"
+    echo "Preserving from backport branch (pipeline.yml): ${k8s_version_line}, ${kind_version_line}"
+  fi
+  if [ -f "${pipeline_serverless_yml}" ]; then
+    serverless_k8s_version_line=$(grep -E '^\s*K8S_VERSION:' "${pipeline_serverless_yml}" || true)
+    serverless_kind_version_line=$(grep -E '^\s*KIND_VERSION:' "${pipeline_serverless_yml}" || true)
+    echo "Preserving from backport branch (pipeline.serverless.yml): ${serverless_k8s_version_line}, ${serverless_kind_version_line}"
   fi
 
   echo "--- Copying $BUILDKITE_FOLDER_PATH from $SOURCE_BRANCH..."
@@ -171,6 +179,14 @@ updateBackportBranchContents() {
   if [ -n "${kind_version_line}" ]; then
     echo "--- Restoring KIND_VERSION in ${pipeline_yml}..."
     sed -i "s|^\s*KIND_VERSION:.*|${kind_version_line}|" "${pipeline_yml}"
+  fi
+  if [ -n "${serverless_k8s_version_line}" ]; then
+    echo "--- Restoring K8S_VERSION in ${pipeline_serverless_yml}..."
+    sed -i "s|^\s*K8S_VERSION:.*|${serverless_k8s_version_line}|" "${pipeline_serverless_yml}"
+  fi
+  if [ -n "${serverless_kind_version_line}" ]; then
+    echo "--- Restoring KIND_VERSION in ${pipeline_serverless_yml}..."
+    sed -i "s|^\s*KIND_VERSION:.*|${serverless_kind_version_line}|" "${pipeline_serverless_yml}"
   fi
 
   git add $BUILDKITE_FOLDER_PATH


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

```
[backport_branch]: preserve K8S_VERSION/KIND_VERSION in pipeline.serverless.yml

WHAT:
- Extend the version-pin preservation introduced in #20432 to also cover
  `.buildkite/pipeline.serverless.yml`.
- Before overwriting `.buildkite/` from the source branch, the script now
  captures the full `K8S_VERSION` and `KIND_VERSION` lines from both
  `pipeline.yml` and `pipeline.serverless.yml` on the backport branch, then
  restores them with `sed` after the checkout.

WHY:
- `pipeline.serverless.yml` also contains `KIND_VERSION` and `K8S_VERSION`
  pins. Without this fix, syncing a backport branch would blindly overwrite
  those pins with the current main-branch values, potentially breaking
  serverless CI for that branch — the same problem #20432 fixed for
  `pipeline.yml`.
```

## Author's Checklist

- [x] Verified that `pipeline.serverless.yml` exists on the relevant backport branches (kubernetes) and contains `K8S_VERSION`/`KIND_VERSION` pins to be preserved.

## How to test this PR locally

Run `backport_branch.sh` in dry-run mode against a kubernetes backport branch
(e.g. `backport-kubernetes-1.83`) and confirm the diff shows the
`pipeline.serverless.yml` version pins unchanged from the backport branch
rather than overwritten with main-branch values.

## Related issues

- Relates #20432
- Relates https://github.com/elastic/integrations/issues/19016
- Relates https://github.com/elastic/integrations/issues/19262
---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).