### PR TITLE
[nozomi_networks] Treat null or empty error values in HTTP 200 as success

### DIFF
--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.3"
+  changes:
+    - description: Treat null or empty `error` values in HTTP 200 responses as success instead of failing evaluation, and surface non-string error values without a type error.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.2"
   changes:
     - description: Surface Nozomi query errors returned in HTTP 200 responses instead of silently collecting no data.

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Treat null or empty `error` values in HTTP 200 responses as success instead of failing evaluation, and surface non-string error values without a type error.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/21184
 - version: "0.4.2"
   changes:
     - description: Surface Nozomi query errors returned in HTTP 200 responses instead of silently collecting no data.

--- a/packages/nozomi_networks/data_stream/alert/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/alert/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the alert data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.alert != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:alerts \| where record_created_at > 1747399017809 \| sort record_created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"6dbf93f8-d8da-4ae3-bf1a-e91a82fc0002","ack":false,"name":"Program change","note":"User Defined Note","synchronized":true,"time":1747398906110,"id_dst":"ab_ethip-1/1.128.0.0","id_src":"ab_ethip-1/1.128.0.11","ip_dst":"89.160.20.112","ip_src":"81.2.69.192","status":"close","mac_dst":"f4:54:33:9f:22:3d","mac_src":"00:0c:29:01:98:be","parents":["id1"],"port_dst":44818,"port_src":58679,"protocol":"ethernetip","severity":10,"zone_dst":"Production_B","zone_src":"Production_B","dst_roles":"producer","label_dst":"private.directinvesting.com1","label_src":"private.directinvesting.com2","src_roles":"consumer, engineering_station","ti_source":"","type_name":"Program change","session_id":"12eszcd-223cds34","replicated":true,"bpf_filter":"(ip host 1.128.0.11 and ip host 1.128.0.0 and tcp port 58679 and tcp port 44818) or (vlan and ip host 1.128.0.11 and ip host 1.128.0.0 and tcp port 58679 and tcp port 44818)","properties":{"to_id":"1.128.0.0","from_id":"1.128.0.11","base_risk":6,"raised_by":"n2os_ids","n2os_version":"25.0.0-03042016_D5AB7","is_dst_public":false,"is_src_public":false,"is_dst_node_learned":true,"is_src_node_learned":true,"mitre_attack_for_ics":{"source":{"types":["Engineering Workstation"],"levels":["2"]},"destination":{"types":["Field Controller/RTU/PLC/IED"],"levels":["2"]}},"is_dst_reputation_bad":false,"is_src_reputation_bad":false},"closed_time":1747399017809,"description":"Online edits have been made on the PLC with IP 1.128.0.0. The following steps were executed:\n[1]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n[2]- Changed Controller [ C1_1756 ] to Run Mode\n[3]- Changed Controller [ C1_1756 ] to Program Mode\n[4]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n[5]- Changed Controller [ C1_1756 ] to Run Mode\n[6]- Changed Controller [ C1_1756 ] to Program Mode\n[7]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n[8]- Changed Controller [ C1_1756 ] to Run Mode\n[9]- Changed Controller [ C1_1756 ] to Program Mode\n[10]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n","is_incident":false,"is_security":true,"threat_name":"Grizzly Steppe Threat Actor","incident_keys":[],"created_time":1747398906110,"appliance_site":"Sandbox","trigger_type":"stix_indicators","appliance_host":"Sandbox-TAE-Guardian3","capture_device":"base.pcap","grouped_visible":true,"custom_fields_dst":{},"custom_fields_src":{},"playbook_contents":null,"transport_protocol":"tcp","sec_profile_visible":true,"close_option":null,"appliance_id":"d5ab7eaa-9a4b-4b4b-9a4b-4b4b9a4b4b4b","appliance_ip":"1.128.0.0","risk":6,"trace_status":"state_unavailable_for_alert_type","trace_sha1":null,"record_created_at":1747399017809,"type_id":"SIGN:PROGRAM:CHANGE","trigger_id":"indicator--fb15c96c-eb73-48ac-a48a-15bcab2f0fe3"}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"6dbf93f8-d8da-4ae3-bf1a-e91a82fc3041","ack":false,"name":"Program change","note":"User Defined Note","synchronized":true,"time":1747398906110,"id_dst":"1.128.0.0","id_src":"1.128.0.11","ip_dst":"89.160.20.112","ip_src":"81.2.69.192","status":"open","mac_dst":"f4:54:33:9f:22:3d","mac_src":"00:0c:29:01:98:be","parents":["id1"],"port_dst":44818,"port_src":58679,"protocol":"ethernetip","severity":10,"zone_dst":"Production_B","zone_src":"Production_B","dst_roles":"producer","label_dst":"private.directinvesting.com1","label_src":"private.directinvesting.com2","src_roles":"consumer, engineering_station","ti_source":"","type_name":"Program change","session_id":"12eszcd-223cds34","replicated":true,"bpf_filter":"(ip host 1.128.0.11 and ip host 1.128.0.0 and tcp port 58679 and tcp port 44818) or (vlan and ip host 1.128.0.11 and ip host 1.128.0.0 and tcp port 58679 and tcp port 44818)","properties":{"to_id":"1.128.0.0","from_id":"1.128.0.11","base_risk":6,"raised_by":"n2os_ids","n2os_version":"25.0.0-03042016_D5AB7","is_dst_public":false,"is_src_public":false,"is_dst_node_learned":true,"is_src_node_learned":true,"mitre_attack_for_ics":{"source":{"types":["Engineering Workstation"],"levels":["2"]},"destination":{"types":["Field Controller/RTU/PLC/IED"],"levels":["2"]}},"is_dst_reputation_bad":false,"is_src_reputation_bad":false},"closed_time":0,"description":"Online edits have been made on the PLC with IP 1.128.0.0. The following steps were executed:\n[1]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n[2]- Changed Controller [ C1_1756 ] to Run Mode\n[3]- Changed Controller [ C1_1756 ] to Program Mode\n[4]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n[5]- Changed Controller [ C1_1756 ] to Run Mode\n[6]- Changed Controller [ C1_1756 ] to Program Mode\n[7]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n[8]- Changed Controller [ C1_1756 ] to Run Mode\n[9]- Changed Controller [ C1_1756 ] to Program Mode\n[10]- Downloaded project [ C:\\USERS\\NOZOMI\\DESKTOP\\LADDERBOMB\\PLC_LOGIC_CHALLENGE2\\challenge2changed.ACD ] to [ \\AB_ETHIP-1\\1.128.0.0\\C1_1756 ]\n","is_incident":false,"is_security":true,"threat_name":"Grizzly Steppe Threat Actor","incident_keys":[],"created_time":1747398906110,"appliance_site":"Sandbox","trigger_type":"stix_indicators","appliance_host":"Sandbox-TAE-Guardian3","capture_device":"base.pcap","grouped_visible":true,"custom_fields_dst":{},"custom_fields_src":{},"playbook_contents":null,"transport_protocol":"tcp","sec_profile_visible":true,"close_option":null,"appliance_id":"d5ab7eaa-9a4b-4b4b-9a4b-4b4b9a4b4b4b","appliance_ip":"1.128.0.0","risk":6,"trace_status":"state_unavailable_for_alert_type","trace_sha1":null,"record_created_at":1747399017809,"type_id":"SIGN:PROGRAM:CHANGE","trigger_id":"indicator--fb15c96c-eb73-48ac-a48a-15bcab2f0fe3"}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/alert/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/asset/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/asset/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the asset data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.asset != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:assets \| where created_at > 1681948201431 \| sort created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"f855ca08-hy50-4953-ba47-abb18464013e","ip":["67.43.156.0"],"os":"Mac OS X","name":"hostname","risk":2,"time":1746643869542,"type":"typehost","level":"level2","roles":["other"],"zones":["Undefined"],"vendor":"unknown","os:info":{"source":"passive"},"lifecycle":"life-cycle","protocols":["smb","http"],"type:info":{"source":"passive"},"created_at":1681948201431,"mac_vendor":["Cisco Systems, Inc"],"mac_address":["d9:a8:80:ef:9d:d2"],"vendor:info":{"source":"passive"},"product_name":"pname","serial_number":"123456789","capture_device":"demo","is_ai_enriched":false,"lifecycle:info":{"source":"passive"},"os_or_firmware":"fware","appliance_hosts":["Demo Sensor iq e6ef8db9"],"end_of_sale_date":1747994334,"firmware_version":"fv2","mac_address_level":{"d9:a8:80:ef:9d:d2":"unconfirmed"},"product_name:info":{"source":"passive"},"last_activity_time":1746638915000,"serial_number:info":{"source":"passive"},"end_of_support_date":1747004353,"technology_category":"IT","end_of_sale_date:info":{"source":"passive"},"firmware_version:info":{"source":"passive"},"end_of_support_date:info":{"source":"passive"},"os_or_firmware:info":{"source":"none"},"properties":{"81.2.69.192":{"_type.passive":"computer","_type.enrichment":"computer","_vendor.enrichment":"Dell","_product_name.enrichment":"Desktop/Laptop Computer","http.last_client_version":"Chrome 91.0.4472.124"}},"custom_fields":{},"is_sp_enriched":true,"is_ti_enriched":false,"is_arc_enriched":true,"record_created_at":1746643887546,"mobility:info":{"source":"asset-kb","confidence":"medium"},"mobility":"static","mobility_votes":{"asset-kb":"unknown"},"risk_configuration":{"type_weight":0.5,"ai_risk_weight":1,"lifecycle_weight":0.5,"asset_criticality":25,"alerts_risk_weight":0.5,"device_risk_weight":0.5,"open_alerts_weight":0.5,"compensating_control":0,"high_risk_alert_level":7,"unsafe_countries_list":["china","russia","north korea","ukraine","vietnam","indonesia"],"unsafe_protocols_list":["ftp","http","imap","llmnr","ntlm","nfs","pop3","rdp","smb","snmp","smtp","sip","telnet"],"connection_type_weight":0.5,"risk_mitigation_factor":0,"high_risk_alerts_weight":0.5,"network_activity_weight":0.5,"unsafe_countries_weight":0.5,"unsafe_protocols_weight":0.5,"asset_criticality_factor":0,"asset_criticality_weight":0.5,"internet_exposure_weight":0.5,"communication_risk_weight":0.5,"technology_category_weight":0.5,"compensating_control_weight":0.2,"open_vulnerabilities_weight":0.5,"vulnerabilities_risk_weight":0.5,"suboptimal_management_weight":0.5,"critical_vulnerabilities_weight":0.5,"high_risk_vulnerabilities_level":7,"open_vulnerabilities_likelihood":0.7,"exploitable_vulnerabilities_weight":0.5,"exploitable_vulnerabilities_epss_score":0.2},"nozomi_risk":2,"activity_times":{"1746639000000":1},"remediations_signatures":["sign1","sign2"],"has_remediations":false,"latitude":"45.505918","longitude":"-73.614830","location:info":{"lat":"-73.615630","lon":"45.509818"},"tags":["asset1tag"],"_asset_kb_id":"id123","device_id":"0000034-54b3-e7c7-0000-000046bffd97","vlan_id":["10"],"nodes":["production_a"]}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"f855ca08-ec50-4953-ba47-abb18464013e","ip":["0.0.0.0"],"os":"Mac OS X","name":"0.0.0.0","risk":2,"time":1746643849541,"type":"typehost","level":"level1","roles":["other"],"zones":["Undefined"],"vendor":"unknown","os:info":{"source":"passive"},"lifecycle":"life-cycle","protocols":["smb","http"],"type:info":{"source":"passive"},"created_at":1681948201431,"mac_vendor":["Cisco Systems, Inc"],"mac_address":["d9:a8:80:ef:9d:d2"],"vendor:info":{"source":"passive"},"product_name":"pname","serial_number":"123456789","capture_device":"demo","is_ai_enriched":false,"lifecycle:info":{"source":"passive"},"os_or_firmware":"fware","appliance_hosts":["Demo Sensor iq e6ef8db9"],"end_of_sale_date":1747994353,"firmware_version":"fv2","mac_address_level":{"d9:a8:80:ef:9d:d2":"unconfirmed"},"product_name:info":{"source":"passive"},"last_activity_time":1746638915000,"serial_number:info":{"source":"passive"},"end_of_support_date":1747994353,"technology_category":"IT","end_of_sale_date:info":{"source":"passive"},"firmware_version:info":{"source":"passive"},"end_of_support_date:info":{"source":"passive"},"os_or_firmware:info":{"source":"none"},"properties":{"81.2.69.144":{"_type.passive":"computer","_type.enrichment":"computer","_vendor.enrichment":"Dell","_product_name.enrichment":"Desktop/Laptop Computer","http.last_client_version":"Chrome 91.0.4472.124"}},"custom_fields":{},"is_sp_enriched":true,"is_ti_enriched":false,"is_arc_enriched":true,"record_created_at":1746643849546,"mobility:info":{"source":"asset-kb","confidence":"medium"},"mobility":"static","mobility_votes":{"asset-kb":"unknown"},"risk_configuration":{"type_weight":0.5,"ai_risk_weight":1,"lifecycle_weight":0.5,"asset_criticality":25,"alerts_risk_weight":0.5,"device_risk_weight":0.5,"open_alerts_weight":0.5,"compensating_control":0,"high_risk_alert_level":7,"unsafe_countries_list":["china","russia","north korea","ukraine","vietnam","indonesia"],"unsafe_protocols_list":["ftp","http","imap","llmnr","ntlm","nfs","pop3","rdp","smb","snmp","smtp","sip","telnet"],"connection_type_weight":0.5,"risk_mitigation_factor":0,"high_risk_alerts_weight":0.5,"network_activity_weight":0.5,"unsafe_countries_weight":0.5,"unsafe_protocols_weight":0.5,"asset_criticality_factor":0,"asset_criticality_weight":0.5,"internet_exposure_weight":0.5,"communication_risk_weight":0.5,"technology_category_weight":0.5,"compensating_control_weight":0.2,"open_vulnerabilities_weight":0.5,"vulnerabilities_risk_weight":0.5,"suboptimal_management_weight":0.5,"critical_vulnerabilities_weight":0.5,"high_risk_vulnerabilities_level":7,"open_vulnerabilities_likelihood":0.7,"exploitable_vulnerabilities_weight":0.5,"exploitable_vulnerabilities_epss_score":0.2},"nozomi_risk":2,"activity_times":{"1746639000000":1},"remediations_signatures":["sign1","sign2"],"has_remediations":false,"latitude":"45.505918","longitude":"-73.614830","location:info":{"lat":"-73.614830","lon":"45.505918"},"tags":["asset1tag"],"_asset_kb_id":"id123","device_id":"00000000-54b3-e7c7-0000-000046bffd97","vlan_id":["10"],"nodes":["production_b"]}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/asset/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/audit/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/audit/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the audit data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.audit != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:audit_log \| where record_created_at > 1747028333580 \| sort record_created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"e68f6c04-fe72-7931-abcf-6a2213249c3c","name":"API key signed in","event":"API key signed in with id 7a6534a6-ee49-4cb3-a0ae-1f3a6cac9f52","action":"create","browser":"python-requests/2.32.3","details":null,"username":"john@gmail.com via APIkey AK6dsf5d","controller":"api/api_key_sessions","ip_address":"81.2.69.193","record_created_at":1747028333580,"time":1747028333579}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"e68f6c04-fe98-4549-abcf-6a2213249c3c","name":"API key signed in","event":"API key signed in with id 7a6534a6-ee49-4cb3-a0ae-1f3a6cac9b26","action":"create","browser":"python-requests/2.32.3","details":null,"username":"edward@gmail.com via APIkey AK6eef5d","controller":"api/api_key_sessions","ip_address":"81.2.69.192","record_created_at":1747028333580,"time":1747028333579}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/audit/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/health/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/health/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the health data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.health != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:health_log \| where record_created_at > 1741869377517 \| sort record_created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"f8c3fe6d-1234-4cbe-b51d-08f38a72c593","info":{"description":"Recommended changes. The following items should be changed to support the updates included in version 22.5.0.\n\nAlert rules:\nNothing to change here\n\nAssertions:\nNothing to change here\n\nQueries:\nNothing to change here\n\nAlert rules:\nNothing to change here\n\nReports:\nNothing to change here\n\nSee the N2OS release notes for further explanations."},"time":1741868841845,"record_created_at":1741869377517,"appliance_id":"1c08da2c-e7e9-4030-b956-cada6e0a9a96","appliance_host":"Sandbox-TAE-Guardian3","sensor_appliance_type":"guardian","appliance_ip":"1.128.0.0"}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"f8c3fe6d-6926-4cbe-b51d-08f38a72c593","info":{"description":"Recommended changes. The following items should be changed to support the updates included in version 22.5.0.\n\nAlert rules:\nNothing to change here\n\nAssertions:\nNothing to change here\n\nQueries:\nNothing to change here\n\nAlert rules:\nNothing to change here\n\nReports:\nNothing to change here\n\nSee the N2OS release notes for further explanations."},"time":1741868841845,"record_created_at":1741869377517,"sensor_id":"1c08da2c-e7e9-4030-b956-cada6e0a9a96","sensor_host":"Sandbox-TAE-Guardian3","sensor_appliance_type":"guardian"}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/health/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/health/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/node/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/node/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the node data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.node != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:nodes \| where record_created_at > 1747210553228 \| sort record_created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"9b492faf-5fd4-4b91-b745-f1e903bba5d1","ip":"2a02:cf40::","os":"Windows XP SP3","name":"00112231@81.2.69.192","type":"controller","zone":"Layer2","label":"ACMEincHQ_SW2","level":"1.5","roles":["other"],"subnet":"10.1.1.0/24","vendor":"Rockwell Automation","os:info":{"source":"none"},"is_public":false,"lifecycle":"end_of_sale","protocols":["ethernetip"],"type:info":{"source":"passive","protocol":"ethernetip"},"bpf_filter":"ip host 81.2.69.192","created_at":1725960106184,"is_learned":false,"label:info":{"source":"none"},"mac_vendor":"Schweitzer Engineering Laboratories","properties":{"_type.passive":"controller","_vendor.passive":"Rockwell Automation/Allen-Bradley","ethernetip/vendor":"Rockwell Automation/Allen-Bradley","ethernetip/vendor_id":"1","_product_name.passive":"ControlLogix 1756-ENBT/A","ethernetip/device_type":"Communications Adapter","ethernetip/product_code":"166","ethernetip/product_name":"1756-ENBT/A","ethernetip/serial_number":"00112231","ethernetip/device_type_id":"12","ethernetip/firmware_version":"18.002"},"reputation":"test reputation","sent.bytes":"40","is_disabled":false,"links_count":"1","mac_address":"00:30:a7:a8:01:65","vendor:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"_is_licensed":true,"is_broadcast":false,"is_confirmed":true,"product_name":"ControlLogix 1756-ENBT/A","sent.packets":"40","vlan_id:info":{"source":"none"},"custom_fields":{"field1":"value1"},"serial_number":"00112232","capture_device":"demo","device_modules":{"vendor":"Rockwell Automation","children":{"cip":[{"type":"port","value":"1","children":[{"type":"address","value":"0","children":[{"type":"port","value":"1","attributes":{"name":"Backplane","type":"1"}},{"type":"port","value":"2","attributes":{"name":"Channel 0","type":"9"}}],"attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Programmable Logic Controller","product_code":"54","product_name":"1756-L61/B LOGIX5561","serial_number":"00112238","device_type_id":"14","firmware_version":"20.055"}},{"type":"address","value":"1","attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"","product_code":"3","product_name":"1756-RM2/A REDUNDANCY MODULE","serial_number":"00010208","device_type_id":"112","firmware_version":"20.004"}},{"type":"address","value":"3","attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Communications Adapter","product_code":"166","product_name":"1756-ENBT/A","serial_number":"00112238","device_type_id":"12","firmware_version":"18.002"}},{"type":"address","value":"4","children":[{"type":"port","value":"1","attributes":{"name":"Backplane"}}],"attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Communications Adapter","product_code":"166","product_name":"1756-ENBT/A","serial_number":"00445568","device_type_id":"12","firmware_version":"10.006"}},{"type":"address","value":"6","children":[{"type":"port","value":"1","attributes":{"name":"Backplane","type":"1"}},{"type":"port","value":"2","attributes":{"name":"A","type":"EtherNet/IP"}},{"type":"port","value":"3","attributes":{"name":"PCviaUSB","type":"107"}}],"attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Communications Adapter","product_code":"200","product_name":"1756-EN2TR/B","serial_number":"00070808","device_type_id":"12","firmware_version":"5.008"}}],"attributes":{"name":"Backplane","type":"1"}},{"type":"port","value":"2","attributes":{"name":"A","type":"EtherNet/IP"}},{"type":"port","value":"3","attributes":{"name":"PCviaUSB","type":"107"}}]},"product_name":"ControlLogix 1756-L61/B LOGIX5561","serial_number":"00112238","firmware_version":"20.055"},"is_ai_enriched":false,"is_compromised":false,"is_sp_enriched":false,"is_ti_enriched":true,"lifecycle:info":{"source":"none"},"received.bytes":"40","_private_status":"no","is_arc_enriched":false,"variables_count":"8","end_of_sale_date":"1727740800001","firmware_version":"18.002","is_fully_learned":true,"mac_address:info":{"source":"none","likelihood":"0","protocol_source":"","likelihood_level":"unconfirmed"},"received.packets":"40","product_name:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"last_activity_time":1747206000022,"sent.last_1d_bytes":"10","sent.last_1h_bytes":"240","sent.last_1w_bytes":"700","sent.last_5m_bytes":"2100","serial_number:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"end_of_support_date":"1727740800000","first_activity_time":1747996284,"sent.last_15m_bytes":"5","sent.last_30m_bytes":"8","end_of_sale_date:info":{"source":"none"},"firmware_version:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"received.last_1d_bytes":"10","received.last_1h_bytes":"240","received.last_1w_bytes":"700","received.last_5m_bytes":"2100","received.last_15m_bytes":"5","received.last_30m_bytes":"8","end_of_support_date:info":{"source":"none"},"tcp_retransmission.bytes":"100","tcp_retransmission.packets":"200","tcp_retransmission.percent":50,"tcp_retransmission.last_5m_bytes":"150","tcp_retransmission.last_15m_bytes":"2500","tcp_retransmission.last_30m_bytes":"3000","record_created_at":1747210553229,"_asset_kb_id":"123id","device_id":"00000000-54b3-e7c7-0000-000046bffd97","vlan_id":"100","asset_id":"54trg","appliance_host":"hname","links":"link1"}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"9b492faf-5cf2-4b91-b745-f1e903bba5d1","ip":"ff02::1:ff35:a124","os":"Windows XP SP3","name":"00112231@81.2.69.144","type":"controller","zone":"Layer2","label":"ACMEincHQ_SW2","level":"1.5","roles":["other"],"subnet":"10.1.1.0/24","vendor":"Rockwell Automation","os:info":{"source":"none"},"is_public":false,"lifecycle":"end_of_sale","protocols":["ethernetip"],"type:info":{"source":"passive","protocol":"ethernetip"},"bpf_filter":"ip host 81.2.69.144","created_at":1725960106182,"is_learned":true,"label:info":{"source":"none"},"mac_vendor":"Schweitzer Engineering Laboratories","properties":{"_type.passive":"controller","_vendor.passive":"Rockwell Automation/Allen-Bradley","ethernetip/vendor":"Rockwell Automation/Allen-Bradley","ethernetip/vendor_id":"1","_product_name.passive":"ControlLogix 1756-ENBT/A","ethernetip/device_type":"Communications Adapter","ethernetip/product_code":"166","ethernetip/product_name":"1756-ENBT/A","ethernetip/serial_number":"00112231","ethernetip/device_type_id":"12","ethernetip/firmware_version":"18.002"},"reputation":"test reputation","sent.bytes":"0","is_disabled":false,"links_count":"1","mac_address":"00:30:a7:a8:01:65","vendor:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"_is_licensed":true,"is_broadcast":false,"is_confirmed":true,"product_name":"ControlLogix 1756-ENBT/A","sent.packets":"0","vlan_id:info":{"source":"none"},"custom_fields":{"field1":"value1"},"serial_number":"00112231","capture_device":"demo","device_modules":{"vendor":"Rockwell Automation","children":{"cip":[{"type":"port","value":"1","children":[{"type":"address","value":"0","children":[{"type":"port","value":"1","attributes":{"name":"Backplane","type":"1"}},{"type":"port","value":"2","attributes":{"name":"Channel 0","type":"9"}}],"attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Programmable Logic Controller","product_code":"54","product_name":"1756-L61/B LOGIX5561","serial_number":"00112237","device_type_id":"14","firmware_version":"20.055"}},{"type":"address","value":"1","attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"","product_code":"3","product_name":"1756-RM2/A REDUNDANCY MODULE","serial_number":"00010207","device_type_id":"112","firmware_version":"20.004"}},{"type":"address","value":"3","attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Communications Adapter","product_code":"166","product_name":"1756-ENBT/A","serial_number":"00112237","device_type_id":"12","firmware_version":"18.002"}},{"type":"address","value":"4","children":[{"type":"port","value":"1","attributes":{"name":"Backplane"}}],"attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Communications Adapter","product_code":"166","product_name":"1756-ENBT/A","serial_number":"00445567","device_type_id":"12","firmware_version":"10.006"}},{"type":"address","value":"6","children":[{"type":"port","value":"1","attributes":{"name":"Backplane","type":"1"}},{"type":"port","value":"2","attributes":{"name":"A","type":"EtherNet/IP"}},{"type":"port","value":"3","attributes":{"name":"PCviaUSB","type":"107"}}],"attributes":{"vendor":"Rockwell Automation/Allen-Bradley","vendor_id":"1","device_type":"Communications Adapter","product_code":"200","product_name":"1756-EN2TR/B","serial_number":"00070807","device_type_id":"12","firmware_version":"5.008"}}],"attributes":{"name":"Backplane","type":"1"}},{"type":"port","value":"2","attributes":{"name":"A","type":"EtherNet/IP"}},{"type":"port","value":"3","attributes":{"name":"PCviaUSB","type":"107"}}]},"product_name":"ControlLogix 1756-L61/B LOGIX5561","serial_number":"00112237","firmware_version":"20.055"},"is_ai_enriched":false,"is_compromised":false,"is_sp_enriched":false,"is_ti_enriched":true,"lifecycle:info":{"source":"none"},"received.bytes":"0","_private_status":"no","is_arc_enriched":false,"variables_count":"8","end_of_sale_date":"1727740800000","firmware_version":"18.002","is_fully_learned":true,"mac_address:info":{"source":"none","likelihood":"0","protocol_source":"","likelihood_level":"unconfirmed"},"received.packets":"0","product_name:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"last_activity_time":1747206000000,"sent.last_1d_bytes":"0","sent.last_1h_bytes":"0","sent.last_1w_bytes":"0","sent.last_5m_bytes":"0","serial_number:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"end_of_support_date":"1727740800000","first_activity_time":0,"sent.last_15m_bytes":"0","sent.last_30m_bytes":"0","end_of_sale_date:info":{"source":"none"},"firmware_version:info":{"source":"passive","protocol":"ethernetip","confidence":"high","granularity":"complete"},"received.last_1d_bytes":"0","received.last_1h_bytes":"0","received.last_1w_bytes":"0","received.last_5m_bytes":"0","received.last_15m_bytes":"0","received.last_30m_bytes":"0","end_of_support_date:info":{"source":"none"},"tcp_retransmission.bytes":"0","tcp_retransmission.packets":"0","tcp_retransmission.percent":0,"tcp_retransmission.last_5m_bytes":"0","tcp_retransmission.last_15m_bytes":"0","tcp_retransmission.last_30m_bytes":"0","record_created_at":1747210553228,"_asset_kb_id":"123id","device_id":"00000000-54b3-e7c7-0000-000046bffd97","vlan_id":"100","asset_id":"54trg","appliance_host":"hname","links":"link1"}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/node/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/node/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/node_cve/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/node_cve/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the node_cve data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.node_cve != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:node_cves \| where record_created_at > 1742300286108 \| sort record_created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"71c9d093-ff8b-4987-ab3f-de7d8a86681a","cve":"CVE-2018-7844","cve_score":7.5,"time":1741889629962,"minimum_hotfix":null,"latest_hotfix":null,"matching_cpes":["cpe:/o:schneider-electric:modicon_m340_cpu_firmware:v2.9:-:-","cpe:/h:schneider-electric:modicon_m340_cpu:-:-:-"],"cwe_name":"Exposure of Sensitive Information to an Unauthorized Actor","cve_summary":"A CWE-200: Information Exposure vulnerability exists in all versions of the Modicon M580, Modicon M340, Modicon Quantum, and Modicon Premium which could cause the disclosure of SNMP information when reading memory blocks from the controller over Modbus.","references":[{"url":"https://www.sample.com/en/download/document/SEVD-2019-134-11/","name":"https://www.sample.com/en/download/document/SEVD-2019-134-11/","source":"SCHNEIDER-ELECTRIC","reference_type":"Vendor Advisory"},{"url":"https://www.security.com/vulnerability_reports/TALOS-2018-0739","name":"TALOS-2018-0739 ||  Cisco Talos Intelligence Group - Comprehensive Threat Intelligence","source":"TALOS INTELLIGENCE","reference_type":"Exploit"},{"url":"https://www.cpcert.com/files?p_Doc_Ref=SEVD-2019-134-11&p_enDocType=Security+and+Safety+Notice&p_File_Name=SEVD-2019-134-11_Modicon_Controllers_Security_Notification.pdf","name":"SEVD-2019-134-11 (V12.0)","source":"cpcert@se.com","reference_type":"Vendor Advisory"}],"is_kev":false,"cve_creation_time":1558560540000,"cve_update_time":1743740841399,"cve_source":null,"probability":"Confirmed","likelihood":1,"resolved":false,"nodes":["81.2.69.142"],"zones":["Production_A"],"name":"plc160.ACME0.xyz.com","type":"controller","vendor":"Schneider Electric","product_name":"BMXP342020 Modicon M340 Processor Module","firmware_version":"v2.9","os":"Firmware: v2.9","record_created_at":1741889629971,"cve_epss_score":0.13834,"cwe_id":"200","asset_id":"00bbd965-f26d-4813-ad45-bdbdd08979a1"}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"4e046f7f-f76f-4d1f-9585-97eedffd863b","cve":"CVE-2021-30992","cve_score":5.5,"time":1742300286262,"minimum_hotfix":"KB3074683","latest_hotfix":"KB5059091","matching_cpes":["cpe:/o:apple:ipados:13.3.1:-:-"],"cwe_name":"Out-of-bounds Read","cve_summary":"This issue was addressed with improved handling of file metadata. This issue is fixed in iOS 15.2 and iPadOS 15.2. A user in a FaceTime call may unexpectedly leak sensitive user information through Live Photos metadata.","references":[{"url":"https://support.xyz.com/en-us","name":"About the security content of iOS 15.2 and iPadOS 15.2","source":"product-security@xyz.com","reference_type":"Vendor Advisory"}],"is_kev":false,"cve_creation_time":1629832523963,"cve_update_time":1732183506837,"cve_source":"product-security@xyz.com","probability":"Confirmed","likelihood":1,"resolved":false,"nodes":["175.16.199.24","localhost","0.0.0.0"],"zones":["Production_B"],"name":"iPad Pro 12.9\" 2nd Gen (Wi-Fi)","type":"tablet","vendor":"Apple","product_name":"iPad Pro 12.9\" 2nd Gen (Wi-Fi)","firmware_version":"","os":"iPadOS 13_3_1","record_created_at":1742300286108,"cve_epss_score":0.00066,"cwe_id":"125","asset_id":"616489ea-7bd3-41e7-a618-aecfa9f3d91a","appliance_host":"sensor-east-01","appliance_id":"appl-12345","appliance_ip":"175.16.199.0","installed_on":"","node_label":"PLC-East-Alpha","node_type":"PLC","node_vendor":"Siemens","node_product_name":"SIMATIC S7-1500","node_os":"Step 7","node_firmware_version":"2.8.1","node_id":"node-001","zone":"Production","resolution_reason":"Patch applied","resolved_source":"Microsoft KB5005565","cve_references":[{"url":"https://support.xyz.com/en-us","name":"About the security content of iOS 15.2 and iPadOS 15.2","source":"product-security@xyz.com","reference_type":"Vendor Advisory"}]}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/node_cve/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/node_cve/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/session/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/session/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the session data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.session != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:sessions \| where last_activity_time > 1745957044875 \| sort last_activity_time asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"5514f626-98s8-123e-a9ad-d06aaf56e5bb","to":"2a02:cf41:abcd::1","key":"2a02:cf41:abcd::1;5355;2a02:cf40::;49740;udp;56710","from":"2a02:cf40::","status":"ACTIVE","to_port":"5355","to_zone":"Undefined","protocol":"llmnr","from_port":"49740","from_zone":"Undefined","bpf_filter":"ip6 host 2a02:cf40:: and ip6 host 2a02:cf41:abcd::1 and udp port 49740 and udp port 5355","is_broadcast":false,"is_to_public":false,"is_from_public":false,"throughput_speed":0,"transferred.bytes":"90","direction_is_known":true,"last_activity_time":1745957044875,"transport_protocol":"udp","first_activity_time":"1745957044874","transferred.packets":"1","transferred.last_5m_bytes":"90","transferred.last_15m_bytes":"90","transferred.last_30m_bytes":"90","transferred.avg_packet_bytes":90,"transferred.biggest_packet_bytes":"90","transferred.smallest_packet_bytes":"90","vlan_id":"100"}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"5514f626-10d8-476e-a9ad-d06eef56e5eb","to":"2a02:cf41:abcd::1234","key":"2a02:cf41:abcd::1234;5355;2a02:cf40::;49740;udp;56710","from":"2a02:cf40::","status":"ACTIVE","to_port":"5355","to_zone":"Undefined","protocol":"llmnr","from_port":"49740","from_zone":"Undefined","bpf_filter":"ip6 host 2a02:cf40:: and ip6 host 2a02:cf41:abcd::1234 and udp port 49740 and udp port 5355","is_broadcast":false,"is_to_public":false,"is_from_public":false,"throughput_speed":0,"transferred.bytes":"90","direction_is_known":true,"last_activity_time":1745957044875,"transport_protocol":"udp","first_activity_time":"1745957044874","transferred.packets":"1","transferred.last_5m_bytes":"90","transferred.last_15m_bytes":"90","transferred.last_30m_bytes":"90","transferred.avg_packet_bytes":90,"transferred.biggest_packet_bytes":"90","transferred.smallest_packet_bytes":"90","vlan_id":"100"}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/session/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/session/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/data_stream/variable/_dev/test/scripts/query_api_benign_error.txt
+++ b/packages/nozomi_networks/data_stream/variable/_dev/test/scripts/query_api_benign_error.txt
@@ -1,0 +1,95 @@
+# Test that the variable data stream treats benign "error" values (JSON null
+# and empty string) in HTTP 200 responses as success and ingests the data.
+#
+# Nozomi can return {"error":null,"result":[...]} (or "error":"") together
+# with valid results. The CEL program must not emit an error event or fail
+# evaluation in that case; only a non-empty error value is a real failure.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} nozomi-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+# Two data documents: one from the "error":null response (first poll) and
+# one from the "error":"" response (second poll, matched on the cursor
+# timestamp of the first record). The confirm window spans further polls to
+# guard against spurious error events or duplicates.
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 45s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# No error events were emitted.
+exec jq '[.hits.hits[]._source.error.message // empty] | flatten | length' got_docs.json
+stdout '^0$'
+
+# Both documents are processed data events.
+exec jq '[.hits.hits[]._source | select(.nozomi_networks.variable != null)] | length' got_docs.json
+stdout '^2$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down nozomi-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://nozomi-mock:8080
+  username: username
+  password: password
+data_stream:
+  vars:
+    interval: 30s
+    initial_interval: 1h
+    batch_size: 2
+    preserve_original_event: true
+    enable_request_tracer: false
+-- nozomi-mock/docker-compose.yml --
+version: '2.3'
+services:
+  nozomi-mock:
+    image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: nozomi-mock
+    ports:
+      - 8080
+    environment:
+      PORT: "8080"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8080
+      - --config=/config.yml
+-- nozomi-mock/config.yml --
+rules:
+  # Second poll: the query embeds the first record's cursor timestamp.
+  # Respond with "error" as an empty string plus a second record.
+  - path: /api/open/query/do
+    methods: [GET]
+    query_params:
+      query: '{query:variables \| where record_created_at > 1744586817566 \| sort record_created_at asc}'
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":"","result":[{"id":"e77d717d-4306-49af-9bfe-d49f81ae0002","host":"localhost","name":"ioa-2-206","type":"analog","unit":"n/a","label":"ioa-2-206 at 6913","scale":"1.000000","value":"","offset":"0.000000","var_key":"localhost/6913/ioa-2-206","protocol":"iec104","bit_value":"00111011011111000000000000000000","max_value":"0.013184","min_value":"0.013184","namespace":"6913","host_label":"plc095.ACME0.corporationnet.com","is_numeric":true,"last_cause":"read:event","last_value":0.01318359375,"flow_status":"CYCLIC","last_client":"localhost:8080","active_checks":[],"changes_count":"4","request_count":"9032","flow_anomalies":"0","flow_stats.avg":300005.2765957447,"flow_stats.var":224189.0462307355,"history_status":false,"last_update_time":"1741982102719","latest_bit_change":"Bit 5 changed from 0 to 1","last_activity_time":"1744585807741","last_function_code":"9","last_value_quality":["invalid"],"first_activity_time":"1741870170944","last_value_is_valid":true,"flow_hiccups_percent":"0","last_range_change_time":"1741870170944","last_function_code_info":"M_ME_NA_1: Measured value, normalized value","last_valid_quality_time":"1744585807741","flow_anomaly_in_progress":false,"record_created_at":1744586817566}],"header":[],"total":1}
+  # Any other poll (including the first): "error" is JSON null.
+  - path: /api/open/query/do
+    methods: [GET]
+    request_headers:
+      Authorization:
+        - "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: |-
+          {"error":null,"result":[{"id":"e77d717d-4306-49af-9bfe-d49f81aebcef","host":"1.128.0.0","name":"ioa-2-206","type":"analog","unit":"n/a","label":"ioa-2-206 at 6913","scale":"1.000000","value":0.003814697265625,"offset":"0.000000","var_key":"1.128.0.0/6913/ioa-2-206","protocol":"iec104","bit_value":"00111011011111000000000000000000","max_value":"0.013184","min_value":"0.013184","namespace":"6913","host_label":"plc095.ACME0.corporationnet.com","is_numeric":true,"last_cause":"read:event","last_value":0.01318359375,"flow_status":"CYCLIC","last_client":"89.160.20.112","active_checks":[],"changes_count":"4","request_count":"9032","flow_anomalies":"0","flow_stats.avg":300005.2765957447,"flow_stats.var":224189.0462307355,"history_status":false,"last_update_time":"1741982102719","latest_bit_change":"Bit 5 changed from 0 to 1","last_activity_time":"1744585807741","last_function_code":"9","last_value_quality":["invalid"],"first_activity_time":"1741870170944","last_value_is_valid":true,"flow_hiccups_percent":"0","last_range_change_time":"1741870170944","last_function_code_info":"M_ME_NA_1: Measured value, normalized value","last_valid_quality_time":"1744585807741","flow_anomaly_in_progress":false,"record_created_at":1744586817566}],"header":[],"total":1}

--- a/packages/nozomi_networks/data_stream/variable/agent/stream/cel.yml.hbs
+++ b/packages/nozomi_networks/data_stream/variable/agent/stream/cel.yml.hbs
@@ -42,11 +42,11 @@ program: |
           }
         }).do_request().as(resp, resp.StatusCode == 200 ?
           resp.Body.decode_json().as(body,
-            body.?error.orValue("") != "" ?
+            body.?error.orValue(null) != null && body.error != "" ?
               {
                 "events": {
                   "error": {
-                    "message": "Nozomi query rejected: " + body.error,
+                    "message": "Nozomi query rejected: " + (type(body.error) == string ? body.error : body.error.encode_json()),
                   },
                 },
                 "want_more": false,

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.4.2
+version: 0.4.3
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
[nozomi_networks] Treat null or empty error values in HTTP 200 as success

The previous error-surfacing guard checked body.?error.orValue("")
!= "", which is true for a present "error" key holding JSON null. Some
Nozomi deployments appear to return {"error":null,"result":[...]} 
for successful queries, so the CEL program took the error branch 
and then failed evaluation on string + null ("no such overload"), 
dropping valid data. Any non-string error value would have failed 
the same way.

Only treat error as a failure when it is non-null and non-empty, and
encode non-string error values with encode_json so the error message can
always be built. Add script tests for every data stream that mock
error:null and error:"" responses carrying valid result data and assert
that no error events are emitted.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

**Added new script test passes**
```
PASS
--- Test results for package: nozomi_networks - START ---
╭─────────────────┬─────────────┬───────────┬────────────────────────┬────────┬───────────────╮
│ PACKAGE         │ DATA STREAM │ TEST TYPE │ TEST NAME              │ RESULT │  TIME ELAPSED │
├─────────────────┼─────────────┼───────────┼────────────────────────┼────────┼───────────────┤
│ nozomi_networks │ audit       │ script    │ env                    │ PASS   │   64.351125ms │
│ nozomi_networks │ audit       │ script    │ query_api_benign_error │ PASS   │ 2m3.14847675s │
│ nozomi_networks │ audit       │ script    │ query_api_error        │ PASS   │     59.49419s │
╰─────────────────┴─────────────┴───────────┴────────────────────────┴────────┴───────────────╯
--- Test results for package: nozomi_networks - END   ---
Done
```
