### PR TITLE
macos: add darwin platform condition to unifiedlogs inputs

### DIFF
--- a/packages/macos/changelog.yml
+++ b/packages/macos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Add darwin platform condition to all unifiedlogs data stream inputs to prevent failures on non-macOS agents in mixed policies.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21181
 - version: "1.0.1"
   changes:
     - description: Transfer package ownership to elastic/security-service-integrations.

--- a/packages/macos/data_stream/advanced_monitoring/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/advanced_monitoring/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/data_stream/authentication/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/authentication/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/data_stream/file_read_write/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/file_read_write/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/data_stream/network_activity/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/network_activity/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/data_stream/process_execution_monitoring/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/process_execution_monitoring/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/data_stream/system_change/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/system_change/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/data_stream/user_and_account_management/agent/stream/unifiedlogs.yml.hbs
+++ b/packages/macos/data_stream/user_and_account_management/agent/stream/unifiedlogs.yml.hbs
@@ -1,3 +1,4 @@
+condition: ${host.platform} == 'darwin'
 predicate:
 {{#each predicate as |p|}}
 - {{p}}

--- a/packages/macos/manifest.yml
+++ b/packages/macos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: macos
 title: macOS Security Events
-version: 1.0.1
+version: 1.0.2
 description: Collect logs from macOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
macos: add darwin platform condition to unifiedlogs inputs

Without a condition guard, non-macOS agents in a mixed policy attempt
to start the unifiedlogs input and fail with "No such input type
exist: 'unifiedlogs'", causing them to report Unhealthy.

Add condition: ${host.platform} == 'darwin' to all seven data stream
stream templates, matching the guard already present in the Custom
macOS Unified Logs (unifiedlogs) package.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
