### PR TITLE
[New Integration] Add LeakData exposure alerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -375,6 +375,7 @@
 /packages/kubernetes/kibana @elastic/obs-ds-hosted-services
 /packages/kubernetes_otel @elastic/obs-signals-metrics-team
 /packages/lastpass @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/leakdata @elastic/integrations-triaging
 /packages/linux @elastic/elastic-agent-data-plane
 /packages/lite_llm @elastic/security-service-integrations
 /packages/lmd @elastic/threat-research-and-detection-engineering @elastic/kibana-management

--- a/packages/leakdata/_dev/build/build.yml
+++ b/packages/leakdata/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: "git@v9.4.0"

--- a/packages/leakdata/_dev/build/docs/README.md
+++ b/packages/leakdata/_dev/build/docs/README.md
@@ -1,0 +1,41 @@
+# LeakData Exposure Monitoring integration
+
+Bring verified breach-exposure alerts into Elastic Security without copying the underlying personal data into your SIEM. Elastic Agent collects alerts from LeakData and maps them to Elastic Common Schema (ECS).
+
+Each alert provides a severity, a finding count, an event ID and timestamps. Use these signals to prioritize an investigation in LeakData alongside your other security telemetry. An exposure alert does not establish that an account has been compromised.
+
+## Requirements
+
+- Elastic Stack 9.3.1 or later within the supported 9.x range, with Fleet and Elastic Agent.
+- An active LeakData account with SIEM integration access.
+- A personal-email monitor with confirmed ownership and monitoring enabled.
+
+Your LeakData plan and Elastic deployment requirements apply separately. [Explore LeakData](https://leakdata.io/integrations/elastic-security) or [view plans](https://leakdata.io/pricing).
+
+## Data and verification boundary
+
+LeakData releases an alert only when an active personal-email monitor still has exact ownership verification, every represented source remains verified at the configured `high` or `critical` threshold, and the account still has the SIEM integration entitlement.
+
+The feed does not include an email address, monitor identifier, breach/source name, source URL, credential, password, exposed value, raw record, or `event.original`.
+
+## Setup
+
+1. In the LeakData dashboard, create an Elastic Security connector and choose the exposure threshold you want to monitor.
+2. Copy the connector token when it is shown. You will use it to connect Elastic Agent.
+3. Add this integration to a Fleet agent policy. Keep the default LeakData URL and paste the token into **Connector token**. Fleet stores this setting as a secret.
+4. Leave the poll interval at five minutes, or adjust it to suit your workflow. Keep the `forwarded` tag; you can add your own tags.
+5. After LeakData detects a new eligible exposure, use Discover to check `logs-leakdata.exposure-*` for the alert.
+
+An empty feed can be expected when there are no new eligible alerts. Check that the monitor is active, its email ownership remains verified and your account still has SIEM integration access before investigating the connection.
+
+## Logs reference
+
+### exposure
+
+{{event "exposure"}}
+
+{{fields "exposure"}}
+
+Version `0.1.0` is a submission candidate and is not represented as Elastic-reviewed or published.
+
+For setup and account questions, contact [support@leakdata.io](mailto:support@leakdata.io). Report security issues privately to [security@leakdata.io](mailto:security@leakdata.io).

--- a/packages/leakdata/_dev/deploy/docker/docker-compose.yml
+++ b/packages/leakdata/_dev/deploy/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  leakdata:
+    image: docker.elastic.co/observability/stream:v0.18.0
+    ports:
+      - 8080
+    volumes:
+      - ./files:/files:ro
+    environment:
+      PORT: 8080
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/files/config.yml

--- a/packages/leakdata/_dev/deploy/docker/files/config.yml
+++ b/packages/leakdata/_dev/deploy/docker/files/config.yml
@@ -1,0 +1,159 @@
+rules:
+  - path: /api/integrations/elastic-security/v1/events
+    methods: [GET]
+    query_params:
+      limit: ["1"]
+      # Gorilla Mux treats an empty query pattern as a wildcard. Match only
+      # the initial empty cursor so later pages reach their own routes.
+      cursor: ["{cursor:$}"]
+    request_headers:
+      Authorization: ["^Bearer synthetic-system-test-token-not-a-credential$"]
+      Accept: ["^application/json$"]
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ["application/json"]
+        body: |-
+          {
+            "events": [
+              {
+                "@timestamp": "2026-08-14T10:00:00.000Z",
+                "ecs": {
+                  "version": "9.4.0"
+                },
+                "event": {
+                  "id": "leakdata-synthetic-page-1",
+                  "kind": "alert",
+                  "category": [
+                    "threat"
+                  ],
+                  "type": [
+                    "indicator"
+                  ],
+                  "action": "verified-exposure-detected",
+                  "module": "leakdata",
+                  "dataset": "leakdata.exposure",
+                  "severity": 90,
+                  "risk_score": 90,
+                  "risk_score_norm": 90,
+                  "created": "2026-08-14T10:00:00.000Z"
+                },
+                "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+                "observer": {
+                  "vendor": "LeakData",
+                  "product": "Exposure Monitoring",
+                  "type": "saas"
+                },
+                "rule": {
+                  "id": "leakdata-verified-exposure-v1",
+                  "name": "Verified identity exposure",
+                  "category": "Data Exposure",
+                  "ruleset": "LeakData verified exposure policy",
+                  "version": "1"
+                },
+                "tags": [
+                  "leakdata",
+                  "verified-exposure",
+                  "privacy-minimized"
+                ],
+                "leakdata": {
+                  "exposure": {
+                    "finding_count": 2,
+                    "minimum_severity": "high",
+                    "maximum_severity": "critical",
+                    "evidence_scope": "verified_source_and_verified_email_ownership",
+                    "contains_personal_data": false
+                  }
+                }
+              }
+            ],
+            "next_cursor": "000000000000000000000001",
+            "has_more": true
+          }
+  - path: /api/integrations/elastic-security/v1/events
+    methods: [GET]
+    query_params:
+      limit: ["1"]
+      cursor: ["000000000000000000000001"]
+    request_headers:
+      Authorization: ["^Bearer synthetic-system-test-token-not-a-credential$"]
+      Accept: ["^application/json$"]
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ["application/json"]
+        body: |-
+          {
+            "events": [
+              {
+                "@timestamp": "2026-08-14T10:00:00.000Z",
+                "ecs": {
+                  "version": "9.4.0"
+                },
+                "event": {
+                  "id": "leakdata-synthetic-page-2",
+                  "kind": "alert",
+                  "category": [
+                    "threat"
+                  ],
+                  "type": [
+                    "indicator"
+                  ],
+                  "action": "verified-exposure-detected",
+                  "module": "leakdata",
+                  "dataset": "leakdata.exposure",
+                  "severity": 90,
+                  "risk_score": 90,
+                  "risk_score_norm": 90,
+                  "created": "2026-08-14T10:00:00.000Z"
+                },
+                "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+                "observer": {
+                  "vendor": "LeakData",
+                  "product": "Exposure Monitoring",
+                  "type": "saas"
+                },
+                "rule": {
+                  "id": "leakdata-verified-exposure-v1",
+                  "name": "Verified identity exposure",
+                  "category": "Data Exposure",
+                  "ruleset": "LeakData verified exposure policy",
+                  "version": "1"
+                },
+                "tags": [
+                  "leakdata",
+                  "verified-exposure",
+                  "privacy-minimized"
+                ],
+                "leakdata": {
+                  "exposure": {
+                    "finding_count": 2,
+                    "minimum_severity": "high",
+                    "maximum_severity": "critical",
+                    "evidence_scope": "verified_source_and_verified_email_ownership",
+                    "contains_personal_data": false
+                  }
+                }
+              }
+            ],
+            "next_cursor": "000000000000000000000002",
+            "has_more": false
+          }
+  - path: /api/integrations/elastic-security/v1/events
+    methods: [GET]
+    query_params:
+      limit: ["1"]
+      cursor: ["000000000000000000000002"]
+    request_headers:
+      Authorization: ["^Bearer synthetic-system-test-token-not-a-credential$"]
+      Accept: ["^application/json$"]
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ["application/json"]
+        body: |-
+          {
+            "events": [],
+            "next_cursor": "000000000000000000000002",
+            "has_more": false
+          }

--- a/packages/leakdata/changelog.yml
+++ b/packages/leakdata/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: Initial candidate package for privacy-minimized verified exposure alerts.
+      type: enhancement
+      link: https://github.com/leakdatahq/leakdata-elastic-integration/pull/1

--- a/packages/leakdata/changelog.yml
+++ b/packages/leakdata/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: Initial candidate package for privacy-minimized verified exposure alerts.
       type: enhancement
-      link: https://github.com/leakdatahq/leakdata-elastic-integration/pull/1
+      link: https://github.com/elastic/integrations/pull/21156

--- a/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-agent-metadata.json
+++ b/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-agent-metadata.json
@@ -1,0 +1,65 @@
+{
+  "events": [
+    {
+      "json": {
+        "@timestamp": "2026-08-14T10:00:00.000Z",
+        "ecs": {
+          "version": "9.4.0"
+        },
+        "event": {
+          "id": "leakdata-elastic-synthetic-example",
+          "kind": "alert",
+          "category": [
+            "threat"
+          ],
+          "type": [
+            "indicator"
+          ],
+          "action": "verified-exposure-detected",
+          "module": "leakdata",
+          "dataset": "leakdata.exposure",
+          "severity": 90,
+          "risk_score": 90,
+          "risk_score_norm": 90,
+          "created": "2026-08-14T10:00:00.000Z"
+        },
+        "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+        "observer": {
+          "vendor": "LeakData",
+          "product": "Exposure Monitoring",
+          "type": "saas"
+        },
+        "rule": {
+          "id": "leakdata-verified-exposure-v1",
+          "name": "Verified identity exposure",
+          "category": "Data Exposure",
+          "ruleset": "LeakData verified exposure policy",
+          "version": "1"
+        },
+        "tags": [
+          "leakdata",
+          "verified-exposure",
+          "privacy-minimized"
+        ],
+        "leakdata": {
+          "exposure": {
+            "finding_count": 2,
+            "minimum_severity": "high",
+            "maximum_severity": "critical",
+            "evidence_scope": "verified_source_and_verified_email_ownership",
+            "contains_personal_data": false
+          }
+        }
+      },
+      "@timestamp": "2026-08-14T10:05:00.000Z",
+      "ecs": {
+        "version": "8.0.0"
+      },
+      "tags": [
+        "forwarded",
+        "leakdata",
+        "secops"
+      ]
+    }
+  ]
+}

--- a/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-agent-metadata.json-config.yml
+++ b/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-agent-metadata.json-config.yml
@@ -1,0 +1,2 @@
+dynamic_fields:
+  event.ingested: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*Z$"

--- a/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-agent-metadata.json-expected.json
+++ b/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-agent-metadata.json-expected.json
@@ -1,0 +1,57 @@
+{
+  "expected": [
+    {
+      "@timestamp": "2026-08-14T10:00:00.000Z",
+      "ecs": {
+        "version": "9.4.0"
+      },
+      "event": {
+        "id": "leakdata-elastic-synthetic-example",
+        "kind": "alert",
+        "category": [
+          "threat"
+        ],
+        "type": [
+          "indicator"
+        ],
+        "action": "verified-exposure-detected",
+        "module": "leakdata",
+        "dataset": "leakdata.exposure",
+        "severity": 90,
+        "risk_score": 90,
+        "risk_score_norm": 90,
+        "created": "2026-08-14T10:00:00.000Z",
+        "ingested": "2026-08-14T10:00:01.000Z"
+      },
+      "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+      "observer": {
+        "vendor": "LeakData",
+        "product": "Exposure Monitoring",
+        "type": "saas"
+      },
+      "rule": {
+        "id": "leakdata-verified-exposure-v1",
+        "name": "Verified identity exposure",
+        "category": "Data Exposure",
+        "ruleset": "LeakData verified exposure policy",
+        "version": "1"
+      },
+      "tags": [
+        "forwarded",
+        "leakdata",
+        "secops",
+        "verified-exposure",
+        "privacy-minimized"
+      ],
+      "leakdata": {
+        "exposure": {
+          "finding_count": 2,
+          "minimum_severity": "high",
+          "maximum_severity": "critical",
+          "evidence_scope": "verified_source_and_verified_email_ownership",
+          "contains_personal_data": false
+        }
+      }
+    }
+  ]
+}

--- a/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-plain.json
+++ b/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-plain.json
@@ -1,0 +1,56 @@
+{
+  "events": [
+    {
+      "json": {
+        "@timestamp": "2026-08-14T10:00:00.000Z",
+        "ecs": {
+          "version": "9.4.0"
+        },
+        "event": {
+          "id": "leakdata-elastic-synthetic-example",
+          "kind": "alert",
+          "category": [
+            "threat"
+          ],
+          "type": [
+            "indicator"
+          ],
+          "action": "verified-exposure-detected",
+          "module": "leakdata",
+          "dataset": "leakdata.exposure",
+          "severity": 90,
+          "risk_score": 90,
+          "risk_score_norm": 90,
+          "created": "2026-08-14T10:00:00.000Z"
+        },
+        "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+        "observer": {
+          "vendor": "LeakData",
+          "product": "Exposure Monitoring",
+          "type": "saas"
+        },
+        "rule": {
+          "id": "leakdata-verified-exposure-v1",
+          "name": "Verified identity exposure",
+          "category": "Data Exposure",
+          "ruleset": "LeakData verified exposure policy",
+          "version": "1"
+        },
+        "tags": [
+          "leakdata",
+          "verified-exposure",
+          "privacy-minimized"
+        ],
+        "leakdata": {
+          "exposure": {
+            "finding_count": 2,
+            "minimum_severity": "high",
+            "maximum_severity": "critical",
+            "evidence_scope": "verified_source_and_verified_email_ownership",
+            "contains_personal_data": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-plain.json-config.yml
+++ b/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-plain.json-config.yml
@@ -1,0 +1,2 @@
+dynamic_fields:
+  event.ingested: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*Z$"

--- a/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-plain.json-expected.json
+++ b/packages/leakdata/data_stream/exposure/_dev/test/pipeline/test-plain.json-expected.json
@@ -1,0 +1,55 @@
+{
+  "expected": [
+    {
+      "@timestamp": "2026-08-14T10:00:00.000Z",
+      "ecs": {
+        "version": "9.4.0"
+      },
+      "event": {
+        "id": "leakdata-elastic-synthetic-example",
+        "kind": "alert",
+        "category": [
+          "threat"
+        ],
+        "type": [
+          "indicator"
+        ],
+        "action": "verified-exposure-detected",
+        "module": "leakdata",
+        "dataset": "leakdata.exposure",
+        "severity": 90,
+        "risk_score": 90,
+        "risk_score_norm": 90,
+        "created": "2026-08-14T10:00:00.000Z",
+        "ingested": "2026-08-14T10:00:01.000Z"
+      },
+      "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+      "observer": {
+        "vendor": "LeakData",
+        "product": "Exposure Monitoring",
+        "type": "saas"
+      },
+      "rule": {
+        "id": "leakdata-verified-exposure-v1",
+        "name": "Verified identity exposure",
+        "category": "Data Exposure",
+        "ruleset": "LeakData verified exposure policy",
+        "version": "1"
+      },
+      "tags": [
+        "leakdata",
+        "verified-exposure",
+        "privacy-minimized"
+      ],
+      "leakdata": {
+        "exposure": {
+          "finding_count": 2,
+          "minimum_severity": "high",
+          "maximum_severity": "critical",
+          "evidence_scope": "verified_source_and_verified_email_ownership",
+          "contains_personal_data": false
+        }
+      }
+    }
+  ]
+}

--- a/packages/leakdata/data_stream/exposure/_dev/test/policy/test-default.expected
+++ b/packages/leakdata/data_stream/exposure/_dev/test/policy/test-default.expected
@@ -1,0 +1,78 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: leakdata
+      name: test-default-leakdata
+      streams:
+        - config_version: 2
+          data_stream:
+            dataset: leakdata.exposure
+          interval: 5m
+          program: |-
+            request(
+              "GET",
+              state.url.trim_right("/") + "/api/integrations/elastic-security/v1/events?" + {
+                "limit": [string(state.batch_size)],
+                "cursor": [state.?cursor.value.orValue("")],
+              }.format_query()
+            ).with({
+              "Header": {
+                "Authorization": ["Bearer " + state.token],
+                "Accept": ["application/json"],
+              },
+            }).do_request().as(resp, resp.StatusCode != 200 ?
+              state.with({
+                "events": {
+                  "error": {
+                    "code": string(resp.StatusCode),
+                    "id": string(resp.Status),
+                    "message": "GET LeakData feed: " + (
+                      size(resp.Body) != 0 ? string(resp.Body) : string(resp.Status)
+                    ),
+                  },
+                },
+                "want_more": false,
+              })
+            :
+              bytes(resp.Body).decode_json().as(body,
+                state.with({
+                  "events": body.events.map(e, {"json": e}),
+                  "cursor": {"value": body.next_cursor},
+                  "want_more": body.has_more && size(body.events) > 0,
+                })
+              )
+            )
+          publisher_pipeline.disable_host: true
+          redact:
+            fields:
+                - token
+          resource.timeout: 30s
+          resource.url: https://leakdata.example
+          state:
+            batch_size: 100
+            token: ${SECRET_0}
+            want_more: false
+          tags:
+            - forwarded
+            - leakdata
+            - secops
+      type: cel
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-leakdata.exposure-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}

--- a/packages/leakdata/data_stream/exposure/_dev/test/policy/test-default.yml
+++ b/packages/leakdata/data_stream/exposure/_dev/test/policy/test-default.yml
@@ -1,0 +1,11 @@
+input: cel
+data_stream:
+  vars:
+    url: https://leakdata.example
+    token: synthetic-policy-test-token-not-a-credential
+    interval: 5m
+    batch_size: 100
+    tags:
+      - forwarded
+      - leakdata
+      - secops

--- a/packages/leakdata/data_stream/exposure/_dev/test/scripts/feed-error.txtar
+++ b/packages/leakdata/data_stream/exposure/_dev/test/scripts/feed-error.txtar
@@ -1,0 +1,50 @@
+# Feed failures must remain actionable errors, never breach alerts.
+# The pipeline runner rejects every error.message by design, so use the
+# official script runner to assert this intentional failure path.
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_pipelines -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_ROOT}
+simulate -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_ROOT} default feed-error.json
+cp stdout actual.json
+exec jq -e --slurpfile expected expected.json -f assertion.jq actual.json
+stdout true
+uninstall_pipelines -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_ROOT}
+
+-- assertion.jq --
+(del(.event.ingested) == $expected[0]) and (.event.ingested | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*Z$"))
+-- feed-error.json --
+{
+  "@timestamp": "2026-08-14T10:05:00.000Z",
+  "ecs": {
+    "version": "8.0.0"
+  },
+  "error": {
+    "code": "403",
+    "id": "403 Forbidden",
+    "message": "GET LeakData feed: connector access is unavailable"
+  },
+  "tags": [
+    "forwarded",
+    "leakdata"
+  ]
+}
+-- expected.json --
+{
+  "@timestamp": "2026-08-14T10:05:00.000Z",
+  "ecs": {
+    "version": "8.0.0"
+  },
+  "error": {
+    "code": "403",
+    "id": "403 Forbidden",
+    "message": "GET LeakData feed: connector access is unavailable"
+  },
+  "tags": [
+    "forwarded",
+    "leakdata"
+  ],
+  "event": {
+    "kind": "pipeline_error",
+    "module": "leakdata",
+    "dataset": "leakdata.exposure"
+  }
+}

--- a/packages/leakdata/data_stream/exposure/_dev/test/system/test-pagination-config.yml
+++ b/packages/leakdata/data_stream/exposure/_dev/test/system/test-pagination-config.yml
@@ -1,0 +1,18 @@
+input: cel
+service: leakdata
+data_stream:
+  vars:
+    url: http://{{Hostname}}:{{Port}}
+    token: synthetic-system-test-token-not-a-credential
+    interval: 1s
+    batch_size: 1
+    tags:
+      - forwarded
+      - leakdata
+      - secops
+assert:
+  hit_count: 2
+  fields_present:
+    - event.id
+    - event.ingested
+    - leakdata.exposure.finding_count

--- a/packages/leakdata/data_stream/exposure/agent/stream/cel.yml.hbs
+++ b/packages/leakdata/data_stream/exposure/agent/stream/cel.yml.hbs
@@ -1,0 +1,60 @@
+config_version: 2
+interval: {{interval}}
+resource.url: {{url}}
+resource.timeout: 30s
+
+state:
+  token: {{token}}
+  batch_size: {{batch_size}}
+  want_more: false
+redact:
+  fields:
+    - token
+
+program: |-
+  request(
+    "GET",
+    state.url.trim_right("/") + "/api/integrations/elastic-security/v1/events?" + {
+      "limit": [string(state.batch_size)],
+      "cursor": [state.?cursor.value.orValue("")],
+    }.format_query()
+  ).with({
+    "Header": {
+      "Authorization": ["Bearer " + state.token],
+      "Accept": ["application/json"],
+    },
+  }).do_request().as(resp, resp.StatusCode != 200 ?
+    state.with({
+      "events": {
+        "error": {
+          "code": string(resp.StatusCode),
+          "id": string(resp.Status),
+          "message": "GET LeakData feed: " + (
+            size(resp.Body) != 0 ? string(resp.Body) : string(resp.Status)
+          ),
+        },
+      },
+      "want_more": false,
+    })
+  :
+    bytes(resp.Body).decode_json().as(body,
+      state.with({
+        "events": body.events.map(e, {"json": e}),
+        "cursor": {"value": body.next_cursor},
+        "want_more": body.has_more && size(body.events) > 0,
+      })
+    )
+  )
+
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
+{{#contains "forwarded" tags}}
+publisher_pipeline.disable_host: true
+{{/contains}}
+
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/leakdata/data_stream/exposure/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/leakdata/data_stream/exposure/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,81 @@
+---
+description: Normalize the allowlisted LeakData ECS alert document.
+processors:
+  - rename:
+      tag: rename_feed_timestamp
+      if: ctx.json != null
+      field: json.@timestamp
+      target_field: '@timestamp'
+      override: true
+  - rename:
+      field: json.ecs
+      tag: rename_feed_ecs
+      if: ctx.json != null
+      target_field: ecs
+      override: true
+  - rename:
+      field: json.event
+      tag: rename_feed_event
+      if: ctx.json != null
+      target_field: event
+      override: true
+  - rename:
+      field: json.message
+      tag: rename_feed_message
+      if: ctx.json != null
+      target_field: message
+      override: true
+  - rename:
+      field: json.observer
+      tag: rename_feed_observer
+      if: ctx.json != null
+      target_field: observer
+      override: true
+  - rename:
+      field: json.rule
+      tag: rename_feed_rule
+      if: ctx.json != null
+      target_field: rule
+      override: true
+  - append:
+      field: tags
+      tag: append_feed_tags
+      if: ctx.json != null
+      copy_from: json.tags
+      allow_duplicates: false
+  - rename:
+      field: json.leakdata
+      tag: rename_feed_exposure
+      if: ctx.json != null
+      target_field: leakdata
+      override: true
+  - remove:
+      field: json
+      tag: remove_feed_wrapper
+      ignore_missing: true
+  - set:
+      field: event.module
+      tag: set_event_module
+      value: leakdata
+  - set:
+      field: event.dataset
+      tag: set_event_dataset
+      value: leakdata.exposure
+  - set:
+      field: event.ingested
+      tag: set_event_ingested
+      value: '{{{_ingest.timestamp}}}'
+  - set:
+      field: event.kind
+      tag: classify_feed_error
+      if: ctx.error != null
+      value: pipeline_error
+on_failure:
+  - set:
+      field: event.kind
+      tag: classify_pipeline_error
+      value: pipeline_error
+  - append:
+      field: error.message
+      tag: append_pipeline_error
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} failed: {{{_ingest.on_failure_message}}}'

--- a/packages/leakdata/data_stream/exposure/fields/base-fields.yml
+++ b/packages/leakdata/data_stream/exposure/fields/base-fields.yml
@@ -1,0 +1,19 @@
+- name: data_stream.type
+  external: ecs
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: '@timestamp'
+  external: ecs
+- name: input.type
+  type: keyword
+  description: Type of Elastic Agent input that collected the event.
+- name: event.module
+  type: constant_keyword
+  external: ecs
+  value: leakdata
+- name: event.dataset
+  type: constant_keyword
+  external: ecs
+  value: leakdata.exposure

--- a/packages/leakdata/data_stream/exposure/fields/fields.yml
+++ b/packages/leakdata/data_stream/exposure/fields/fields.yml
@@ -1,0 +1,23 @@
+- name: leakdata
+  type: group
+  description: Privacy-minimized fields emitted by LeakData.
+  fields:
+    - name: exposure
+      type: group
+      description: Verified exposure alert metadata.
+      fields:
+        - name: finding_count
+          type: long
+          description: Number of newly verified sources represented by this alert.
+        - name: minimum_severity
+          type: keyword
+          description: Minimum severity configured for this connector.
+        - name: maximum_severity
+          type: keyword
+          description: Highest severity represented by this alert.
+        - name: evidence_scope
+          type: keyword
+          description: Verification boundary used before the alert was released.
+        - name: contains_personal_data
+          type: boolean
+          description: Always false for this privacy-minimized feed.

--- a/packages/leakdata/data_stream/exposure/manifest.yml
+++ b/packages/leakdata/data_stream/exposure/manifest.yml
@@ -1,0 +1,56 @@
+title: "LeakData verified exposure alerts"
+type: logs
+streams:
+  - input: cel
+    title: "LeakData alerts via CEL"
+    description: |-
+      Polls the dedicated LeakData Elastic Security feed. LeakData emits only
+      verified, privacy-minimized alerts for exact email addresses whose
+      ownership remains verified at delivery time.
+    template_path: cel.yml.hbs
+    vars:
+      - name: url
+        type: url
+        title: LeakData URL
+        description: Base URL of the LeakData service. Keep the default for production.
+        default: "https://leakdata.io"
+        required: true
+        show_user: true
+      - name: token
+        type: password
+        title: Connector token
+        description: One-time token generated in the LeakData dashboard. Store it as a Fleet secret.
+        required: true
+        show_user: true
+        secret: true
+      - name: interval
+        type: text
+        title: Poll interval
+        description: How often Elastic Agent polls for newly verified alerts.
+        default: 5m
+        required: true
+        show_user: true
+      - name: batch_size
+        type: integer
+        title: Batch size
+        description: Number of alerts requested per page. LeakData allows 1 to 100.
+        default: 100
+        required: true
+        show_user: false
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        default:
+          - forwarded
+          - leakdata
+          - verified-exposure
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Optional Elastic Agent processors. They execute after LeakData has
+          applied its verified-email and privacy boundaries.

--- a/packages/leakdata/data_stream/exposure/sample_event.json
+++ b/packages/leakdata/data_stream/exposure/sample_event.json
@@ -1,0 +1,92 @@
+{
+    "@timestamp": "2026-08-14T10:00:00.000Z",
+    "agent": {
+        "ephemeral_id": "11111111-1111-4111-8111-111111111111",
+        "id": "22222222-2222-4222-8222-222222222222",
+        "name": "elastic-agent-example",
+        "type": "filebeat",
+        "version": "9.3.1"
+    },
+    "cloud": {
+        "account": {
+            "id": "33333333-3333-4333-8333-333333333333"
+        },
+        "availability_zone": "",
+        "instance": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "example-runner"
+        },
+        "machine": {
+            "type": "Standard_D4ads_v5"
+        },
+        "provider": "azure",
+        "region": "westus",
+        "service": {
+            "name": "Virtual Machines"
+        }
+    },
+    "data_stream": {
+        "dataset": "leakdata.exposure",
+        "namespace": "default",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "9.4.0"
+    },
+    "elastic_agent": {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "snapshot": false,
+        "version": "9.3.1"
+    },
+    "event": {
+        "action": "verified-exposure-detected",
+        "agent_id_status": "verified",
+        "category": [
+            "threat"
+        ],
+        "created": "2026-08-14T10:00:00.000Z",
+        "dataset": "leakdata.exposure",
+        "id": "leakdata-synthetic-page-1",
+        "ingested": "2026-08-14T10:00:01Z",
+        "kind": "alert",
+        "module": "leakdata",
+        "risk_score": 90,
+        "risk_score_norm": 90,
+        "severity": 90,
+        "type": [
+            "indicator"
+        ]
+    },
+    "input": {
+        "type": "cel"
+    },
+    "leakdata": {
+        "exposure": {
+            "contains_personal_data": false,
+            "evidence_scope": "verified_source_and_verified_email_ownership",
+            "finding_count": 2,
+            "maximum_severity": "critical",
+            "minimum_severity": "high"
+        }
+    },
+    "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+    "observer": {
+        "product": "Exposure Monitoring",
+        "type": "saas",
+        "vendor": "LeakData"
+    },
+    "rule": {
+        "category": "Data Exposure",
+        "id": "leakdata-verified-exposure-v1",
+        "name": "Verified identity exposure",
+        "ruleset": "LeakData verified exposure policy",
+        "version": "1"
+    },
+    "tags": [
+        "forwarded",
+        "leakdata",
+        "secops",
+        "verified-exposure",
+        "privacy-minimized"
+    ]
+}

--- a/packages/leakdata/docs/README.md
+++ b/packages/leakdata/docs/README.md
@@ -1,0 +1,152 @@
+# LeakData Exposure Monitoring integration
+
+Bring verified breach-exposure alerts into Elastic Security without copying the underlying personal data into your SIEM. Elastic Agent collects alerts from LeakData and maps them to Elastic Common Schema (ECS).
+
+Each alert provides a severity, a finding count, an event ID and timestamps. Use these signals to prioritize an investigation in LeakData alongside your other security telemetry. An exposure alert does not establish that an account has been compromised.
+
+## Requirements
+
+- Elastic Stack 9.3.1 or later within the supported 9.x range, with Fleet and Elastic Agent.
+- An active LeakData account with SIEM integration access.
+- A personal-email monitor with confirmed ownership and monitoring enabled.
+
+Your LeakData plan and Elastic deployment requirements apply separately. [Explore LeakData](https://leakdata.io/integrations/elastic-security) or [view plans](https://leakdata.io/pricing).
+
+## Data and verification boundary
+
+LeakData releases an alert only when an active personal-email monitor still has exact ownership verification, every represented source remains verified at the configured `high` or `critical` threshold, and the account still has the SIEM integration entitlement.
+
+The feed does not include an email address, monitor identifier, breach/source name, source URL, credential, password, exposed value, raw record, or `event.original`.
+
+## Setup
+
+1. In the LeakData dashboard, create an Elastic Security connector and choose the exposure threshold you want to monitor.
+2. Copy the connector token when it is shown. You will use it to connect Elastic Agent.
+3. Add this integration to a Fleet agent policy. Keep the default LeakData URL and paste the token into **Connector token**. Fleet stores this setting as a secret.
+4. Leave the poll interval at five minutes, or adjust it to suit your workflow. Keep the `forwarded` tag; you can add your own tags.
+5. After LeakData detects a new eligible exposure, use Discover to check `logs-leakdata.exposure-*` for the alert.
+
+An empty feed can be expected when there are no new eligible alerts. Check that the monitor is active, its email ownership remains verified and your account still has SIEM integration access before investigating the connection.
+
+## Logs reference
+
+### exposure
+
+An example event for `exposure` looks as following:
+
+```json
+{
+    "@timestamp": "2026-08-14T10:00:00.000Z",
+    "agent": {
+        "ephemeral_id": "11111111-1111-4111-8111-111111111111",
+        "id": "22222222-2222-4222-8222-222222222222",
+        "name": "elastic-agent-example",
+        "type": "filebeat",
+        "version": "9.3.1"
+    },
+    "cloud": {
+        "account": {
+            "id": "33333333-3333-4333-8333-333333333333"
+        },
+        "availability_zone": "",
+        "instance": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "example-runner"
+        },
+        "machine": {
+            "type": "Standard_D4ads_v5"
+        },
+        "provider": "azure",
+        "region": "westus",
+        "service": {
+            "name": "Virtual Machines"
+        }
+    },
+    "data_stream": {
+        "dataset": "leakdata.exposure",
+        "namespace": "default",
+        "type": "logs"
+    },
+    "ecs": {
+        "version": "9.4.0"
+    },
+    "elastic_agent": {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "snapshot": false,
+        "version": "9.3.1"
+    },
+    "event": {
+        "action": "verified-exposure-detected",
+        "agent_id_status": "verified",
+        "category": [
+            "threat"
+        ],
+        "created": "2026-08-14T10:00:00.000Z",
+        "dataset": "leakdata.exposure",
+        "id": "leakdata-synthetic-page-1",
+        "ingested": "2026-08-14T10:00:01Z",
+        "kind": "alert",
+        "module": "leakdata",
+        "risk_score": 90,
+        "risk_score_norm": 90,
+        "severity": 90,
+        "type": [
+            "indicator"
+        ]
+    },
+    "input": {
+        "type": "cel"
+    },
+    "leakdata": {
+        "exposure": {
+            "contains_personal_data": false,
+            "evidence_scope": "verified_source_and_verified_email_ownership",
+            "finding_count": 2,
+            "maximum_severity": "critical",
+            "minimum_severity": "high"
+        }
+    },
+    "message": "LeakData detected 2 new verified exposure sources at or above the configured threshold. This event contains no monitored identity, source name, credential, exposed value, or raw record.",
+    "observer": {
+        "product": "Exposure Monitoring",
+        "type": "saas",
+        "vendor": "LeakData"
+    },
+    "rule": {
+        "category": "Data Exposure",
+        "id": "leakdata-verified-exposure-v1",
+        "name": "Verified identity exposure",
+        "ruleset": "LeakData verified exposure policy",
+        "version": "1"
+    },
+    "tags": [
+        "forwarded",
+        "leakdata",
+        "secops",
+        "verified-exposure",
+        "privacy-minimized"
+    ]
+}
+```
+
+**Exported fields**
+
+| Field | Description | Type |
+|---|---|---|
+| @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
+| data_stream.dataset | The field can contain anything that makes sense to signify the source of the data. Examples include `nginx.access`, `prometheus`, `endpoint` etc. For data streams that otherwise fit, but that do not have dataset set we use the value "generic" for the dataset value. `event.dataset` should have the same value as `data_stream.dataset`. Beyond the Elasticsearch data stream naming criteria noted above, the `dataset` value has additional restrictions:   \* Must not contain `-`   \* No longer than 100 characters | constant_keyword |
+| data_stream.namespace | A user defined namespace. Namespaces are useful to allow grouping of data. Many users already organize their indices this way, and the data stream naming scheme now provides this best practice as a default. Many users will populate this field with `default`. If no value is used, it falls back to `default`. Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:   \* Must not contain `-`   \* No longer than 100 characters | constant_keyword |
+| data_stream.type | An overarching type for the data stream. Currently allowed values are "logs" and "metrics". We expect to also add "traces" and "synthetics" in the near future. | constant_keyword |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | constant_keyword |
+| event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | constant_keyword |
+| input.type | Type of Elastic Agent input that collected the event. | keyword |
+| leakdata.exposure.contains_personal_data | Always false for this privacy-minimized feed. | boolean |
+| leakdata.exposure.evidence_scope | Verification boundary used before the alert was released. | keyword |
+| leakdata.exposure.finding_count | Number of newly verified sources represented by this alert. | long |
+| leakdata.exposure.maximum_severity | Highest severity represented by this alert. | keyword |
+| leakdata.exposure.minimum_severity | Minimum severity configured for this connector. | keyword |
+
+
+Version `0.1.0` is a submission candidate and is not represented as Elastic-reviewed or published.
+
+For setup and account questions, contact [support@leakdata.io](mailto:support@leakdata.io). Report security issues privately to [security@leakdata.io](mailto:security@leakdata.io).

--- a/packages/leakdata/img/leakdata-logo.svg
+++ b/packages/leakdata/img/leakdata-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">LeakData</title>
+  <rect width="64" height="64" rx="12" fill="#fff7f2"/>
+  <g fill="#e85d1f" transform="translate(10 6) scale(1.45)">
+    <path d="M16 3c2 5 7 7 11 8-3 2-5 4-6 7 4-2 8-2 11 0-4 1-7 4-9 8-2 4-5 7-10 9 2-4 2-8 0-11-2-4-2-8 3-13 1-2 1-5 0-8Z"/>
+    <path d="M13 12c-4 0-8-2-11-5 1 6 4 10 9 13l2-8Zm4 14c-4 1-8 4-10 8 5 0 9-2 12-5l-2-3Z" opacity=".9"/>
+  </g>
+</svg>

--- a/packages/leakdata/manifest.yml
+++ b/packages/leakdata/manifest.yml
@@ -1,0 +1,32 @@
+format_version: 3.5.8
+name: leakdata
+title: "LeakData Exposure Monitoring"
+version: "0.1.0"
+source:
+  license: "Elastic-2.0"
+description: "Collect privacy-minimized, verified exposure alerts from LeakData with Elastic Agent."
+type: integration
+categories:
+  - custom
+  - security
+conditions:
+  kibana:
+    version: "^9.3.1"
+  elastic:
+    subscription: "basic"
+icons:
+  - src: /img/leakdata-logo.svg
+    title: LeakData logo
+    size: 64x64
+    type: image/svg+xml
+policy_templates:
+  - name: leakdata
+    title: LeakData verified exposure alerts
+    description: Collect privacy-minimized verified exposure alerts from the LeakData API.
+    inputs:
+      - type: cel
+        title: Collect LeakData alerts via API
+        description: Polls a dedicated LeakData feed with a one-time connector token.
+owner:
+  github: uzmanwebmaster
+  type: community


### PR DESCRIPTION
## Proposed commit message

Add a community integration that brings LeakData's verified breach-exposure alerts into Elastic Security through the CEL input. Each alert includes a severity, finding count, opaque event ID and ECS classification. The source feed excludes monitored identities, breach names, credentials and raw records, and rechecks account access and exact email ownership before delivery.

The package uses a Fleet secret for bearer authentication and persists an opaque pagination cursor. Its ingest pipeline preserves customer tags, normalizes Agent metadata safely and retains the original details of feed failures. The package includes a logo, an English setup guide, field mappings and synthetic tests for normal events, existing Agent metadata, feed errors, policy rendering and a two-page HTTP feed.

## Checklist

- [x] I have reviewed the integration-building tips and aligned the package with them.
- [x] The exposure data stream collects logs.
- [x] The package includes an initial 0.1.0 changelog entry.
- [x] Version constraints cover the tested Elastic 9.3.1 minimum and current 9.5.3 release.
- [x] No Kibana dashboards are included in this initial package; dashboard-specific checks are not applicable.

## Author's checklist

- [x] The changelog links to this upstream pull request.
- [x] The sample was generated by the system test; ephemeral runner identifiers were anonymized and the resulting package passed check/build/static validation.
- [x] Community ownership review is requested below; CODEOWNERS uses the repository's existing integrations-triaging team for new packages.

## How to test this PR locally

From `packages/leakdata`, use elastic-package 0.126.4:

```sh
elastic-package check
elastic-package test static
elastic-package stack up -d --version 9.3.1
elastic-package test pipeline
elastic-package test script
elastic-package test policy
elastic-package test asset
elastic-package test system
elastic-package stack down
```

The same checks are run on Elastic 9.5.3. The system fixture serves two synthetic pages, validates the bearer header and cursor, and expects exactly two indexed events. It then returns an empty feed. The error-path script asserts that an access failure remains an error with its original details rather than becoming an exposure alert.

For a live connection, users need LeakData SIEM integration access and an active personal-email monitor with confirmed ownership. The synthetic suite exercises Elastic Agent and the package; it does not represent delivery from a live customer account.

Validation passed on both Elastic 9.3.1 and 9.5.3 using elastic-package 0.126.4: check/build, static, two ingest scenarios and pipeline-warning checks, intentional-error script, Fleet policy, installed assets, and the two-page system test. [Complete CI evidence](https://github.com/leakdatahq/leakdata-elastic-integration/actions/runs/34377828952).

The same package also passes 17 checks in the LeakData application repository. The public package is a development preview while this integration is reviewed.

Please review the community ownership entry and advise whether a different CODEOWNERS team is preferred. The contributor agreement was signed via DocuSign on 10 September 2026 for `uzmanwebmaster`. The CLA check passed on 10 September 2026.
