### PR TITLE
[Enhancement] Windows,System: Add AD CS audit event support

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.24.0"
+  changes:
+    - description: Normalize Active Directory Certificate Services (AD CS) audit events with native field mappings, `winlog.adcs` request fields, ECS user mappings, and event categorization.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/21136
 - version: "2.23.4"
   changes:
     - description: Include Windows Security event 6272 in subject-field ECS mapping (SubjectUserSid, SubjectUserName, SubjectDomainName) like other audited events.

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-4868.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-4868.json-expected.json
@@ -54,6 +54,11 @@
             },
             "winlog": {
                 "activity_id": "{AE8DEF25-FE68-0000-4DEF-8DAE68FED801}",
+                "adcs": {
+                    "request": {
+                        "id": 15
+                    }
+                },
                 "api": "wineventlog",
                 "channel": "Security",
                 "computer_name": "Server2.test1.local",

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-4869.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-4869.json-expected.json
@@ -54,6 +54,11 @@
             },
             "winlog": {
                 "activity_id": "{AE8DEF25-FE68-0000-4DEF-8DAE68FED801}",
+                "adcs": {
+                    "request": {
+                        "id": 7
+                    }
+                },
                 "api": "wineventlog",
                 "channel": "Security",
                 "computer_name": "Server2.test1.local",

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-actor-normalization.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-actor-normalization.json
@@ -1,0 +1,177 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-08-22T03:05:12.373Z",
+            "event": {
+                "code": "4870"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "CertificateSerialNumber": "130000000a1e268cbaf3d2cb0000000000000a",
+                    "RevocationReason": "0",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4870",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4772"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:12.44Z",
+            "event": {
+                "code": "4871"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "NextPublishForBaseCRL": "Yes",
+                    "NextPublishForDeltaCRL": "No",
+                    "NextUpdate": "0",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4871",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4773"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.565Z",
+            "event": {
+                "code": "4873"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "ExtensionData": "aAB0AHQAcABzADoALwAvAGEAdABsAGEAcwAuAGkAbgB2AGEAbABpAGQALwBiAGUA\nbgBpAGcAbgAtAGMAbwBuAHQAcgBvAGwAAAA=",
+                    "ExtensionDataType": "4",
+                    "ExtensionName": "1.3.6.1.4.1.311.99.1",
+                    "ExtensionPolicyFlags": "0",
+                    "RequestId": "11",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4873",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4348"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.556Z",
+            "event": {
+                "code": "4874"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "Atlas-Manager-Note: benign-one\nATLAS manager note:benign-two",
+                    "RequestId": "11",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4874",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4347"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.923Z",
+            "event": {
+                "code": "4875"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "SubjectLogonId": "0xa3711a",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4875",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5014"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.765Z",
+            "event": {
+                "code": "4891"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Entry": "PublishCertFlags",
+                    "Node": "ExitModules\\CertificateAuthority_MicrosoftDefault.Exit",
+                    "SubjectLogonId": "0xa3711a",
+                    "Value": "3",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4891",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5012"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T21:53:51.753Z",
+            "event": {
+                "code": "4892"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "PropertyIndex": "0",
+                    "PropertyName": "29",
+                    "PropertyType": "4",
+                    "PropertyValue": "DirectoryEmailReplication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.29\nDomainControllerAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.28\nKerberosAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.33\nEFSRecovery\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.8\nEFS\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.6\nDomainController\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.15\nWebServer\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.16\nMachine\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.14\nUser\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.1\nSubCA\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.18\nAdministrator\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x47e42df",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4892",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "38747"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-actor-normalization.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-actor-normalization.json-expected.json
@@ -1,0 +1,352 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-08-22T03:05:12.373Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-revoked",
+                "category": [
+                    "iam"
+                ],
+                "code": "4870",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "CertificateSerialNumber": "130000000a1e268cbaf3d2cb0000000000000a",
+                    "RevocationReason": "0",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4870",
+                "logon": {
+                    "id": "0x9b4df7"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4772"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:12.44Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-revocation-list-publication-requested",
+                "category": [
+                    "iam"
+                ],
+                "code": "4871",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "NextPublishForBaseCRL": "Yes",
+                    "NextPublishForDeltaCRL": "No",
+                    "NextUpdate": "0",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4871",
+                "logon": {
+                    "id": "0x9b4df7"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4773"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.565Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-extension-changed",
+                "category": [
+                    "iam"
+                ],
+                "code": "4873",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "extension": {
+                            "name": "1.3.6.1.4.1.311.99.1",
+                            "oid": "1.3.6.1.4.1.311.99.1"
+                        },
+                        "id": 11
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "ExtensionData": "aAB0AHQAcABzADoALwAvAGEAdABsAGEAcwAuAGkAbgB2AGEAbABpAGQALwBiAGUA\nbgBpAGcAbgAtAGMAbwBuAHQAcgBvAGwAAAA=",
+                    "ExtensionDataType": "4",
+                    "ExtensionName": "1.3.6.1.4.1.311.99.1",
+                    "ExtensionPolicyFlags": "0",
+                    "RequestId": "11",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4873",
+                "logon": {
+                    "id": "0x97c883"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4348"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.556Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-attributes-changed",
+                "category": [
+                    "iam"
+                ],
+                "code": "4874",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "id": 11
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "Atlas-Manager-Note: benign-one\nATLAS manager note:benign-two",
+                    "RequestId": "11",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4874",
+                "logon": {
+                    "id": "0x97c883"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4347"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.923Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-services-shutdown-requested",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4875",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0xa3711a",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4875",
+                "logon": {
+                    "id": "0xa3711a"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5014"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.765Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-services-configuration-entry-changed",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4891",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Entry": "PublishCertFlags",
+                    "Node": "ExitModules\\CertificateAuthority_MicrosoftDefault.Exit",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0xa3711a",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500",
+                    "Value": "3"
+                },
+                "event_id": "4891",
+                "logon": {
+                    "id": "0xa3711a"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5012"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T21:53:51.753Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-services-property-changed",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4892",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "PropertyIndex": "0",
+                    "PropertyName": "29",
+                    "PropertyType": "4",
+                    "PropertyValue": "DirectoryEmailReplication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.29\nDomainControllerAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.28\nKerberosAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.33\nEFSRecovery\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.8\nEFS\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.6\nDomainController\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.15\nWebServer\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.16\nMachine\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.14\nUser\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.1\nSubCA\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.18\nAdministrator\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x47e42df",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4892",
+                "logon": {
+                    "id": "0x47e42df"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "38747"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json
@@ -450,6 +450,41 @@
                     "Disposition": "-2146875392"
                 }
             }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:07.752Z",
+            "event": {
+                "code": "4888"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "activity_id": "{11b78485-31d3-0001-d984-b711d331dd01}",
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Disposition": "2",
+                    "RequestId": "12",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "63 c4 21 2e 83 d0 e9 df 87 ea 94 a8 28 b1 7d 2e 0a 72 0a c6"
+                },
+                "event_id": "4888",
+                "keywords": [
+                    "Audit Failure"
+                ],
+                "opcode": "Info",
+                "process": {
+                    "pid": 700,
+                    "thread": {
+                        "id": 5480
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4653",
+                "task": "Certification Services"
+            }
         }
     ]
 }

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json
@@ -1,0 +1,455 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "2148091904"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "+2148091904"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875359"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146828289"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4887"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4887",
+                "event_data": {
+                    "Disposition": "3"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4889"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4889",
+                "event_data": {
+                    "Disposition": "5"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "6443059200"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-6441842688"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "9223372036854775807"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-9223372036854775808"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "0x80094800"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": " -2146875392 "
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {}
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": null
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 1,
+                            "name": "STALE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875393"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {},
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "invalid"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4886"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4886",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "name": {
+                                "unexpected": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": "invalid",
+                            "name": "STALE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-06T12:00:00.000Z",
+            "event": {
+                "code": "4888",
+                "action": "ADCS-DENIED",
+                "category": [
+                    "configuration",
+                    "authentication"
+                ],
+                "outcome": "failure"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Synthetic-Other-Provider",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Application",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4890"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4890",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json-expected.json
@@ -1,0 +1,783 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 2148091904,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "2148091904"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 2148091904,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "+2148091904"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875359,
+                            "name": "CERTSRV_E_SEC_EXT_DIRECTORY_SID_REQUIRED"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875359"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146828289
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146828289"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "3"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-pending",
+                "category": [
+                    "iam"
+                ],
+                "code": "4889",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 5,
+                            "name": "CR_DISP_UNDER_SUBMISSION"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "5"
+                },
+                "event_id": "4889",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 0
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "0"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 6443059200
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "6443059200"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -6441842688
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-6441842688"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 9223372036854775807
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "9223372036854775807"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -9223372036854775808
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-9223372036854775808"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "0x80094800"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392.0"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": " -2146875392 "
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875393
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875393"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "invalid"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-received",
+                "category": [
+                    "iam"
+                ],
+                "code": "4886",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4886",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-06T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "outcome": "failure",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Synthetic-Other-Provider"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "channel": "Application",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "code": "4890"
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4890",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-disposition-name.json-expected.json
@@ -242,7 +242,8 @@
                 "adcs": {
                     "request": {
                         "disposition": {
-                            "code": 0
+                            "code": 0,
+                            "name": "CR_DISP_INCOMPLETE"
                         }
                     }
                 },
@@ -640,12 +641,6 @@
                 ]
             },
             "winlog": {
-                "channel": "Security",
-                "event_data": {
-                    "Disposition": "-2146875392"
-                },
-                "event_id": "4888",
-                "provider_name": "Microsoft-Windows-Security-Auditing",
                 "adcs": {
                     "request": {
                         "disposition": {
@@ -653,7 +648,13 @@
                             "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
                         }
                     }
-                }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
             }
         },
         {
@@ -672,12 +673,6 @@
                 ]
             },
             "winlog": {
-                "channel": "Security",
-                "event_data": {
-                    "Disposition": "-2146875392"
-                },
-                "event_id": "4888",
-                "provider_name": "Microsoft-Windows-Security-Auditing",
                 "adcs": {
                     "request": {
                         "disposition": {
@@ -685,7 +680,13 @@
                             "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
                         }
                     }
-                }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
             }
         },
         {
@@ -777,6 +778,73 @@
                 },
                 "event_id": "4890",
                 "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:07.752Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "activity_id": "{11b78485-31d3-0001-d984-b711d331dd01}",
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 2,
+                            "name": "CR_DISP_DENIED"
+                        },
+                        "id": 12,
+                        "requester": {
+                            "domain": "ADCSLAB",
+                            "name": "Administrator"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Disposition": "2",
+                    "RequestId": "12",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "63 c4 21 2e 83 d0 e9 df 87 ea 94 a8 28 b1 7d 2e 0a 72 0a c6"
+                },
+                "event_id": "4888",
+                "keywords": [
+                    "Audit Failure"
+                ],
+                "opcode": "Info",
+                "process": {
+                    "pid": 700,
+                    "thread": {
+                        "id": 5480
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4653",
+                "task": "Certification Services"
             }
         }
     ]

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-request-attributes.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-request-attributes.json
@@ -1,0 +1,162 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-08-26T09:14:14.389Z",
+            "event": {
+                "code": "4888"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:CODEX-WEF-ADCS-Persistent-20260826-v1\nSAN:upn=administrator@adcsresearch.local&dns=adcs-dc01.adcsresearch.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500\nRequestClientInfo:codex-wef-forwarded-persistent-v1\nCodexRunLabel:adcs-ws2022-wef-forwarded-persistent-20260826-v1\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "-2146875392",
+                    "RequestId": "28",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "03 0b 55 1f 76 c2 1b 15 b1 b5 63 3a 8e cb ae fc bd 1c e3 56"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "44677"
+            }
+        },
+        {
+            "@timestamp": "2026-08-04T15:28:40.294Z",
+            "event": {
+                "code": "4887"
+            },
+            "host": {
+                "name": "wdc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "WDC01.certighost.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:User",
+                    "CertificateTemplate": "User",
+                    "Disposition": "3",
+                    "RequestId": "3",
+                    "Requester": "CERTIGHOST\\normaluser",
+                    "Subject": "CN=normaluser, CN=Users, DC=certighost, DC=local",
+                    "SubjectKeyIdentifier": "1a e1 14 3d ca 4f 01 c1 74 a9 02 bc 3b 48 65 f1 be e8 92 cc"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "12692"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:25:24.956Z",
+            "event": {
+                "code": "4887"
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ESC1\nSAN:upn=khal.drogo@essos.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115&url=S-1-5-21-2038103339-2155116624-3331879844-1115",
+                    "Disposition": "3",
+                    "RequestId": "17",
+                    "Requester": "ESSOS\\khal.drogo",
+                    "Subject": "CN=khal.drogo",
+                    "SubjectKeyIdentifier": "14 11 a0 af ea bb 2f 70 12 f6 38 cd 57 de 5e af 8b 58 40 b4"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2077058"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:43:04.482Z",
+            "event": {
+                "code": "4887"
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "\n\nccm:braavos.essos.local",
+                    "Disposition": "3",
+                    "RequestId": "18",
+                    "Requester": "ESSOS\\BRAAVOS$",
+                    "Subject": "CN=braavos.essos.local",
+                    "SubjectKeyIdentifier": "3d fb c6 d9 7d a0 36 83 5a 5c fa a7 30 f4 92 ef d7 dd 31 5e"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2078682"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.515Z",
+            "event": {
+                "code": "4889"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:ATLAS-WS22-Pend-v1\nRequestClientInfo:atlas-pending-resubmit\ncdc:ADCS-DC01.adcsresearch.local\nrmd:ADCS-DC01.adcsresearch.local\nccm:ADCS-DC01.adcsresearch.local\nAtlasRunLabel:adcs-ws2022-atlas-20260822-v1-continuation-pending\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "5",
+                    "RequestId": "11",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "7e 75 cc 7d 37 f0 77 6d 7b f7 29 f1 ad 0b 47 50 71 a5 36 f8"
+                },
+                "event_id": "4889",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4346"
+            }
+        },
+        {
+            "event": {
+                "code": 4888
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ValidTemplate\nmalformed line\nSAN:UPN&=x&dns=&url=tag:microsoft.com,2022-09-14:sid:\nCertificateTemplate:",
+                    "RequestId": "101"
+                }
+            }
+        },
+        {
+            "event": {
+                "code": 4886
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:TemplateA\nCertificateTemplate:TemplateA\nSAN:upn=user@synthetic.invalid&upn=user@synthetic.invalid&dns=host.synthetic.invalid&dns=host.synthetic.invalid",
+                    "RequestId": "102"
+                }
+            }
+        },
+        {
+            "event": {
+                "code": 4886
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_data": {
+                    "Attributes": "SAN:email=user@synthetic.invalid&ip=192.0.2.1",
+                    "RequestId": "104"
+                }
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-request-attributes.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-adcs-request-attributes.json-expected.json
@@ -1,0 +1,480 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-08-26T09:14:14.389Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "ccm": [
+                                "ADCS-DC01.adcsresearch.local"
+                            ],
+                            "certificate_template": [
+                                "CODEX-WEF-ADCS-Persistent-20260826-v1"
+                            ],
+                            "request_client_info": [
+                                "codex-wef-forwarded-persistent-v1"
+                            ],
+                            "san": [
+                                "upn=administrator@adcsresearch.local&dns=adcs-dc01.adcsresearch.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500"
+                            ]
+                        },
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        },
+                        "id": 28,
+                        "requester": {
+                            "domain": "ADCSLAB",
+                            "name": "Administrator"
+                        },
+                        "subject_alt_name": {
+                            "dns": [
+                                "adcs-dc01.adcsresearch.local"
+                            ],
+                            "sid": [
+                                "S-1-5-21-1718524055-4226609492-735728866-500"
+                            ],
+                            "upn": [
+                                "administrator@adcsresearch.local"
+                            ],
+                            "uri": [
+                                "tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:CODEX-WEF-ADCS-Persistent-20260826-v1\nSAN:upn=administrator@adcsresearch.local&dns=adcs-dc01.adcsresearch.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500\nRequestClientInfo:codex-wef-forwarded-persistent-v1\nCodexRunLabel:adcs-ws2022-wef-forwarded-persistent-20260826-v1\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "-2146875392",
+                    "RequestId": "28",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "03 0b 55 1f 76 c2 1b 15 b1 b5 63 3a 8e cb ae fc bd 1c e3 56"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "44677"
+            }
+        },
+        {
+            "@timestamp": "2026-08-04T15:28:40.294Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "name": "wdc01"
+            },
+            "related": {
+                "user": [
+                    "normaluser"
+                ]
+            },
+            "user": {
+                "domain": "CERTIGHOST",
+                "name": "normaluser"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "User"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        },
+                        "id": 3,
+                        "requester": {
+                            "domain": "CERTIGHOST",
+                            "name": "normaluser"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "WDC01.certighost.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:User",
+                    "CertificateTemplate": "User",
+                    "Disposition": "3",
+                    "RequestId": "3",
+                    "Requester": "CERTIGHOST\\normaluser",
+                    "Subject": "CN=normaluser, CN=Users, DC=certighost, DC=local",
+                    "SubjectKeyIdentifier": "1a e1 14 3d ca 4f 01 c1 74 a9 02 bc 3b 48 65 f1 be e8 92 cc"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "12692"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:25:24.956Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "related": {
+                "user": [
+                    "khal.drogo"
+                ]
+            },
+            "user": {
+                "domain": "ESSOS",
+                "name": "khal.drogo"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "ESC1"
+                            ],
+                            "san": [
+                                "upn=khal.drogo@essos.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115&url=S-1-5-21-2038103339-2155116624-3331879844-1115"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        },
+                        "id": 17,
+                        "requester": {
+                            "domain": "ESSOS",
+                            "name": "khal.drogo"
+                        },
+                        "subject_alt_name": {
+                            "sid": [
+                                "S-1-5-21-2038103339-2155116624-3331879844-1115"
+                            ],
+                            "upn": [
+                                "khal.drogo@essos.local"
+                            ],
+                            "uri": [
+                                "tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115",
+                                "S-1-5-21-2038103339-2155116624-3331879844-1115"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ESC1\nSAN:upn=khal.drogo@essos.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115&url=S-1-5-21-2038103339-2155116624-3331879844-1115",
+                    "Disposition": "3",
+                    "RequestId": "17",
+                    "Requester": "ESSOS\\khal.drogo",
+                    "Subject": "CN=khal.drogo",
+                    "SubjectKeyIdentifier": "14 11 a0 af ea bb 2f 70 12 f6 38 cd 57 de 5e af 8b 58 40 b4"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2077058"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:43:04.482Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "related": {
+                "user": [
+                    "BRAAVOS$"
+                ]
+            },
+            "user": {
+                "domain": "ESSOS",
+                "name": "BRAAVOS$"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "ccm": [
+                                "braavos.essos.local"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        },
+                        "id": 18,
+                        "requester": {
+                            "domain": "ESSOS",
+                            "name": "BRAAVOS$"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "\n\nccm:braavos.essos.local",
+                    "Disposition": "3",
+                    "RequestId": "18",
+                    "Requester": "ESSOS\\BRAAVOS$",
+                    "Subject": "CN=braavos.essos.local",
+                    "SubjectKeyIdentifier": "3d fb c6 d9 7d a0 36 83 5a 5c fa a7 30 f4 92 ef d7 dd 31 5e"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2078682"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.515Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-pending",
+                "category": [
+                    "iam"
+                ],
+                "code": "4889",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "ccm": [
+                                "ADCS-DC01.adcsresearch.local",
+                                "ADCS-DC01.adcsresearch.local"
+                            ],
+                            "cdc": [
+                                "ADCS-DC01.adcsresearch.local"
+                            ],
+                            "certificate_template": [
+                                "ATLAS-WS22-Pend-v1"
+                            ],
+                            "request_client_info": [
+                                "atlas-pending-resubmit"
+                            ],
+                            "rmd": [
+                                "ADCS-DC01.adcsresearch.local"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 5,
+                            "name": "CR_DISP_UNDER_SUBMISSION"
+                        },
+                        "id": 11,
+                        "requester": {
+                            "domain": "ADCSLAB",
+                            "name": "Administrator"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:ATLAS-WS22-Pend-v1\nRequestClientInfo:atlas-pending-resubmit\ncdc:ADCS-DC01.adcsresearch.local\nrmd:ADCS-DC01.adcsresearch.local\nccm:ADCS-DC01.adcsresearch.local\nAtlasRunLabel:adcs-ws2022-atlas-20260822-v1-continuation-pending\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "5",
+                    "RequestId": "11",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "7e 75 cc 7d 37 f0 77 6d 7b f7 29 f1 ad 0b 47 50 71 a5 36 f8"
+                },
+                "event_id": "4889",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4346"
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "ValidTemplate"
+                            ],
+                            "san": [
+                                "UPN&=x&dns=&url=tag:microsoft.com,2022-09-14:sid:"
+                            ]
+                        },
+                        "id": 101,
+                        "subject_alt_name": {
+                            "uri": [
+                                "tag:microsoft.com,2022-09-14:sid:"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ValidTemplate\nmalformed line\nSAN:UPN&=x&dns=&url=tag:microsoft.com,2022-09-14:sid:\nCertificateTemplate:",
+                    "RequestId": "101"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-received",
+                "category": [
+                    "iam"
+                ],
+                "code": "4886",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "TemplateA",
+                                "TemplateA"
+                            ],
+                            "san": [
+                                "upn=user@synthetic.invalid&upn=user@synthetic.invalid&dns=host.synthetic.invalid&dns=host.synthetic.invalid"
+                            ]
+                        },
+                        "id": 102,
+                        "subject_alt_name": {
+                            "dns": [
+                                "host.synthetic.invalid",
+                                "host.synthetic.invalid"
+                            ],
+                            "upn": [
+                                "user@synthetic.invalid",
+                                "user@synthetic.invalid"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:TemplateA\nCertificateTemplate:TemplateA\nSAN:upn=user@synthetic.invalid&upn=user@synthetic.invalid&dns=host.synthetic.invalid&dns=host.synthetic.invalid",
+                    "RequestId": "102"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "certificate-request-received",
+                "category": [
+                    "iam"
+                ],
+                "code": "4886",
+                "type": [
+                    "info"
+                ]
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "san": [
+                                "email=user@synthetic.invalid&ip=192.0.2.1"
+                            ]
+                        },
+                        "id": 104
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Attributes": "SAN:email=user@synthetic.invalid&ip=192.0.2.1",
+                    "RequestId": "104"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
@@ -52,9 +52,14 @@ processors:
         # microsoft/win32metadata@1bfb76db1c360653bdcb56512af0fdf987aceab8
         # generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h
         names:
-          # Common CR_DISP_* request dispositions.
+          # CR_DISP_* request dispositions from the Windows SDK (CertCli.h).
+          '0': CR_DISP_INCOMPLETE
+          '1': CR_DISP_ERROR
+          '2': CR_DISP_DENIED
           '3': CR_DISP_ISSUED
+          '4': CR_DISP_ISSUED_OUT_OF_BAND
           '5': CR_DISP_UNDER_SUBMISSION
+          '6': CR_DISP_REVOKED
           '2148089857': CERTSRV_E_BAD_REQUESTSUBJECT
           '2148089858': CERTSRV_E_NO_REQUEST
           '2148089859': CERTSRV_E_BAD_REQUESTSTATUS

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
@@ -1,0 +1,446 @@
+---
+# Keep this pipeline byte-identical in:
+# - packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
+# - packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
+description: Pipeline for normalizing Active Directory Certificate Services audit events.
+processors:
+  - remove:
+      field: winlog.adcs
+      ignore_missing: true
+  - set:
+      tag: initialize_adcs_rebuild
+      field: _temp_adcs
+      value:
+        request: {}
+        limits:
+          attributes_chars: 16384
+          physical_lines: 128
+          line_chars: 4096
+          key_chars: 128
+          values_per_key: 64
+          san_components: 64
+  - fail:
+      message: winlog.event_data must be an object
+      if: ctx.winlog?.event_data != null && !(ctx.winlog.event_data instanceof Map)
+  - grok:
+      tag: parse_adcs_request_id
+      field: winlog.event_data.RequestId
+      patterns:
+        - '\A%{ADCS_SIGNED_DECIMAL:_temp_adcs.request.id:long}\z'
+      pattern_definitions:
+        ADCS_SIGNED_DECIMAL: '[+-]?[0-9]+'
+      if: ctx.event?.code != null && ['4868', '4869', '4873', '4874', '4886', '4887', '4888', '4889'].contains(ctx.event.code)
+      ignore_missing: true
+      ignore_failure: true
+  - grok:
+      tag: parse_adcs_disposition_code
+      field: winlog.event_data.Disposition
+      patterns:
+        - '\A%{ADCS_SIGNED_DECIMAL:_temp_adcs.request.disposition.code:long}\z'
+      pattern_definitions:
+        ADCS_SIGNED_DECIMAL: '[+-]?[0-9]+'
+      if: ctx.event?.code != null && ['4887', '4888', '4889'].contains(ctx.event.code)
+      ignore_missing: true
+      ignore_failure: true
+  - script:
+      tag: decode_adcs_disposition_name
+      description: Resolve recognized Certificate Services dispositions and HRESULTs without changing the source code.
+      if: ctx._temp_adcs?.request?.disposition?.code != null
+      lang: painless
+      params:
+        # CERTSRV_E_* constants from Windows SDK 10.0.26100.7705.
+        # microsoft/win32metadata@1bfb76db1c360653bdcb56512af0fdf987aceab8
+        # generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h
+        names:
+          # Common CR_DISP_* request dispositions.
+          '3': CR_DISP_ISSUED
+          '5': CR_DISP_UNDER_SUBMISSION
+          '2148089857': CERTSRV_E_BAD_REQUESTSUBJECT
+          '2148089858': CERTSRV_E_NO_REQUEST
+          '2148089859': CERTSRV_E_BAD_REQUESTSTATUS
+          '2148089860': CERTSRV_E_PROPERTY_EMPTY
+          '2148089861': CERTSRV_E_INVALID_CA_CERTIFICATE
+          '2148089862': CERTSRV_E_SERVER_SUSPENDED
+          '2148089863': CERTSRV_E_ENCODING_LENGTH
+          '2148089864': CERTSRV_E_ROLECONFLICT
+          '2148089865': CERTSRV_E_RESTRICTEDOFFICER
+          '2148089866': CERTSRV_E_KEY_ARCHIVAL_NOT_CONFIGURED
+          '2148089867': CERTSRV_E_NO_VALID_KRA
+          '2148089868': CERTSRV_E_BAD_REQUEST_KEY_ARCHIVAL
+          '2148089869': CERTSRV_E_NO_CAADMIN_DEFINED
+          '2148089870': CERTSRV_E_BAD_RENEWAL_CERT_ATTRIBUTE
+          '2148089871': CERTSRV_E_NO_DB_SESSIONS
+          '2148089872': CERTSRV_E_ALIGNMENT_FAULT
+          '2148089873': CERTSRV_E_ENROLL_DENIED
+          '2148089874': CERTSRV_E_TEMPLATE_DENIED
+          '2148089875': CERTSRV_E_DOWNLEVEL_DC_SSL_OR_UPGRADE
+          '2148089876': CERTSRV_E_ADMIN_DENIED_REQUEST
+          '2148089877': CERTSRV_E_NO_POLICY_SERVER
+          '2148089878': CERTSRV_E_WEAK_SIGNATURE_OR_KEY
+          '2148089879': CERTSRV_E_KEY_ATTESTATION_NOT_SUPPORTED
+          '2148089880': CERTSRV_E_ENCRYPTION_CERT_REQUIRED
+          '2148091904': CERTSRV_E_UNSUPPORTED_CERT_TYPE
+          '2148091905': CERTSRV_E_NO_CERT_TYPE
+          '2148091906': CERTSRV_E_TEMPLATE_CONFLICT
+          '2148091907': CERTSRV_E_SUBJECT_ALT_NAME_REQUIRED
+          '2148091908': CERTSRV_E_ARCHIVED_KEY_REQUIRED
+          '2148091909': CERTSRV_E_SMIME_REQUIRED
+          '2148091910': CERTSRV_E_BAD_RENEWAL_SUBJECT
+          '2148091911': CERTSRV_E_BAD_TEMPLATE_VERSION
+          '2148091912': CERTSRV_E_TEMPLATE_POLICY_REQUIRED
+          '2148091913': CERTSRV_E_SIGNATURE_POLICY_REQUIRED
+          '2148091914': CERTSRV_E_SIGNATURE_COUNT
+          '2148091915': CERTSRV_E_SIGNATURE_REJECTED
+          '2148091916': CERTSRV_E_ISSUANCE_POLICY_REQUIRED
+          '2148091917': CERTSRV_E_SUBJECT_UPN_REQUIRED
+          '2148091918': CERTSRV_E_SUBJECT_DIRECTORY_GUID_REQUIRED
+          '2148091919': CERTSRV_E_SUBJECT_DNS_REQUIRED
+          '2148091920': CERTSRV_E_ARCHIVED_KEY_UNEXPECTED
+          '2148091921': CERTSRV_E_KEY_LENGTH
+          '2148091922': CERTSRV_E_SUBJECT_EMAIL_REQUIRED
+          '2148091923': CERTSRV_E_UNKNOWN_CERT_TYPE
+          '2148091924': CERTSRV_E_CERT_TYPE_OVERLAP
+          '2148091925': CERTSRV_E_TOO_MANY_SIGNATURES
+          '2148091926': CERTSRV_E_RENEWAL_BAD_PUBLIC_KEY
+          '2148091927': CERTSRV_E_INVALID_EK
+          '2148091928': CERTSRV_E_INVALID_IDBINDING
+          '2148091929': CERTSRV_E_INVALID_ATTESTATION
+          '2148091930': CERTSRV_E_KEY_ATTESTATION
+          '2148091931': CERTSRV_E_CORRUPT_KEY_ATTESTATION
+          '2148091932': CERTSRV_E_EXPIRED_CHALLENGE
+          '2148091933': CERTSRV_E_INVALID_RESPONSE
+          '2148091934': CERTSRV_E_INVALID_REQUESTID
+          '2148091935': CERTSRV_E_REQUEST_PRECERTIFICATE_MISMATCH
+          '2148091936': CERTSRV_E_PENDING_CLIENT_RESPONSE
+          '2148091937': CERTSRV_E_SEC_EXT_DIRECTORY_SID_REQUIRED
+      source: |
+        long code = ctx._temp_adcs.request.disposition.code;
+        // Accept signed and unsigned 32-bit representations, without wrapping larger values.
+        if (code < -2147483648L || code > 4294967295L) {
+          return;
+        }
+        if (code < 0) {
+          code += 4294967296L;
+        }
+        def name = params.names.get(Long.toString(code));
+        if (name != null) {
+          ctx._temp_adcs.request.disposition.name = name;
+        }
+  - grok:
+      tag: parse_adcs_requester
+      field: winlog.event_data.Requester
+      patterns:
+        - '\A%{ADCS_REQUESTER_PART:_temp_adcs.requester.domain}\\%{ADCS_REQUESTER_PART:_temp_adcs.requester.name}\z'
+      pattern_definitions:
+        ADCS_REQUESTER_PART: '[^\x09-\x0D \\](?:[^\\]*[^\x09-\x0D \\])?'
+      if: ctx.event?.code != null && ['4886', '4887', '4888', '4889'].contains(ctx.event.code)
+      ignore_missing: true
+      ignore_failure: true
+  - set:
+      tag: set_adcs_requester_domain
+      field: _temp_adcs.request.requester.domain
+      copy_from: _temp_adcs.requester.domain
+      if: ctx._temp_adcs?.requester?.domain instanceof String && ctx._temp_adcs.requester.name instanceof String && ctx._temp_adcs.requester.domain.length() <= 8191 && ctx._temp_adcs.requester.name.length() <= 1024
+  - set:
+      tag: set_adcs_requester_name
+      field: _temp_adcs.request.requester.name
+      copy_from: _temp_adcs.requester.name
+      if: ctx._temp_adcs?.requester?.domain instanceof String && ctx._temp_adcs.requester.name instanceof String && ctx._temp_adcs.requester.domain.length() <= 8191 && ctx._temp_adcs.requester.name.length() <= 1024
+  # Bound the input before using the native line splitter; retain trailing blank lines for the line limit.
+  - split:
+      tag: split_adcs_attribute_lines
+      field: winlog.event_data.Attributes
+      target_field: _temp_adcs.attribute_lines
+      separator: '\n'
+      preserve_trailing: true
+      if: ctx.event?.code != null && ['4886', '4887', '4888', '4889'].contains(ctx.event.code) && ctx.winlog?.event_data?.Attributes instanceof String && ctx.winlog.event_data.Attributes.length() <= ctx._temp_adcs.limits.attributes_chars
+  # Parse bounded, allowlisted request attributes and SAN claims.
+  - script:
+      tag: parse_adcs_request_attributes
+      if: ctx.event?.code != null && ['4886', '4887', '4888', '4889'].contains(ctx.event.code) && ctx.winlog?.event_data?.Attributes != null
+      description: Parse only allowlisted AD CS request attributes within explicit resource limits.
+      lang: painless
+      params:
+        outer_keys:
+          certificatetemplate: certificate_template
+          requestclientinfo: request_client_info
+          cdc: cdc
+          rmd: rmd
+          ccm: ccm
+          san: san
+        microsoft_sid_uri_prefix: 'tag:microsoft.com,2022-09-14:sid:'
+      source: |
+        boolean edgeWhitespace(int character) {
+          return character == 32 || character == 9;
+        }
+
+        int trimmedStart(String text, int start, int end) {
+          while (start < end && edgeWhitespace(text.charAt(start))) {
+            start++;
+          }
+          return start;
+        }
+
+        int trimmedEnd(String text, int start, int end) {
+          while (end > start && edgeWhitespace(text.charAt(end - 1))) {
+            end--;
+          }
+          return end;
+        }
+
+        int firstCharacter(String text, int start, int end, int target) {
+          for (int index = start; index < end; index++) {
+            if (text.charAt(index) == target) {
+              return index;
+            }
+          }
+          return -1;
+        }
+
+        String normalizedKey(String text, int start, int end, boolean removeSeparators) {
+          StringBuilder builder = new StringBuilder();
+          for (int index = start; index < end; index++) {
+            int character = text.charAt(index);
+            if (removeSeparators && (character == 32 || character == 9 || character == 45)) {
+              continue;
+            }
+            if (character >= 65 && character <= 90) {
+              character += 32;
+            }
+            builder.append((char) character);
+          }
+          return builder.toString();
+        }
+
+        boolean asciiPrefix(String value, String prefix) {
+          if (value.length() < prefix.length()) {
+            return false;
+          }
+          for (int index = 0; index < prefix.length(); index++) {
+            int left = value.charAt(index);
+            int right = prefix.charAt(index);
+            if (left >= 65 && left <= 90) {
+              left += 32;
+            }
+            if (right >= 65 && right <= 90) {
+              right += 32;
+            }
+            if (left != right) {
+              return false;
+            }
+          }
+          return true;
+        }
+
+        void appendValue(HashMap values, String key, String value) {
+          def existing = values.get(key);
+          ArrayList output;
+          if (existing == null) {
+            output = new ArrayList();
+            values.put(key, output);
+          } else {
+            output = existing;
+          }
+          output.add(value);
+        }
+
+        HashMap parserResult(String status) {
+          HashMap result = new HashMap();
+          result.put('attributes', new HashMap());
+          result.put('subject_alt_name', new HashMap());
+          result.put('status', status);
+          return result;
+        }
+
+        HashMap parseAttributes(List lines, Map outerKeys, Map limits, String sidPrefix) {
+          if (lines.size() > limits.get('physical_lines')) {
+            return parserResult('skipped_limit');
+          }
+          HashMap result = parserResult(null);
+          HashMap attributes = result.get('attributes');
+          HashMap subjectAltName = result.get('subject_alt_name');
+          HashMap occurrenceCounts = new HashMap();
+          int componentCount = 0;
+
+          for (String rawLine : lines) {
+            String line = (rawLine.length() > 0 && rawLine.charAt(rawLine.length() - 1) == 13) ? rawLine.substring(0, rawLine.length() - 1) : rawLine;
+            if (line.length() > limits.get('line_chars')) {
+              return parserResult('skipped_limit');
+            }
+            int start = trimmedStart(line, 0, line.length());
+            int end = trimmedEnd(line, start, line.length());
+            int colon = firstCharacter(line, start, end, 58);
+            if (colon < 0) {
+              continue;
+            }
+            int keyStart = trimmedStart(line, start, colon);
+            int keyEnd = trimmedEnd(line, keyStart, colon);
+            if (keyEnd - keyStart > limits.get('key_chars')) {
+              return parserResult('skipped_limit');
+            }
+            String key = normalizedKey(line, keyStart, keyEnd, true);
+            if (!outerKeys.containsKey(key)) {
+              continue;
+            }
+            int count = occurrenceCounts.containsKey(key) ? occurrenceCounts.get(key) + 1 : 1;
+            occurrenceCounts.put(key, count);
+            if (count > limits.get('values_per_key')) {
+              return parserResult('skipped_limit');
+            }
+            int valueStart = trimmedStart(line, colon + 1, end);
+            int valueEnd = trimmedEnd(line, valueStart, end);
+            if (valueStart == valueEnd) {
+              continue;
+            }
+            String value = line.substring(valueStart, valueEnd);
+            appendValue(attributes, outerKeys.get(key), value);
+            if (!key.equals('san')) {
+              continue;
+            }
+
+            for (String component : value.splitOnToken('&')) {
+              int cleanStart = trimmedStart(component, 0, component.length());
+              int cleanEnd = trimmedEnd(component, cleanStart, component.length());
+              if (cleanStart == cleanEnd) {
+                continue;
+              }
+              componentCount++;
+              if (componentCount > limits.get('san_components')) {
+                return parserResult('skipped_limit');
+              }
+              int equals = firstCharacter(component, cleanStart, cleanEnd, 61);
+              if (equals < 0) {
+                continue;
+              }
+              int sanKeyStart = trimmedStart(component, cleanStart, equals);
+              int sanKeyEnd = trimmedEnd(component, sanKeyStart, equals);
+              if (sanKeyEnd - sanKeyStart > limits.get('key_chars')) {
+                return parserResult('skipped_limit');
+              }
+              String sanKey = normalizedKey(component, sanKeyStart, sanKeyEnd, false);
+              int sanValueStart = trimmedStart(component, equals + 1, cleanEnd);
+              int sanValueEnd = trimmedEnd(component, sanValueStart, cleanEnd);
+              if (sanValueStart == sanValueEnd) {
+                continue;
+              }
+              String sanValue = component.substring(sanValueStart, sanValueEnd);
+              if (sanKey.equals('upn')) {
+                appendValue(subjectAltName, 'upn', sanValue);
+              } else if (sanKey.equals('dns')) {
+                appendValue(subjectAltName, 'dns', sanValue);
+              } else if (sanKey.equals('url')) {
+                appendValue(subjectAltName, 'uri', sanValue);
+                if (asciiPrefix(sanValue, sidPrefix)) {
+                  String sid = sanValue.substring(sidPrefix.length());
+                  if (!sid.isEmpty()) {
+                    appendValue(subjectAltName, 'sid', sid);
+                  }
+                }
+              }
+            }
+          }
+          return result;
+        }
+
+        def rawAttributes = ctx.winlog.event_data.Attributes;
+        HashMap parsed;
+        if (!(rawAttributes instanceof String)) {
+          parsed = parserResult('error');
+        } else if (rawAttributes.length() > ctx._temp_adcs.limits.attributes_chars) {
+          parsed = parserResult('skipped_limit');
+        } else {
+          try {
+            parsed = parseAttributes(ctx._temp_adcs.attribute_lines, params.outer_keys,
+              ctx._temp_adcs.limits, params.microsoft_sid_uri_prefix);
+          } catch (Exception internalException) {
+            parsed = parserResult('error');
+          }
+        }
+        if (!parsed.attributes.isEmpty()) {
+          ctx._temp_adcs.request.put('attributes', parsed.attributes);
+        }
+        if (!parsed.subject_alt_name.isEmpty()) {
+          ctx._temp_adcs.request.put('subject_alt_name', parsed.subject_alt_name);
+        }
+        ctx._temp_adcs.put('status', parsed.get('status'));
+  - append:
+      description: Mark events when resource limits prevent AD CS request attribute parsing.
+      field: tags
+      value: adcs_attributes_skipped_limit
+      allow_duplicates: false
+      if: ctx._temp_adcs?.status == 'skipped_limit'
+  - append:
+      description: Mark errors caught within AD CS request attribute parsing.
+      field: tags
+      value: adcs_normalization_failed
+      allow_duplicates: false
+      if: ctx._temp_adcs?.status == 'error'
+  # Preserve nonblank names; recognize dotted-decimal identifiers without decoding values.
+  - grok:
+      tag: parse_adcs_extension_name
+      field: winlog.event_data.ExtensionName
+      patterns:
+        - '\A%{ADCS_EXTENSION_NAME:_temp_adcs.request.extension.name}\z'
+      pattern_definitions:
+        ADCS_EXTENSION_NAME: '(?=[\s\S]*[^\x09-\x0D ])[\s\S]+'
+      if: ctx.event?.code == '4873' && ctx.winlog?.event_data?.ExtensionName instanceof String && ctx.winlog.event_data.ExtensionName.length() <= 8191
+      ignore_missing: true
+      ignore_failure: true
+  - grok:
+      tag: parse_adcs_extension_oid
+      field: _temp_adcs.request.extension.name
+      patterns:
+        - '\A%{ADCS_EXTENSION_OID:_temp_adcs.request.extension.oid}\z'
+      pattern_definitions:
+        ADCS_EXTENSION_OID: '[0-9]+(?:\.[0-9]+)+'
+      ignore_missing: true
+      ignore_failure: true
+  - set:
+      tag: publish_adcs_overlay
+      description: Publish the rebuilt overlay once normalization has completed.
+      field: winlog.adcs.request
+      copy_from: _temp_adcs.request
+      if: ctx._temp_adcs?.request instanceof Map && !ctx._temp_adcs.request.isEmpty()
+  - set:
+      tag: identify_adcs_requester_user_fallback
+      description: Use the requester only when the request event has no root user identity.
+      field: _temp_adcs.requester_user_fallback
+      value: true
+      if: >-
+        ['4886', '4887', '4888', '4889'].contains(ctx.event?.code) &&
+        ctx.winlog?.adcs?.request?.requester?.name != null &&
+        ctx.winlog.adcs.request.requester.domain != null &&
+        ctx.user?.id == null && ctx.user?.name == null && ctx.user?.domain == null &&
+        ctx.user?.email == null && ctx.user?.full_name == null
+  - set:
+      tag: set_adcs_requester_user_name
+      field: user.name
+      copy_from: winlog.adcs.request.requester.name
+      if: ctx._temp_adcs?.requester_user_fallback == true
+  - set:
+      tag: set_adcs_requester_user_domain
+      field: user.domain
+      copy_from: winlog.adcs.request.requester.domain
+      if: ctx._temp_adcs?.requester_user_fallback == true
+  - append:
+      tag: append_adcs_requester_related_user
+      field: related.user
+      value: '{{{winlog.adcs.request.requester.name}}}'
+      allow_duplicates: false
+      if: ctx.winlog?.adcs?.request?.requester?.name instanceof String
+  - remove:
+      field: _temp_adcs
+      ignore_missing: true
+on_failure:
+  - remove:
+      field:
+        - winlog.adcs
+        - _temp_adcs
+      ignore_missing: true
+      ignore_failure: true
+  - append:
+      description: Mark events when AD CS normalization fails unexpectedly.
+      field: tags
+      value: adcs_normalization_failed
+      allow_duplicates: false
+      ignore_failure: true

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
@@ -49,10 +49,10 @@ processors:
       lang: painless
       params:
         # CERTSRV_E_* constants from Windows SDK 10.0.26100.7705.
-        # microsoft/win32metadata@1bfb76db1c360653bdcb56512af0fdf987aceab8
-        # generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h
+        # https://github.com/microsoft/win32metadata/blob/1bfb76db1c360653bdcb56512af0fdf987aceab8/generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h#L38754
         names:
           # CR_DISP_* request dispositions from the Windows SDK (CertCli.h).
+          # https://github.com/microsoft/win32metadata/blob/29896383c51d9dd6a2ea0ec6304d095baca9418c/generation/WinSDK/RecompiledIdlHeaders/um/CertCli.h#L1619-L1631
           '0': CR_DISP_INCOMPLETE
           '1': CR_DISP_ERROR
           '2': CR_DISP_DENIED

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,16 @@ processors:
       name: '{{ IngestPipeline "standard" }}'
       if: 'ctx.winlog?.provider_name != null && ["Microsoft-Windows-Eventlog", "Microsoft-Windows-Security-Auditing"].contains(ctx.winlog.provider_name)'
   - pipeline:
+      name: '{{ IngestPipeline "adcs" }}'
+      if: >-
+        ctx.winlog != null &&
+        ctx.winlog.provider_name == 'Microsoft-Windows-Security-Auditing' &&
+        ctx.winlog.channel instanceof String &&
+        ctx.winlog.channel.toLowerCase() == 'security' &&
+        ctx.event != null &&
+        ctx.event.code != null &&
+        ['4868', '4869', '4873', '4874', '4886', '4887', '4888', '4889'].contains(ctx.event.code)
+  - pipeline:
       name: '{{ IngestPipeline "scheduled_task" }}'
       if: >-
         ctx.winlog != null &&

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -773,12 +773,78 @@ processors:
           type:
             - info
           action: certificate-services-received-resubmitted-certificate-request
+        "4870":
+          category:
+            - iam
+          type:
+            - change
+          action: certificate-revoked
+        "4871":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-revocation-list-publication-requested
+        "4873":
+          category:
+            - iam
+          type:
+            - change
+          action: certificate-request-extension-changed
+        "4874":
+          category:
+            - iam
+          type:
+            - change
+          action: certificate-request-attributes-changed
+        "4875":
+          category:
+            - configuration
+          type:
+            - info
+          action: certificate-services-shutdown-requested
         "4876":
           category:
             - session
           type:
             - start
           action: certificate-services-backup-started
+        "4886":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-request-received
+        "4887":
+          category:
+            - iam
+          type:
+            - creation
+          action: certificate-issued
+        "4888":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-request-denied
+        "4889":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-request-pending
+        "4891":
+          category:
+            - configuration
+          type:
+            - change
+          action: certificate-services-configuration-entry-changed
+        "4892":
+          category:
+            - configuration
+          type:
+            - change
+          action: certificate-services-property-changed
         "4902":
           category:
             - iam
@@ -3839,7 +3905,8 @@ processors:
               "4738", "4739", "4740", "4741", "4742", "4743", "4744", "4745", "4746", "4747",
               "4748", "4749", "4750", "4751", "4752", "4753", "4754", "4755", "4756", "4757",
               "4758", "4759", "4760", "4761", "4762", "4763", "4764", "4767", "4781", "4793",
-              "4797", "4798", "4799", "4817", "4868", "4869", "4876", "4904", "4905", "4907",
+              "4797", "4798", "4799", "4817", "4868", "4869", "4870", "4871", "4873",
+              "4874", "4875", "4876", "4891", "4892", "4904", "4905", "4907",
               "4912", "4985", "5058", "5059", "5061", "5136", "5140", "5142", "5145", "5379",
               "5380", "5381", "5382", "6272", "6416", "6419", "6420", "6421", "6422"].contains(ctx.event.code)) {
           return;

--- a/packages/system/data_stream/security/fields/winlog.yml
+++ b/packages/system/data_stream/security/fields/winlog.yml
@@ -13,6 +13,126 @@
       description: >
         A globally unique identifier that identifies the current activity. The events that are published with this identifier are part of the same activity.
 
+    - name: adcs
+      type: group
+      description: >
+        Normalized data from Active Directory Certificate Services audit events. This group is rebuilt from native fields on each normalization; existing values in this group are replaced. Native event values remain available under `winlog.event_data`.
+
+      fields:
+        - name: request
+          type: group
+          description: >
+            Typed certificate request data derived from native audit fields.
+
+          fields:
+            - name: id
+              type: long
+              description: >
+                Strict signed-ASCII-decimal request identifier derived from `winlog.event_data.RequestId`.
+
+            - name: disposition
+              type: group
+              description: >
+                Certificate request disposition code and recognized Certificate Services disposition or error name.
+
+              fields:
+                - name: code
+                  type: long
+                  description: >
+                    Strict signed-ASCII-decimal disposition code derived from `winlog.event_data.Disposition`.
+
+                - name: name
+                  type: keyword
+                  description: >
+                    Canonical CR_DISP_* or CERTSRV_E_* name for a recognized Certificate Services disposition or HRESULT in `winlog.adcs.request.disposition.code`. Signed and unsigned decimal representations of an HRESULT resolve to the same name. Unknown codes have no derived name.
+
+            - name: requester
+              type: group
+              description: >
+                Certificate requester identity. Also populates ECS `user.name` and `user.domain` for events 4886–4889 when no ECS user identity is already present.
+
+              fields:
+                - name: domain
+                  type: keyword
+                  ignore_above: 8191
+                  description: >
+                    Exact requester domain component from `winlog.event_data.Requester`, with source case preserved.
+
+                - name: name
+                  type: keyword
+                  ignore_above: 1024
+                  description: >
+                    Exact requester name component from `winlog.event_data.Requester`, with source case preserved.
+
+            - name: extension
+              type: group
+              description: Neutral identifiers for an extension changed on a pending certificate request.
+              fields:
+                - name: name
+                  type: keyword
+                  ignore_above: 8191
+                  description: Exact nonblank event 4873 ExtensionName without value decoding.
+                - name: oid
+                  type: keyword
+                  ignore_above: 8191
+                  description: Conservative dotted-ASCII-decimal identifier derived from event 4873 ExtensionName.
+            - name: attributes
+              type: group
+              description: >
+                Bounded allowlisted values parsed from `winlog.event_data.Attributes` without changing the raw field.
+
+              fields:
+                - name: certificate_template
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Ordered CertificateTemplate request values, kept separate from the native `winlog.event_data.CertificateTemplate` field.
+
+                - name: request_client_info
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered RequestClientInfo request values.
+                - name: cdc
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Active Directory server names supplied in the cdc enrollment attribute for the CA to use when requester information cannot be obtained from its working directory. Values are preserved in request order without hostname validation.
+                - name: rmd
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Machine object FQDNs supplied in the rmd enrollment attribute for the certificate request. Values are preserved in request order without hostname validation.
+                - name: ccm
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Values extracted from the ccm enrollment attribute in `winlog.event_data.Attributes`, preserved in request order.
+                - name: san
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered, outer-trimmed SAN request values.
+            - name: subject_alt_name
+              type: group
+              description: Allowlisted subject alternative name request claims.
+              fields:
+                - name: upn
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered UPN SAN request claims.
+                - name: dns
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered DNS SAN request claims.
+                - name: uri
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered URL or URI SAN request claims.
+                - name: sid
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Exact unvalidated suffix from a recognized Microsoft SID URI.
+
     - name: channel
       type: keyword
       description: >
@@ -83,6 +203,8 @@
           type: keyword
         - name: AttributeLDAPDisplayName
           type: keyword
+        - name: Attributes
+          type: keyword
         - name: AttributeSyntaxOID
           type: keyword
         - name: AttributeValue
@@ -97,8 +219,16 @@
           type: keyword
         - name: AuditSourceName
           type: keyword
+        - name: AuthenticationLevel
+          type: keyword
+          description: >
+            Authentication level reported in the AD CS audit event.
         - name: AuthenticationPackageName
           type: keyword
+        - name: AuthenticationService
+          type: keyword
+          description: >
+            Authentication service reported in the AD CS audit event.
         - name: BackupType
           type: keyword
         - name: BackupTypeDescription
@@ -113,6 +243,8 @@
           type: keyword
         - name: BuildVersion
           type: keyword
+        - name: CACertificateHash
+          type: keyword
         - name: CallerProcessId
           type: keyword
         - name: CallerProcessName
@@ -125,9 +257,17 @@
           type: keyword
         - name: CalloutType
           type: keyword
+        - name: CAPublicKeyHash
+          type: keyword
         - name: Category
           type: keyword
         - name: CategoryId
+          type: keyword
+        - name: CertificateDatabaseHash
+          type: keyword
+        - name: CertificateSerialNumber
+          type: keyword
+        - name: CertificateTemplate
           type: keyword
         - name: ChangeType
           type: keyword
@@ -161,11 +301,21 @@
           type: keyword
         - name: CreationUtcTime
           type: keyword
+        - name: CRLNumber
+          type: keyword
         - name: CurrentProfile
           type: keyword
         - name: CryptoAlgorithms
           type: keyword
         - name: DataDescription
+          type: keyword
+        - name: DCDNSName
+          type: keyword
+        - name: DCOMorRPC
+          type: keyword
+          description: >
+            DCOM or RPC transport indicator reported for the AD CS certificate request.
+        - name: Disposition
           type: keyword
         - name: DSName
           type: keyword
@@ -219,6 +369,8 @@
           type: keyword
         - name: EnabledPrivilegeList
           type: keyword
+        - name: Entry
+          type: keyword
         - name: EntryCount
           type: keyword
         - name: ErrorCode
@@ -228,6 +380,14 @@
         - name: EventIdx
           type: long
         - name: EventSourceId
+          type: keyword
+        - name: ExtensionData
+          type: keyword
+        - name: ExtensionDataType
+          type: keyword
+        - name: ExtensionName
+          type: keyword
+        - name: ExtensionPolicyFlags
           type: keyword
         - name: ExtraInfo
           type: keyword
@@ -295,9 +455,13 @@
           type: keyword
         - name: IpPort
           type: keyword
+        - name: IsBaseCRL
+          type: keyword
         - name: IsLoopback
           type: keyword
         - name: KerberosPolicyChange
+          type: keyword
+        - name: KeyContainer
           type: keyword
         - name: KeyFilePath
           type: keyword
@@ -393,6 +557,16 @@
           type: keyword
         - name: NewUacValue
           type: keyword
+        - name: NextPublish
+          type: keyword
+        - name: NextPublishForBaseCRL
+          type: keyword
+        - name: NextPublishForDeltaCRL
+          type: keyword
+        - name: NextUpdate
+          type: keyword
+        - name: Node
+          type: keyword
         - name: NominalFrequency
           type: keyword
         - name: Number
@@ -465,7 +639,17 @@
           type: keyword
         - name: PrimaryGroupId
           type: keyword
+        - name: PrivateKeyUsageCount
+          type: keyword
         - name: PrivilegeList
+          type: keyword
+        - name: PropertyIndex
+          type: keyword
+        - name: PropertyName
+          type: keyword
+        - name: PropertyType
+          type: keyword
+        - name: PropertyValue
           type: keyword
         - name: ProtectedDataFlags
           type: keyword
@@ -509,6 +693,8 @@
           type: keyword
         - name: PuaPolicyId
           type: keyword
+        - name: PublishURLs
+          type: keyword
         - name: QfeVersion
           type: keyword
         - name: ReadOperation
@@ -535,6 +721,20 @@
           type: keyword
         - name: RemoteUserID
           type: keyword
+        - name: RequestClientInfo
+          type: keyword
+          description: >
+            Native client information reported for the AD CS certificate request, separate from values parsed from request attributes.
+        - name: RequestCSPProvider
+          type: keyword
+          description: >
+            Cryptographic service provider reported for the AD CS certificate request.
+        - name: RequestOSVersion
+          type: keyword
+          description: >
+            Operating system version reported for the AD CS certificate request client.
+        - name: Requester
+          type: keyword
         - name: RequestId
           type: keyword
         - name: Resource
@@ -547,12 +747,22 @@
           type: keyword
         - name: ReturnCode
           type: keyword
+        - name: RevocationReason
+          type: keyword
+        - name: RoleSeparationEnabled
+          type: keyword
         - name: RuleAttr
           type: keyword
         - name: RuleId
           type: keyword
         - name: RuleName
           type: keyword
+        - name: SecurityDescriptor
+          type: keyword
+        - name: SerialNumber
+          type: keyword
+          description: >
+            Serial number of the certificate issued by AD CS.
         - name: SPI
           type: keyword
         - name: SamAccountName
@@ -635,6 +845,14 @@
           type: keyword
         - name: SubCategoryId
           type: keyword
+        - name: Subject
+          type: keyword
+        - name: SubjectAlternativeName
+          type: keyword
+          description: >
+            Native subject alternative name information reported by the AD CS audit event, separate from SAN values parsed from request attributes.
+        - name: SubjectKeyIdentifier
+          type: keyword
         - name: SubStatus
           type: keyword
         - name: SubcategoryGuid
@@ -648,6 +866,18 @@
         - name: SubjectUserName
           type: keyword
         - name: SubjectUserSid
+          type: keyword
+        - name: TemplateContent
+          type: keyword
+        - name: TemplateDSObjectFQDN
+          type: keyword
+        - name: TemplateInternalName
+          type: keyword
+        - name: TemplateOID
+          type: keyword
+        - name: TemplateSchemaVersion
+          type: keyword
+        - name: TemplateVersion
           type: keyword
         - name: TSId
           type: keyword
@@ -706,6 +936,8 @@
         - name: UserSid
           type: keyword
         - name: UserWorkstations
+          type: keyword
+        - name: Value
           type: keyword
         - name: VendorIds
           type: keyword

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -546,6 +546,23 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | process.name.caseless | Multi-field of `process.name`. | keyword |
 | process.name.text | Multi-field of `process.name`. | match_only_text |
 | winlog.activity_id | A globally unique identifier that identifies the current activity. The events that are published with this identifier are part of the same activity. | keyword |
+| winlog.adcs.request.attributes.ccm | Values extracted from the ccm enrollment attribute in `winlog.event_data.Attributes`, preserved in request order. | keyword |
+| winlog.adcs.request.attributes.cdc | Active Directory server names supplied in the cdc enrollment attribute for the CA to use when requester information cannot be obtained from its working directory. Values are preserved in request order without hostname validation. | keyword |
+| winlog.adcs.request.attributes.certificate_template | Ordered CertificateTemplate request values, kept separate from the native `winlog.event_data.CertificateTemplate` field. | keyword |
+| winlog.adcs.request.attributes.request_client_info | Ordered RequestClientInfo request values. | keyword |
+| winlog.adcs.request.attributes.rmd | Machine object FQDNs supplied in the rmd enrollment attribute for the certificate request. Values are preserved in request order without hostname validation. | keyword |
+| winlog.adcs.request.attributes.san | Ordered, outer-trimmed SAN request values. | keyword |
+| winlog.adcs.request.disposition.code | Strict signed-ASCII-decimal disposition code derived from `winlog.event_data.Disposition`. | long |
+| winlog.adcs.request.disposition.name | Canonical CR_DISP_\* or CERTSRV_E_\* name for a recognized Certificate Services disposition or HRESULT in `winlog.adcs.request.disposition.code`. Signed and unsigned decimal representations of an HRESULT resolve to the same name. Unknown codes have no derived name. | keyword |
+| winlog.adcs.request.extension.name | Exact nonblank event 4873 ExtensionName without value decoding. | keyword |
+| winlog.adcs.request.extension.oid | Conservative dotted-ASCII-decimal identifier derived from event 4873 ExtensionName. | keyword |
+| winlog.adcs.request.id | Strict signed-ASCII-decimal request identifier derived from `winlog.event_data.RequestId`. | long |
+| winlog.adcs.request.requester.domain | Exact requester domain component from `winlog.event_data.Requester`, with source case preserved. | keyword |
+| winlog.adcs.request.requester.name | Exact requester name component from `winlog.event_data.Requester`, with source case preserved. | keyword |
+| winlog.adcs.request.subject_alt_name.dns | Ordered DNS SAN request claims. | keyword |
+| winlog.adcs.request.subject_alt_name.sid | Exact unvalidated suffix from a recognized Microsoft SID URI. | keyword |
+| winlog.adcs.request.subject_alt_name.upn | Ordered UPN SAN request claims. | keyword |
+| winlog.adcs.request.subject_alt_name.uri | Ordered URL or URI SAN request claims. | keyword |
 | winlog.api | The event log API type used to read the record. The possible values are "wineventlog" for the Windows Event Log API or "eventlogging" for the Event Logging API. The Event Logging API was designed for Windows Server 2003 or Windows 2000 operating systems. In Windows Vista, the event logging infrastructure was redesigned. On Windows Vista or later operating systems, the Windows Event Log API is used. Winlogbeat automatically detects which API to use for reading event logs. | keyword |
 | winlog.channel | The name of the channel from which this record was read. This value is one of the names from the `event_logs` collection in the configuration. | keyword |
 | winlog.computerObject.domain |  | keyword |
@@ -574,10 +591,13 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.AttributeSyntaxOID |  | keyword |
 | winlog.event_data.AttributeValue |  | keyword |
 | winlog.event_data.AttributeValue.wildcard | Multi-field of `winlog.event_data.AttributeValue`. | wildcard |
+| winlog.event_data.Attributes |  | keyword |
 | winlog.event_data.AuditPolicyChanges |  | keyword |
 | winlog.event_data.AuditPolicyChangesDescription |  | keyword |
 | winlog.event_data.AuditSourceName |  | keyword |
+| winlog.event_data.AuthenticationLevel | Authentication level reported in the AD CS audit event. | keyword |
 | winlog.event_data.AuthenticationPackageName |  | keyword |
+| winlog.event_data.AuthenticationService | Authentication service reported in the AD CS audit event. | keyword |
 | winlog.event_data.BackupType |  | keyword |
 | winlog.event_data.BackupTypeDescription |  | keyword |
 | winlog.event_data.Binary |  | keyword |
@@ -585,6 +605,9 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.BootMode |  | keyword |
 | winlog.event_data.BootType |  | keyword |
 | winlog.event_data.BuildVersion |  | keyword |
+| winlog.event_data.CACertificateHash |  | keyword |
+| winlog.event_data.CAPublicKeyHash |  | keyword |
+| winlog.event_data.CRLNumber |  | keyword |
 | winlog.event_data.CallerProcessId |  | keyword |
 | winlog.event_data.CallerProcessName |  | keyword |
 | winlog.event_data.CalloutId |  | keyword |
@@ -593,6 +616,9 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.CalloutType |  | keyword |
 | winlog.event_data.Category |  | keyword |
 | winlog.event_data.CategoryId |  | keyword |
+| winlog.event_data.CertificateDatabaseHash |  | keyword |
+| winlog.event_data.CertificateSerialNumber |  | keyword |
+| winlog.event_data.CertificateTemplate |  | keyword |
 | winlog.event_data.ChangeType |  | keyword |
 | winlog.event_data.ClassId |  | keyword |
 | winlog.event_data.ClassName |  | keyword |
@@ -611,6 +637,8 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.CreationUtcTime |  | keyword |
 | winlog.event_data.CryptoAlgorithms |  | keyword |
 | winlog.event_data.CurrentProfile |  | keyword |
+| winlog.event_data.DCDNSName |  | keyword |
+| winlog.event_data.DCOMorRPC | DCOM or RPC transport indicator reported for the AD CS certificate request. | keyword |
 | winlog.event_data.DSName |  | keyword |
 | winlog.event_data.DSType |  | keyword |
 | winlog.event_data.DataDescription |  | keyword |
@@ -627,6 +655,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.DeviceVersionMinor |  | keyword |
 | winlog.event_data.Direction |  | keyword |
 | winlog.event_data.DisplayName |  | keyword |
+| winlog.event_data.Disposition |  | keyword |
 | winlog.event_data.DnsHostName |  | keyword |
 | winlog.event_data.DomainBehaviorVersion |  | keyword |
 | winlog.event_data.DomainName |  | keyword |
@@ -638,11 +667,16 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.Dummy |  | keyword |
 | winlog.event_data.DwordVal |  | keyword |
 | winlog.event_data.EnabledPrivilegeList |  | keyword |
+| winlog.event_data.Entry |  | keyword |
 | winlog.event_data.EntryCount |  | keyword |
 | winlog.event_data.ErrorCode |  | keyword |
 | winlog.event_data.EventCountTotal |  | long |
 | winlog.event_data.EventIdx |  | long |
 | winlog.event_data.EventSourceId |  | keyword |
+| winlog.event_data.ExtensionData |  | keyword |
+| winlog.event_data.ExtensionDataType |  | keyword |
+| winlog.event_data.ExtensionName |  | keyword |
+| winlog.event_data.ExtensionPolicyFlags |  | keyword |
 | winlog.event_data.ExtraInfo |  | keyword |
 | winlog.event_data.FailureName |  | keyword |
 | winlog.event_data.FailureNameLength |  | keyword |
@@ -676,8 +710,10 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.InterfaceIndex |  | keyword |
 | winlog.event_data.IpAddress |  | keyword |
 | winlog.event_data.IpPort |  | keyword |
+| winlog.event_data.IsBaseCRL |  | keyword |
 | winlog.event_data.IsLoopback |  | keyword |
 | winlog.event_data.KerberosPolicyChange |  | keyword |
+| winlog.event_data.KeyContainer |  | keyword |
 | winlog.event_data.KeyFilePath |  | keyword |
 | winlog.event_data.KeyLength |  | keyword |
 | winlog.event_data.KeyName |  | keyword |
@@ -725,6 +761,11 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.NewTime |  | keyword |
 | winlog.event_data.NewUACList |  | keyword |
 | winlog.event_data.NewUacValue |  | keyword |
+| winlog.event_data.NextPublish |  | keyword |
+| winlog.event_data.NextPublishForBaseCRL |  | keyword |
+| winlog.event_data.NextPublishForDeltaCRL |  | keyword |
+| winlog.event_data.NextUpdate |  | keyword |
+| winlog.event_data.Node |  | keyword |
 | winlog.event_data.NominalFrequency |  | keyword |
 | winlog.event_data.Number |  | keyword |
 | winlog.event_data.ObjectClass |  | keyword |
@@ -761,6 +802,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.PreviousCreationUtcTime |  | keyword |
 | winlog.event_data.PreviousTime |  | keyword |
 | winlog.event_data.PrimaryGroupId |  | keyword |
+| winlog.event_data.PrivateKeyUsageCount |  | keyword |
 | winlog.event_data.PrivilegeList |  | keyword |
 | winlog.event_data.ProcessCreationTime |  | keyword |
 | winlog.event_data.ProcessID |  | keyword |
@@ -774,6 +816,10 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.ProfilePath |  | keyword |
 | winlog.event_data.ProfileUsed |  | keyword |
 | winlog.event_data.Properties |  | keyword |
+| winlog.event_data.PropertyIndex |  | keyword |
+| winlog.event_data.PropertyName |  | keyword |
+| winlog.event_data.PropertyType |  | keyword |
+| winlog.event_data.PropertyValue |  | keyword |
 | winlog.event_data.ProtectedDataFlags |  | keyword |
 | winlog.event_data.Protocol |  | keyword |
 | winlog.event_data.ProviderContextKey |  | keyword |
@@ -783,6 +829,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.ProviderName |  | keyword |
 | winlog.event_data.PuaCount |  | keyword |
 | winlog.event_data.PuaPolicyId |  | keyword |
+| winlog.event_data.PublishURLs |  | keyword |
 | winlog.event_data.QfeVersion |  | keyword |
 | winlog.event_data.ReadOperation |  | keyword |
 | winlog.event_data.Reason |  | keyword |
@@ -796,12 +843,18 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.RemoteMachineID |  | keyword |
 | winlog.event_data.RemoteUserDescription |  | keyword |
 | winlog.event_data.RemoteUserID |  | keyword |
+| winlog.event_data.RequestCSPProvider | Cryptographic service provider reported for the AD CS certificate request. | keyword |
+| winlog.event_data.RequestClientInfo | Native client information reported for the AD CS certificate request, separate from values parsed from request attributes. | keyword |
 | winlog.event_data.RequestId |  | keyword |
+| winlog.event_data.RequestOSVersion | Operating system version reported for the AD CS certificate request client. | keyword |
+| winlog.event_data.Requester |  | keyword |
 | winlog.event_data.Resource |  | keyword |
 | winlog.event_data.ResourceAttributes |  | keyword |
 | winlog.event_data.ResourceManager |  | keyword |
 | winlog.event_data.ReturnCode |  | keyword |
 | winlog.event_data.ReturnCodeOutcome |  | keyword |
+| winlog.event_data.RevocationReason |  | keyword |
+| winlog.event_data.RoleSeparationEnabled |  | keyword |
 | winlog.event_data.RuleAttr |  | keyword |
 | winlog.event_data.RuleId |  | keyword |
 | winlog.event_data.RuleName |  | keyword |
@@ -813,6 +866,8 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.ScriptBlockText |  | keyword |
 | winlog.event_data.ScriptPath |  | keyword |
 | winlog.event_data.SearchString |  | keyword |
+| winlog.event_data.SecurityDescriptor |  | keyword |
+| winlog.event_data.SerialNumber | Serial number of the certificate issued by AD CS. | keyword |
 | winlog.event_data.Service |  | keyword |
 | winlog.event_data.ServiceAccount |  | keyword |
 | winlog.event_data.ServiceFileName |  | keyword |
@@ -849,7 +904,10 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.SubStatus |  | keyword |
 | winlog.event_data.SubcategoryGuid |  | keyword |
 | winlog.event_data.SubcategoryId |  | keyword |
+| winlog.event_data.Subject |  | keyword |
+| winlog.event_data.SubjectAlternativeName | Native subject alternative name information reported by the AD CS audit event, separate from SAN values parsed from request attributes. | keyword |
 | winlog.event_data.SubjectDomainName |  | keyword |
+| winlog.event_data.SubjectKeyIdentifier |  | keyword |
 | winlog.event_data.SubjectLogonId |  | keyword |
 | winlog.event_data.SubjectUserName |  | keyword |
 | winlog.event_data.SubjectUserSid |  | keyword |
@@ -867,6 +925,12 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.TdoDirection |  | keyword |
 | winlog.event_data.TdoSid |  | keyword |
 | winlog.event_data.TdoType |  | keyword |
+| winlog.event_data.TemplateContent |  | keyword |
+| winlog.event_data.TemplateDSObjectFQDN |  | keyword |
+| winlog.event_data.TemplateInternalName |  | keyword |
+| winlog.event_data.TemplateOID |  | keyword |
+| winlog.event_data.TemplateSchemaVersion |  | keyword |
+| winlog.event_data.TemplateVersion |  | keyword |
 | winlog.event_data.TerminalSessionId |  | keyword |
 | winlog.event_data.TicketEncryptionType |  | keyword |
 | winlog.event_data.TicketEncryptionTypeDescription |  | keyword |
@@ -882,6 +946,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | winlog.event_data.UserPrincipalName |  | keyword |
 | winlog.event_data.UserSid |  | keyword |
 | winlog.event_data.UserWorkstations |  | keyword |
+| winlog.event_data.Value |  | keyword |
 | winlog.event_data.VendorIds |  | keyword |
 | winlog.event_data.Version |  | keyword |
 | winlog.event_data.Weight |  | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.23.4"
+version: "2.24.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.0"
+  changes:
+    - description: Normalize Active Directory Certificate Services (AD CS) audit events with native field mappings, `winlog.adcs` request fields, ECS user mappings, and event categorization.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/21136
 - version: "3.9.5"
   changes:
     - description: Include Windows Security event 6272 in subject-field ECS mapping for forwarded events.

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-actor-normalization.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-actor-normalization.json
@@ -1,0 +1,247 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-08-22T03:05:12.373Z",
+            "event": {
+                "code": "4870"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "CertificateSerialNumber": "130000000a1e268cbaf3d2cb0000000000000a",
+                    "RevocationReason": "0",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4870",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4772"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:12.44Z",
+            "event": {
+                "code": "4871"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "NextPublishForBaseCRL": "Yes",
+                    "NextPublishForDeltaCRL": "No",
+                    "NextUpdate": "0",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4871",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4773"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.565Z",
+            "event": {
+                "code": "4873"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "ExtensionData": "aAB0AHQAcABzADoALwAvAGEAdABsAGEAcwAuAGkAbgB2AGEAbABpAGQALwBiAGUA\nbgBpAGcAbgAtAGMAbwBuAHQAcgBvAGwAAAA=",
+                    "ExtensionDataType": "4",
+                    "ExtensionName": "1.3.6.1.4.1.311.99.1",
+                    "ExtensionPolicyFlags": "0",
+                    "RequestId": "11",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4873",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4348"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.556Z",
+            "event": {
+                "code": "4874"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "Atlas-Manager-Note: benign-one\nATLAS manager note:benign-two",
+                    "RequestId": "11",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4874",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4347"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.923Z",
+            "event": {
+                "code": "4875"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "SubjectLogonId": "0xa3711a",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4875",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5014"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.765Z",
+            "event": {
+                "code": "4891"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Entry": "PublishCertFlags",
+                    "Node": "ExitModules\\CertificateAuthority_MicrosoftDefault.Exit",
+                    "SubjectLogonId": "0xa3711a",
+                    "Value": "3",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4891",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5012"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:07.752Z",
+            "event": {
+                "code": "4868"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "RequestId": "12",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4868",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4654"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.621Z",
+            "event": {
+                "code": "4869"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "RequestId": "11",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4869",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4351"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T20:24:43.1Z",
+            "event": {
+                "code": "4876"
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "BackupType": "1",
+                    "BackupTypeDescription": "full backup",
+                    "SubjectDomainName": "ESSOS",
+                    "SubjectLogonId": "0x3e7",
+                    "SubjectUserName": "BRAAVOS$",
+                    "SubjectUserSid": "S-1-5-18"
+                },
+                "event_id": "4876",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2102983"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T21:53:51.753Z",
+            "event": {
+                "code": "4892"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "PropertyIndex": "0",
+                    "PropertyName": "29",
+                    "PropertyType": "4",
+                    "PropertyValue": "DirectoryEmailReplication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.29\nDomainControllerAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.28\nKerberosAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.33\nEFSRecovery\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.8\nEFS\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.6\nDomainController\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.15\nWebServer\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.16\nMachine\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.14\nUser\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.1\nSubCA\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.18\nAdministrator\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x47e42df",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4892",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "38747"
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-actor-normalization.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-actor-normalization.json-expected.json
@@ -1,0 +1,541 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-08-22T03:05:12.373Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-revoked",
+                "category": [
+                    "iam"
+                ],
+                "code": "4870",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "CertificateSerialNumber": "130000000a1e268cbaf3d2cb0000000000000a",
+                    "RevocationReason": "0",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4870",
+                "logon": {
+                    "id": "0x9b4df7"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4772"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:12.44Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-revocation-list-publication-requested",
+                "category": [
+                    "iam"
+                ],
+                "code": "4871",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "NextPublishForBaseCRL": "Yes",
+                    "NextPublishForDeltaCRL": "No",
+                    "NextUpdate": "0",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4871",
+                "logon": {
+                    "id": "0x9b4df7"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4773"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.565Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-extension-changed",
+                "category": [
+                    "iam"
+                ],
+                "code": "4873",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "extension": {
+                            "name": "1.3.6.1.4.1.311.99.1",
+                            "oid": "1.3.6.1.4.1.311.99.1"
+                        },
+                        "id": 11
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "ExtensionData": "aAB0AHQAcABzADoALwAvAGEAdABsAGEAcwAuAGkAbgB2AGEAbABpAGQALwBiAGUA\nbgBpAGcAbgAtAGMAbwBuAHQAcgBvAGwAAAA=",
+                    "ExtensionDataType": "4",
+                    "ExtensionName": "1.3.6.1.4.1.311.99.1",
+                    "ExtensionPolicyFlags": "0",
+                    "RequestId": "11",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4873",
+                "logon": {
+                    "id": "0x97c883"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4348"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.556Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-attributes-changed",
+                "category": [
+                    "iam"
+                ],
+                "code": "4874",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "id": 11
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "Atlas-Manager-Note: benign-one\nATLAS manager note:benign-two",
+                    "RequestId": "11",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4874",
+                "logon": {
+                    "id": "0x97c883"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4347"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.923Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-services-shutdown-requested",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4875",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0xa3711a",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4875",
+                "logon": {
+                    "id": "0xa3711a"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5014"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:19:47.765Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-services-configuration-entry-changed",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4891",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Entry": "PublishCertFlags",
+                    "Node": "ExitModules\\CertificateAuthority_MicrosoftDefault.Exit",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0xa3711a",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500",
+                    "Value": "3"
+                },
+                "event_id": "4891",
+                "logon": {
+                    "id": "0xa3711a"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5012"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:07.752Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-manager-denied-pending-certificate-request",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4868",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "id": 12
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "RequestId": "12",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x9b4df7",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4868",
+                "logon": {
+                    "id": "0x9b4df7"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4654"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.621Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-services-received-resubmitted-certificate-request",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4869",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "id": 11
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "RequestId": "11",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x97c883",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4869",
+                "logon": {
+                    "id": "0x97c883"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4351"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T20:24:43.1Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-services-backup-started",
+                "category": [
+                    "session"
+                ],
+                "code": "4876",
+                "type": [
+                    "start"
+                ]
+            },
+            "host": {
+                "name": "braavos",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "BRAAVOS$"
+                ]
+            },
+            "user": {
+                "domain": "ESSOS",
+                "id": "S-1-5-18",
+                "name": "BRAAVOS$"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "BackupType": "1",
+                    "BackupTypeDescription": "full backup",
+                    "SubjectDomainName": "ESSOS",
+                    "SubjectLogonId": "0x3e7",
+                    "SubjectUserName": "BRAAVOS$",
+                    "SubjectUserSid": "S-1-5-18"
+                },
+                "event_id": "4876",
+                "logon": {
+                    "id": "0x3e7"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2102983"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T21:53:51.753Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-services-property-changed",
+                "category": [
+                    "configuration"
+                ],
+                "code": "4892",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "id": "S-1-5-21-1718524055-4226609492-735728866-500",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "PropertyIndex": "0",
+                    "PropertyName": "29",
+                    "PropertyType": "4",
+                    "PropertyValue": "DirectoryEmailReplication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.29\nDomainControllerAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.28\nKerberosAuthentication\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.33\nEFSRecovery\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.8\nEFS\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.6\nDomainController\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.15\nWebServer\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.16\nMachine\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.14\nUser\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.1\nSubCA\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.18\nAdministrator\n1.3.6.1.4.1.311.21.8.4857691.1333008.2703509.9243065.7931139.13.1.7",
+                    "SubjectDomainName": "ADCSLAB",
+                    "SubjectLogonId": "0x47e42df",
+                    "SubjectUserName": "Administrator",
+                    "SubjectUserSid": "S-1-5-21-1718524055-4226609492-735728866-500"
+                },
+                "event_id": "4892",
+                "logon": {
+                    "id": "0x47e42df"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "38747"
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json
@@ -450,6 +450,41 @@
                     "Disposition": "-2146875392"
                 }
             }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:07.752Z",
+            "event": {
+                "code": "4888"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "activity_id": "{11b78485-31d3-0001-d984-b711d331dd01}",
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Disposition": "2",
+                    "RequestId": "12",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "63 c4 21 2e 83 d0 e9 df 87 ea 94 a8 28 b1 7d 2e 0a 72 0a c6"
+                },
+                "event_id": "4888",
+                "keywords": [
+                    "Audit Failure"
+                ],
+                "opcode": "Info",
+                "process": {
+                    "pid": 700,
+                    "thread": {
+                        "id": 5480
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4653",
+                "task": "Certification Services"
+            }
         }
     ]
 }

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json
@@ -1,0 +1,455 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "2148091904"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "+2148091904"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875359"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146828289"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4887"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4887",
+                "event_data": {
+                    "Disposition": "3"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4889"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4889",
+                "event_data": {
+                    "Disposition": "5"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "6443059200"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-6441842688"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "9223372036854775807"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-9223372036854775808"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "0x80094800"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": " -2146875392 "
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {}
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": null
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 1,
+                            "name": "STALE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875393"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {},
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "invalid"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4886"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4886",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "name": {
+                                "unexpected": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": "invalid",
+                            "name": "STALE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-06T12:00:00.000Z",
+            "event": {
+                "code": "4888",
+                "action": "ADCS-DENIED",
+                "category": [
+                    "configuration",
+                    "authentication"
+                ],
+                "outcome": "failure"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Synthetic-Other-Provider",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "winlog": {
+                "channel": "Application",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4888",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4890"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_id": "4890",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                }
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json-expected.json
@@ -1,0 +1,938 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 2148091904,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "2148091904"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 2148091904,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "+2148091904"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875359,
+                            "name": "CERTSRV_E_SEC_EXT_DIRECTORY_SID_REQUIRED"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875359"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146828289
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146828289"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "3"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-pending",
+                "category": [
+                    "iam"
+                ],
+                "code": "4889",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 5,
+                            "name": "CR_DISP_UNDER_SUBMISSION"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "5"
+                },
+                "event_id": "4889",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 0
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "0"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 6443059200
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "6443059200"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -6441842688
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-6441842688"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 9223372036854775807
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "9223372036854775807"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -9223372036854775808
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-9223372036854775808"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "0x80094800"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392.0"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": " -2146875392 "
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875393
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875393"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "invalid"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-received",
+                "category": [
+                    "iam"
+                ],
+                "code": "4886",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4886",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-09-06T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "outcome": "failure",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Synthetic-Other-Provider"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "event": {
+                "code": "4888"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Application",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-09-05T12:00:00.000Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "code": "4890"
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4890",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-disposition-name.json-expected.json
@@ -290,7 +290,8 @@
                 "adcs": {
                     "request": {
                         "disposition": {
-                            "code": 0
+                            "code": 0,
+                            "name": "CR_DISP_INCOMPLETE"
                         }
                     }
                 },
@@ -778,12 +779,6 @@
                 }
             },
             "winlog": {
-                "channel": "Security",
-                "event_data": {
-                    "Disposition": "-2146875392"
-                },
-                "event_id": "4888",
-                "provider_name": "Microsoft-Windows-Security-Auditing",
                 "adcs": {
                     "request": {
                         "disposition": {
@@ -791,7 +786,13 @@
                             "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
                         }
                     }
-                }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
             }
         },
         {
@@ -816,12 +817,6 @@
                 }
             },
             "winlog": {
-                "channel": "Security",
-                "event_data": {
-                    "Disposition": "-2146875392"
-                },
-                "event_id": "4888",
-                "provider_name": "Microsoft-Windows-Security-Auditing",
                 "adcs": {
                     "request": {
                         "disposition": {
@@ -829,7 +824,13 @@
                             "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
                         }
                     }
-                }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Disposition": "-2146875392"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing"
             }
         },
         {
@@ -932,6 +933,77 @@
                 },
                 "event_id": "4890",
                 "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T03:05:07.752Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "activity_id": "{11b78485-31d3-0001-d984-b711d331dd01}",
+                "adcs": {
+                    "request": {
+                        "disposition": {
+                            "code": 2,
+                            "name": "CR_DISP_DENIED"
+                        },
+                        "id": 12,
+                        "requester": {
+                            "domain": "ADCSLAB",
+                            "name": "Administrator"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Disposition": "2",
+                    "RequestId": "12",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "63 c4 21 2e 83 d0 e9 df 87 ea 94 a8 28 b1 7d 2e 0a 72 0a c6"
+                },
+                "event_id": "4888",
+                "keywords": [
+                    "Audit Failure"
+                ],
+                "opcode": "Info",
+                "process": {
+                    "pid": 700,
+                    "thread": {
+                        "id": 5480
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4653",
+                "task": "Certification Services"
             }
         }
     ]

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-request-attributes.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-request-attributes.json
@@ -1,0 +1,162 @@
+{
+    "events": [
+        {
+            "@timestamp": "2026-08-26T09:14:14.389Z",
+            "event": {
+                "code": "4888"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:CODEX-WEF-ADCS-Persistent-20260826-v1\nSAN:upn=administrator@adcsresearch.local&dns=adcs-dc01.adcsresearch.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500\nRequestClientInfo:codex-wef-forwarded-persistent-v1\nCodexRunLabel:adcs-ws2022-wef-forwarded-persistent-20260826-v1\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "-2146875392",
+                    "RequestId": "28",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "03 0b 55 1f 76 c2 1b 15 b1 b5 63 3a 8e cb ae fc bd 1c e3 56"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "44677"
+            }
+        },
+        {
+            "@timestamp": "2026-08-04T15:28:40.294Z",
+            "event": {
+                "code": "4887"
+            },
+            "host": {
+                "name": "wdc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "WDC01.certighost.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:User",
+                    "CertificateTemplate": "User",
+                    "Disposition": "3",
+                    "RequestId": "3",
+                    "Requester": "CERTIGHOST\\normaluser",
+                    "Subject": "CN=normaluser, CN=Users, DC=certighost, DC=local",
+                    "SubjectKeyIdentifier": "1a e1 14 3d ca 4f 01 c1 74 a9 02 bc 3b 48 65 f1 be e8 92 cc"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "12692"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:25:24.956Z",
+            "event": {
+                "code": "4887"
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ESC1\nSAN:upn=khal.drogo@essos.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115&url=S-1-5-21-2038103339-2155116624-3331879844-1115",
+                    "Disposition": "3",
+                    "RequestId": "17",
+                    "Requester": "ESSOS\\khal.drogo",
+                    "Subject": "CN=khal.drogo",
+                    "SubjectKeyIdentifier": "14 11 a0 af ea bb 2f 70 12 f6 38 cd 57 de 5e af 8b 58 40 b4"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2077058"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:43:04.482Z",
+            "event": {
+                "code": "4887"
+            },
+            "host": {
+                "name": "braavos"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "\n\nccm:braavos.essos.local",
+                    "Disposition": "3",
+                    "RequestId": "18",
+                    "Requester": "ESSOS\\BRAAVOS$",
+                    "Subject": "CN=braavos.essos.local",
+                    "SubjectKeyIdentifier": "3d fb c6 d9 7d a0 36 83 5a 5c fa a7 30 f4 92 ef d7 dd 31 5e"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2078682"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.515Z",
+            "event": {
+                "code": "4889"
+            },
+            "host": {
+                "name": "adcs-dc01"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:ATLAS-WS22-Pend-v1\nRequestClientInfo:atlas-pending-resubmit\ncdc:ADCS-DC01.adcsresearch.local\nrmd:ADCS-DC01.adcsresearch.local\nccm:ADCS-DC01.adcsresearch.local\nAtlasRunLabel:adcs-ws2022-atlas-20260822-v1-continuation-pending\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "5",
+                    "RequestId": "11",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "7e 75 cc 7d 37 f0 77 6d 7b f7 29 f1 ad 0b 47 50 71 a5 36 f8"
+                },
+                "event_id": "4889",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4346"
+            }
+        },
+        {
+            "event": {
+                "code": 4888
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ValidTemplate\nmalformed line\nSAN:UPN&=x&dns=&url=tag:microsoft.com,2022-09-14:sid:\nCertificateTemplate:",
+                    "RequestId": "101"
+                }
+            }
+        },
+        {
+            "event": {
+                "code": 4886
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:TemplateA\nCertificateTemplate:TemplateA\nSAN:upn=user@synthetic.invalid&upn=user@synthetic.invalid&dns=host.synthetic.invalid&dns=host.synthetic.invalid",
+                    "RequestId": "102"
+                }
+            }
+        },
+        {
+            "event": {
+                "code": 4886
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "event_data": {
+                    "Attributes": "SAN:email=user@synthetic.invalid&ip=192.0.2.1",
+                    "RequestId": "104"
+                }
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-request-attributes.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-security-adcs-request-attributes.json-expected.json
@@ -1,0 +1,518 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-08-26T09:14:14.389Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "ccm": [
+                                "ADCS-DC01.adcsresearch.local"
+                            ],
+                            "certificate_template": [
+                                "CODEX-WEF-ADCS-Persistent-20260826-v1"
+                            ],
+                            "request_client_info": [
+                                "codex-wef-forwarded-persistent-v1"
+                            ],
+                            "san": [
+                                "upn=administrator@adcsresearch.local&dns=adcs-dc01.adcsresearch.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500"
+                            ]
+                        },
+                        "disposition": {
+                            "code": -2146875392,
+                            "name": "CERTSRV_E_UNSUPPORTED_CERT_TYPE"
+                        },
+                        "id": 28,
+                        "requester": {
+                            "domain": "ADCSLAB",
+                            "name": "Administrator"
+                        },
+                        "subject_alt_name": {
+                            "dns": [
+                                "adcs-dc01.adcsresearch.local"
+                            ],
+                            "sid": [
+                                "S-1-5-21-1718524055-4226609492-735728866-500"
+                            ],
+                            "upn": [
+                                "administrator@adcsresearch.local"
+                            ],
+                            "uri": [
+                                "tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:CODEX-WEF-ADCS-Persistent-20260826-v1\nSAN:upn=administrator@adcsresearch.local&dns=adcs-dc01.adcsresearch.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-1718524055-4226609492-735728866-500\nRequestClientInfo:codex-wef-forwarded-persistent-v1\nCodexRunLabel:adcs-ws2022-wef-forwarded-persistent-20260826-v1\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "-2146875392",
+                    "RequestId": "28",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "03 0b 55 1f 76 c2 1b 15 b1 b5 63 3a 8e cb ae fc bd 1c e3 56"
+                },
+                "event_id": "4888",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "44677"
+            }
+        },
+        {
+            "@timestamp": "2026-08-04T15:28:40.294Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "name": "wdc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "normaluser"
+                ]
+            },
+            "user": {
+                "domain": "CERTIGHOST",
+                "name": "normaluser"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "User"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        },
+                        "id": 3,
+                        "requester": {
+                            "domain": "CERTIGHOST",
+                            "name": "normaluser"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "WDC01.certighost.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:User",
+                    "CertificateTemplate": "User",
+                    "Disposition": "3",
+                    "RequestId": "3",
+                    "Requester": "CERTIGHOST\\normaluser",
+                    "Subject": "CN=normaluser, CN=Users, DC=certighost, DC=local",
+                    "SubjectKeyIdentifier": "1a e1 14 3d ca 4f 01 c1 74 a9 02 bc 3b 48 65 f1 be e8 92 cc"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "12692"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:25:24.956Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "name": "braavos",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "khal.drogo"
+                ]
+            },
+            "user": {
+                "domain": "ESSOS",
+                "name": "khal.drogo"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "ESC1"
+                            ],
+                            "san": [
+                                "upn=khal.drogo@essos.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115&url=S-1-5-21-2038103339-2155116624-3331879844-1115"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        },
+                        "id": 17,
+                        "requester": {
+                            "domain": "ESSOS",
+                            "name": "khal.drogo"
+                        },
+                        "subject_alt_name": {
+                            "sid": [
+                                "S-1-5-21-2038103339-2155116624-3331879844-1115"
+                            ],
+                            "upn": [
+                                "khal.drogo@essos.local"
+                            ],
+                            "uri": [
+                                "tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115",
+                                "S-1-5-21-2038103339-2155116624-3331879844-1115"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ESC1\nSAN:upn=khal.drogo@essos.local&url=tag:microsoft.com,2022-09-14:sid:S-1-5-21-2038103339-2155116624-3331879844-1115&url=S-1-5-21-2038103339-2155116624-3331879844-1115",
+                    "Disposition": "3",
+                    "RequestId": "17",
+                    "Requester": "ESSOS\\khal.drogo",
+                    "Subject": "CN=khal.drogo",
+                    "SubjectKeyIdentifier": "14 11 a0 af ea bb 2f 70 12 f6 38 cd 57 de 5e af 8b 58 40 b4"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2077058"
+            }
+        },
+        {
+            "@timestamp": "2026-08-25T14:43:04.482Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-issued",
+                "category": [
+                    "iam"
+                ],
+                "code": "4887",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "name": "braavos",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "BRAAVOS$"
+                ]
+            },
+            "user": {
+                "domain": "ESSOS",
+                "name": "BRAAVOS$"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "ccm": [
+                                "braavos.essos.local"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 3,
+                            "name": "CR_DISP_ISSUED"
+                        },
+                        "id": 18,
+                        "requester": {
+                            "domain": "ESSOS",
+                            "name": "BRAAVOS$"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "braavos.essos.local",
+                "event_data": {
+                    "Attributes": "\n\nccm:braavos.essos.local",
+                    "Disposition": "3",
+                    "RequestId": "18",
+                    "Requester": "ESSOS\\BRAAVOS$",
+                    "Subject": "CN=braavos.essos.local",
+                    "SubjectKeyIdentifier": "3d fb c6 d9 7d a0 36 83 5a 5c fa a7 30 f4 92 ef d7 dd 31 5e"
+                },
+                "event_id": "4887",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "2078682"
+            }
+        },
+        {
+            "@timestamp": "2026-08-22T02:57:41.515Z",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-pending",
+                "category": [
+                    "iam"
+                ],
+                "code": "4889",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "adcs-dc01",
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "related": {
+                "user": [
+                    "Administrator"
+                ]
+            },
+            "user": {
+                "domain": "ADCSLAB",
+                "name": "Administrator"
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "ccm": [
+                                "ADCS-DC01.adcsresearch.local",
+                                "ADCS-DC01.adcsresearch.local"
+                            ],
+                            "cdc": [
+                                "ADCS-DC01.adcsresearch.local"
+                            ],
+                            "certificate_template": [
+                                "ATLAS-WS22-Pend-v1"
+                            ],
+                            "request_client_info": [
+                                "atlas-pending-resubmit"
+                            ],
+                            "rmd": [
+                                "ADCS-DC01.adcsresearch.local"
+                            ]
+                        },
+                        "disposition": {
+                            "code": 5,
+                            "name": "CR_DISP_UNDER_SUBMISSION"
+                        },
+                        "id": 11,
+                        "requester": {
+                            "domain": "ADCSLAB",
+                            "name": "Administrator"
+                        }
+                    }
+                },
+                "channel": "Security",
+                "computer_name": "ADCS-DC01.adcsresearch.local",
+                "event_data": {
+                    "Attributes": "\nCertificateTemplate:ATLAS-WS22-Pend-v1\nRequestClientInfo:atlas-pending-resubmit\ncdc:ADCS-DC01.adcsresearch.local\nrmd:ADCS-DC01.adcsresearch.local\nccm:ADCS-DC01.adcsresearch.local\nAtlasRunLabel:adcs-ws2022-atlas-20260822-v1-continuation-pending\nccm:ADCS-DC01.adcsresearch.local",
+                    "Disposition": "5",
+                    "RequestId": "11",
+                    "Requester": "ADCSLAB\\Administrator",
+                    "SubjectKeyIdentifier": "7e 75 cc 7d 37 f0 77 6d 7b f7 29 f1 ad 0b 47 50 71 a5 36 f8"
+                },
+                "event_id": "4889",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "4346"
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-denied",
+                "category": [
+                    "iam"
+                ],
+                "code": "4888",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "ValidTemplate"
+                            ],
+                            "san": [
+                                "UPN&=x&dns=&url=tag:microsoft.com,2022-09-14:sid:"
+                            ]
+                        },
+                        "id": 101,
+                        "subject_alt_name": {
+                            "uri": [
+                                "tag:microsoft.com,2022-09-14:sid:"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:ValidTemplate\nmalformed line\nSAN:UPN&=x&dns=&url=tag:microsoft.com,2022-09-14:sid:\nCertificateTemplate:",
+                    "RequestId": "101"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-received",
+                "category": [
+                    "iam"
+                ],
+                "code": "4886",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "certificate_template": [
+                                "TemplateA",
+                                "TemplateA"
+                            ],
+                            "san": [
+                                "upn=user@synthetic.invalid&upn=user@synthetic.invalid&dns=host.synthetic.invalid&dns=host.synthetic.invalid"
+                            ]
+                        },
+                        "id": 102,
+                        "subject_alt_name": {
+                            "dns": [
+                                "host.synthetic.invalid",
+                                "host.synthetic.invalid"
+                            ],
+                            "upn": [
+                                "user@synthetic.invalid",
+                                "user@synthetic.invalid"
+                            ]
+                        }
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Attributes": "CertificateTemplate:TemplateA\nCertificateTemplate:TemplateA\nSAN:upn=user@synthetic.invalid&upn=user@synthetic.invalid&dns=host.synthetic.invalid&dns=host.synthetic.invalid",
+                    "RequestId": "102"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        },
+        {
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "certificate-request-received",
+                "category": [
+                    "iam"
+                ],
+                "code": "4886",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "os": {
+                    "family": "windows",
+                    "type": "windows"
+                }
+            },
+            "winlog": {
+                "adcs": {
+                    "request": {
+                        "attributes": {
+                            "san": [
+                                "email=user@synthetic.invalid&ip=192.0.2.1"
+                            ]
+                        },
+                        "id": 104
+                    }
+                },
+                "channel": "Security",
+                "event_data": {
+                    "Attributes": "SAN:email=user@synthetic.invalid&ip=192.0.2.1",
+                    "RequestId": "104"
+                },
+                "provider_name": "Microsoft-Windows-Security-Auditing"
+            }
+        }
+    ]
+}

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
@@ -52,9 +52,14 @@ processors:
         # microsoft/win32metadata@1bfb76db1c360653bdcb56512af0fdf987aceab8
         # generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h
         names:
-          # Common CR_DISP_* request dispositions.
+          # CR_DISP_* request dispositions from the Windows SDK (CertCli.h).
+          '0': CR_DISP_INCOMPLETE
+          '1': CR_DISP_ERROR
+          '2': CR_DISP_DENIED
           '3': CR_DISP_ISSUED
+          '4': CR_DISP_ISSUED_OUT_OF_BAND
           '5': CR_DISP_UNDER_SUBMISSION
+          '6': CR_DISP_REVOKED
           '2148089857': CERTSRV_E_BAD_REQUESTSUBJECT
           '2148089858': CERTSRV_E_NO_REQUEST
           '2148089859': CERTSRV_E_BAD_REQUESTSTATUS

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
@@ -1,0 +1,446 @@
+---
+# Keep this pipeline byte-identical in:
+# - packages/system/data_stream/security/elasticsearch/ingest_pipeline/adcs.yml
+# - packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
+description: Pipeline for normalizing Active Directory Certificate Services audit events.
+processors:
+  - remove:
+      field: winlog.adcs
+      ignore_missing: true
+  - set:
+      tag: initialize_adcs_rebuild
+      field: _temp_adcs
+      value:
+        request: {}
+        limits:
+          attributes_chars: 16384
+          physical_lines: 128
+          line_chars: 4096
+          key_chars: 128
+          values_per_key: 64
+          san_components: 64
+  - fail:
+      message: winlog.event_data must be an object
+      if: ctx.winlog?.event_data != null && !(ctx.winlog.event_data instanceof Map)
+  - grok:
+      tag: parse_adcs_request_id
+      field: winlog.event_data.RequestId
+      patterns:
+        - '\A%{ADCS_SIGNED_DECIMAL:_temp_adcs.request.id:long}\z'
+      pattern_definitions:
+        ADCS_SIGNED_DECIMAL: '[+-]?[0-9]+'
+      if: ctx.event?.code != null && ['4868', '4869', '4873', '4874', '4886', '4887', '4888', '4889'].contains(ctx.event.code)
+      ignore_missing: true
+      ignore_failure: true
+  - grok:
+      tag: parse_adcs_disposition_code
+      field: winlog.event_data.Disposition
+      patterns:
+        - '\A%{ADCS_SIGNED_DECIMAL:_temp_adcs.request.disposition.code:long}\z'
+      pattern_definitions:
+        ADCS_SIGNED_DECIMAL: '[+-]?[0-9]+'
+      if: ctx.event?.code != null && ['4887', '4888', '4889'].contains(ctx.event.code)
+      ignore_missing: true
+      ignore_failure: true
+  - script:
+      tag: decode_adcs_disposition_name
+      description: Resolve recognized Certificate Services dispositions and HRESULTs without changing the source code.
+      if: ctx._temp_adcs?.request?.disposition?.code != null
+      lang: painless
+      params:
+        # CERTSRV_E_* constants from Windows SDK 10.0.26100.7705.
+        # microsoft/win32metadata@1bfb76db1c360653bdcb56512af0fdf987aceab8
+        # generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h
+        names:
+          # Common CR_DISP_* request dispositions.
+          '3': CR_DISP_ISSUED
+          '5': CR_DISP_UNDER_SUBMISSION
+          '2148089857': CERTSRV_E_BAD_REQUESTSUBJECT
+          '2148089858': CERTSRV_E_NO_REQUEST
+          '2148089859': CERTSRV_E_BAD_REQUESTSTATUS
+          '2148089860': CERTSRV_E_PROPERTY_EMPTY
+          '2148089861': CERTSRV_E_INVALID_CA_CERTIFICATE
+          '2148089862': CERTSRV_E_SERVER_SUSPENDED
+          '2148089863': CERTSRV_E_ENCODING_LENGTH
+          '2148089864': CERTSRV_E_ROLECONFLICT
+          '2148089865': CERTSRV_E_RESTRICTEDOFFICER
+          '2148089866': CERTSRV_E_KEY_ARCHIVAL_NOT_CONFIGURED
+          '2148089867': CERTSRV_E_NO_VALID_KRA
+          '2148089868': CERTSRV_E_BAD_REQUEST_KEY_ARCHIVAL
+          '2148089869': CERTSRV_E_NO_CAADMIN_DEFINED
+          '2148089870': CERTSRV_E_BAD_RENEWAL_CERT_ATTRIBUTE
+          '2148089871': CERTSRV_E_NO_DB_SESSIONS
+          '2148089872': CERTSRV_E_ALIGNMENT_FAULT
+          '2148089873': CERTSRV_E_ENROLL_DENIED
+          '2148089874': CERTSRV_E_TEMPLATE_DENIED
+          '2148089875': CERTSRV_E_DOWNLEVEL_DC_SSL_OR_UPGRADE
+          '2148089876': CERTSRV_E_ADMIN_DENIED_REQUEST
+          '2148089877': CERTSRV_E_NO_POLICY_SERVER
+          '2148089878': CERTSRV_E_WEAK_SIGNATURE_OR_KEY
+          '2148089879': CERTSRV_E_KEY_ATTESTATION_NOT_SUPPORTED
+          '2148089880': CERTSRV_E_ENCRYPTION_CERT_REQUIRED
+          '2148091904': CERTSRV_E_UNSUPPORTED_CERT_TYPE
+          '2148091905': CERTSRV_E_NO_CERT_TYPE
+          '2148091906': CERTSRV_E_TEMPLATE_CONFLICT
+          '2148091907': CERTSRV_E_SUBJECT_ALT_NAME_REQUIRED
+          '2148091908': CERTSRV_E_ARCHIVED_KEY_REQUIRED
+          '2148091909': CERTSRV_E_SMIME_REQUIRED
+          '2148091910': CERTSRV_E_BAD_RENEWAL_SUBJECT
+          '2148091911': CERTSRV_E_BAD_TEMPLATE_VERSION
+          '2148091912': CERTSRV_E_TEMPLATE_POLICY_REQUIRED
+          '2148091913': CERTSRV_E_SIGNATURE_POLICY_REQUIRED
+          '2148091914': CERTSRV_E_SIGNATURE_COUNT
+          '2148091915': CERTSRV_E_SIGNATURE_REJECTED
+          '2148091916': CERTSRV_E_ISSUANCE_POLICY_REQUIRED
+          '2148091917': CERTSRV_E_SUBJECT_UPN_REQUIRED
+          '2148091918': CERTSRV_E_SUBJECT_DIRECTORY_GUID_REQUIRED
+          '2148091919': CERTSRV_E_SUBJECT_DNS_REQUIRED
+          '2148091920': CERTSRV_E_ARCHIVED_KEY_UNEXPECTED
+          '2148091921': CERTSRV_E_KEY_LENGTH
+          '2148091922': CERTSRV_E_SUBJECT_EMAIL_REQUIRED
+          '2148091923': CERTSRV_E_UNKNOWN_CERT_TYPE
+          '2148091924': CERTSRV_E_CERT_TYPE_OVERLAP
+          '2148091925': CERTSRV_E_TOO_MANY_SIGNATURES
+          '2148091926': CERTSRV_E_RENEWAL_BAD_PUBLIC_KEY
+          '2148091927': CERTSRV_E_INVALID_EK
+          '2148091928': CERTSRV_E_INVALID_IDBINDING
+          '2148091929': CERTSRV_E_INVALID_ATTESTATION
+          '2148091930': CERTSRV_E_KEY_ATTESTATION
+          '2148091931': CERTSRV_E_CORRUPT_KEY_ATTESTATION
+          '2148091932': CERTSRV_E_EXPIRED_CHALLENGE
+          '2148091933': CERTSRV_E_INVALID_RESPONSE
+          '2148091934': CERTSRV_E_INVALID_REQUESTID
+          '2148091935': CERTSRV_E_REQUEST_PRECERTIFICATE_MISMATCH
+          '2148091936': CERTSRV_E_PENDING_CLIENT_RESPONSE
+          '2148091937': CERTSRV_E_SEC_EXT_DIRECTORY_SID_REQUIRED
+      source: |
+        long code = ctx._temp_adcs.request.disposition.code;
+        // Accept signed and unsigned 32-bit representations, without wrapping larger values.
+        if (code < -2147483648L || code > 4294967295L) {
+          return;
+        }
+        if (code < 0) {
+          code += 4294967296L;
+        }
+        def name = params.names.get(Long.toString(code));
+        if (name != null) {
+          ctx._temp_adcs.request.disposition.name = name;
+        }
+  - grok:
+      tag: parse_adcs_requester
+      field: winlog.event_data.Requester
+      patterns:
+        - '\A%{ADCS_REQUESTER_PART:_temp_adcs.requester.domain}\\%{ADCS_REQUESTER_PART:_temp_adcs.requester.name}\z'
+      pattern_definitions:
+        ADCS_REQUESTER_PART: '[^\x09-\x0D \\](?:[^\\]*[^\x09-\x0D \\])?'
+      if: ctx.event?.code != null && ['4886', '4887', '4888', '4889'].contains(ctx.event.code)
+      ignore_missing: true
+      ignore_failure: true
+  - set:
+      tag: set_adcs_requester_domain
+      field: _temp_adcs.request.requester.domain
+      copy_from: _temp_adcs.requester.domain
+      if: ctx._temp_adcs?.requester?.domain instanceof String && ctx._temp_adcs.requester.name instanceof String && ctx._temp_adcs.requester.domain.length() <= 8191 && ctx._temp_adcs.requester.name.length() <= 1024
+  - set:
+      tag: set_adcs_requester_name
+      field: _temp_adcs.request.requester.name
+      copy_from: _temp_adcs.requester.name
+      if: ctx._temp_adcs?.requester?.domain instanceof String && ctx._temp_adcs.requester.name instanceof String && ctx._temp_adcs.requester.domain.length() <= 8191 && ctx._temp_adcs.requester.name.length() <= 1024
+  # Bound the input before using the native line splitter; retain trailing blank lines for the line limit.
+  - split:
+      tag: split_adcs_attribute_lines
+      field: winlog.event_data.Attributes
+      target_field: _temp_adcs.attribute_lines
+      separator: '\n'
+      preserve_trailing: true
+      if: ctx.event?.code != null && ['4886', '4887', '4888', '4889'].contains(ctx.event.code) && ctx.winlog?.event_data?.Attributes instanceof String && ctx.winlog.event_data.Attributes.length() <= ctx._temp_adcs.limits.attributes_chars
+  # Parse bounded, allowlisted request attributes and SAN claims.
+  - script:
+      tag: parse_adcs_request_attributes
+      if: ctx.event?.code != null && ['4886', '4887', '4888', '4889'].contains(ctx.event.code) && ctx.winlog?.event_data?.Attributes != null
+      description: Parse only allowlisted AD CS request attributes within explicit resource limits.
+      lang: painless
+      params:
+        outer_keys:
+          certificatetemplate: certificate_template
+          requestclientinfo: request_client_info
+          cdc: cdc
+          rmd: rmd
+          ccm: ccm
+          san: san
+        microsoft_sid_uri_prefix: 'tag:microsoft.com,2022-09-14:sid:'
+      source: |
+        boolean edgeWhitespace(int character) {
+          return character == 32 || character == 9;
+        }
+
+        int trimmedStart(String text, int start, int end) {
+          while (start < end && edgeWhitespace(text.charAt(start))) {
+            start++;
+          }
+          return start;
+        }
+
+        int trimmedEnd(String text, int start, int end) {
+          while (end > start && edgeWhitespace(text.charAt(end - 1))) {
+            end--;
+          }
+          return end;
+        }
+
+        int firstCharacter(String text, int start, int end, int target) {
+          for (int index = start; index < end; index++) {
+            if (text.charAt(index) == target) {
+              return index;
+            }
+          }
+          return -1;
+        }
+
+        String normalizedKey(String text, int start, int end, boolean removeSeparators) {
+          StringBuilder builder = new StringBuilder();
+          for (int index = start; index < end; index++) {
+            int character = text.charAt(index);
+            if (removeSeparators && (character == 32 || character == 9 || character == 45)) {
+              continue;
+            }
+            if (character >= 65 && character <= 90) {
+              character += 32;
+            }
+            builder.append((char) character);
+          }
+          return builder.toString();
+        }
+
+        boolean asciiPrefix(String value, String prefix) {
+          if (value.length() < prefix.length()) {
+            return false;
+          }
+          for (int index = 0; index < prefix.length(); index++) {
+            int left = value.charAt(index);
+            int right = prefix.charAt(index);
+            if (left >= 65 && left <= 90) {
+              left += 32;
+            }
+            if (right >= 65 && right <= 90) {
+              right += 32;
+            }
+            if (left != right) {
+              return false;
+            }
+          }
+          return true;
+        }
+
+        void appendValue(HashMap values, String key, String value) {
+          def existing = values.get(key);
+          ArrayList output;
+          if (existing == null) {
+            output = new ArrayList();
+            values.put(key, output);
+          } else {
+            output = existing;
+          }
+          output.add(value);
+        }
+
+        HashMap parserResult(String status) {
+          HashMap result = new HashMap();
+          result.put('attributes', new HashMap());
+          result.put('subject_alt_name', new HashMap());
+          result.put('status', status);
+          return result;
+        }
+
+        HashMap parseAttributes(List lines, Map outerKeys, Map limits, String sidPrefix) {
+          if (lines.size() > limits.get('physical_lines')) {
+            return parserResult('skipped_limit');
+          }
+          HashMap result = parserResult(null);
+          HashMap attributes = result.get('attributes');
+          HashMap subjectAltName = result.get('subject_alt_name');
+          HashMap occurrenceCounts = new HashMap();
+          int componentCount = 0;
+
+          for (String rawLine : lines) {
+            String line = (rawLine.length() > 0 && rawLine.charAt(rawLine.length() - 1) == 13) ? rawLine.substring(0, rawLine.length() - 1) : rawLine;
+            if (line.length() > limits.get('line_chars')) {
+              return parserResult('skipped_limit');
+            }
+            int start = trimmedStart(line, 0, line.length());
+            int end = trimmedEnd(line, start, line.length());
+            int colon = firstCharacter(line, start, end, 58);
+            if (colon < 0) {
+              continue;
+            }
+            int keyStart = trimmedStart(line, start, colon);
+            int keyEnd = trimmedEnd(line, keyStart, colon);
+            if (keyEnd - keyStart > limits.get('key_chars')) {
+              return parserResult('skipped_limit');
+            }
+            String key = normalizedKey(line, keyStart, keyEnd, true);
+            if (!outerKeys.containsKey(key)) {
+              continue;
+            }
+            int count = occurrenceCounts.containsKey(key) ? occurrenceCounts.get(key) + 1 : 1;
+            occurrenceCounts.put(key, count);
+            if (count > limits.get('values_per_key')) {
+              return parserResult('skipped_limit');
+            }
+            int valueStart = trimmedStart(line, colon + 1, end);
+            int valueEnd = trimmedEnd(line, valueStart, end);
+            if (valueStart == valueEnd) {
+              continue;
+            }
+            String value = line.substring(valueStart, valueEnd);
+            appendValue(attributes, outerKeys.get(key), value);
+            if (!key.equals('san')) {
+              continue;
+            }
+
+            for (String component : value.splitOnToken('&')) {
+              int cleanStart = trimmedStart(component, 0, component.length());
+              int cleanEnd = trimmedEnd(component, cleanStart, component.length());
+              if (cleanStart == cleanEnd) {
+                continue;
+              }
+              componentCount++;
+              if (componentCount > limits.get('san_components')) {
+                return parserResult('skipped_limit');
+              }
+              int equals = firstCharacter(component, cleanStart, cleanEnd, 61);
+              if (equals < 0) {
+                continue;
+              }
+              int sanKeyStart = trimmedStart(component, cleanStart, equals);
+              int sanKeyEnd = trimmedEnd(component, sanKeyStart, equals);
+              if (sanKeyEnd - sanKeyStart > limits.get('key_chars')) {
+                return parserResult('skipped_limit');
+              }
+              String sanKey = normalizedKey(component, sanKeyStart, sanKeyEnd, false);
+              int sanValueStart = trimmedStart(component, equals + 1, cleanEnd);
+              int sanValueEnd = trimmedEnd(component, sanValueStart, cleanEnd);
+              if (sanValueStart == sanValueEnd) {
+                continue;
+              }
+              String sanValue = component.substring(sanValueStart, sanValueEnd);
+              if (sanKey.equals('upn')) {
+                appendValue(subjectAltName, 'upn', sanValue);
+              } else if (sanKey.equals('dns')) {
+                appendValue(subjectAltName, 'dns', sanValue);
+              } else if (sanKey.equals('url')) {
+                appendValue(subjectAltName, 'uri', sanValue);
+                if (asciiPrefix(sanValue, sidPrefix)) {
+                  String sid = sanValue.substring(sidPrefix.length());
+                  if (!sid.isEmpty()) {
+                    appendValue(subjectAltName, 'sid', sid);
+                  }
+                }
+              }
+            }
+          }
+          return result;
+        }
+
+        def rawAttributes = ctx.winlog.event_data.Attributes;
+        HashMap parsed;
+        if (!(rawAttributes instanceof String)) {
+          parsed = parserResult('error');
+        } else if (rawAttributes.length() > ctx._temp_adcs.limits.attributes_chars) {
+          parsed = parserResult('skipped_limit');
+        } else {
+          try {
+            parsed = parseAttributes(ctx._temp_adcs.attribute_lines, params.outer_keys,
+              ctx._temp_adcs.limits, params.microsoft_sid_uri_prefix);
+          } catch (Exception internalException) {
+            parsed = parserResult('error');
+          }
+        }
+        if (!parsed.attributes.isEmpty()) {
+          ctx._temp_adcs.request.put('attributes', parsed.attributes);
+        }
+        if (!parsed.subject_alt_name.isEmpty()) {
+          ctx._temp_adcs.request.put('subject_alt_name', parsed.subject_alt_name);
+        }
+        ctx._temp_adcs.put('status', parsed.get('status'));
+  - append:
+      description: Mark events when resource limits prevent AD CS request attribute parsing.
+      field: tags
+      value: adcs_attributes_skipped_limit
+      allow_duplicates: false
+      if: ctx._temp_adcs?.status == 'skipped_limit'
+  - append:
+      description: Mark errors caught within AD CS request attribute parsing.
+      field: tags
+      value: adcs_normalization_failed
+      allow_duplicates: false
+      if: ctx._temp_adcs?.status == 'error'
+  # Preserve nonblank names; recognize dotted-decimal identifiers without decoding values.
+  - grok:
+      tag: parse_adcs_extension_name
+      field: winlog.event_data.ExtensionName
+      patterns:
+        - '\A%{ADCS_EXTENSION_NAME:_temp_adcs.request.extension.name}\z'
+      pattern_definitions:
+        ADCS_EXTENSION_NAME: '(?=[\s\S]*[^\x09-\x0D ])[\s\S]+'
+      if: ctx.event?.code == '4873' && ctx.winlog?.event_data?.ExtensionName instanceof String && ctx.winlog.event_data.ExtensionName.length() <= 8191
+      ignore_missing: true
+      ignore_failure: true
+  - grok:
+      tag: parse_adcs_extension_oid
+      field: _temp_adcs.request.extension.name
+      patterns:
+        - '\A%{ADCS_EXTENSION_OID:_temp_adcs.request.extension.oid}\z'
+      pattern_definitions:
+        ADCS_EXTENSION_OID: '[0-9]+(?:\.[0-9]+)+'
+      ignore_missing: true
+      ignore_failure: true
+  - set:
+      tag: publish_adcs_overlay
+      description: Publish the rebuilt overlay once normalization has completed.
+      field: winlog.adcs.request
+      copy_from: _temp_adcs.request
+      if: ctx._temp_adcs?.request instanceof Map && !ctx._temp_adcs.request.isEmpty()
+  - set:
+      tag: identify_adcs_requester_user_fallback
+      description: Use the requester only when the request event has no root user identity.
+      field: _temp_adcs.requester_user_fallback
+      value: true
+      if: >-
+        ['4886', '4887', '4888', '4889'].contains(ctx.event?.code) &&
+        ctx.winlog?.adcs?.request?.requester?.name != null &&
+        ctx.winlog.adcs.request.requester.domain != null &&
+        ctx.user?.id == null && ctx.user?.name == null && ctx.user?.domain == null &&
+        ctx.user?.email == null && ctx.user?.full_name == null
+  - set:
+      tag: set_adcs_requester_user_name
+      field: user.name
+      copy_from: winlog.adcs.request.requester.name
+      if: ctx._temp_adcs?.requester_user_fallback == true
+  - set:
+      tag: set_adcs_requester_user_domain
+      field: user.domain
+      copy_from: winlog.adcs.request.requester.domain
+      if: ctx._temp_adcs?.requester_user_fallback == true
+  - append:
+      tag: append_adcs_requester_related_user
+      field: related.user
+      value: '{{{winlog.adcs.request.requester.name}}}'
+      allow_duplicates: false
+      if: ctx.winlog?.adcs?.request?.requester?.name instanceof String
+  - remove:
+      field: _temp_adcs
+      ignore_missing: true
+on_failure:
+  - remove:
+      field:
+        - winlog.adcs
+        - _temp_adcs
+      ignore_missing: true
+      ignore_failure: true
+  - append:
+      description: Mark events when AD CS normalization fails unexpectedly.
+      field: tags
+      value: adcs_normalization_failed
+      allow_duplicates: false
+      ignore_failure: true

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_adcs.yml
@@ -49,10 +49,10 @@ processors:
       lang: painless
       params:
         # CERTSRV_E_* constants from Windows SDK 10.0.26100.7705.
-        # microsoft/win32metadata@1bfb76db1c360653bdcb56512af0fdf987aceab8
-        # generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h
+        # https://github.com/microsoft/win32metadata/blob/1bfb76db1c360653bdcb56512af0fdf987aceab8/generation/WinSDK/RecompiledIdlHeaders/shared/winerror.h#L38754
         names:
           # CR_DISP_* request dispositions from the Windows SDK (CertCli.h).
+          # https://github.com/microsoft/win32metadata/blob/29896383c51d9dd6a2ea0ec6304d095baca9418c/generation/WinSDK/RecompiledIdlHeaders/um/CertCli.h#L1619-L1631
           '0': CR_DISP_INCOMPLETE
           '1': CR_DISP_ERROR
           '2': CR_DISP_DENIED

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_default.yml
@@ -14,6 +14,16 @@ processors:
       name: '{{ IngestPipeline "security_standard" }}'
       if: 'ctx.winlog?.provider_name != null && ["Microsoft-Windows-Eventlog", "Microsoft-Windows-Security-Auditing"].contains(ctx.winlog.provider_name)'
   - pipeline:
+      name: '{{ IngestPipeline "security_adcs" }}'
+      if: >-
+        ctx.winlog != null &&
+        ctx.winlog.provider_name == 'Microsoft-Windows-Security-Auditing' &&
+        ctx.winlog.channel instanceof String &&
+        ctx.winlog.channel.toLowerCase() == 'security' &&
+        ctx.event != null &&
+        ctx.event.code != null &&
+        ['4868', '4869', '4873', '4874', '4886', '4887', '4888', '4889'].contains(ctx.event.code)
+  - pipeline:
       name: '{{ IngestPipeline "security_scheduled_task" }}'
       if: >-
         ctx.winlog != null &&

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
@@ -646,6 +646,90 @@ processors:
             - admin
             - change
           action: object-audit-changed
+        "4868":
+          category:
+            - configuration
+          type:
+            - change
+          action: certificate-manager-denied-pending-certificate-request
+        "4869":
+          category:
+            - configuration
+          type:
+            - info
+          action: certificate-services-received-resubmitted-certificate-request
+        "4870":
+          category:
+            - iam
+          type:
+            - change
+          action: certificate-revoked
+        "4871":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-revocation-list-publication-requested
+        "4873":
+          category:
+            - iam
+          type:
+            - change
+          action: certificate-request-extension-changed
+        "4874":
+          category:
+            - iam
+          type:
+            - change
+          action: certificate-request-attributes-changed
+        "4875":
+          category:
+            - configuration
+          type:
+            - info
+          action: certificate-services-shutdown-requested
+        "4876":
+          category:
+            - session
+          type:
+            - start
+          action: certificate-services-backup-started
+        "4886":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-request-received
+        "4887":
+          category:
+            - iam
+          type:
+            - creation
+          action: certificate-issued
+        "4888":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-request-denied
+        "4889":
+          category:
+            - iam
+          type:
+            - info
+          action: certificate-request-pending
+        "4891":
+          category:
+            - configuration
+          type:
+            - change
+          action: certificate-services-configuration-entry-changed
+        "4892":
+          category:
+            - configuration
+          type:
+            - change
+          action: certificate-services-property-changed
         "4902":
           category:
             - iam
@@ -3433,7 +3517,8 @@ processors:
               "4740", "4741", "4742", "4743", "4744", "4745", "4746", "4747", "4748", "4749",
               "4750", "4751", "4752", "4753", "4754", "4755", "4756", "4757", "4758", "4759",
               "4760", "4761", "4762", "4763", "4764", "4767", "4781", "4797", "4798", "4799",
-              "4817", "4904", "4905", "4907", "4912", "5136", "5140", "5145", "5379", "5380",
+              "4817", "4868", "4869", "4870", "4871", "4873", "4874", "4875", "4876", "4891",
+              "4892", "4904", "4905", "4907", "4912", "5136", "5140", "5145", "5379", "5380",
               "5381", "5382", "6272"].contains(ctx.event.code)) {
           return;
         }

--- a/packages/windows/data_stream/forwarded/fields/winlog.yml
+++ b/packages/windows/data_stream/forwarded/fields/winlog.yml
@@ -13,6 +13,126 @@
       description: >
         A globally unique identifier that identifies the current activity. The events that are published with this identifier are part of the same activity.
 
+    - name: adcs
+      type: group
+      description: >
+        Normalized data from Active Directory Certificate Services audit events. This group is rebuilt from native fields on each normalization; existing values in this group are replaced. Native event values remain available under `winlog.event_data`.
+
+      fields:
+        - name: request
+          type: group
+          description: >
+            Typed certificate request data derived from native audit fields.
+
+          fields:
+            - name: id
+              type: long
+              description: >
+                Strict signed-ASCII-decimal request identifier derived from `winlog.event_data.RequestId`.
+
+            - name: disposition
+              type: group
+              description: >
+                Certificate request disposition code and recognized Certificate Services disposition or error name.
+
+              fields:
+                - name: code
+                  type: long
+                  description: >
+                    Strict signed-ASCII-decimal disposition code derived from `winlog.event_data.Disposition`.
+
+                - name: name
+                  type: keyword
+                  description: >
+                    Canonical CR_DISP_* or CERTSRV_E_* name for a recognized Certificate Services disposition or HRESULT in `winlog.adcs.request.disposition.code`. Signed and unsigned decimal representations of an HRESULT resolve to the same name. Unknown codes have no derived name.
+
+            - name: requester
+              type: group
+              description: >
+                Certificate requester identity. Also populates ECS `user.name` and `user.domain` for events 4886–4889 when no ECS user identity is already present.
+
+              fields:
+                - name: domain
+                  type: keyword
+                  ignore_above: 8191
+                  description: >
+                    Exact requester domain component from `winlog.event_data.Requester`, with source case preserved.
+
+                - name: name
+                  type: keyword
+                  ignore_above: 1024
+                  description: >
+                    Exact requester name component from `winlog.event_data.Requester`, with source case preserved.
+
+            - name: extension
+              type: group
+              description: Neutral identifiers for an extension changed on a pending certificate request.
+              fields:
+                - name: name
+                  type: keyword
+                  ignore_above: 8191
+                  description: Exact nonblank event 4873 ExtensionName without value decoding.
+                - name: oid
+                  type: keyword
+                  ignore_above: 8191
+                  description: Conservative dotted-ASCII-decimal identifier derived from event 4873 ExtensionName.
+            - name: attributes
+              type: group
+              description: >
+                Bounded allowlisted values parsed from `winlog.event_data.Attributes` without changing the raw field.
+
+              fields:
+                - name: certificate_template
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Ordered CertificateTemplate request values, kept separate from the native `winlog.event_data.CertificateTemplate` field.
+
+                - name: request_client_info
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered RequestClientInfo request values.
+                - name: cdc
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Active Directory server names supplied in the cdc enrollment attribute for the CA to use when requester information cannot be obtained from its working directory. Values are preserved in request order without hostname validation.
+                - name: rmd
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Machine object FQDNs supplied in the rmd enrollment attribute for the certificate request. Values are preserved in request order without hostname validation.
+                - name: ccm
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Values extracted from the ccm enrollment attribute in `winlog.event_data.Attributes`, preserved in request order.
+                - name: san
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered, outer-trimmed SAN request values.
+            - name: subject_alt_name
+              type: group
+              description: Allowlisted subject alternative name request claims.
+              fields:
+                - name: upn
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered UPN SAN request claims.
+                - name: dns
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered DNS SAN request claims.
+                - name: uri
+                  type: keyword
+                  ignore_above: 4096
+                  description: Ordered URL or URI SAN request claims.
+                - name: sid
+                  type: keyword
+                  ignore_above: 4096
+                  description: >
+                    Exact unvalidated suffix from a recognized Microsoft SID URI.
+
     - name: computer_name
       type: keyword
       description: >
@@ -87,7 +207,19 @@
           type: keyword
         - name: AuditSourceName
           type: keyword
+        - name: Attributes
+          type: keyword
+        - name: AuthenticationLevel
+          type: keyword
+          description: >
+            Authentication level reported in the AD CS audit event.
         - name: AuthenticationPackageName
+          type: keyword
+        - name: AuthenticationService
+          type: keyword
+          description: >
+            Authentication service reported in the AD CS audit event.
+        - name: BackupType
           type: keyword
         - name: Binary
           type: keyword
@@ -99,13 +231,23 @@
           type: keyword
         - name: BuildVersion
           type: keyword
+        - name: CACertificateHash
+          type: keyword
         - name: CallerProcessId
           type: keyword
         - name: CallerProcessName
           type: keyword
+        - name: CAPublicKeyHash
+          type: keyword
         - name: Category
           type: keyword
         - name: CategoryId
+          type: keyword
+        - name: CertificateDatabaseHash
+          type: keyword
+        - name: CertificateSerialNumber
+          type: keyword
+        - name: CertificateTemplate
           type: keyword
         - name: ClientAddress
           type: keyword
@@ -127,6 +269,14 @@
           type: keyword
         - name: CreationUtcTime
           type: keyword
+        - name: CRLNumber
+          type: keyword
+        - name: DCDNSName
+          type: keyword
+        - name: DCOMorRPC
+          type: keyword
+          description: >
+            DCOM or RPC transport indicator reported for the AD CS certificate request.
         - name: Description
           type: keyword
         - name: Details
@@ -142,6 +292,8 @@
         - name: DeviceVersionMinor
           type: keyword
         - name: DisplayName
+          type: keyword
+        - name: Disposition
           type: keyword
         - name: DnsHostName
           type: keyword
@@ -169,11 +321,21 @@
           type: keyword
         - name: EnabledPrivilegeList
           type: keyword
+        - name: Entry
+          type: keyword
         - name: EntryCount
           type: keyword
         - name: EventSourceId
           type: keyword
         - name: EventType
+          type: keyword
+        - name: ExtensionData
+          type: keyword
+        - name: ExtensionDataType
+          type: keyword
+        - name: ExtensionName
+          type: keyword
+        - name: ExtensionPolicyFlags
           type: keyword
         - name: ExtraInfo
           type: keyword
@@ -209,7 +371,11 @@
           type: keyword
         - name: IpPort
           type: keyword
+        - name: IsBaseCRL
+          type: keyword
         - name: KerberosPolicyChange
+          type: keyword
+        - name: KeyContainer
           type: keyword
         - name: KeyLength
           type: keyword
@@ -279,6 +445,16 @@
           type: keyword
         - name: NewUacValue
           type: keyword
+        - name: NextPublish
+          type: keyword
+        - name: NextPublishForBaseCRL
+          type: keyword
+        - name: NextPublishForDeltaCRL
+          type: keyword
+        - name: NextUpdate
+          type: keyword
+        - name: Node
+          type: keyword
         - name: NominalFrequency
           type: keyword
         - name: Number
@@ -343,6 +519,8 @@
           type: keyword
         - name: PrimaryGroupId
           type: keyword
+        - name: PrivateKeyUsageCount
+          type: keyword
         - name: PrivilegeList
           type: keyword
         - name: ProcessId
@@ -357,13 +535,43 @@
           type: keyword
         - name: ProfilePath
           type: keyword
+        - name: PropertyIndex
+          type: keyword
+        - name: PropertyName
+          type: keyword
+        - name: PropertyType
+          type: keyword
+        - name: PropertyValue
+          type: keyword
         - name: PuaCount
           type: keyword
         - name: PuaPolicyId
           type: keyword
+        - name: PublishURLs
+          type: keyword
         - name: QfeVersion
           type: keyword
         - name: Reason
+          type: keyword
+        - name: RequestClientInfo
+          type: keyword
+          description: >
+            Native client information reported for the AD CS certificate request, separate from values parsed from request attributes.
+        - name: RequestCSPProvider
+          type: keyword
+          description: >
+            Cryptographic service provider reported for the AD CS certificate request.
+        - name: RequestOSVersion
+          type: keyword
+          description: >
+            Operating system version reported for the AD CS certificate request client.
+        - name: Requester
+          type: keyword
+        - name: RequestId
+          type: keyword
+        - name: RevocationReason
+          type: keyword
+        - name: RoleSeparationEnabled
           type: keyword
         - name: SamAccountName
           type: keyword
@@ -371,6 +579,12 @@
           type: keyword
         - name: ScriptPath
           type: keyword
+        - name: SecurityDescriptor
+          type: keyword
+        - name: SerialNumber
+          type: keyword
+          description: >
+            Serial number of the certificate issued by AD CS.
         - name: Session
           type: keyword
         - name: SidHistory
@@ -435,11 +649,31 @@
           type: keyword
         - name: SubjectLogonId
           type: keyword
+        - name: Subject
+          type: keyword
+        - name: SubjectAlternativeName
+          type: keyword
+          description: >
+            Native subject alternative name information reported by the AD CS audit event, separate from SAN values parsed from request attributes.
+        - name: SubjectKeyIdentifier
+          type: keyword
         - name: SubjectUserName
           type: keyword
         - name: SubjectUserSid
           type: keyword
         - name: SubStatus
+          type: keyword
+        - name: TemplateContent
+          type: keyword
+        - name: TemplateDSObjectFQDN
+          type: keyword
+        - name: TemplateInternalName
+          type: keyword
+        - name: TemplateOID
+          type: keyword
+        - name: TemplateSchemaVersion
+          type: keyword
+        - name: TemplateVersion
           type: keyword
         - name: TSId
           type: keyword
@@ -490,6 +724,8 @@
         - name: UserSid
           type: keyword
         - name: UserWorkstations
+          type: keyword
+        - name: Value
           type: keyword
         - name: Version
           type: keyword

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 3.9.5
+version: 3.10.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
windows, system: normalize AD CS audit events

Normalize certificate request details into winlog.adcs.* for System
Security and Windows Forwarded events. Expand native field mappings,
ECS user mappings, and event categorization so enrollment and CA
administration activity can be queried without parsing raw attributes
in search time.
```

## Summary

AD CS Security events contain certificate request and CA administration details, but they are included in `winlog.event_data.Attributes` as raw data, which lack normalization and forces us to parse them in search time, making rules more complex and expensive.

This PR normalizes selected request details into `winlog.adcs.*` in the System `security` and Windows `forwarded` data streams. It also expands native field mappings, administrative actor mappings, and event categorization.

## Issues

Part of https://github.com/elastic/detection-rules/issues/3865

## What changed

Request normalization covers Security events `4868`, `4869`, `4873`, `4874`, and `4886`–`4889`.

Normalized fields include:

* numeric request IDs
* disposition codes and recognized `CR_DISP_*` / `CERTSRV_E_*` names
* requester name and domain
* selected enrollment attributes: `CertificateTemplate`, `RequestClientInfo`, `cdc`, `rmd`, `ccm`, and `SAN`
* requested SAN values: UPN, DNS, URI, and SID URI suffixes
* extension name and OID for event `4873`

## Validation

Validated with `elastic-package` v0.126.4 and Elasticsearch 9.5.0:

* System and Windows package builds and checks
* System Security pipeline suite: 159 tests passed
* Windows Forwarded pipeline suite: 105 tests passed
* byte-identical AD CS pipelines across both packages
* captured request, disposition, extension, and administrative events, including `4892`
* existing parser edge cases
* regenerated documentation

## Checklist

* [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
* [ ] I have verified that all data streams collect metrics or logs.
* [x] I have added an entry to my package's `changelog.yml` file.
* [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
* [ ] I have verified that any added dashboard complies with [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices). No dashboards are added.

## How to test this PR locally

From the repository root, test System:

```sh
cd packages/system
elastic-package build
elastic-package check
elastic-package test pipeline --data-streams security
```

From the repository root, test Windows:

```sh
cd packages/windows
elastic-package build
elastic-package check
elastic-package test pipeline --data-streams forwarded
```

The pipeline suites include the AD CS fixtures and existing events for regression coverage.