### PR TITLE
aws.cloudtrail: widen ARN partition grok pattern to include aws-cn and aws-iso* (7.1.x)

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "7.1.3"
+  changes:
+    - description: Fix the CloudTrail ingest pipeline failing to extract the session name from `aws.cloudtrail.user_identity.arn` on aws-cn and aws-iso* partitions. The grok pattern `arn:(aws|aws-us-gov)` did not match those partition strings; it is widened to `arn:[a-z0-9-]+`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21161
 - version: "7.1.2"
   changes:
     - description: Add an `Instance or Pod IAM Role` option to the `Setup Access` selector so Elastic Agent can authenticate with the AWS SDK default credential chain (EC2 instance profile, EKS Pod Identity or IRSA) without entering access keys or a Role ARN. Since 7.0.0 every option required at least one credential field, which made this documented path impossible to save.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix the CloudTrail ingest pipeline failing to extract the session name from `aws.cloudtrail.user_identity.arn` on aws-cn and aws-iso* partitions. The grok pattern `arn:(aws|aws-us-gov)` did not match those partition strings; it is widened to `arn:[a-z0-9-]+`.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/21161
+      link: https://github.com/elastic/integrations/pull/21160
 - version: "7.1.2"
   changes:
     - description: Add an `Instance or Pod IAM Role` option to the `Setup Access` selector so Elastic Agent can authenticate with the AWS SDK default credential chain (EC2 instance profile, EKS Pod Identity or IRSA) without entering access keys or a Role ARN. Since 7.0.0 every option required at least one credential field, which made this documented path impossible to save.

--- a/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
@@ -1093,7 +1093,7 @@ processors:
   - grok:
       field: aws.cloudtrail.user_identity.arn
       patterns:
-        - "arn:(aws|aws-us-gov):sts:.*/%{GREEDYDATA:_tmp.session_name}$"
+        - "arn:[a-z0-9-]+:sts:.*/%{GREEDYDATA:_tmp.session_name}$"
       ignore_missing: true
       if: (ctx.aws?.cloudtrail?.user_identity?.type == 'AssumedRole' || ctx.aws?.cloudtrail?.user_identity?.type == 'FederatedUser') && ctx.aws?.cloudtrail?.user_identity?.arn != null
       tag: extract_session_name_from_arn

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.1
 name: aws
 title: AWS
-version: 7.1.2
+version: 7.1.3
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Backport of the `arn:(aws|aws-us-gov)` → `arn:[a-z0-9-]+` change from #20403 to the 7.1.x line.

The grok processor that extracts the session name from `aws.cloudtrail.user_identity.arn` matched only `arn:aws:…` and `arn:aws-us-gov:…` partitions. Identities from `aws-cn` and `aws-iso*` partitions were silently ignored, leaving `user.changes.name` unpopulated.

Widening the character class to `[a-z0-9-]` covers all current and future AWS partition strings.
