### PR TITLE
[doppel] Add API V2 support with OAuth 2.0 client credentials

### DIFF
--- a/packages/doppel/_dev/build/docs/README.md
+++ b/packages/doppel/_dev/build/docs/README.md
@@ -4,10 +4,10 @@
 The Doppel integration for Elastic enables the automated collection of security alerts directly from the Doppel API. By ingesting these alerts into the Elastic Common Schema (ECS), security teams can centralize their threat monitoring, perform cross-source correlation, and visualize Doppel data within Kibana dashboards.
 
 ### Compatibility
-This integration is compatible with the Doppel API v1 and Elastic Stack version 8.12.0 or higher.
+This integration is compatible with the Doppel API v1 and v2. Refer to the version constraints shown in Kibana for the Elastic Stack versions this release supports.
 
 ### How it works
-This integration uses the `httpjson` input to periodically poll the Doppel `/v1/alerts` endpoint. It uses a cursor-based polling mechanism (stateful) to ensure that only new or updated alerts are ingested, minimizing API overhead and preventing data gaps.
+This integration uses the `cel` input to periodically poll the Doppel alerts endpoint. It uses a cursor-based polling mechanism (stateful) to ensure that only new or updated alerts are ingested, minimizing API overhead and preventing data gaps.
 
 ## What data does this integration collect?
 The Doppel integration collects security alerts, including:
@@ -23,9 +23,17 @@ All data is mapped to the [Elastic Common Schema (ECS)](https://www.elastic.co/g
 * **Historical Analysis:** Trend Doppel alert severity and volume over time to identify persistent threat patterns.
 
 ## What do I need to use this integration?
-To use this integration, you will need:
+This integration supports two versions of the Doppel API. Choose one with the **API Version** setting:
+
+**V1 (API Key)** — the default. You will need:
 * A valid Doppel **API Key**.
-* An optional **Organization Code** (if required by your Doppel instance).
+* An optional **User API Key**.
+* An optional **Organization Code** (if your user belongs to more than one organization).
+
+**V2 (OAuth 2.0)** — client credentials. You will need:
+* An **OAuth Client ID** and **Client Secret** issued by Doppel.
+
+With V2 the integration requests an access token from Doppel and sends it as a bearer token on every request. The organization is taken from the token, so the User API Key and Organization Code do not apply. Contact Doppel to have OAuth credentials issued for your organization.
 
 ## How do I deploy this integration?
 
@@ -35,12 +43,12 @@ Elastic Agent must be installed on a host with outbound internet access to reach
 The agent will act as a centralized poller, fetching data from the API and shipping it to your Elastic cluster.
 
 ### Agentless deployment
-This integration supports **Agentless (BETA)** deployment in Elastic Cloud environments. When using Agentless mode, Elastic manages the polling infrastructure for you, eliminating the need to install or maintain a local Elastic Agent.
+This integration supports **Agentless** deployment in Elastic Cloud environments. When using Agentless mode, Elastic manages the polling infrastructure for you, eliminating the need to install or maintain a local Elastic Agent.
 
 ## Onboard / configure
 1. Navigate to **Management > Integrations** in Kibana.
 2. Search for **Doppel** and click **Add Doppel**.
-3. Enter your **API Key** and configure the **Polling Interval**.
+3. Select the **API Version**, then enter the credentials it requires — the **API Key** for V1, or the **Client ID** and **Client Secret** for V2 — and configure the **Polling Interval**.
 4. Choose your deployment mode (Agent-based or Agentless).
 5. Save the integration to begin ingesting data.
 

--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -9,7 +9,6 @@
     - description: Correct the README's input name, stack version claim, and agentless release stage.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/21159
-
 - version: "1.1.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -2,13 +2,13 @@
   changes:
     - description: Add support for Doppel API V2 using OAuth 2.0 client credentials.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/21100
+      link: https://github.com/elastic/integrations/pull/21159
     - description: Map the alert summary field to `doppel.alert_summary`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/21100
+      link: https://github.com/elastic/integrations/pull/21159
     - description: Correct the README's input name, stack version claim, and agentless release stage.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/21100
+      link: https://github.com/elastic/integrations/pull/21159
 
 - version: "1.1.0"
   changes:

--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -1,3 +1,15 @@
+- version: "1.2.0"
+  changes:
+    - description: Add support for Doppel API V2 using OAuth 2.0 client credentials.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/21100
+    - description: Map the alert summary field to `doppel.alert_summary`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/21100
+    - description: Correct the README's input name, stack version claim, and agentless release stage.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/21100
+
 - version: "1.1.0"
   changes:
     - description: Add tags to ingest pipeline processors.

--- a/packages/doppel/data_stream/alerts/_dev/deploy/docker/files/config.yml
+++ b/packages/doppel/data_stream/alerts/_dev/deploy/docker/files/config.yml
@@ -8,7 +8,9 @@ rules:
     request_headers:
       X-Api-Key:
         - "test-api-key"
-    responses:
+      x-doppel-client:
+        - "elastic/1.2.0"
+    responses: &alerts_page_0
       - status_code: 200
         headers:
           Content-Type:
@@ -73,7 +75,9 @@ rules:
     request_headers:
       X-Api-Key:
         - "test-api-key"
-    responses:
+      x-doppel-client:
+        - "elastic/1.2.0"
+    responses: &alerts_page_1
       - status_code: 200
         headers:
           Content-Type:
@@ -147,7 +151,9 @@ rules:
     request_headers:
       X-Api-Key:
         - "test-api-key"
-    responses:
+      x-doppel-client:
+        - "elastic/1.2.0"
+    responses: &alerts_overshoot
       - status_code: 200
         headers:
           Content-Type:
@@ -184,3 +190,54 @@ rules:
               "total_pages": 2
             }
           }
+
+  # --- API V2: OAuth 2.0 client credentials ---
+  # Filebeat's CEL input mints the token itself (form-encoded), then sends it as a
+  # bearer token on every alerts request. The alert payloads are identical to V1,
+  # so the V2 rules alias the response blocks defined above.
+  - path: /oauth/token
+    methods: ['POST']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        body: |-
+          {
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 86400
+          }
+  - path: /v2/alerts
+    methods: ['GET']
+    query_params:
+      page: "0"
+      page_size: "1"
+    request_headers:
+      Authorization:
+        - "Bearer test-access-token"
+      x-doppel-client:
+        - "elastic/1.2.0"
+    responses: *alerts_page_0
+  - path: /v2/alerts
+    methods: ['GET']
+    query_params:
+      page: "1"
+      page_size: "1"
+    request_headers:
+      Authorization:
+        - "Bearer test-access-token"
+      x-doppel-client:
+        - "elastic/1.2.0"
+    responses: *alerts_page_1
+  - path: /v2/alerts
+    methods: ['GET']
+    query_params:
+      page: "2"
+      page_size: "1"
+    request_headers:
+      Authorization:
+        - "Bearer test-access-token"
+      x-doppel-client:
+        - "elastic/1.2.0"
+    responses: *alerts_overshoot

--- a/packages/doppel/data_stream/alerts/_dev/test/pipeline/test-alerts.json
+++ b/packages/doppel/data_stream/alerts/_dev/test/pipeline/test-alerts.json
@@ -11,6 +11,7 @@
             "platform": "domains",
             "source": "API Upload",
             "notes": null,
+            "alert_summary": "Lookalike domain impersonating the brand's login page; registered 2 days ago.",
             "created_at": "2026-04-23T08:35:59.681856",
             "screenshot_url": null,
             "last_activity_timestamp": "2026-04-23T08:38:58.572317",

--- a/packages/doppel/data_stream/alerts/_dev/test/pipeline/test-alerts.json-expected.json
+++ b/packages/doppel/data_stream/alerts/_dev/test/pipeline/test-alerts.json-expected.json
@@ -3,6 +3,7 @@
         {
             "@timestamp": "2026-04-23T08:38:58.572Z",
             "doppel": {
+                "alert_summary": "Lookalike domain impersonating the brand's login page; registered 2 days ago.",
                 "alert_updated_at": "2026-04-23T08:38:58.572Z",
                 "entity_state": "down",
                 "platform": "domains",

--- a/packages/doppel/data_stream/alerts/_dev/test/system/test-oauth-config.yml
+++ b/packages/doppel/data_stream/alerts/_dev/test/system/test-oauth-config.yml
@@ -3,8 +3,10 @@ service: doppel-mock
 data_stream:
   vars:
     url: http://{{Hostname}}:{{Port}}
-    api_version: v1
-    api_key: test-api-key
+    api_version: v2
+    client_id: test-client-id
+    client_secret: test-client-secret
+    token_url: http://{{Hostname}}:{{Port}}/oauth/token
     page_size: 1
     initial_interval: 720h
     interval: 10s

--- a/packages/doppel/data_stream/alerts/agent/stream/stream.yml.hbs
+++ b/packages/doppel/data_stream/alerts/agent/stream/stream.yml.hbs
@@ -5,7 +5,26 @@ resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"
   maxbackups: 5
+{{! Fleet's handlebars has no `eq`; `contains` compares strings and is the only
+    equality test available. Its else branch is never rendered, so each API version
+    gets its own block. }}
+{{#contains "v2" api_version}}
+auth.oauth2:
+  client.id: {{client_id}}
+  client.secret: {{client_secret}}
+  token_url: {{token_url}}
+  endpoint_params:
+    grant_type:
+      - client_credentials
+    audience:
+      - doppel-external
+{{/contains}}
 state:
+{{#contains "v2" api_version}}
+  alerts_path: /v2/alerts
+{{/contains}}
+{{#contains "v1" api_version}}
+  alerts_path: /v1/alerts
   api_key: {{api_key}}
 {{#if x_user_api_key}}
   x_user_api_key: {{x_user_api_key}}
@@ -13,8 +32,12 @@ state:
 {{#if organization_code}}
   organization_code: {{organization_code}}
 {{/if}}
+{{/contains}}
   initial_interval: {{initial_interval}}
   page_size: {{page_size}}
+  # Usage attribution only; never affects request handling. Bump on every release,
+  # the package version is not readable from the CEL program.
+  client_attribution: elastic/1.2.0
 redact:
   fields:
     - api_key
@@ -38,14 +61,21 @@ program: |
     state.with(
       request(
         "GET",
-        state.url.trim_right("/") + "/v1/alerts?" + {
+        state.url.trim_right("/") + state.alerts_path + "?" + {
           "page": [string(int(state.page))],
           "page_size": [string(int(state.page_size))],
           "last_activity_timestamp": [state.last_activity_ts],
         }.format_query()
       ).with({
         "Header": {
-          "X-Api-Key": [state.api_key],
+          // Set explicitly rather than relying on the input's default User-Agent:
+          // that default is not applied when auth.oauth2 is enabled before stack
+          // 9.3.0. See https://github.com/elastic/beats/issues/50867.
+          "User-Agent": ["doppel-" + state.client_attribution],
+          "x-doppel-client": [state.client_attribution],
+          // V2 sends an OAuth bearer token, attached by the input, and takes the
+          // organisation from that token; the V1 headers are absent from state.
+          ?"X-Api-Key": state.?api_key.optMap(v, [v]),
           ?"X-User-Api-Key": state.?x_user_api_key.optMap(v, [v]),
           ?"X-Organization-Code": state.?organization_code.optMap(v, [v]),
         }
@@ -65,7 +95,7 @@ program: |
             "error": {
               "code": string(resp.StatusCode),
               "id": string(resp.Status),
-              "message": "GET " + state.url.trim_right("/") + "/v1/alerts: " + (
+              "message": "GET " + state.url.trim_right("/") + state.alerts_path + ": " + (
                 size(resp.Body) != 0 ?
                   string(resp.Body)
                 :

--- a/packages/doppel/data_stream/alerts/agent/stream/stream.yml.hbs
+++ b/packages/doppel/data_stream/alerts/agent/stream/stream.yml.hbs
@@ -35,9 +35,11 @@ state:
 {{/contains}}
   initial_interval: {{initial_interval}}
   page_size: {{page_size}}
-  # Usage attribution only; never affects request handling. Bump on every release,
-  # the package version is not readable from the CEL program.
-  client_attribution: elastic/1.2.0
+  # Usage attribution only; never affects request handling. `_meta.package.version` is
+  # populated from Kibana 9.4.0 onwards; the literal is the fallback for the older stacks
+  # this package still supports, and can be dropped along with the conditional once 9.4.0
+  # is the lowest supported Kibana version.
+  client_attribution: elastic/{{#if _meta.package.version}}{{_meta.package.version}}{{else}}1.2.0{{/if}}
 redact:
   fields:
     - api_key

--- a/packages/doppel/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/doppel/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -110,6 +110,13 @@ processors:
       copy_from: notes
       ignore_failure: true
       ignore_empty_value: true
+  - set:
+      tag: set_doppel_alert_summary_4c1de8b7
+      if: ctx.alert_summary != null
+      field: doppel.alert_summary
+      copy_from: alert_summary
+      ignore_failure: true
+      ignore_empty_value: true
 
   # --- MAPPING DIRECTLY 
   - set:
@@ -494,6 +501,7 @@ processors:
         - platform
         - source
         - notes
+        - alert_summary
         - screenshot_url
         - score
         - assignee

--- a/packages/doppel/data_stream/alerts/fields/fields.yml
+++ b/packages/doppel/data_stream/alerts/fields/fields.yml
@@ -25,6 +25,9 @@
     - name: notes
       type: text
       description: Internal notes, comments, or analyst observations added to the alert.
+    - name: alert_summary
+      type: text
+      description: AI-generated summary of the alert.
     - name: tags
       type: keyword
       description: Custom tags associated with the alert for categorization.

--- a/packages/doppel/data_stream/alerts/manifest.yml
+++ b/packages/doppel/data_stream/alerts/manifest.yml
@@ -4,6 +4,16 @@ streams:
   - input: cel
     title: Doppel API Poller
     description: Periodically polls the Doppel API for new alerts.
+    required_vars:
+      api_key_auth:
+        - name: api_version
+          value: v1
+        - name: api_key
+      oauth_auth:
+        - name: api_version
+          value: v2
+        - name: client_id
+        - name: client_secret
     vars:
       - name: url
         type: text
@@ -12,25 +22,60 @@ streams:
         required: true
         show_user: true
         default: https://api.doppel.com
+      - name: api_version
+        type: select
+        title: API Version
+        description: >-
+          Doppel API version to poll. V1 authenticates with an API key. V2 uses OAuth 2.0
+          client credentials and takes the organisation from the access token, so the
+          User API Key and Organization Code below do not apply to it.
+        required: false
+        show_user: true
+        default: v1
+        options:
+          - value: v1
+            text: V1 (API Key)
+          - value: v2
+            text: V2 (OAuth 2.0)
       - name: api_key
         type: password
         title: Doppel API Key
-        description: Doppel API Key for authentication.
-        required: true
+        description: Doppel API Key for authentication. Required for API version V1.
+        required: false
         secret: true
       - name: x_user_api_key
         type: password
         title: Doppel User API Key
-        description: Doppel User API Key for authentication.
+        description: Doppel User API Key for authentication. API version V1 only.
         show_user: true
         required: false
         secret: true
       - name: organization_code
         type: text
         title: Organization Code
-        description: Organisation code for authentication if the user is part of multiple organisations.
+        description: Organisation code for authentication if the user is part of multiple organisations. API version V1 only.
         show_user: true
         required: false
+      - name: client_id
+        type: text
+        title: OAuth Client ID
+        description: OAuth 2.0 client ID issued by Doppel. Required for API version V2.
+        show_user: true
+        required: false
+      - name: client_secret
+        type: password
+        title: OAuth Client Secret
+        description: OAuth 2.0 client secret issued by Doppel. Required for API version V2.
+        show_user: true
+        required: false
+        secret: true
+      - name: token_url
+        type: text
+        title: OAuth Token URL
+        description: Endpoint that issues the OAuth 2.0 access token. Change this only if the Doppel API URL was changed. API version V2 only.
+        show_user: false
+        required: false
+        default: https://api.doppel.com/oauth/token
       - name: initial_interval
         type: text
         title: Initial Interval

--- a/packages/doppel/docs/README.md
+++ b/packages/doppel/docs/README.md
@@ -4,10 +4,10 @@
 The Doppel integration for Elastic enables the automated collection of security alerts directly from the Doppel API. By ingesting these alerts into the Elastic Common Schema (ECS), security teams can centralize their threat monitoring, perform cross-source correlation, and visualize Doppel data within Kibana dashboards.
 
 ### Compatibility
-This integration is compatible with the Doppel API v1 and Elastic Stack version 8.12.0 or higher.
+This integration is compatible with the Doppel API v1 and v2. Refer to the version constraints shown in Kibana for the Elastic Stack versions this release supports.
 
 ### How it works
-This integration uses the `httpjson` input to periodically poll the Doppel `/v1/alerts` endpoint. It uses a cursor-based polling mechanism (stateful) to ensure that only new or updated alerts are ingested, minimizing API overhead and preventing data gaps.
+This integration uses the `cel` input to periodically poll the Doppel alerts endpoint. It uses a cursor-based polling mechanism (stateful) to ensure that only new or updated alerts are ingested, minimizing API overhead and preventing data gaps.
 
 ## What data does this integration collect?
 The Doppel integration collects security alerts, including:
@@ -23,9 +23,17 @@ All data is mapped to the [Elastic Common Schema (ECS)](https://www.elastic.co/g
 * **Historical Analysis:** Trend Doppel alert severity and volume over time to identify persistent threat patterns.
 
 ## What do I need to use this integration?
-To use this integration, you will need:
+This integration supports two versions of the Doppel API. Choose one with the **API Version** setting:
+
+**V1 (API Key)** — the default. You will need:
 * A valid Doppel **API Key**.
-* An optional **Organization Code** (if required by your Doppel instance).
+* An optional **User API Key**.
+* An optional **Organization Code** (if your user belongs to more than one organization).
+
+**V2 (OAuth 2.0)** — client credentials. You will need:
+* An **OAuth Client ID** and **Client Secret** issued by Doppel.
+
+With V2 the integration requests an access token from Doppel and sends it as a bearer token on every request. The organization is taken from the token, so the User API Key and Organization Code do not apply. Contact Doppel to have OAuth credentials issued for your organization.
 
 ## How do I deploy this integration?
 
@@ -35,12 +43,12 @@ Elastic Agent must be installed on a host with outbound internet access to reach
 The agent will act as a centralized poller, fetching data from the API and shipping it to your Elastic cluster.
 
 ### Agentless deployment
-This integration supports **Agentless (BETA)** deployment in Elastic Cloud environments. When using Agentless mode, Elastic manages the polling infrastructure for you, eliminating the need to install or maintain a local Elastic Agent.
+This integration supports **Agentless** deployment in Elastic Cloud environments. When using Agentless mode, Elastic manages the polling infrastructure for you, eliminating the need to install or maintain a local Elastic Agent.
 
 ## Onboard / configure
 1. Navigate to **Management > Integrations** in Kibana.
 2. Search for **Doppel** and click **Add Doppel**.
-3. Enter your **API Key** and configure the **Polling Interval**.
+3. Select the **API Version**, then enter the credentials it requires — the **API Key** for V1, or the **Client ID** and **Client Secret** for V2 — and configure the **Polling Interval**.
 4. Choose your deployment mode (Agent-based or Agentless).
 5. Save the integration to begin ingesting data.
 
@@ -58,6 +66,7 @@ The `alerts` data stream provides security events from the Doppel API.
 | data_stream.dataset | Data stream dataset. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| doppel.alert_summary | AI-generated summary of the alert. | text |
 | doppel.alert_updated_at | The timestamp when the alert was last updated. | date |
 | doppel.app.bundle_id | The unique bundle identifier of the application. | keyword |
 | doppel.app.developer_name | The listed developer name for the rogue application. | keyword |

--- a/packages/doppel/manifest.yml
+++ b/packages/doppel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: doppel
 title: "Doppel"
-version: 1.1.0
+version: 1.2.0
 description: "Collects Doppel alerts and sends them to Elastic"
 type: integration
 source:


### PR DESCRIPTION
## What does this PR do?

Adds support for the Doppel API **V2**, which authenticates with OAuth 2.0 client credentials, alongside the existing V1 API-key auth. A new **API Version** setting selects between them and defaults to `v1`, so existing policies are unaffected.

V2 uses the CEL input's native `auth.oauth2` client-credentials support rather than minting tokens in the program: Doppel's token endpoint is rate limited to a few mints per hour per client, and the input's in-memory token cache keeps this to roughly one mint per 24h. In V2 the organization comes from the access token, so the User API Key and Organization Code do not apply.

Also included:
- **Attribution headers** (`x-doppel-client`, `User-Agent`) on every request. These are set inside the CEL program rather than relying on the input default, because that default is not applied when `auth.oauth2` is enabled before Stack 9.3.0 (elastic/beats#50867).
- **`alert_summary` mapping.** The API returns an AI-generated summary that the pipeline dropped; it now maps to `doppel.alert_summary`.
- **README corrections**: the integration uses the `cel` input (the doc said `httpjson`), the stack-version claim no longer contradicts the manifest, and agentless is no longer labelled BETA since #20421 set it to GA.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/documentation_guidelines.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/integrations/blob/main/docs/generic_guidelines.md#kibana-version-constraints).

## How to test this PR locally

`elastic-package lint`, `build`, `check`, `test pipeline`, and `test system` all pass. The system tests cover both auth paths — `default` (V1 API key) and `oauth` (V2) — against the bundled mock, which now serves `/oauth/token` and `/v2/alerts` and asserts the attribution header on every alerts request.

```
elastic-package test pipeline
elastic-package test system
```

## Related issues

Adds support for Doppel's V2 API, which mirrors the OAuth support recently added to Doppel's other integrations.
