### PR TITLE
[kolide] Rename transform lookup indexes

### DIFF
--- a/packages/kolide/changelog.yml
+++ b/packages/kolide/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Convert the latest device and people transform destination indices to lookup indices and bump their destination index versions.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/21154#discussion_r3970246584
+      link: https://github.com/elastic/integrations/pull/21154
 - version: "0.3.0"
   changes:
     - description: Add latest_device and latest_people transforms, which maintain a current-state index of every Kolide device and person.

--- a/packages/kolide/changelog.yml
+++ b/packages/kolide/changelog.yml
@@ -1,9 +1,11 @@
 # later versions go on top
-- version: "0.3.0"
+- version: "0.4.0"
   changes:
     - description: Convert the latest device and people transform destination indices to lookup indices and bump their destination index versions.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/21154
+      link: https://github.com/elastic/integrations/pull/21154#discussion_r3970246584
+- version: "0.3.0"
+  changes:
     - description: Add latest_device and latest_people transforms, which maintain a current-state index of every Kolide device and person.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/21005

--- a/packages/kolide/changelog.yml
+++ b/packages/kolide/changelog.yml
@@ -1,6 +1,9 @@
 # later versions go on top
 - version: "0.3.0"
   changes:
+    - description: Convert the latest device and people transform destination indices to lookup indices and bump their destination index versions.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/21154
     - description: Add latest_device and latest_people transforms, which maintain a current-state index of every Kolide device and person.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/21005

--- a/packages/kolide/docs/README.md
+++ b/packages/kolide/docs/README.md
@@ -1998,7 +1998,7 @@ An example event for `osquery_status` looks as following:
 #### latest_device
 * Description: Latest devices from Kolide. As devices get updated, this transform stores only the latest state of each device inside the destination index. Thus the transform's destination index contains only the latest state of the device.
 * Source Index: logs-kolide.device-\*
-* Destination Index: logs-kolide_latest.dest_device-1
+* Destination Index: logs-kolide_latest.dest_device-2
 
 **Exported fields**
 
@@ -2072,7 +2072,7 @@ An example event for `osquery_status` looks as following:
 #### latest_people
 * Description: Latest people from Kolide. As people get updated, this transform stores only the latest state of each person inside the destination index. Thus the transform's destination index contains only the latest state of the person.
 * Source Index: logs-kolide.people-\*
-* Destination Index: logs-kolide_latest.dest_people-1
+* Destination Index: logs-kolide_latest.dest_people-2
 
 **Exported fields**
 

--- a/packages/kolide/elasticsearch/transform/latest_device/manifest.yml
+++ b/packages/kolide/elasticsearch/transform/latest_device/manifest.yml
@@ -1,5 +1,8 @@
 start: true
 destination_index_template:
+  settings:
+    index:
+      mode: lookup
   mappings:
     dynamic: true
     dynamic_templates:

--- a/packages/kolide/elasticsearch/transform/latest_device/transform.yml
+++ b/packages/kolide/elasticsearch/transform/latest_device/transform.yml
@@ -32,7 +32,7 @@ dest:
   # https://github.com/elastic/package-spec/issues/523 to give us that ability
   # in order to prevent having duplicate data and prevent query time field type
   # conflicts.
-  index: "logs-kolide_latest.dest_device-1"
+  index: "logs-kolide_latest.dest_device-2"
   aliases:
     - alias: "logs-kolide_latest.device"
       move_on_creation: true

--- a/packages/kolide/elasticsearch/transform/latest_device/transform.yml
+++ b/packages/kolide/elasticsearch/transform/latest_device/transform.yml
@@ -68,5 +68,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.1.1
   run_as_kibana_system: false

--- a/packages/kolide/elasticsearch/transform/latest_people/manifest.yml
+++ b/packages/kolide/elasticsearch/transform/latest_people/manifest.yml
@@ -1,5 +1,8 @@
 start: true
 destination_index_template:
+  settings:
+    index:
+      mode: lookup
   mappings:
     dynamic: true
     dynamic_templates:

--- a/packages/kolide/elasticsearch/transform/latest_people/transform.yml
+++ b/packages/kolide/elasticsearch/transform/latest_people/transform.yml
@@ -65,5 +65,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.1.1
   run_as_kibana_system: false

--- a/packages/kolide/elasticsearch/transform/latest_people/transform.yml
+++ b/packages/kolide/elasticsearch/transform/latest_people/transform.yml
@@ -29,7 +29,7 @@ dest:
   # https://github.com/elastic/package-spec/issues/523 to give us that ability
   # in order to prevent having duplicate data and prevent query time field type
   # conflicts.
-  index: "logs-kolide_latest.dest_people-1"
+  index: "logs-kolide_latest.dest_people-2"
   aliases:
     - alias: "logs-kolide_latest.people"
       move_on_creation: true

--- a/packages/kolide/manifest.yml
+++ b/packages/kolide/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.2"
 name: kolide
 title: "Kolide"
-version: "0.3.0"
+version: "0.4.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Kolide (by 1Password) Device Trust with Elastic Agent."


### PR DESCRIPTION
## Summary
- Rename Kolide latest device and people transform destination indexes to the lookup namespace.
- Rename their aliases and update enrich-policy documentation.
- Release the correction as Kolide 0.4.1.

## Testing
- `elastic-package build`
- `elastic-package check` (blocked by the unrelated `packages/kolide/data_stream/auth/_dev/.claude` validation error)