### PR TITLE
[auditd] Faster parsing for common kernel record types

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "3.25.0"
+  changes:
+    - description: Parse common kernel record types (SYSCALL, PATH, CWD, PROCTITLE, EXECVE, SOCKADDR, ...) in the raw pipeline with dissect instead of grok to reduce ingest CPU. Output is unchanged.
+      type: enhancement
+      link: https://github.com/elastic/beats/issues/52594
 - version: "3.24.2"
   changes:
     - description: Fix quadratic grok backtracking in the raw pipeline on EXECVE records with oversized split arguments (aN[0], aN[1], ...), which could exceed the grok watchdog timeout and consume excessive ingest CPU. Bracket-suffixed argument chunk keys are now also captured instead of being dropped.

--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,9 +1,9 @@
 # later versions go on top
 - version: "3.25.0"
   changes:
-    - description: Parse common kernel record types (SYSCALL, PATH, CWD, PROCTITLE, EXECVE, SOCKADDR, ...) in the raw pipeline with dissect instead of grok to reduce ingest CPU. Output is unchanged.
+    - description: Faster parsing for common kernel record types.
       type: enhancement
-      link: https://github.com/elastic/beats/issues/52594
+      link: https://github.com/elastic/integrations/pull/21146
 - version: "3.24.2"
   changes:
     - description: Fix quadratic grok backtracking in the raw pipeline on EXECVE records with oversized split arguments (aN[0], aN[1], ...), which could exceed the grok watchdog timeout and consume excessive ingest CPU. Bracket-suffixed argument chunk keys are now also captured instead of being dropped.

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/raw.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/raw.yml
@@ -39,6 +39,34 @@ processors:
         AUDIT_PREFIX: '^(?:%{AUDIT_NODE})?%{AUDIT_TYPE} msg=audit\(%{NUMBER:auditd.log.epoch}:%{NUMBER:auditd.log.sequence}\):'
       patterns:
         - '%{AUDIT_PREFIX}\s*(?<auditd.log.kv>.*?)(?=\x1d%{WORD}=\{ )\x1d%{WORD:auditd.log.original_field}={ (?<auditd.log.sub_kv>.*) }$'
+  # Fast path for record types whose body is always key=value pairs from the first
+  # character. Anything else falls through to grok_audit_original. The %{+kv}=%{+kv}
+  # capture reproduces the body verbatim and fails on a body with no "=".
+  - dissect:
+      tag: dissect_audit_kv
+      if: |-
+        if (ctx.auditd?.log?.record_type != null || ctx.event?.original == null) {
+          return false;
+        }
+        String line = ctx.event.original;
+        int typeKey = line.startsWith('node=') ? line.indexOf(' type=') + 1 : 0;
+        int typeValueEnd = line.indexOf(' msg=audit(', typeKey);
+        if (typeValueEnd < 0 || !line.startsWith('type=', typeKey)) {
+          return false;
+        }
+        String recordType = line.substring(typeKey + 'type='.length(), typeValueEnd);
+        return ['SYSCALL', 'PATH', 'CWD', 'PROCTITLE', 'EXECVE', 'SOCKADDR', 'BPRM_FCAPS', 'LOGIN', 'CONFIG_CHANGE', 'NETFILTER_CFG'].contains(recordType);
+      field: event.original
+      pattern: '%{?prefix}type=%{auditd.log.record_type} msg=audit(%{auditd.log.epoch}:%{auditd.log.sequence}):%{->} %{+auditd.log.kv}=%{+auditd.log.kv}'
+      append_separator: '='
+      ignore_failure: true
+  # Capture the optional node= prefix that the dissect above skipped.
+  - dissect:
+      tag: dissect_audit_node
+      if: ctx.auditd?.log?.record_type != null && ctx.auditd.log.node == null && ctx.event.original.startsWith('node=')
+      field: event.original
+      pattern: 'node=%{auditd.log.node} %{}'
+      ignore_failure: true
   - grok:
       tag: grok_audit_original
       if: ctx.auditd?.log?.record_type == null
@@ -103,10 +131,12 @@ processors:
       field: auditd.log.original_field
       ignore_missing: true
   - rename:
+      ignore_missing: true
       ignore_failure: true
       field: auditd.log.old-auid
       target_field: auditd.log.old_auid
   - rename:
+      ignore_missing: true
       ignore_failure: true
       field: auditd.log.old-ses
       target_field: auditd.log.old_ses

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd Logs
-version: "3.24.2"
+version: "3.25.0"
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

```
[auditd] Faster parsing for common kernel record types

Add a dissect fast path in raw.yml for the high-volume kernel record
types (SYSCALL, PATH, CWD, PROCTITLE, EXECVE, SOCKADDR, ...), whose
body is key=value pairs from the first character. grok_audit_original
now only runs for records with a prose preamble (AVC, TTY, DAEMON_END,
...).

Also add ignore_missing to two renames that were throwing and
swallowing an exception on almost every document.

Output is unchanged: existing fixtures pass without regeneration and a
differential simulate over 25k records shows no differences.

On a SYSCALL-heavy ENRICHED dataset the raw pipeline drops from ~27 to
~18 us/doc (about 30% less). The fallback grok cost ~5.8 us/doc; the
dissect that replaces it costs ~1.5 us/doc (about 4x less). The kv
processor (~12 us/doc) is now the dominant cost and is not addressed.

Closes elastic/beats#52594
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Performance

Synthetic RHEL 8 style ENRICHED log, 86% syscall events, ES 9.5.3, `raw.yml` alone, three runs each of 300k docs, per-processor times from `_nodes/stats/ingest`:

| | before | after | change |
|---|---|---|---|
| raw pipeline total | ~27 µs/doc | ~18 µs/doc | -31% |
| fallback (`grok_audit_original` → `dissect_audit_kv`) | 5.8 µs/doc | 1.5 µs/doc | -74% |
| `rename old-auid` + `old-ses` | 3.2 µs/doc | 0.2 µs/doc | -94% |
| `kv` | ~12 µs/doc | ~12 µs/doc | unchanged, now ~65% of the pipeline |

The 0.52 ms/doc in the issue is most likely the split-EXECVE backtracking fixed in 3.24.2 (#21003, #20966), not the steady-state cost addressed here.

<details>
<summary>Reproducing with the package fixtures</summary>

```
cd packages/auditd
elastic-package stack up -d --services elasticsearch
elastic-package benchmark pipeline -d log
```

The fixtures are a mix of record types, so a smaller share hits the fast path than in a real syscall-audit stream: `processing_time` for 1000 docs went from 0.21s to 0.18s on the same machine. The SYSCALL-heavy numbers above come from a synthetic dataset bulk-indexed through `raw.yml` installed as a standalone pipeline.
</details>

## Related issues

- Closes https://github.com/elastic/beats/issues/52594