### PR TITLE
github: preserve security_advisories state in error path

### DIFF
--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.27.1"
+  changes:
+    - description: Preserve state fields in the security advisories error path to prevent advisory_type, batch size and API key being lost across interval restarts.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21140
 - version: "2.27.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/github/data_stream/security_advisories/agent/stream/cel.yml.hbs
+++ b/packages/github/data_stream/security_advisories/agent/stream/cel.yml.hbs
@@ -40,6 +40,9 @@ program: |-
     },
   }).do_request().as(resp, (resp.StatusCode != 200) ?
     {
+      ?"api_key": state.?api_key,
+      "advisory_type": state.advisory_type,
+      "batch_size": state.batch_size,
       "events": {
         "error": {
           "code": string(resp.StatusCode),
@@ -52,6 +55,7 @@ program: |-
           ),
         },
       },
+      "url": state.url,
       "want_more": false,
     }
   :
@@ -68,8 +72,7 @@ program: |-
               optional.none()
           ),
         },
-        "events": body.map(
-          e,
+        "events": body.map(e,
           {
             "message": e.encode_json(),
           }

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "2.27.0"
+version: "2.27.1"
 description: Collect logs from GitHub with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
github: preserve security_advisories state in error path

When a request returns a non-200 status the error branch returned
only {"events": ..., "want_more": false}. After the runtime strips
those two fields the remaining state is empty. If the CEL input then
carries that empty state into the next interval rather than restoring
the initial config state, subsequent executions fail with "no such
key: advisory_type" because the field is no longer present.

Echo advisory_type, batch_size, url, and api_key back from the error
path so they survive regardless of how the runtime handles the
state transition.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
