### PR TITLE
[backport-kubernetes-1.39] Remove ELASTIC_PACKAGE_REPOSITORY_LICENSE from publish pipeline

### DIFF
--- a/.buildkite/pipeline.publish.yml
+++ b/.buildkite/pipeline.publish.yml
@@ -10,8 +10,6 @@ env:
   # Elastic package settings
   # Manage docker output/logs
   ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
-  # Default license to use by `elastic-package build`
-  ELASTIC_PACKAGE_REPOSITORY_LICENSE: "licenses/Elastic-2.0.txt"
   # Link definitions path (full path to be set in the corresponding step)
   ELASTIC_PACKAGE_LINKS_FILE_PATH: "links_table.yml"
   # Disable comparison of results in pipeline tests to avoid errors related to GeoIP fields


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Removes the `ELASTIC_PACKAGE_REPOSITORY_LICENSE` environment variable from the global env section of `.buildkite/pipeline.publish.yml`.

This variable should not be used for two reasons:
- The version of `elastic-package` used in this branch did not support the `ELASTIC_PACKAGE_REPOSITORY_LICENSE` flag.
- There is no `licenses/` folder in this branch, so the referenced path (`licenses/Elastic-2.0.txt`) does not exist and would cause unexpected behavior if relied upon.

## Author's Checklist

- [ ] Verified that removing the env var does not affect the publish pipeline behavior.

## How to test this PR locally

No local testing required — the change only affects the Buildkite publish pipeline configuration. Verify by inspecting `.buildkite/pipeline.publish.yml` and confirming the variable is absent.

## Related issues

- Relates #19262

---

## Proposed commit

\`\`\`
Remove ELASTIC_PACKAGE_REPOSITORY_LICENSE from publish pipeline

The version of elastic-package used in this branch did not support
ELASTIC_PACKAGE_REPOSITORY_LICENSE, and there is no licenses/ folder
in this branch, so the referenced path would not exist. Remove the
variable from the global env section of .buildkite/pipeline.publish.yml.

Relates: #19262

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
\`\`\`

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).