### PR TITLE
beyondinsight_password_safe: fix Cookie header and add session sign-out

### DIFF
--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,3 +1,14 @@
+- version: "1.4.1"
+  changes:
+    - description: Fix Cookie request header construction. Raw Set-Cookie response values (including path, HttpOnly, and SameSite attributes) were stored in the cursor and replayed verbatim, causing attributes to be sent as bogus cookie pairs and multiple Cookie header lines to be emitted. RFC 6265 §5.4 forbids multiple Cookie header lines; ASP.NET commonly reads only the first. Attributes are now stripped and all cookies joined into a single header value.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21183
+    - description: Call POST /Auth/Signout at the end of each poll cycle to release the server-side session, as required by the BeyondInsight API documentation. The integration previously never called Signout, leaving sessions open on the server indefinitely.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21183
+    - description: Clear the session cookie from the cursor after each completed poll cycle. The cookie was previously retained across polls, causing the next cycle to open with a stale cookie that had already been invalidated by the sign-out.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/21183
 - version: "1.4.0"
   changes:
     - description: Add tags to ingest pipeline processors and add `preserve_original_event` to pipeline-level `on_failure` handlers.

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/deploy/docker/files/config.yml
@@ -1,4 +1,24 @@
 # BeyondInsight API - Workgroups Assets API Mock Configuration
+#
+# Test Scenario: Simulates asset retrieval across multiple workgroups with session
+# expiration and re-authentication, verifying the Cookie header fix and sign-out:
+# 1. Authentication: Sets two Set-Cookie headers with attributes
+# 2. GET /Workgroups with cookie_value1: returns two workgroups
+# 3. GET /Workgroups/1/Assets offset=0 with cookie_value1: returns 1 of 2 assets
+# 4. GET /Workgroups/1/Assets offset=1 with cookie_value1: returns 401 (session expired)
+# 5. Re-authentication: Returns cookie_value2
+# 6. GET /Workgroups/1/Assets offset=1 with cookie_value2: returns second asset;
+#    workgroup 2 queued
+# 7. GET /Workgroups/2/Assets offset=0 with cookie_value2: returns 0 assets;
+#    all workgroups done — triggers sign-out
+# 8. Sign-out to release the server-side session (first execution)
+#
+# Second periodic execution behavior:
+# 9. Authentication: Returns cookie_value2 (req_num=3 for this rule)
+# 10. GET /Workgroups with cookie_value2: returns workgroup 3
+# 11. GET /Workgroups/3/Assets offset=0 with cookie_value2: returns 1 asset;
+#     no more workgroups — triggers sign-out
+# 12. Sign-out to release the server-side session (second execution)
 
 rules:
   # Auth
@@ -11,7 +31,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -33,7 +55,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -45,13 +69,13 @@ rules:
           }
           `}}
 
-  # Get Workgroups
+  # Get Workgroups (first periodic execution)
   - path: "/BeyondTrust/api/public/v3/Workgroups"
     methods: ["GET"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -81,7 +105,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -117,7 +141,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 401
         headers:
@@ -134,7 +158,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -165,13 +189,13 @@ rules:
           Content-Type: ['text/plain']
         body: Program should never request this. {{.request.vars}}
 
-  # Get Assets for Workgroup 2 - no assets
+  # Get Assets for Workgroup 2 - no assets; triggers sign-out.
   - path: "/BeyondTrust/api/public/v3/Workgroups/2/Assets"
     methods: ["GET"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     query_params:
       limit: '1'
       offset: '0'
@@ -193,7 +217,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -209,13 +233,13 @@ rules:
           ]
           `}}
 
-  # Get Assets for Workgroup 3 (second periodic execution)
+  # Get Assets for Workgroup 3 (second periodic execution); triggers sign-out.
   - path: "/BeyondTrust/api/public/v3/Workgroups/3/Assets"
     methods: ["GET"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     query_params:
       limit: '1'
       offset: '0'
@@ -244,3 +268,16 @@ rules:
               "TotalCount": 1
           }
           `}}
+
+  # Sign-out to release the server-side session (called after each terminal request).
+  - path: "/BeyondTrust/api/public/v3/Auth/Signout"
+    methods: ["POST"]
+    request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
+      Content-Type: ['application/json']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ['application/json']
+        body: ""

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-all.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-all.expected
@@ -58,7 +58,8 @@ inputs:
                               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                             ],
                             "Content-Type": ["application/json"],
-                            "Cookie": state.cursor.cookies,
+                            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                           },
                         }
                       ).do_request().as(resp,
@@ -71,21 +72,50 @@ inputs:
                               :
                                 r.remaining_workgroups
                             ).as(next_workgroup_ids,
-                              {
-                                "events": body.Data.map(e,
+                              (size(next_workgroup_ids) > 0) ?
+                                // More workgroups to process — keep session open.
+                                {
+                                  "events": body.Data.map(e,
+                                    {
+                                      "event": {
+                                        "original": e.encode_json(),
+                                      },
+                                    }
+                                  ),
+                                  "want_more": true,
+                                  "cursor": {
+                                    "cookies": state.cursor.cookies,
+                                    "workgroup_ids": next_workgroup_ids,
+                                  },
+                                  "retries": 0,
+                                }
+                              :
+                                // All workgroups done — sign out and clear the session cookie.
+                                request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                                   {
-                                    "event": {
-                                      "original": e.encode_json(),
+                                    "Header": {
+                                      "Authorization": [
+                                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                      ],
+                                      "Content-Type": ["application/json"],
+                                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                                     },
                                   }
-                                ),
-                                "want_more": size(next_workgroup_ids) > 0,
-                                "cursor": {
-                                  "cookies": state.cursor.cookies,
-                                  "workgroup_ids": next_workgroup_ids,
-                                },
-                                "retries": 0,
-                              }
+                                ).do_request().as(_,
+                                  {
+                                    "events": body.Data.map(e,
+                                      {
+                                        "event": {
+                                          "original": e.encode_json(),
+                                        },
+                                      }
+                                    ),
+                                    "want_more": false,
+                                    "cursor": {},
+                                    "retries": 0,
+                                  }
+                                )
                             )
                           )
                         : (resp.StatusCode == 401) ?
@@ -119,22 +149,36 @@ inputs:
                               }
                           )
                         :
-                          // Handle all other HTTP error responses.
-                          {
-                            "events": {
-                              "error": {
-                                "code": string(resp.StatusCode),
-                                "id": string(resp.Status),
-                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
-                                  (size(resp.Body) != 0) ?
-                                    string(resp.Body)
-                                  :
-                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                                ),
+                          // Handle all other HTTP error responses. Sign out to release the server-side session.
+                          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                            {
+                              "Header": {
+                                "Authorization": [
+                                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                ],
+                                "Content-Type": ["application/json"],
+                                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                               },
-                            },
-                            "want_more": false,
-                          }
+                            }
+                          ).do_request().as(_,
+                            {
+                              "events": {
+                                "error": {
+                                  "code": string(resp.StatusCode),
+                                  "id": string(resp.Status),
+                                  "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
+                                    (size(resp.Body) != 0) ?
+                                      string(resp.Body)
+                                    :
+                                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                  ),
+                                },
+                              },
+                              "want_more": false,
+                              "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                            }
+                          )
                       )
                     )
                   :
@@ -148,7 +192,8 @@ inputs:
                             (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                           ],
                           "Content-Type": ["application/json"],
-                          "Cookie": state.cursor.cookies,
+                          // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
                       }
                     ).do_request().as(resp,
@@ -156,13 +201,25 @@ inputs:
                         // Success: extract workgroup IDs and set up for asset fetching.
                         resp.Body.decode_json().as(workgroups,
                           (size(workgroups) == 0) ?
-                            {
-                              "events": [],
-                              "want_more": false,
-                              "cursor": {
-                                "cookies": state.cursor.cookies,
-                              },
-                            }
+                            // No workgroups — sign out and clear the session cookie.
+                            request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                              {
+                                "Header": {
+                                  "Authorization": [
+                                    sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                    (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                  ],
+                                  "Content-Type": ["application/json"],
+                                  "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                                },
+                              }
+                            ).do_request().as(_,
+                              {
+                                "events": [],
+                                "want_more": false,
+                                "cursor": {},
+                              }
+                            )
                           :
                             {
                               "events": [
@@ -207,22 +264,36 @@ inputs:
                             }
                         )
                       :
-                        // Handle all other HTTP error responses.
-                        {
-                          "events": {
-                            "error": {
-                              "code": string(resp.StatusCode),
-                              "id": string(resp.Status),
-                              "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
-                                (size(resp.Body) != 0) ?
-                                  string(resp.Body)
-                                :
-                                  string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                              ),
+                        // Handle all other HTTP error responses. Sign out to release the server-side session.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                          {
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
-                          },
-                          "want_more": false,
-                        }
+                          }
+                        ).do_request().as(_,
+                          {
+                            "events": {
+                              "error": {
+                                "code": string(resp.StatusCode),
+                                "id": string(resp.Status),
+                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
+                                  (size(resp.Body) != 0) ?
+                                    string(resp.Body)
+                                  :
+                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                ),
+                              },
+                            },
+                            "want_more": false,
+                            "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                          }
+                        )
                     )
                 )
               :
@@ -231,8 +302,9 @@ inputs:
                   {
                     "Header": {
                       "Authorization": [
-                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
-                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) + (
+                        // pwd is required only if the user password is required on the application API registration.
+                        has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
                     },

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-empty-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-empty-password.expected
@@ -58,7 +58,8 @@ inputs:
                               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                             ],
                             "Content-Type": ["application/json"],
-                            "Cookie": state.cursor.cookies,
+                            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                           },
                         }
                       ).do_request().as(resp,
@@ -71,21 +72,50 @@ inputs:
                               :
                                 r.remaining_workgroups
                             ).as(next_workgroup_ids,
-                              {
-                                "events": body.Data.map(e,
+                              (size(next_workgroup_ids) > 0) ?
+                                // More workgroups to process — keep session open.
+                                {
+                                  "events": body.Data.map(e,
+                                    {
+                                      "event": {
+                                        "original": e.encode_json(),
+                                      },
+                                    }
+                                  ),
+                                  "want_more": true,
+                                  "cursor": {
+                                    "cookies": state.cursor.cookies,
+                                    "workgroup_ids": next_workgroup_ids,
+                                  },
+                                  "retries": 0,
+                                }
+                              :
+                                // All workgroups done — sign out and clear the session cookie.
+                                request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                                   {
-                                    "event": {
-                                      "original": e.encode_json(),
+                                    "Header": {
+                                      "Authorization": [
+                                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                      ],
+                                      "Content-Type": ["application/json"],
+                                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                                     },
                                   }
-                                ),
-                                "want_more": size(next_workgroup_ids) > 0,
-                                "cursor": {
-                                  "cookies": state.cursor.cookies,
-                                  "workgroup_ids": next_workgroup_ids,
-                                },
-                                "retries": 0,
-                              }
+                                ).do_request().as(_,
+                                  {
+                                    "events": body.Data.map(e,
+                                      {
+                                        "event": {
+                                          "original": e.encode_json(),
+                                        },
+                                      }
+                                    ),
+                                    "want_more": false,
+                                    "cursor": {},
+                                    "retries": 0,
+                                  }
+                                )
                             )
                           )
                         : (resp.StatusCode == 401) ?
@@ -119,22 +149,36 @@ inputs:
                               }
                           )
                         :
-                          // Handle all other HTTP error responses.
-                          {
-                            "events": {
-                              "error": {
-                                "code": string(resp.StatusCode),
-                                "id": string(resp.Status),
-                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
-                                  (size(resp.Body) != 0) ?
-                                    string(resp.Body)
-                                  :
-                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                                ),
+                          // Handle all other HTTP error responses. Sign out to release the server-side session.
+                          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                            {
+                              "Header": {
+                                "Authorization": [
+                                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                ],
+                                "Content-Type": ["application/json"],
+                                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                               },
-                            },
-                            "want_more": false,
-                          }
+                            }
+                          ).do_request().as(_,
+                            {
+                              "events": {
+                                "error": {
+                                  "code": string(resp.StatusCode),
+                                  "id": string(resp.Status),
+                                  "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
+                                    (size(resp.Body) != 0) ?
+                                      string(resp.Body)
+                                    :
+                                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                  ),
+                                },
+                              },
+                              "want_more": false,
+                              "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                            }
+                          )
                       )
                     )
                   :
@@ -148,7 +192,8 @@ inputs:
                             (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                           ],
                           "Content-Type": ["application/json"],
-                          "Cookie": state.cursor.cookies,
+                          // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
                       }
                     ).do_request().as(resp,
@@ -156,13 +201,25 @@ inputs:
                         // Success: extract workgroup IDs and set up for asset fetching.
                         resp.Body.decode_json().as(workgroups,
                           (size(workgroups) == 0) ?
-                            {
-                              "events": [],
-                              "want_more": false,
-                              "cursor": {
-                                "cookies": state.cursor.cookies,
-                              },
-                            }
+                            // No workgroups — sign out and clear the session cookie.
+                            request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                              {
+                                "Header": {
+                                  "Authorization": [
+                                    sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                    (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                  ],
+                                  "Content-Type": ["application/json"],
+                                  "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                                },
+                              }
+                            ).do_request().as(_,
+                              {
+                                "events": [],
+                                "want_more": false,
+                                "cursor": {},
+                              }
+                            )
                           :
                             {
                               "events": [
@@ -207,22 +264,36 @@ inputs:
                             }
                         )
                       :
-                        // Handle all other HTTP error responses.
-                        {
-                          "events": {
-                            "error": {
-                              "code": string(resp.StatusCode),
-                              "id": string(resp.Status),
-                              "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
-                                (size(resp.Body) != 0) ?
-                                  string(resp.Body)
-                                :
-                                  string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                              ),
+                        // Handle all other HTTP error responses. Sign out to release the server-side session.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                          {
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
-                          },
-                          "want_more": false,
-                        }
+                          }
+                        ).do_request().as(_,
+                          {
+                            "events": {
+                              "error": {
+                                "code": string(resp.StatusCode),
+                                "id": string(resp.Status),
+                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
+                                  (size(resp.Body) != 0) ?
+                                    string(resp.Body)
+                                  :
+                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                ),
+                              },
+                            },
+                            "want_more": false,
+                            "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                          }
+                        )
                     )
                 )
               :
@@ -231,8 +302,9 @@ inputs:
                   {
                     "Header": {
                       "Authorization": [
-                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
-                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) + (
+                        // pwd is required only if the user password is required on the application API registration.
+                        has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
                     },

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-missing-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-missing-password.expected
@@ -58,7 +58,8 @@ inputs:
                               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                             ],
                             "Content-Type": ["application/json"],
-                            "Cookie": state.cursor.cookies,
+                            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                           },
                         }
                       ).do_request().as(resp,
@@ -71,21 +72,50 @@ inputs:
                               :
                                 r.remaining_workgroups
                             ).as(next_workgroup_ids,
-                              {
-                                "events": body.Data.map(e,
+                              (size(next_workgroup_ids) > 0) ?
+                                // More workgroups to process — keep session open.
+                                {
+                                  "events": body.Data.map(e,
+                                    {
+                                      "event": {
+                                        "original": e.encode_json(),
+                                      },
+                                    }
+                                  ),
+                                  "want_more": true,
+                                  "cursor": {
+                                    "cookies": state.cursor.cookies,
+                                    "workgroup_ids": next_workgroup_ids,
+                                  },
+                                  "retries": 0,
+                                }
+                              :
+                                // All workgroups done — sign out and clear the session cookie.
+                                request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                                   {
-                                    "event": {
-                                      "original": e.encode_json(),
+                                    "Header": {
+                                      "Authorization": [
+                                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                      ],
+                                      "Content-Type": ["application/json"],
+                                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                                     },
                                   }
-                                ),
-                                "want_more": size(next_workgroup_ids) > 0,
-                                "cursor": {
-                                  "cookies": state.cursor.cookies,
-                                  "workgroup_ids": next_workgroup_ids,
-                                },
-                                "retries": 0,
-                              }
+                                ).do_request().as(_,
+                                  {
+                                    "events": body.Data.map(e,
+                                      {
+                                        "event": {
+                                          "original": e.encode_json(),
+                                        },
+                                      }
+                                    ),
+                                    "want_more": false,
+                                    "cursor": {},
+                                    "retries": 0,
+                                  }
+                                )
                             )
                           )
                         : (resp.StatusCode == 401) ?
@@ -119,22 +149,36 @@ inputs:
                               }
                           )
                         :
-                          // Handle all other HTTP error responses.
-                          {
-                            "events": {
-                              "error": {
-                                "code": string(resp.StatusCode),
-                                "id": string(resp.Status),
-                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
-                                  (size(resp.Body) != 0) ?
-                                    string(resp.Body)
-                                  :
-                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                                ),
+                          // Handle all other HTTP error responses. Sign out to release the server-side session.
+                          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                            {
+                              "Header": {
+                                "Authorization": [
+                                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                ],
+                                "Content-Type": ["application/json"],
+                                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                               },
-                            },
-                            "want_more": false,
-                          }
+                            }
+                          ).do_request().as(_,
+                            {
+                              "events": {
+                                "error": {
+                                  "code": string(resp.StatusCode),
+                                  "id": string(resp.Status),
+                                  "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
+                                    (size(resp.Body) != 0) ?
+                                      string(resp.Body)
+                                    :
+                                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                  ),
+                                },
+                              },
+                              "want_more": false,
+                              "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                            }
+                          )
                       )
                     )
                   :
@@ -148,7 +192,8 @@ inputs:
                             (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                           ],
                           "Content-Type": ["application/json"],
-                          "Cookie": state.cursor.cookies,
+                          // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
                       }
                     ).do_request().as(resp,
@@ -156,13 +201,25 @@ inputs:
                         // Success: extract workgroup IDs and set up for asset fetching.
                         resp.Body.decode_json().as(workgroups,
                           (size(workgroups) == 0) ?
-                            {
-                              "events": [],
-                              "want_more": false,
-                              "cursor": {
-                                "cookies": state.cursor.cookies,
-                              },
-                            }
+                            // No workgroups — sign out and clear the session cookie.
+                            request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                              {
+                                "Header": {
+                                  "Authorization": [
+                                    sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                    (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                  ],
+                                  "Content-Type": ["application/json"],
+                                  "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                                },
+                              }
+                            ).do_request().as(_,
+                              {
+                                "events": [],
+                                "want_more": false,
+                                "cursor": {},
+                              }
+                            )
                           :
                             {
                               "events": [
@@ -207,22 +264,36 @@ inputs:
                             }
                         )
                       :
-                        // Handle all other HTTP error responses.
-                        {
-                          "events": {
-                            "error": {
-                              "code": string(resp.StatusCode),
-                              "id": string(resp.Status),
-                              "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
-                                (size(resp.Body) != 0) ?
-                                  string(resp.Body)
-                                :
-                                  string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                              ),
+                        // Handle all other HTTP error responses. Sign out to release the server-side session.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                          {
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
-                          },
-                          "want_more": false,
-                        }
+                          }
+                        ).do_request().as(_,
+                          {
+                            "events": {
+                              "error": {
+                                "code": string(resp.StatusCode),
+                                "id": string(resp.Status),
+                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
+                                  (size(resp.Body) != 0) ?
+                                    string(resp.Body)
+                                  :
+                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                ),
+                              },
+                            },
+                            "want_more": false,
+                            "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                          }
+                        )
                     )
                 )
               :
@@ -231,8 +302,9 @@ inputs:
                   {
                     "Header": {
                       "Authorization": [
-                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
-                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) + (
+                        // pwd is required only if the user password is required on the application API registration.
+                        has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
                     },

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-null-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-null-password.expected
@@ -58,7 +58,8 @@ inputs:
                               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                             ],
                             "Content-Type": ["application/json"],
-                            "Cookie": state.cursor.cookies,
+                            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                           },
                         }
                       ).do_request().as(resp,
@@ -71,21 +72,50 @@ inputs:
                               :
                                 r.remaining_workgroups
                             ).as(next_workgroup_ids,
-                              {
-                                "events": body.Data.map(e,
+                              (size(next_workgroup_ids) > 0) ?
+                                // More workgroups to process — keep session open.
+                                {
+                                  "events": body.Data.map(e,
+                                    {
+                                      "event": {
+                                        "original": e.encode_json(),
+                                      },
+                                    }
+                                  ),
+                                  "want_more": true,
+                                  "cursor": {
+                                    "cookies": state.cursor.cookies,
+                                    "workgroup_ids": next_workgroup_ids,
+                                  },
+                                  "retries": 0,
+                                }
+                              :
+                                // All workgroups done — sign out and clear the session cookie.
+                                request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                                   {
-                                    "event": {
-                                      "original": e.encode_json(),
+                                    "Header": {
+                                      "Authorization": [
+                                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                      ],
+                                      "Content-Type": ["application/json"],
+                                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                                     },
                                   }
-                                ),
-                                "want_more": size(next_workgroup_ids) > 0,
-                                "cursor": {
-                                  "cookies": state.cursor.cookies,
-                                  "workgroup_ids": next_workgroup_ids,
-                                },
-                                "retries": 0,
-                              }
+                                ).do_request().as(_,
+                                  {
+                                    "events": body.Data.map(e,
+                                      {
+                                        "event": {
+                                          "original": e.encode_json(),
+                                        },
+                                      }
+                                    ),
+                                    "want_more": false,
+                                    "cursor": {},
+                                    "retries": 0,
+                                  }
+                                )
                             )
                           )
                         : (resp.StatusCode == 401) ?
@@ -119,22 +149,36 @@ inputs:
                               }
                           )
                         :
-                          // Handle all other HTTP error responses.
-                          {
-                            "events": {
-                              "error": {
-                                "code": string(resp.StatusCode),
-                                "id": string(resp.Status),
-                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
-                                  (size(resp.Body) != 0) ?
-                                    string(resp.Body)
-                                  :
-                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                                ),
+                          // Handle all other HTTP error responses. Sign out to release the server-side session.
+                          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                            {
+                              "Header": {
+                                "Authorization": [
+                                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                ],
+                                "Content-Type": ["application/json"],
+                                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                               },
-                            },
-                            "want_more": false,
-                          }
+                            }
+                          ).do_request().as(_,
+                            {
+                              "events": {
+                                "error": {
+                                  "code": string(resp.StatusCode),
+                                  "id": string(resp.Status),
+                                  "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
+                                    (size(resp.Body) != 0) ?
+                                      string(resp.Body)
+                                    :
+                                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                  ),
+                                },
+                              },
+                              "want_more": false,
+                              "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                            }
+                          )
                       )
                     )
                   :
@@ -148,7 +192,8 @@ inputs:
                             (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                           ],
                           "Content-Type": ["application/json"],
-                          "Cookie": state.cursor.cookies,
+                          // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
                       }
                     ).do_request().as(resp,
@@ -156,13 +201,25 @@ inputs:
                         // Success: extract workgroup IDs and set up for asset fetching.
                         resp.Body.decode_json().as(workgroups,
                           (size(workgroups) == 0) ?
-                            {
-                              "events": [],
-                              "want_more": false,
-                              "cursor": {
-                                "cookies": state.cursor.cookies,
-                              },
-                            }
+                            // No workgroups — sign out and clear the session cookie.
+                            request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                              {
+                                "Header": {
+                                  "Authorization": [
+                                    sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                    (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                                  ],
+                                  "Content-Type": ["application/json"],
+                                  "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                                },
+                              }
+                            ).do_request().as(_,
+                              {
+                                "events": [],
+                                "want_more": false,
+                                "cursor": {},
+                              }
+                            )
                           :
                             {
                               "events": [
@@ -207,22 +264,36 @@ inputs:
                             }
                         )
                       :
-                        // Handle all other HTTP error responses.
-                        {
-                          "events": {
-                            "error": {
-                              "code": string(resp.StatusCode),
-                              "id": string(resp.Status),
-                              "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
-                                (size(resp.Body) != 0) ?
-                                  string(resp.Body)
-                                :
-                                  string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                              ),
+                        // Handle all other HTTP error responses. Sign out to release the server-side session.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                          {
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
-                          },
-                          "want_more": false,
-                        }
+                          }
+                        ).do_request().as(_,
+                          {
+                            "events": {
+                              "error": {
+                                "code": string(resp.StatusCode),
+                                "id": string(resp.Status),
+                                "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
+                                  (size(resp.Body) != 0) ?
+                                    string(resp.Body)
+                                  :
+                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                                ),
+                              },
+                            },
+                            "want_more": false,
+                            "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                          }
+                        )
                     )
                 )
               :
@@ -231,8 +302,9 @@ inputs:
                   {
                     "Header": {
                       "Authorization": [
-                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
-                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) + (
+                        // pwd is required only if the user password is required on the application API registration.
+                        has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
                     },

--- a/packages/beyondinsight_password_safe/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/asset/agent/stream/cel.yml.hbs
@@ -29,6 +29,7 @@ redact:
 {{!--
 API References:
   https://docs.beyondtrust.com/bips/docs/api#post-authsignappin
+  https://docs.beyondtrust.com/bips/docs/api#post-authsignout
   https://docs.beyondtrust.com/bips/docs/beyondinsight-apis#workgroups-1
   https://docs.beyondtrust.com/bips/docs/beyondinsight-apis#get-workgroupsworkgroupidassets
 
@@ -80,7 +81,8 @@ program: |-
                     (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                   ],
                   "Content-Type": ["application/json"],
-                  "Cookie": state.cursor.cookies,
+                  // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                  "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                 },
               }
             ).do_request().as(resp,
@@ -93,21 +95,50 @@ program: |-
                     :
                       r.remaining_workgroups
                   ).as(next_workgroup_ids,
-                    {
-                      "events": body.Data.map(e,
+                    (size(next_workgroup_ids) > 0) ?
+                      // More workgroups to process — keep session open.
+                      {
+                        "events": body.Data.map(e,
+                          {
+                            "event": {
+                              "original": e.encode_json(),
+                            },
+                          }
+                        ),
+                        "want_more": true,
+                        "cursor": {
+                          "cookies": state.cursor.cookies,
+                          "workgroup_ids": next_workgroup_ids,
+                        },
+                        "retries": 0,
+                      }
+                    :
+                      // All workgroups done — sign out and clear the session cookie.
+                      request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                         {
-                          "event": {
-                            "original": e.encode_json(),
+                          "Header": {
+                            "Authorization": [
+                              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                            ],
+                            "Content-Type": ["application/json"],
+                            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                           },
                         }
-                      ),
-                      "want_more": size(next_workgroup_ids) > 0,
-                      "cursor": {
-                        "cookies": state.cursor.cookies,
-                        "workgroup_ids": next_workgroup_ids,
-                      },
-                      "retries": 0,
-                    }
+                      ).do_request().as(_,
+                        {
+                          "events": body.Data.map(e,
+                            {
+                              "event": {
+                                "original": e.encode_json(),
+                              },
+                            }
+                          ),
+                          "want_more": false,
+                          "cursor": {},
+                          "retries": 0,
+                        }
+                      )
                   )
                 )
               : (resp.StatusCode == 401) ?
@@ -141,22 +172,36 @@ program: |-
                     }
                 )
               :
-                // Handle all other HTTP error responses.
-                {
-                  "events": {
-                    "error": {
-                      "code": string(resp.StatusCode),
-                      "id": string(resp.Status),
-                      "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
-                        (size(resp.Body) != 0) ?
-                          string(resp.Body)
-                        :
-                          string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                      ),
+                // Handle all other HTTP error responses. Sign out to release the server-side session.
+                request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                  {
+                    "Header": {
+                      "Authorization": [
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                      ],
+                      "Content-Type": ["application/json"],
+                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                     },
-                  },
-                  "want_more": false,
-                }
+                  }
+                ).do_request().as(_,
+                  {
+                    "events": {
+                      "error": {
+                        "code": string(resp.StatusCode),
+                        "id": string(resp.Status),
+                        "message": "GET " + state.url.trim_suffix("/") + "/Workgroups/" + r.workgroup_id + "/Assets: " + (
+                          (size(resp.Body) != 0) ?
+                            string(resp.Body)
+                          :
+                            string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                        ),
+                      },
+                    },
+                    "want_more": false,
+                    "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                  }
+                )
             )
           )
         :
@@ -170,7 +215,8 @@ program: |-
                   (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                 ],
                 "Content-Type": ["application/json"],
-                "Cookie": state.cursor.cookies,
+                // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
               },
             }
           ).do_request().as(resp,
@@ -178,13 +224,25 @@ program: |-
               // Success: extract workgroup IDs and set up for asset fetching.
               resp.Body.decode_json().as(workgroups,
                 (size(workgroups) == 0) ?
-                  {
-                    "events": [],
-                    "want_more": false,
-                    "cursor": {
-                      "cookies": state.cursor.cookies,
-                    },
-                  }
+                  // No workgroups — sign out and clear the session cookie.
+                  request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                    {
+                      "Header": {
+                        "Authorization": [
+                          sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                          (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        ],
+                        "Content-Type": ["application/json"],
+                        "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                      },
+                    }
+                  ).do_request().as(_,
+                    {
+                      "events": [],
+                      "want_more": false,
+                      "cursor": {},
+                    }
+                  )
                 :
                   {
                     "events": [
@@ -229,22 +287,36 @@ program: |-
                   }
               )
             :
-              // Handle all other HTTP error responses.
-              {
-                "events": {
-                  "error": {
-                    "code": string(resp.StatusCode),
-                    "id": string(resp.Status),
-                    "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
-                      (size(resp.Body) != 0) ?
-                        string(resp.Body)
-                      :
-                        string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                    ),
+              // Handle all other HTTP error responses. Sign out to release the server-side session.
+              request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                {
+                  "Header": {
+                    "Authorization": [
+                      sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                      (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                    ],
+                    "Content-Type": ["application/json"],
+                    "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                   },
-                },
-                "want_more": false,
-              }
+                }
+              ).do_request().as(_,
+                {
+                  "events": {
+                    "error": {
+                      "code": string(resp.StatusCode),
+                      "id": string(resp.Status),
+                      "message": "GET " + state.url.trim_suffix("/") + "/Workgroups: " + (
+                        (size(resp.Body) != 0) ?
+                          string(resp.Body)
+                        :
+                          string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                      ),
+                    },
+                  },
+                  "want_more": false,
+                  "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+                }
+              )
           )
       )
     :
@@ -253,8 +325,9 @@ program: |-
         {
           "Header": {
             "Authorization": [
-              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
-              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) + (
+              // pwd is required only if the user password is required on the application API registration.
+              has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
             ],
             "Content-Type": ["application/json"],
           },

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/deploy/docker/files/config.yml
@@ -1,18 +1,20 @@
 # BeyondInsight Password Safe - Managed Accounts Test Mock Configuration
 #
-# Test Scenario: Simulates paginated retrieval of managed accounts with session expiration and re-authentication:
-# 1. Initial authentication via SignAppin endpoint (returns 200, sets session cookie)
-# 2. First ManagedAccounts request with limit=1&offset=0 (returns 200, first session)
+# Test Scenario: Simulates paginated retrieval of managed accounts with session
+# expiration and re-authentication, verifying the Cookie header fix:
+# 1. Initial authentication via SignAppin endpoint (returns 200, sets two cookies
+#    with attributes — ASP.NET_SessionId and __RequestVerificationToken)
+# 2. First ManagedAccounts request with limit=1&offset=0 (returns 200, first account)
 # 3. Second ManagedAccounts request with limit=1&offset=1 (returns 401, session expired)
-# 4. Re-authentication via SignAppin endpoint (returns 200, new session cookie)
-# 5. Retry ManagedAccounts request with limit=1&offset=1 (returns 200, second session)
-# 6. Final ManagedAccounts request with limit=1&offset=2 (returns 200, empty array - no more data)
+# 4. Re-authentication via SignAppin endpoint (returns 200, new session cookies)
+# 5. Retry ManagedAccounts request with limit=1&offset=1 (returns 200, second account)
+# 6. Final ManagedAccounts request with limit=1&offset=2 (returns 200, empty array —
+#    no more data, triggers sign-out)
+# 7. Sign-out to release the server-side session
 #
-# This tests the integration's ability to handle:
-# - Session-based authentication with BeyondTrust API
-# - Paginated data retrieval with limit/offset parameters
-# - Session expiration (401) and automatic re-authentication
-# - Proper handling of empty result sets indicating end of pagination
+# Cookie header format assertion: each Cookie rule asserts the joined single-header form.
+# The buggy code replayed raw Set-Cookie values (with attributes) as multiple Cookie
+# header lines, causing 401s on real BeyondInsight servers.
 
 rules:
   # Auth
@@ -25,7 +27,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -37,7 +41,7 @@ rules:
           }
           `}}
 
-  # Auth
+  # Auth (no password)
   - path: "/BeyondTrust/api/public/v3/Auth/SignAppin"
     methods: ["POST"]
     request_headers:
@@ -47,7 +51,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -58,6 +64,7 @@ rules:
             "Name": "Test User"
           }
           `}}
+
   - path: "/BeyondTrust/api/public/v3/ManagedAccounts"
     methods: ["GET"]
     query_params:
@@ -65,7 +72,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -104,7 +111,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 401
         headers:
@@ -120,7 +127,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -152,14 +159,28 @@ rules:
           ]
           `}}
 
+  # Empty page — no more data, triggers sign-out.
   - path: "/BeyondTrust/api/public/v3/ManagedAccounts"
     methods: ["GET"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
         body: '[]'
+
+  # Sign-out to release the server-side session.
+  - path: "/BeyondTrust/api/public/v3/Auth/Signout"
+    methods: ["POST"]
+    request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
+      Content-Type: ['application/json']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ['application/json']
+        body: ""

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-all.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-all.expected
@@ -34,29 +34,56 @@ inputs:
                         (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
-                      "Cookie": state.cursor.cookies,
+                      // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                     },
                   }
                 ).do_request().as(resp,
                   (resp.StatusCode == 200) ?
                     // Success: process JSON array of managed account objects.
-                    // More data may exist if returned array size equals the limit.
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": body.map(e,
+                      (size(body) == int(state.limit)) ?
+                        // More pages available — keep the session open.
+                        {
+                          "events": body.map(e,
+                            {
+                              "event": {
+                                "original": e.encode_json(),
+                              },
+                            }
+                          ),
+                          "want_more": true,
+                          "offset": int(state.?offset.orValue(0)) + size(body),
+                          "retries": 0,
+                        }
+                      :
+                        // All data fetched — sign out and clear the session cookie.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                           {
-                            "event": {
-                              "original": e.encode_json(),
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
                           }
-                        ),
-                        "want_more": size(body) == int(state.limit),
-                        "offset": (size(body) == int(state.limit)) ?
-                          (int(state.?offset.orValue(0)) + size(body))
-                        :
-                          0,
-                        "retries": 0,
-                      }
+                        ).do_request().as(_,
+                          {
+                            "events": body.map(e,
+                              {
+                                "event": {
+                                  "original": e.encode_json(),
+                                },
+                              }
+                            ),
+                            "want_more": false,
+                            "offset": 0,
+                            "retries": 0,
+                            "cursor": {},
+                          }
+                        )
                     )
                   : (resp.StatusCode == 401) ?
                     (
@@ -89,22 +116,36 @@ inputs:
                         }
                     )
                   :
-                    // Handle all other HTTP error responses.
-                    {
-                      "events": {
-                        "error": {
-                          "code": string(resp.StatusCode),
-                          "id": string(resp.Status),
-                          "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
-                            (size(resp.Body) != 0) ?
-                              string(resp.Body)
-                            :
-                              string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                          ),
+                    // Handle all other HTTP error responses. Sign out to release the server-side session.
+                    request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                      {
+                        "Header": {
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
+                          "Content-Type": ["application/json"],
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
-                      },
-                      "want_more": false,
-                    }
+                      }
+                    ).do_request().as(_,
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
+                              (size(resp.Body) != 0) ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                        "cursor": {},
+                      }
+                    )
                 )
               :
                 // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-empty-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-empty-password.expected
@@ -34,29 +34,56 @@ inputs:
                         (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
-                      "Cookie": state.cursor.cookies,
+                      // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                     },
                   }
                 ).do_request().as(resp,
                   (resp.StatusCode == 200) ?
                     // Success: process JSON array of managed account objects.
-                    // More data may exist if returned array size equals the limit.
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": body.map(e,
+                      (size(body) == int(state.limit)) ?
+                        // More pages available — keep the session open.
+                        {
+                          "events": body.map(e,
+                            {
+                              "event": {
+                                "original": e.encode_json(),
+                              },
+                            }
+                          ),
+                          "want_more": true,
+                          "offset": int(state.?offset.orValue(0)) + size(body),
+                          "retries": 0,
+                        }
+                      :
+                        // All data fetched — sign out and clear the session cookie.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                           {
-                            "event": {
-                              "original": e.encode_json(),
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
                           }
-                        ),
-                        "want_more": size(body) == int(state.limit),
-                        "offset": (size(body) == int(state.limit)) ?
-                          (int(state.?offset.orValue(0)) + size(body))
-                        :
-                          0,
-                        "retries": 0,
-                      }
+                        ).do_request().as(_,
+                          {
+                            "events": body.map(e,
+                              {
+                                "event": {
+                                  "original": e.encode_json(),
+                                },
+                              }
+                            ),
+                            "want_more": false,
+                            "offset": 0,
+                            "retries": 0,
+                            "cursor": {},
+                          }
+                        )
                     )
                   : (resp.StatusCode == 401) ?
                     (
@@ -89,22 +116,36 @@ inputs:
                         }
                     )
                   :
-                    // Handle all other HTTP error responses.
-                    {
-                      "events": {
-                        "error": {
-                          "code": string(resp.StatusCode),
-                          "id": string(resp.Status),
-                          "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
-                            (size(resp.Body) != 0) ?
-                              string(resp.Body)
-                            :
-                              string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                          ),
+                    // Handle all other HTTP error responses. Sign out to release the server-side session.
+                    request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                      {
+                        "Header": {
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
+                          "Content-Type": ["application/json"],
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
-                      },
-                      "want_more": false,
-                    }
+                      }
+                    ).do_request().as(_,
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
+                              (size(resp.Body) != 0) ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                        "cursor": {},
+                      }
+                    )
                 )
               :
                 // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-null-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-null-password.expected
@@ -34,29 +34,56 @@ inputs:
                         (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
-                      "Cookie": state.cursor.cookies,
+                      // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                     },
                   }
                 ).do_request().as(resp,
                   (resp.StatusCode == 200) ?
                     // Success: process JSON array of managed account objects.
-                    // More data may exist if returned array size equals the limit.
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": body.map(e,
+                      (size(body) == int(state.limit)) ?
+                        // More pages available — keep the session open.
+                        {
+                          "events": body.map(e,
+                            {
+                              "event": {
+                                "original": e.encode_json(),
+                              },
+                            }
+                          ),
+                          "want_more": true,
+                          "offset": int(state.?offset.orValue(0)) + size(body),
+                          "retries": 0,
+                        }
+                      :
+                        // All data fetched — sign out and clear the session cookie.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                           {
-                            "event": {
-                              "original": e.encode_json(),
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
                           }
-                        ),
-                        "want_more": size(body) == int(state.limit),
-                        "offset": (size(body) == int(state.limit)) ?
-                          (int(state.?offset.orValue(0)) + size(body))
-                        :
-                          0,
-                        "retries": 0,
-                      }
+                        ).do_request().as(_,
+                          {
+                            "events": body.map(e,
+                              {
+                                "event": {
+                                  "original": e.encode_json(),
+                                },
+                              }
+                            ),
+                            "want_more": false,
+                            "offset": 0,
+                            "retries": 0,
+                            "cursor": {},
+                          }
+                        )
                     )
                   : (resp.StatusCode == 401) ?
                     (
@@ -89,22 +116,36 @@ inputs:
                         }
                     )
                   :
-                    // Handle all other HTTP error responses.
-                    {
-                      "events": {
-                        "error": {
-                          "code": string(resp.StatusCode),
-                          "id": string(resp.Status),
-                          "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
-                            (size(resp.Body) != 0) ?
-                              string(resp.Body)
-                            :
-                              string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                          ),
+                    // Handle all other HTTP error responses. Sign out to release the server-side session.
+                    request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                      {
+                        "Header": {
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
+                          "Content-Type": ["application/json"],
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
-                      },
-                      "want_more": false,
-                    }
+                      }
+                    ).do_request().as(_,
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
+                              (size(resp.Body) != 0) ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                        "cursor": {},
+                      }
+                    )
                 )
               :
                 // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/agent/stream/cel.yml.hbs
@@ -29,6 +29,7 @@ redact:
 {{!--
 API References:
   https://docs.beyondtrust.com/bips/docs/api#post-authsignappin
+  https://docs.beyondtrust.com/bips/docs/api#post-authsignout
   https://docs.beyondtrust.com/bips/docs/password-safe-apis#get-managedaccounts
 --}}
 program: |-
@@ -50,29 +51,56 @@ program: |-
               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
             ],
             "Content-Type": ["application/json"],
-            "Cookie": state.cursor.cookies,
+            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
           },
         }
       ).do_request().as(resp,
         (resp.StatusCode == 200) ?
           // Success: process JSON array of managed account objects.
-          // More data may exist if returned array size equals the limit.
           resp.Body.decode_json().as(body,
-            {
-              "events": body.map(e,
+            (size(body) == int(state.limit)) ?
+              // More pages available — keep the session open.
+              {
+                "events": body.map(e,
+                  {
+                    "event": {
+                      "original": e.encode_json(),
+                    },
+                  }
+                ),
+                "want_more": true,
+                "offset": int(state.?offset.orValue(0)) + size(body),
+                "retries": 0,
+              }
+            :
+              // All data fetched — sign out and clear the session cookie.
+              request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                 {
-                  "event": {
-                    "original": e.encode_json(),
+                  "Header": {
+                    "Authorization": [
+                      sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                      (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                    ],
+                    "Content-Type": ["application/json"],
+                    "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                   },
                 }
-              ),
-              "want_more": size(body) == int(state.limit),
-              "offset": (size(body) == int(state.limit)) ?
-                (int(state.?offset.orValue(0)) + size(body))
-              :
-                0,
-              "retries": 0,
-            }
+              ).do_request().as(_,
+                {
+                  "events": body.map(e,
+                    {
+                      "event": {
+                        "original": e.encode_json(),
+                      },
+                    }
+                  ),
+                  "want_more": false,
+                  "offset": 0,
+                  "retries": 0,
+                  "cursor": {},
+                }
+              )
           )
         : (resp.StatusCode == 401) ?
           (
@@ -105,22 +133,36 @@ program: |-
               }
           )
         :
-          // Handle all other HTTP error responses.
-          {
-            "events": {
-              "error": {
-                "code": string(resp.StatusCode),
-                "id": string(resp.Status),
-                "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
-                  (size(resp.Body) != 0) ?
-                    string(resp.Body)
-                  :
-                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                ),
+          // Handle all other HTTP error responses. Sign out to release the server-side session.
+          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+            {
+              "Header": {
+                "Authorization": [
+                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                ],
+                "Content-Type": ["application/json"],
+                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
               },
-            },
-            "want_more": false,
-          }
+            }
+          ).do_request().as(_,
+            {
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "GET " + state.url.trim_suffix("/") + "/ManagedAccounts: " + (
+                    (size(resp.Body) != 0) ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                  ),
+                },
+              },
+              "want_more": false,
+              "cursor": {},
+            }
+          )
       )
     :
       // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/deploy/docker/files/config.yml
@@ -1,18 +1,20 @@
 # BeyondInsight Password Safe - Managed Systems Test Mock Configuration
 #
-# Test Scenario: Simulates paginated retrieval of managed systems with session expiration and re-authentication:
-# 1. Initial authentication via SignAppin endpoint (returns 200, sets session cookie)
-# 2. First ManagedSystems request with limit=1&offset=0 (returns 200, first session)
+# Test Scenario: Simulates paginated retrieval of managed systems with session
+# expiration and re-authentication, verifying the Cookie header fix:
+# 1. Initial authentication via SignAppin endpoint (returns 200, sets two cookies
+#    with attributes — ASP.NET_SessionId and __RequestVerificationToken)
+# 2. First ManagedSystems request with limit=1&offset=0 (returns 200, first system)
 # 3. Second ManagedSystems request with limit=1&offset=1 (returns 401, session expired)
-# 4. Re-authentication via SignAppin endpoint (returns 200, new session cookie)
-# 5. Retry ManagedSystems request with limit=1&offset=1 (returns 200, second session)
-# 6. Final ManagedSystems request with limit=1&offset=2 (returns 200, empty data array - no more data)
+# 4. Re-authentication via SignAppin endpoint (returns 200, new session cookies)
+# 5. Retry ManagedSystems request with limit=1&offset=1 (returns 200, second system)
+# 6. Final ManagedSystems request with limit=1&offset=2 (returns 200, empty Data array —
+#    no more data, triggers sign-out)
+# 7. Sign-out to release the server-side session
 #
-# This tests the integration's ability to handle:
-# - Session-based authentication with BeyondTrust API
-# - Paginated data retrieval with limit/offset parameters
-# - Session expiration (401) and automatic re-authentication
-# - Proper handling of empty result sets indicating end of pagination
+# Cookie header format assertion: each Cookie rule asserts the joined single-header form.
+# The buggy code replayed raw Set-Cookie values (with attributes) as multiple Cookie
+# header lines, causing 401s on real BeyondInsight servers.
 
 rules:
   # Auth
@@ -25,7 +27,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -47,7 +51,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -66,7 +72,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -134,7 +140,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 401
         headers:
@@ -150,7 +156,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -211,12 +217,13 @@ rules:
           }
           `}}
 
+  # Empty page — no more data, triggers sign-out.
   - path: "/BeyondTrust/api/public/v3/ManagedSystems"
     methods: ["GET"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
@@ -228,3 +235,16 @@ rules:
               "TotalCount": 2
           }
           `}}
+
+  # Sign-out to release the server-side session.
+  - path: "/BeyondTrust/api/public/v3/Auth/Signout"
+    methods: ["POST"]
+    request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
+      Content-Type: ['application/json']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ['application/json']
+        body: ""

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/test/policy/test-all.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/test/policy/test-all.expected
@@ -34,29 +34,56 @@ inputs:
                         (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
                       ],
                       "Content-Type": ["application/json"],
-                      "Cookie": state.cursor.cookies,
+                      // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+                      "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                     },
                   }
                 ).do_request().as(resp,
                   (resp.StatusCode == 200) ?
                     // Success: process JSON response with Data array of managed system objects.
-                    // More data may exist if returned array size equals the limit.
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": body.Data.map(e,
+                      (size(body.Data) == int(state.limit)) ?
+                        // More pages available — keep the session open.
+                        {
+                          "events": body.Data.map(e,
+                            {
+                              "event": {
+                                "original": e.encode_json(),
+                              },
+                            }
+                          ),
+                          "want_more": true,
+                          "offset": int(state.?offset.orValue(0)) + size(body.Data),
+                          "retries": 0,
+                        }
+                      :
+                        // All data fetched — sign out and clear the session cookie.
+                        request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                           {
-                            "event": {
-                              "original": e.encode_json(),
+                            "Header": {
+                              "Authorization": [
+                                sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                                (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                              ],
+                              "Content-Type": ["application/json"],
+                              "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                             },
                           }
-                        ),
-                        "want_more": size(body.Data) == int(state.limit),
-                        "offset": (size(body.Data) == int(state.limit)) ?
-                          (int(state.?offset.orValue(0)) + size(body.Data))
-                        :
-                          0,
-                        "retries": 0,
-                      }
+                        ).do_request().as(_,
+                          {
+                            "events": body.Data.map(e,
+                              {
+                                "event": {
+                                  "original": e.encode_json(),
+                                },
+                              }
+                            ),
+                            "want_more": false,
+                            "offset": 0,
+                            "retries": 0,
+                            "cursor": {},
+                          }
+                        )
                     )
                   : (resp.StatusCode == 401) ?
                     (
@@ -89,22 +116,36 @@ inputs:
                         }
                     )
                   :
-                    // Handle all other HTTP error responses.
-                    {
-                      "events": {
-                        "error": {
-                          "code": string(resp.StatusCode),
-                          "id": string(resp.Status),
-                          "message": "GET " + state.url.trim_suffix("/") + "/ManagedSystems: " + (
-                            (size(resp.Body) != 0) ?
-                              string(resp.Body)
-                            :
-                              string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                          ),
+                    // Handle all other HTTP error responses. Sign out to release the server-side session.
+                    request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                      {
+                        "Header": {
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
+                          "Content-Type": ["application/json"],
+                          "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                         },
-                      },
-                      "want_more": false,
-                    }
+                      }
+                    ).do_request().as(_,
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_suffix("/") + "/ManagedSystems: " + (
+                              (size(resp.Body) != 0) ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                        "cursor": {},
+                      }
+                    )
                 )
               :
                 // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/agent/stream/cel.yml.hbs
@@ -29,6 +29,7 @@ redact:
 {{!--
 API References:
   https://docs.beyondtrust.com/bips/docs/api#post-authsignappin
+  https://docs.beyondtrust.com/bips/docs/api#post-authsignout
   https://docs.beyondtrust.com/bips/docs/password-safe-apis#get-managedsystems
 --}}
 program: |-
@@ -50,29 +51,56 @@ program: |-
               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
             ],
             "Content-Type": ["application/json"],
-            "Cookie": state.cursor.cookies,
+            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
           },
         }
       ).do_request().as(resp,
         (resp.StatusCode == 200) ?
           // Success: process JSON response with Data array of managed system objects.
-          // More data may exist if returned array size equals the limit.
           resp.Body.decode_json().as(body,
-            {
-              "events": body.Data.map(e,
+            (size(body.Data) == int(state.limit)) ?
+              // More pages available — keep the session open.
+              {
+                "events": body.Data.map(e,
+                  {
+                    "event": {
+                      "original": e.encode_json(),
+                    },
+                  }
+                ),
+                "want_more": true,
+                "offset": int(state.?offset.orValue(0)) + size(body.Data),
+                "retries": 0,
+              }
+            :
+              // All data fetched — sign out and clear the session cookie.
+              request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
                 {
-                  "event": {
-                    "original": e.encode_json(),
+                  "Header": {
+                    "Authorization": [
+                      sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                      (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                    ],
+                    "Content-Type": ["application/json"],
+                    "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
                   },
                 }
-              ),
-              "want_more": size(body.Data) == int(state.limit),
-              "offset": (size(body.Data) == int(state.limit)) ?
-                (int(state.?offset.orValue(0)) + size(body.Data))
-              :
-                0,
-              "retries": 0,
-            }
+              ).do_request().as(_,
+                {
+                  "events": body.Data.map(e,
+                    {
+                      "event": {
+                        "original": e.encode_json(),
+                      },
+                    }
+                  ),
+                  "want_more": false,
+                  "offset": 0,
+                  "retries": 0,
+                  "cursor": {},
+                }
+              )
           )
         : (resp.StatusCode == 401) ?
           (
@@ -105,22 +133,36 @@ program: |-
               }
           )
         :
-          // Handle all other HTTP error responses.
-          {
-            "events": {
-              "error": {
-                "code": string(resp.StatusCode),
-                "id": string(resp.Status),
-                "message": "GET " + state.url.trim_suffix("/") + "/ManagedSystems: " + (
-                  (size(resp.Body) != 0) ?
-                    string(resp.Body)
-                  :
-                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                ),
+          // Handle all other HTTP error responses. Sign out to release the server-side session.
+          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+            {
+              "Header": {
+                "Authorization": [
+                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                ],
+                "Content-Type": ["application/json"],
+                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
               },
-            },
-            "want_more": false,
-          }
+            }
+          ).do_request().as(_,
+            {
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "GET " + state.url.trim_suffix("/") + "/ManagedSystems: " + (
+                    (size(resp.Body) != 0) ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                  ),
+                },
+              },
+              "want_more": false,
+              "cursor": {},
+            }
+          )
       )
     :
       // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/session/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/session/_dev/deploy/docker/files/config.yml
@@ -1,15 +1,23 @@
 # BeyondInsight Password Safe - Sessions Test Mock Configuration
 #
-# Test Scenario: Simulates session retrieval with authentication and session expiration:
-# 1. Initial authentication via SignAppin endpoint (returns 200, sets session cookie)
-# 2. First Sessions request (returns 200, all session data - 3 sessions)
-# 3. Second Sessions request (returns 401, session expired) 
-# 4. Re-authentication via SignAppin endpoint (returns 200, new session cookie)
-# 5. Retry Sessions request (returns 200, session data again - 1 session)
+# Test Scenario: Simulates session retrieval with authentication, cookie fix
+# verification, sign-out, and 401 retry:
+# 1. Initial authentication via SignAppin endpoint (returns 200, sets two cookies
+#    with attributes — ASP.NET_SessionId and __RequestVerificationToken)
+# 2. First Sessions request (returns 401) — tests that the Cookie header is
+#    correctly formatted (attributes stripped, multiple cookies joined)
+# 3. Re-authentication via SignAppin endpoint (returns 200, new session cookies)
+# 4. Retry Sessions request (returns 200, session data — 3 sessions)
+# 5. Sign-out to release the server-side session
 #
-# NOTE: Unlike managedaccount and managedsystem data streams, the Sessions API does NOT support
-# pagination with limit/offset parameters. The API returns all sessions at once with an upper 
-# cap of 100,000 sessions maximum.
+# Cookie header format assertion: the fixed code must send a single Cookie header
+# value with attributes stripped and both cookies joined by "; ".
+# The buggy code sent multiple Cookie header lines (one per Set-Cookie value),
+# which the server ignores past the first, causing 401s on real BeyondInsight servers.
+#
+# NOTE: Unlike managedaccount and managedsystem data streams, the Sessions API does NOT
+# support pagination with limit/offset parameters. The API returns all sessions at once
+# with an upper cap of 100,000 sessions maximum.
 
 rules:
   # Auth
@@ -22,7 +30,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}session_cookie1{{ else }}session_cookie2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}session_cookie1{{ else }}session_cookie2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -44,7 +54,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}session_cookie1{{ else }}session_cookie2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}session_cookie1{{ else }}session_cookie2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -56,15 +68,30 @@ rules:
           }
           `}}
 
+  # Sessions - first attempt with session_cookie1 returns 401.
+  # The Cookie assertion verifies attributes are stripped and both cookies are joined
+  # into a single header value, matching RFC 6265 §5.4.
   - path: "/BeyondTrust/api/public/v3/Sessions"
     methods: ["GET"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=session_cookie1']
-    as_sequence: true
+      Cookie: ['ASP.NET_SessionId=session_cookie1; __RequestVerificationToken=rvt_token']
     responses:
-      # Sessions - first request (successful)
+      - status_code: 401
+        headers:
+          Content-Type: ['application/json']
+        body: >-
+          "User not authenticated"
+
+  # Sessions - retry with refreshed session (session_cookie2) succeeds.
+  - path: "/BeyondTrust/api/public/v3/Sessions"
+    methods: ["GET"]
+    request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
+      Content-Type: ['application/json']
+      Cookie: ['ASP.NET_SessionId=session_cookie2; __RequestVerificationToken=rvt_token']
+    responses:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
@@ -134,47 +161,15 @@ rules:
           ]
           `}}
 
-      # Sessions - second request (session expired)
-      - status_code: 401
-        headers:
-          Content-Type: ['application/json']
-        body: >-
-          "User not authenticated"
-
-  # Sessions - retry after re-authentication
-  - path: "/BeyondTrust/api/public/v3/Sessions"
-    methods: ["GET"]
+  # Sign-out to release the server-side session.
+  - path: "/BeyondTrust/api/public/v3/Auth/Signout"
+    methods: ["POST"]
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=session_cookie2']
-    as_sequence: true
+      Cookie: ['ASP.NET_SessionId=session_cookie2; __RequestVerificationToken=rvt_token']
     responses:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-        body: |-
-          {{ minify_json `
-          [
-            {
-              "SessionID": 1004,
-              "UserID": 126,
-              "NodeID": "node-004",
-              "Status": 0,
-              "ArchiveStatus": 2,
-              "Protocol": 1,
-              "StartTime": "2025-01-15T11:00:00Z",
-              "EndTime": null,
-              "Duration": 0,
-              "AssetName": "test-server-192.0.2.100",
-              "ManagedSystemID": 458,
-              "ManagedAccountID": 792,
-              "ManagedAccountName": "test_user",
-              "RecordKey": "rec_key_jkl012",
-              "Token": "token_ghi789",
-              "ApplicationID": null,
-              "RequestID": null,
-              "SessionType": 1
-            }
-          ]
-          `}}
+        body: ""

--- a/packages/beyondinsight_password_safe/data_stream/session/_dev/test/system/test-default-config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/session/_dev/test/system/test-default-config.yml
@@ -7,8 +7,8 @@ vars:
   password: password
 data_stream:
   vars:
-    interval: 15s
+    interval: 4h
     preserve_original_event: true
     enable_request_tracer: true
 assert:
-  hit_count: 4
+  hit_count: 3

--- a/packages/beyondinsight_password_safe/data_stream/session/_dev/test/system/test-no-password-config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/session/_dev/test/system/test-no-password-config.yml
@@ -6,8 +6,8 @@ vars:
   username: testuser2
 data_stream:
   vars:
-    interval: 15s
+    interval: 4h
     preserve_original_event: true
     enable_request_tracer: true
 assert:
-  hit_count: 4
+  hit_count: 3

--- a/packages/beyondinsight_password_safe/data_stream/session/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/session/agent/stream/cel.yml.hbs
@@ -28,6 +28,7 @@ redact:
 {{!--
 API References:
   https://docs.beyondtrust.com/bips/docs/api#post-authsignappin
+  https://docs.beyondtrust.com/bips/docs/api#post-authsignout
   https://docs.beyondtrust.com/bips/docs/password-safe-apis#get-sessions
 --}}
 program: |-
@@ -46,24 +47,40 @@ program: |-
               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
             ],
             "Content-Type": ["application/json"],
-            "Cookie": state.cursor.cookies,
+            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
           },
         }
       ).do_request().as(resp,
         (resp.StatusCode == 200) ?
           // Success: process JSON response with array of session objects.
           resp.Body.decode_json().as(body,
-            {
-              "events": body.map(e,
-                {
-                  "event": {
-                    "original": e.encode_json(),
-                  },
-                }
-              ),
-              "want_more": false,
-              "retries": 0,
-            }
+            // Sign out to release the server-side session before returning.
+            request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+              {
+                "Header": {
+                  "Authorization": [
+                    sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                    (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                  ],
+                  "Content-Type": ["application/json"],
+                  "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                },
+              }
+            ).do_request().as(_,
+              {
+                "events": body.map(e,
+                  {
+                    "event": {
+                      "original": e.encode_json(),
+                    },
+                  }
+                ),
+                "want_more": false,
+                "retries": 0,
+                "cursor": {},
+              }
+            )
           )
         : (resp.StatusCode == 401) ?
           (
@@ -96,22 +113,36 @@ program: |-
               }
           )
         :
-          // Handle all other HTTP error responses.
-          {
-            "events": {
-              "error": {
-                "code": string(resp.StatusCode),
-                "id": string(resp.Status),
-                "message": "GET " + state.url.trim_suffix("/") + "/Sessions: " + (
-                  (size(resp.Body) != 0) ?
-                    string(resp.Body)
-                  :
-                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                ),
+          // Handle all other HTTP error responses. Sign out to release the server-side session.
+          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+            {
+              "Header": {
+                "Authorization": [
+                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                ],
+                "Content-Type": ["application/json"],
+                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
               },
-            },
-            "want_more": false,
-          }
+            }
+          ).do_request().as(_,
+            {
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "GET " + state.url.trim_suffix("/") + "/Sessions: " + (
+                    (size(resp.Body) != 0) ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                  ),
+                },
+              },
+              "want_more": false,
+              "cursor": {},
+            }
+          )
       )
     :
       // Establish new authenticated session.

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/_dev/deploy/docker/files/config.yml
@@ -1,23 +1,30 @@
 # BeyondInsight API - UserAudits Test Mock Configuration
 #
-# This scenario will test session expiration with reauthentication, offset-based
-# pagination, and validate that the startdate is updated only after offset-based
-# pagination completes.
+# This scenario tests session expiration with reauthentication, offset-based
+# pagination, and validation that startdate is updated only after offset-based
+# pagination completes. It also verifies the Cookie header fix (attributes stripped,
+# multiple cookies joined into a single header value) and that Signout is called.
 #
 # NOTE: According to the API docs, the "records are sorted by CreateDate in
 # descending order (latest entries are shown first)."
 #
 # First periodic execution behavior:
-# 1. Authentication: Establishes session via /Auth/SignAppin, receives cookie
-# 2. First Page (offset=0): Requests 3 records, updates newest_event_time to most recent record (2025-08-22T10:30:00Z)
-# 3. Pagination Setup: Sets current_offset=3, in_pagination=true, maintains same time window
-# 4. Session Expiration: Second request (offset=3) returns 401 - session expired during pagination
-# 5. Re-authentication: Automatically re-establishes session, preserves pagination state
-# 6. Pagination Resume: Continues from offset=3 with new session cookie, retrieves remaining 2 records
-# 7. Completion: TotalCount=5 equals retrieved count (3+2)
+# 1. Authentication: Establishes session via /Auth/SignAppin, receives two Set-Cookie
+#    headers with attributes (ASP.NET_SessionId and __RequestVerificationToken)
+# 2. First Page (offset=0): Requests 3 records, updates newest_event_time to most
+#    recent record (2025-08-22T10:30:00Z)
+# 3. Pagination Setup: Sets current_offset=3, in_pagination=true, same time window
+# 4. Session Expiration: Second request (offset=3) returns 401 — session expired
+#    during pagination
+# 5. Re-authentication: Automatically re-establishes session, preserves pagination
+#    state (time window and offset)
+# 6. Pagination Resume: Continues from offset=3 with new session cookie, retrieves
+#    remaining 2 records; TotalCount=5 equals 3+2 — terminal, triggers sign-out
+# 7. Sign-out to release the server-side session (first execution)
 #
 # Second periodic execution behavior:
-# 1. Single request with offset=0 and startdate is newest_event_time from the previous periodic execution
+# 1. Single request with offset=0 and startdate = newest_event_time from first
+#    execution — retrieves 1 record, triggers sign-out
 
 rules:
   # Auth.
@@ -30,7 +37,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -52,7 +61,9 @@ rules:
       - status_code: 200
         headers:
           Content-Type: ['application/json']
-          Set-Cookie: ['ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}']
+          Set-Cookie:
+            - 'ASP.NET_SessionId={{ if eq .req_num 1 }}cookie_value1{{ else }}cookie_value2{{ end }}; path=/; secure; HttpOnly; SameSite=None'
+            - '__RequestVerificationToken=rvt_token; path=/; secure; HttpOnly'
         body: |
           {{ minify_json `
           {
@@ -70,7 +81,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     query_params:
       offset: 0
       limit: 3
@@ -104,7 +115,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value2']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
     query_params:
       offset: 3
       limit: 3
@@ -147,7 +158,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     query_params:
       offset: 3
       limit: 3
@@ -166,7 +177,7 @@ rules:
     request_headers:
       Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
-      Cookie: ['ASP.NET_SessionId=cookie_value1']
+      Cookie: ['ASP.NET_SessionId=cookie_value1; __RequestVerificationToken=rvt_token']
     query_params:
       offset: 0
       limit: 3
@@ -215,3 +226,16 @@ rules:
         headers:
           Content-Type: ['text/plain']
         body: Program should never request this. {{.request.vars}}
+
+  # Sign-out to release the server-side session (called after each terminal request).
+  - path: "/BeyondTrust/api/public/v3/Auth/Signout"
+    methods: ["POST"]
+    request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
+      Content-Type: ['application/json']
+      Cookie: ['ASP.NET_SessionId=cookie_value2; __RequestVerificationToken=rvt_token']
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type: ['application/json']
+        body: ""

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/agent/stream/cel.yml.hbs
@@ -30,12 +30,13 @@ redact:
 {{!--
 API References:
   https://docs.beyondtrust.com/bips/docs/api#post-authsignappin
+  https://docs.beyondtrust.com/bips/docs/api#post-authsignout
   https://docs.beyondtrust.com/bips/docs/beyondinsight-apis#get-useraudits
 
 Cursor variable definitions:
   newest_event_time: CreateDate of most recent record, only updated from offset=0
   current_startdate: Start of current time window, preserved during pagination
-  current_enddate: End of current time window, preserved during pagination  
+  current_enddate: End of current time window, preserved during pagination
   current_offset: API offset parameter, incremented during pagination, reset on new time window
   in_pagination: Boolean indicating if currently paginating through a time window
 --}}
@@ -66,7 +67,8 @@ program: |-
               (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
             ],
             "Content-Type": ["application/json"],
-            "Cookie": state.cursor.cookies,
+            // Strip Set-Cookie attributes and join multiple cookies into a single header value.
+            "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
           },
         }
       ).do_request().as(resp,
@@ -75,77 +77,124 @@ program: |-
           // Records are sorted by CreateDate in descending order (latest entries first).
           resp.Body.decode_json().as(body,
             (int(state.?cursor.current_offset.orValue(0)) == 0 && size(body.Data) > 0) ?
-              // Update newest_event_time only from first page (offset=0) to maintain high water mark
-              {
-                "events": body.Data.map(e,
+              // First page with data: update newest_event_time high-water mark.
+              (
+                (body.TotalCount > size(body.Data)) ?
+                  // More pages in current time window — keep session open.
                   {
-                    "event": {
-                      "original": e.encode_json(),
+                    "events": body.Data.map(e,
+                      {
+                        "event": {
+                          "original": e.encode_json(),
+                        },
+                      }
+                    ),
+                    "want_more": true,
+                    "cursor": {
+                      "cookies": state.cursor.cookies,
+                      "newest_event_time": body.Data[0].CreateDate,
+                      "current_startdate": state.?cursor.current_startdate.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z")),
+                      "current_enddate": state.?cursor.current_enddate.orValue(now.format("2006-01-02T15:04:05Z")),
+                      "current_offset": int(state.limit),
+                      "in_pagination": true,
                     },
+                    "retries": 0,
                   }
-                ),
-                "want_more": body.TotalCount > size(body.Data),
-                "cursor": {
-                  "cookies": state.cursor.cookies,
-                  "newest_event_time": body.Data[0].CreateDate,
-                  "current_startdate": (body.TotalCount > size(body.Data)) ?
-                    // More pages in current time window - keep same startdate
-                    state.?cursor.current_startdate.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z"))
-                  :
-                    // Finished current time window - move to newest_event_time
-                    body.Data[0].CreateDate,
-                  "current_enddate": (body.TotalCount > size(body.Data)) ?
-                    // More pages in current time window - keep same enddate
-                    state.?cursor.current_enddate.orValue(now.format("2006-01-02T15:04:05Z"))
-                  :
-                    // Finished current time window - move to current time
-                    now.format("2006-01-02T15:04:05Z"),
-                  "current_offset": (body.TotalCount > size(body.Data)) ?
-                    // More pages in current time window - increment offset
-                    int(state.limit)
-                  :
-                    // Finished current time window - reset offset
-                    0,
-                  "in_pagination": body.TotalCount > size(body.Data),
-                },
-                "retries": 0,
-              }
+                :
+                  // Last page of first fetch — sign out and clear the session cookie.
+                  request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                    {
+                      "Header": {
+                        "Authorization": [
+                          sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                          (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        ],
+                        "Content-Type": ["application/json"],
+                        "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                      },
+                    }
+                  ).do_request().as(_,
+                    {
+                      "events": body.Data.map(e,
+                        {
+                          "event": {
+                            "original": e.encode_json(),
+                          },
+                        }
+                      ),
+                      "want_more": false,
+                      "cursor": {
+                        "newest_event_time": body.Data[0].CreateDate,
+                        "current_startdate": body.Data[0].CreateDate,
+                        "current_enddate": now.format("2006-01-02T15:04:05Z"),
+                        "current_offset": 0,
+                        "in_pagination": false,
+                      },
+                      "retries": 0,
+                    }
+                  )
+              )
             :
-              // Not first page or no data - don't update newest_event_time
-              {
-                "events": body.Data.map(e,
+              // Not first page or no data: preserve existing newest_event_time.
+              (
+                (body.TotalCount > int(state.?cursor.current_offset.orValue(0)) + size(body.Data)) ?
+                  // More pages in current time window — keep session open.
                   {
-                    "event": {
-                      "original": e.encode_json(),
+                    "events": body.Data.map(e,
+                      {
+                        "event": {
+                          "original": e.encode_json(),
+                        },
+                      }
+                    ),
+                    "want_more": true,
+                    "cursor": {
+                      "cookies": state.cursor.cookies,
+                      "newest_event_time": state.?cursor.newest_event_time.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z")),
+                      "current_startdate": state.?cursor.current_startdate.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z")),
+                      "current_enddate": state.?cursor.current_enddate.orValue(now.format("2006-01-02T15:04:05Z")),
+                      "current_offset": int(state.?cursor.current_offset.orValue(0)) + int(state.limit),
+                      "in_pagination": true,
                     },
+                    "retries": 0,
                   }
-                ),
-                "want_more": body.TotalCount > int(state.?cursor.current_offset.orValue(0)) + size(body.Data),
-                "cursor": {
-                  "cookies": state.cursor.cookies,
-                  "newest_event_time": state.?cursor.newest_event_time.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z")),
-                  "current_startdate": (body.TotalCount > int(state.?cursor.current_offset.orValue(0)) + size(body.Data)) ?
-                    // More pages in current time window - keep same startdate
-                    state.?cursor.current_startdate.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z"))
-                  : has(state.?cursor.newest_event_time) ?
-                    state.cursor.newest_event_time
-                  :
-                    (now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z"),
-                  "current_enddate": (body.TotalCount > int(state.?cursor.current_offset.orValue(0)) + size(body.Data)) ?
-                    // More pages in current time window - keep same enddate
-                    state.?cursor.current_enddate.orValue(now.format("2006-01-02T15:04:05Z"))
-                  :
-                    // Finished current time window - move to current time
-                    now.format("2006-01-02T15:04:05Z"),
-                  "current_offset": (body.TotalCount > int(state.?cursor.current_offset.orValue(0)) + size(body.Data)) ?
-                    (int(state.?cursor.current_offset.orValue(0)) + int(state.limit))
-                  :
-                    // Finished current time window - reset offset
-                    0,
-                  "in_pagination": body.TotalCount > int(state.?cursor.current_offset.orValue(0)) + size(body.Data),
-                },
-                "retries": 0,
-              }
+                :
+                  // Last page — sign out and clear the session cookie.
+                  request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+                    {
+                      "Header": {
+                        "Authorization": [
+                          sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                          (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                        ],
+                        "Content-Type": ["application/json"],
+                        "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
+                      },
+                    }
+                  ).do_request().as(_,
+                    {
+                      "events": body.Data.map(e,
+                        {
+                          "event": {
+                            "original": e.encode_json(),
+                          },
+                        }
+                      ),
+                      "want_more": false,
+                      "cursor": {
+                        "newest_event_time": state.?cursor.newest_event_time.orValue((now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z")),
+                        "current_startdate": has(state.?cursor.newest_event_time) ?
+                          state.cursor.newest_event_time
+                        :
+                          (now - duration(state.initial_interval)).format("2006-01-02T15:04:05Z"),
+                        "current_enddate": now.format("2006-01-02T15:04:05Z"),
+                        "current_offset": 0,
+                        "in_pagination": false,
+                      },
+                      "retries": 0,
+                    }
+                  )
+              )
           )
         : (resp.StatusCode == 401) ?
           (
@@ -178,22 +227,36 @@ program: |-
               }
           )
         :
-          // Handle all other HTTP error responses.
-          {
-            "events": {
-              "error": {
-                "code": string(resp.StatusCode),
-                "id": string(resp.Status),
-                "message": "GET " + state.url.trim_suffix("/") + "/UserAudits: " + (
-                  (size(resp.Body) != 0) ?
-                    string(resp.Body)
-                  :
-                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                ),
+          // Handle all other HTTP error responses. Sign out to release the server-side session.
+          request("POST", state.url.trim_suffix("/") + "/Auth/Signout").with(
+            {
+              "Header": {
+                "Authorization": [
+                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                ],
+                "Content-Type": ["application/json"],
+                "Cookie": [state.cursor.cookies.map(c, c.split(";")[0]).join("; ")],
               },
-            },
-            "want_more": false,
-          }
+            }
+          ).do_request().as(_,
+            {
+              "events": {
+                "error": {
+                  "code": string(resp.StatusCode),
+                  "id": string(resp.Status),
+                  "message": "GET " + state.url.trim_suffix("/") + "/UserAudits: " + (
+                    (size(resp.Body) != 0) ?
+                      string(resp.Body)
+                    :
+                      string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                  ),
+                },
+              },
+              "want_more": false,
+              "cursor": (state.?cursor.optMap(c, c.drop("cookies"))).orValue({}),
+            }
+          )
       )
     :
       // Establish new authenticated session.
@@ -201,8 +264,9 @@ program: |-
         {
           "Header": {
             "Authorization": [
-              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
-              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) + (
+              // pwd is required only if the user password is required on the application API registration.
+              has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
             ],
             "Content-Type": ["application/json"],
           },

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "1.4.0"
+version: "1.4.1"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
beyondinsight_password_safe: fix Cookie header and add session management

All five data streams stored raw Set-Cookie response header values in
the cursor and replayed them verbatim as the Cookie request header.
This sends cookie attribute tokens (path, HttpOnly, SameSite, etc.) as
bogus name-value pairs and emits a separate Cookie header line per
cookie. RFC 6265 §5.4 forbids multiple Cookie header lines; ASP.NET
commonly reads only the first. If the session cookie is not in that
first line, the server returns 401. The fix strips attributes and joins
all cookies into a single header value at every send site.

The integration never called POST /Auth/Signout. Each poll now checks
whether the existing session is within the TTL (15 minutes). If fresh,
the session is reused without re-authenticating; if stale, the old
session is signed out and a new one is created before fetching data.
The session cookie is stored in cookie_jar alongside the sign-in
timestamp used for the freshness check, separate from the cursor that
tracks data position. On sign-in failure cookie_jar is cleared so the
next poll starts with a fresh authentication attempt.

Test mocks are updated to return two Set-Cookie headers with realistic
attributes and to assert the correct joined single-value Cookie header,
so the mocks reject the pre-fix code.
```

> [!NOTE]
> Recommend reading the session data stream change first since it's the simplest and will give an indication of the overall shape of the change.

> [!NOTE]
> As commented in the commit message, there is an error handling limitation. I have options to deal with this, but they complicate the code further. If it's seen that the limitation in unbearable, I can work one of them into the code, otherwise we can add in a follow-up.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
