### PR TITLE
fix: detect legacy snapshot.yml in is_stack_created

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -328,6 +328,11 @@ is_stack_created() {
     if [ "${files}" -gt 0 ]; then
         return 0
     fi
+    # snapshot.yml was the name used before elastic-package v0.101.0 renamed it to docker-compose.yml
+    files=$(find ~/.elastic-package -type f -name "snapshot.yml" | wc -l)
+    if [ "${files}" -gt 0 ]; then
+        return 0
+    fi
     return 1
 }
 


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

```
fix: detect legacy snapshot.yml in is_stack_created

The `is_stack_created` function in `.buildkite/scripts/common.sh` only
checked for `docker-compose.yml` files under `~/.elastic-package` to
determine if a stack is running. However, versions of `elastic-package`
prior to v0.101.0 used `snapshot.yml` as the stack filename (renamed
in elastic/elastic-package#1835, released July 2024).

This change adds a fallback check for `snapshot.yml` so that CI
correctly detects stacks created with older versions of the tool,
preventing false negatives when running against legacy stack setups.
```

## Author's Checklist

- [ ] Verify CI passes on a pipeline using `elastic-package` < v0.101.0 that generates `snapshot.yml`

## How to test this PR locally

Run the `is_stack_created` function manually after starting a stack with `elastic-package` < v0.101.0 that creates `~/.elastic-package/stack/snapshot.yml` instead of `docker-compose.yml`. Confirm the function returns 0 (stack detected).

Tested in https://github.com/elastic/integrations/pull/20555.

## Related issues

- Relates https://github.com/elastic/integrations/issues/19262

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)